### PR TITLE
Fix EagleEye keyword filter

### DIFF
--- a/backend/src/database/repositories/__tests__/eagleEyeContentRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/eagleEyeContentRepository.test.ts
@@ -477,6 +477,59 @@ describe('eagleEyeContentRepository tests', () => {
 
       await addAll(mockIRepositoryOptions)
 
+      const k1 = {
+        sourceId: 'sourceIdk1',
+        vectorId: 'sourceIdk1',
+        status: null,
+        platform: 'hacker_news',
+        title: 'title',
+        userAttributes: { github: 'hey', twitter: 'ho' },
+        text: 'text',
+        postAttributes: {
+          score: 10,
+        },
+        url: 'url',
+        timestamp: new Date(),
+        username: 'username',
+        keywords: ['keyword1'],
+        similarityScore: 0.9,
+      }
+
+      await new EagleEyeContentService(mockIRepositoryOptions).upsert(k1)
+
+      const k2 = {
+        sourceId: 'sourceIdk2',
+        vectorId: 'sourceIdk2',
+        status: null,
+        platform: 'hacker_news',
+        title: 'title',
+        userAttributes: { github: 'hey', twitter: 'ho' },
+        text: 'text',
+        postAttributes: {
+          score: 10,
+        },
+        url: 'url',
+        timestamp: new Date(),
+        username: 'username',
+        keywords: ['keyword2'],
+        similarityScore: 0.9,
+      }
+
+      try {
+        await EagleEyeContentRepository.findAndCountAll(
+          {
+            filter: {
+              keywords: 'keyword1,keyword2',
+            },
+          },
+          mockIRepositoryOptions,
+        )
+      } catch (e) {
+        console.log(e)
+      }
+
+      await new EagleEyeContentService(mockIRepositoryOptions).upsert(k2)
+
       expect(
         (
           await EagleEyeContentRepository.findAndCountAll(
@@ -488,7 +541,7 @@ describe('eagleEyeContentRepository tests', () => {
             mockIRepositoryOptions,
           )
         ).count,
-      ).toBe(2)
+      ).toBe(5)
     })
   })
 

--- a/backend/src/database/repositories/eagleEyeContentRepository.ts
+++ b/backend/src/database/repositories/eagleEyeContentRepository.ts
@@ -211,9 +211,10 @@ export default class EagleEyeContentRepository {
       }
 
       if (filter.keywords) {
+        // Overlap will take a post where any keyword matches any of the filter keywords
         whereAnd.push({
           keywords: {
-            [Op.contains]: filter.keywords.split(','),
+            [Op.overlap]: filter.keywords.split(','),
           },
         })
       }


### PR DESCRIPTION
# Changes proposed ✍️
- Fix EagleEye keyword filter: if more than 1 keyword it will find content matching one or the other
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.