### PR TITLE
Fix starred typo

### DIFF
--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -185,7 +185,7 @@ export default class ActivityService {
     } else {
       // neither child nor parent is in a conversation, create one from parent
       const conversationTitle = await conversationService.generateTitle(
-        parent.crowdInfo.body,
+        parent.crowdInfo.title ? parent.crowdInfo.title : parent.crowdInfo.body,
         ActivityService.hasHtmlActivities(parent.platform),
       )
       const conversationSettings = await ConversationSettingsService.findOrCreateDefault(

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -249,8 +249,8 @@ const en = {
       },
       github: {
         fork: 'forked',
-        star: 'stared',
-        unstar: 'unstared',
+        star: 'starred',
+        unstar: 'unstarred',
         'pull_request-open': 'opened a new pull request',
         'pull_request-opened': 'opened a new pull request',
         'pull_request-close': 'closed a pull request',


### PR DESCRIPTION
# Changes proposed ✍️
- Fixed a typo in GitHub labels. _star_ activities are now displayed as _starred_
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.