### PR TITLE
Base iterator looses dynamic endpoints information on consecutive runs

### DIFF
--- a/backend/src/serverless/integrations/coordinators/devtoCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/devtoCoordinator.ts
@@ -19,7 +19,7 @@ async function devtoCoordinator(): Promise<void> {
       integrationId: integration.id,
       tenant: integration.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {},
     }
 

--- a/backend/src/serverless/integrations/coordinators/discordCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/discordCoordinator.ts
@@ -16,7 +16,7 @@ async function discordCoordinator(): Promise<void> {
       sleep: Math.floor(Math.random() * 1200),
       tenant: integration.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {
         guildId: integration.integrationIdentifier,
         channels: integration.settings.channels || [],

--- a/backend/src/serverless/integrations/coordinators/slackCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/slackCoordinator.ts
@@ -16,7 +16,7 @@ async function slackCoordinator(): Promise<void> {
       sleep: 0,
       tenant: integration.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints:[] },
       args: {
         channels: integration.settings.channels || [],
       },

--- a/backend/src/serverless/integrations/coordinators/slackCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/slackCoordinator.ts
@@ -16,7 +16,7 @@ async function slackCoordinator(): Promise<void> {
       sleep: 0,
       tenant: integration.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '', endpoints:[] },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {
         channels: integration.settings.channels || [],
       },

--- a/backend/src/serverless/integrations/coordinators/twitterCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/twitterCoordinator.ts
@@ -16,7 +16,7 @@ async function twitterCoordinator(): Promise<void> {
       sleep: 0,
       tenant: integration.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {
         profileId: integration.integrationIdentifier,
         hashtags: integration.settings.hashtags,

--- a/backend/src/serverless/integrations/coordinators/twitterReachCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/twitterReachCoordinator.ts
@@ -15,7 +15,7 @@ async function twitterReachCoordinator(): Promise<void> {
       sleep: 0,
       tenant: microservice.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints:[] },
       args: {
         profileId: microservice.microserviceIdentifier,
       },

--- a/backend/src/serverless/integrations/coordinators/twitterReachCoordinator.ts
+++ b/backend/src/serverless/integrations/coordinators/twitterReachCoordinator.ts
@@ -15,7 +15,7 @@ async function twitterReachCoordinator(): Promise<void> {
       sleep: 0,
       tenant: microservice.tenantId.toString(),
       onboarding: false,
-      state: { endpoint: '', page: '', endpoints:[] },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {
         profileId: microservice.microserviceIdentifier,
       },

--- a/backend/src/serverless/integrations/iterators/__tests__/baseIteration.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/baseIteration.test.ts
@@ -34,7 +34,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint1',
         page: '123',
-        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3'],
       })
     })
 
@@ -47,7 +47,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
     })
 
@@ -72,7 +72,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
     })
 
@@ -85,7 +85,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
     })
 
@@ -116,7 +116,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
     })
   })
@@ -210,7 +210,7 @@ describe('BaseIterator tests', () => {
         { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
-        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
         { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
@@ -238,7 +238,7 @@ describe('BaseIterator tests', () => {
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
-        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3'],
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -272,7 +272,7 @@ describe('BaseIterator tests', () => {
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
-        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3'],
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -301,8 +301,8 @@ describe('BaseIterator tests', () => {
         { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
-        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
-        { endpoint: 'endpoint3', page: '' , endpoints: []},
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(iter.state).toStrictEqual(TestIterator.endState)
       expect(out).toStrictEqual(success)
@@ -335,15 +335,15 @@ describe('BaseIterator tests', () => {
         { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
-        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
-        { endpoint: 'endpoint3', page: '' , endpoints: ['endpoint3']},
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint3', page: 'p1' ,endpoints: ['endpoint3']},
+        { endpoint: 'endpoint3', page: 'p1', endpoints: ['endpoint3'] },
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint3',
         page: 'p1',
-        endpoints: ['endpoint3']
+        endpoints: ['endpoint3'],
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -361,7 +361,7 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: '',
-        endpoints: []
+        endpoints: [],
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
@@ -389,12 +389,12 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: 'p1',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
         { endpoint: 'endpoint2', page: 'p1', endpoints: ['endpoint2', 'endpoint3'] },
-        { endpoint: 'endpoint2', page: 'p2',endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint2', page: 'p2', endpoints: ['endpoint3'] },
         { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
         { endpoint: 'endpoint3', page: 'p1', endpoints: [] },
       ])
@@ -419,7 +419,7 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: 'p1',
-        endpoints: ['endpoint2', 'endpoint3']
+        endpoints: ['endpoint2', 'endpoint3'],
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
@@ -432,7 +432,7 @@ describe('BaseIterator tests', () => {
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint3',
         page: 'p1',
-        endpoints: ['endpoint3']
+        endpoints: ['endpoint3'],
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -470,14 +470,14 @@ describe('BaseIterator tests', () => {
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
-        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3'],
       })
       expect(out).toStrictEqual(limitReached)
 
       const iter2 = new TestIterator(itFn2, {
         endpoint: 'endpoint1',
         page: 'p2',
-        endpoints: []
+        endpoints: [],
       })
       const out2 = await iter2.iterate()
       expect(iter2.audits).toStrictEqual([
@@ -618,24 +618,24 @@ describe('BaseIterator tests', () => {
     })
 
     it('Should start before iteration when a small limit is provided as init count', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: []}, true, 5)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true, 5)
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([
         {
           endpoint: 'endpoint1',
           page: '',
-          endpoints: ['endpoint2', 'endpoint3']
+          endpoints: ['endpoint2', 'endpoint3'],
         },
         {
           endpoint: 'endpoint2',
           page: '',
-          endpoints: ['endpoint3']
+          endpoints: ['endpoint3'],
         },
         {
           endpoint: 'endpoint3',
           page: '',
-          endpoints: []
+          endpoints: [],
         },
       ])
     })
@@ -648,7 +648,7 @@ describe('BaseIterator tests', () => {
         {
           endpoint: 'endpoint1',
           page: '',
-          endpoints: []
+          endpoints: [],
         },
       ])
     })

--- a/backend/src/serverless/integrations/iterators/__tests__/baseIteration.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/baseIteration.test.ts
@@ -34,6 +34,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint1',
         page: '123',
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
       })
     })
 
@@ -46,6 +47,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
+        endpoints: ['endpoint2', 'endpoint3']
       })
     })
 
@@ -70,6 +72,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
+        endpoints: ['endpoint2', 'endpoint3']
       })
     })
 
@@ -82,6 +85,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
+        endpoints: ['endpoint2', 'endpoint3']
       })
     })
 
@@ -112,6 +116,7 @@ describe('BaseIterator tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'endpoint2',
         page: '',
+        endpoints: ['endpoint2', 'endpoint3']
       })
     })
   })
@@ -130,10 +135,11 @@ describe('BaseIterator tests', () => {
 
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
+
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
     })
@@ -168,14 +174,14 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint2', page: 'p1' },
-        { endpoint: 'endpoint2', page: 'p2' },
-        { endpoint: 'endpoint3', page: '' },
-        { endpoint: 'endpoint3', page: 'p1' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: 'p1', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: 'p2', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: 'p1', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
     })
@@ -201,11 +207,11 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
+        { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
     })
@@ -224,14 +230,15 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint1', page: 'p2' },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -257,14 +264,15 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint1', page: 'p2' },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -290,11 +298,11 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
+        { endpoint: 'endpoint3', page: '' , endpoints: []},
       ])
       expect(iter.state).toStrictEqual(TestIterator.endState)
       expect(out).toStrictEqual(success)
@@ -324,17 +332,18 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '' , endpoints: ['endpoint3']},
+        { endpoint: 'endpoint3', page: '' , endpoints: ['endpoint3']},
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint3', page: 'p1' },
+        { endpoint: 'endpoint3', page: 'p1' ,endpoints: ['endpoint3']},
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint3',
         page: 'p1',
+        endpoints: ['endpoint3']
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -352,11 +361,12 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: '',
+        endpoints: []
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
     })
@@ -379,13 +389,14 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: 'p1',
+        endpoints: ['endpoint2', 'endpoint3']
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint2', page: 'p1' },
-        { endpoint: 'endpoint2', page: 'p2' },
-        { endpoint: 'endpoint3', page: '' },
-        { endpoint: 'endpoint3', page: 'p1' },
+        { endpoint: 'endpoint2', page: 'p1', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: 'p2',endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: 'p1', endpoints: [] },
       ])
       expect(out).toStrictEqual(success)
     })
@@ -408,18 +419,20 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn, {
         endpoint: 'endpoint2',
         page: 'p1',
+        endpoints: ['endpoint2', 'endpoint3']
       })
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint2', page: 'p1' },
-        { endpoint: 'endpoint2', page: 'p2' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint2', page: 'p1', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: 'p2', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint3', page: 'p1' },
+        { endpoint: 'endpoint3', page: 'p1', endpoints: ['endpoint3'] },
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint3',
         page: 'p1',
+        endpoints: ['endpoint3']
       })
       expect(out).toStrictEqual(limitReached)
     })
@@ -449,26 +462,28 @@ describe('BaseIterator tests', () => {
       const iter = new TestIterator(itFn)
       const out = await iter.iterate()
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
         TestIterator.limitReachedState,
-        { endpoint: 'endpoint1', page: 'p2' },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] }, // still all endpoints because next is not called
       ])
       expect(iter.state).toStrictEqual({
         endpoint: 'endpoint1',
         page: 'p2',
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
       })
       expect(out).toStrictEqual(limitReached)
 
       const iter2 = new TestIterator(itFn2, {
         endpoint: 'endpoint1',
         page: 'p2',
+        endpoints: []
       })
       const out2 = await iter2.iterate()
       expect(iter2.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: [] },
       ])
       expect(out2).toStrictEqual(success)
     })
@@ -510,12 +525,12 @@ describe('BaseIterator tests', () => {
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([
-        { endpoint: 'endpoint1', page: '' },
-        { endpoint: 'endpoint1', page: 'p1' },
-        { endpoint: 'endpoint1', page: 'p2' },
-        { endpoint: 'endpoint2', page: '' },
-        { endpoint: 'endpoint3', page: '' },
-        { endpoint: 'endpoint3', page: 'p3' },
+        { endpoint: 'endpoint1', page: '', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p1', endpoints: ['endpoint1', 'endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint1', page: 'p2', endpoints: ['endpoint2', 'endpoint3'] },
+        { endpoint: 'endpoint2', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: '', endpoints: ['endpoint3'] },
+        { endpoint: 'endpoint3', page: 'p3', endpoints: [] },
       ])
     })
   })
@@ -561,27 +576,27 @@ describe('BaseIterator tests', () => {
   describe('isFinished tests', () => {
     const endpoints = ['endpoint1', 'endpoint2', 'endpoint3']
     it('Should return not finished for a nextPage given', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true)
       const nextPage = 'here'
       const isFinished = iter.isFinished(endpoints, 'endpoint2', nextPage)
       expect(isFinished).toBe(false)
     })
 
     it('Should return not finished for not nextPage given but in the middle of endpoints', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true)
       const nextPage = undefined
       const isFinished = iter.isFinished(endpoints, 'endpoint2', nextPage)
       expect(isFinished).toBe(false)
     })
 
     it('Should return not finished for page given and last endpoint', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true)
       const isFinished = iter.isFinished(endpoints, 'endpoint3', 'here')
       expect(isFinished).toBe(false)
     })
 
     it('Should return finished for no nextPage given and last endpoint', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true)
       const isFinished = iter.isFinished(endpoints, 'endpoint3', undefined)
       expect(isFinished).toBe(true)
     })
@@ -589,47 +604,51 @@ describe('BaseIterator tests', () => {
 
   describe('Global limit reached before execution tests', () => {
     it('Should stop before iteration when the global limit or larger is provided as init count', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true, 18)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true, 18)
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([])
     })
 
     it('Should stop before iteration when the global limit or larger is provided as init count', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true, 25)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true, 25)
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([])
     })
 
     it('Should start before iteration when a small limit is provided as init count', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true, 5)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: []}, true, 5)
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([
         {
           endpoint: 'endpoint1',
           page: '',
+          endpoints: ['endpoint2', 'endpoint3']
         },
         {
           endpoint: 'endpoint2',
           page: '',
+          endpoints: ['endpoint3']
         },
         {
           endpoint: 'endpoint3',
           page: '',
+          endpoints: []
         },
       ])
     })
 
     it('Should stop when a limit almost as the global limit is provided', async () => {
-      const iter = new TestIterator((n) => n, { endpoint: '', page: '' }, true, 17)
+      const iter = new TestIterator((n) => n, { endpoint: '', page: '', endpoints: [] }, true, 17)
       const out = await iter.iterate()
       expect(out).toStrictEqual(TestIterator.success)
       expect(iter.audits).toStrictEqual([
         {
           endpoint: 'endpoint1',
           page: '',
+          endpoints: []
         },
       ])
     })

--- a/backend/src/serverless/integrations/iterators/__tests__/baseIteratorStatic.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/baseIteratorStatic.test.ts
@@ -5,35 +5,35 @@ describe('Integrations worker static tests', () => {
   const endpoints = ['endpoint1', 'endpoint2', 'endpoint3']
   describe('Get iterator tests', () => {
     it('Should return the endpoints to iterate for a standard state', async () => {
-      const state = { endpoint: 'endpoint2', page: 'here' }
+      const state = { endpoint: 'endpoint2', page: 'here', endpoints: [] }
       const iterator = BaseIterator.getEndPointsIterator(endpoints, state)
 
       expect(iterator).toStrictEqual(['endpoint2', 'endpoint3'])
     })
 
     it('Should return the endpoints to iterate for a state with no page', async () => {
-      const state = { endpoint: 'endpoint2', page: '' }
+      const state = { endpoint: 'endpoint2', page: '', endpoints: [] }
       const iterator = BaseIterator.getEndPointsIterator(endpoints, state)
 
       expect(iterator).toStrictEqual(['endpoint2', 'endpoint3'])
     })
 
     it('Should return the whole endpoints when the state is in the first endpoint with a page', async () => {
-      const state = { endpoint: 'endpoint1', page: 'here' }
+      const state = { endpoint: 'endpoint1', page: 'here', endpoints: [] }
       const iterator = BaseIterator.getEndPointsIterator(endpoints, state)
 
       expect(iterator).toStrictEqual(endpoints)
     })
 
     it('Should return the last endpoint when the state is in the last endpoint', async () => {
-      const state = { endpoint: 'endpoint3', page: '' }
+      const state = { endpoint: 'endpoint3', page: '', endpoints: [] }
       const iterator = BaseIterator.getEndPointsIterator(endpoints, state)
 
       expect(iterator).toStrictEqual(['endpoint3'])
     })
 
     it('Should throw an error when state.endpoint is not in endpoints', async () => {
-      const state = { endpoint: 'endpoint4', page: '' }
+      const state = { endpoint: 'endpoint4', page: '', endpoints: [] }
       try {
         BaseIterator.getEndPointsIterator(endpoints, state)
       } catch (error: any) {
@@ -48,10 +48,12 @@ describe('Integrations worker static tests', () => {
       const state = BaseIterator.initState(endpoints, {
         endpoint: '',
         page: '',
+        endpoints: []
       })
       expect(state).toStrictEqual({
         endpoint: 'endpoint1',
         page: '',
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
       })
     })
 
@@ -59,6 +61,7 @@ describe('Integrations worker static tests', () => {
       const givenState = {
         endpoint: 'endpoint2',
         page: 'here',
+        endpoints: []
       }
       const state = BaseIterator.initState(endpoints, givenState)
       expect(state).toStrictEqual(givenState)

--- a/backend/src/serverless/integrations/iterators/__tests__/baseIteratorStatic.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/baseIteratorStatic.test.ts
@@ -48,12 +48,12 @@ describe('Integrations worker static tests', () => {
       const state = BaseIterator.initState(endpoints, {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       })
       expect(state).toStrictEqual({
         endpoint: 'endpoint1',
         page: '',
-        endpoints: ['endpoint1', 'endpoint2', 'endpoint3']
+        endpoints: ['endpoint1', 'endpoint2', 'endpoint3'],
       })
     })
 
@@ -61,7 +61,7 @@ describe('Integrations worker static tests', () => {
       const givenState = {
         endpoint: 'endpoint2',
         page: 'here',
-        endpoints: []
+        endpoints: [],
       }
       const state = BaseIterator.initState(endpoints, givenState)
       expect(state).toStrictEqual(givenState)

--- a/backend/src/serverless/integrations/iterators/__tests__/devtoIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/devtoIterator.test.ts
@@ -76,7 +76,7 @@ async function getDevtoIterator(articles: DevtoArticle[]) {
     {
       endpoint: '',
       page: '',
-      endpoints: []
+      endpoints: [],
     },
     false,
   )

--- a/backend/src/serverless/integrations/iterators/__tests__/devtoIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/devtoIterator.test.ts
@@ -76,6 +76,7 @@ async function getDevtoIterator(articles: DevtoArticle[]) {
     {
       endpoint: '',
       page: '',
+      endpoints: []
     },
     false,
   )

--- a/backend/src/serverless/integrations/iterators/__tests__/discordIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/discordIterator.test.ts
@@ -589,7 +589,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('1', recentRecord)
@@ -605,7 +605,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('4', recentRecord)
@@ -621,7 +621,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('3', recentRecord)
@@ -637,7 +637,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('1', oldRecord)
@@ -653,7 +653,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('3', oldRecord)
@@ -669,7 +669,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOver = iter.integrationSpecificIsEndpointFinished('4', oldRecord)
@@ -685,7 +685,7 @@ describe('Discord iterator tests', () => {
           'guild12345',
           'token12345',
           channels,
-          { endpoint: '', page: '' },
+          { endpoint: '', page: '', endpoints: [] },
           true,
         )
         const isOverGeneral = iter.isEndpointFinished('4', {}, [])

--- a/backend/src/serverless/integrations/iterators/__tests__/githubIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/githubIterator.test.ts
@@ -38,6 +38,7 @@ async function getGithubIterator(repos: Repos, options: IRepositoryOptions) {
     {
       endpoint: '',
       page: '',
+      endpoints: []
     },
     true,
   )

--- a/backend/src/serverless/integrations/iterators/__tests__/githubIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/githubIterator.test.ts
@@ -38,7 +38,7 @@ async function getGithubIterator(repos: Repos, options: IRepositoryOptions) {
     {
       endpoint: '',
       page: '',
-      endpoints: []
+      endpoints: [],
     },
     true,
   )

--- a/backend/src/serverless/integrations/iterators/__tests__/slackIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/slackIterator.test.ts
@@ -30,7 +30,7 @@ async function getSlackIterator(members = {}, channels = [{ name: 'dev', id: 'C0
     members,
     integrationId,
     mockIRepositoryOptions,
-    { endpoint: '', page: '' },
+    { endpoint: '', page: '', endpoints: [] },
     false,
   )
 }

--- a/backend/src/serverless/integrations/iterators/__tests__/testIterator.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/testIterator.ts
@@ -1,11 +1,9 @@
 /* eslint @typescript-eslint/no-unused-vars: 0 */
 /* eslint class-methods-use-this: 0 */
 
-import { endpoint } from 'aws-sdk/clients/sns'
 import moment from 'moment'
-import { Endpoint } from 'aws-sdk'
 import { BaseOutput, parseOutput, IntegrationResponse } from '../../types/iteratorTypes'
-import { State } from '../../types/regularTypes'
+import { Endpoint, State } from '../../types/regularTypes'
 
 import BaseIterator from '../baseIterator'
 import { AddActivitiesSingle } from '../../types/messageTypes'
@@ -19,6 +17,7 @@ export default class TestIterator extends BaseIterator {
 
   static limitReachedState: State = {
     endpoint: '__limit',
+    endpoints: [],
     page: '__limit',
   }
 
@@ -33,7 +32,7 @@ export default class TestIterator extends BaseIterator {
    */
   constructor(
     transitionFn: Function,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
     limitCount: number = 0,
   ) {
@@ -137,5 +136,14 @@ export default class TestIterator extends BaseIterator {
 
   async iterate(maxTime: number = 12 * 60): Promise<BaseOutput> {
     return super.iterate(maxTime, false)
+  }
+
+  next(currentEndpoint: Endpoint, nextPage: string | undefined, parseOutput: parseOutput): State {
+    const next = super.next(currentEndpoint, nextPage, parseOutput)
+    if (this.audits.length > 0 ){
+      this.audits[this.audits.length - 1].endpoints = next.endpoints
+    }
+    return next
+
   }
 }

--- a/backend/src/serverless/integrations/iterators/__tests__/testIterator.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/testIterator.ts
@@ -140,10 +140,9 @@ export default class TestIterator extends BaseIterator {
 
   next(currentEndpoint: Endpoint, nextPage: string | undefined, parseOutput: parseOutput): State {
     const next = super.next(currentEndpoint, nextPage, parseOutput)
-    if (this.audits.length > 0 ){
+    if (this.audits.length > 0) {
       this.audits[this.audits.length - 1].endpoints = next.endpoints
     }
     return next
-
   }
 }

--- a/backend/src/serverless/integrations/iterators/__tests__/twitterIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/twitterIterator.test.ts
@@ -47,14 +47,14 @@ describe('Integrations worker static tests', () => {
     it('It should return the proper message', async () => {
       const iter = new TwitterIterator('tenant12345', 'profile12345', 'token', ['#1', '#2'])
       const message: TwitterIntegrationMessage = iter.getSQSBody(
-        { endpoint: 'hashtag/#1', page: '1' },
+        { endpoint: 'hashtag/#1', page: '1', endpoints: [] },
         42,
       )
       expect(message).toStrictEqual({
         tenant: 'tenant12345',
         integration: PlatformType.TWITTER,
         onboarding: false,
-        state: { endpoint: 'hashtag/#1', page: '1' },
+        state: { endpoint: 'hashtag/#1', page: '1', endpoints: [] },
         sleep: 42,
         args: {
           profileId: 'profile12345',
@@ -653,7 +653,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
       )
       const { activities } = iter.parseActivities(followers, 'followers')
@@ -947,7 +947,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         10,
         existingFollowers,
@@ -1000,7 +1000,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         10,
         existingFollowers,
@@ -1058,7 +1058,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         10,
         existingFollowers,
@@ -1098,7 +1098,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         10,
         existingFollowers,
@@ -1134,7 +1134,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         10,
         existingFollowers,
@@ -1154,7 +1154,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         10,
         existingFollowers,
@@ -1171,7 +1171,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         10,
         existingFollowers,
@@ -1220,7 +1220,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         10,
         existingFollowers,
@@ -1250,7 +1250,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         10,
         existingFollowers,
@@ -1278,7 +1278,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         10,
         existingFollowers,
@@ -1308,7 +1308,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         initialCount,
       )
@@ -1361,7 +1361,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         initialCount,
       )
@@ -1414,7 +1414,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         true,
         initialCount,
       )
@@ -1431,7 +1431,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         initialCount,
       )
@@ -1443,6 +1443,7 @@ describe('Integrations worker static tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'followers',
         page: 'p124',
+        endpoints: ['followers', 'mentions', 'hashtag/#1', 'hashtag/#2']
       })
     })
 
@@ -1453,7 +1454,7 @@ describe('Integrations worker static tests', () => {
         'profile12345',
         'token',
         ['#1', '#2'],
-        { endpoint: '', page: '' },
+        { endpoint: '', page: '', endpoints: [] },
         false,
         initialCount,
       )
@@ -1471,6 +1472,7 @@ describe('Integrations worker static tests', () => {
       const iter = new TwitterIterator('tenant12345', 'profile12345', 'token', ['#1', '#2'], {
         endpoint: '',
         page: '',
+        endpoints: []
       })
       const date = iter.getAfterDate()
       expect(moment(date).unix()).toBeCloseTo(

--- a/backend/src/serverless/integrations/iterators/__tests__/twitterIterator.test.ts
+++ b/backend/src/serverless/integrations/iterators/__tests__/twitterIterator.test.ts
@@ -1443,7 +1443,7 @@ describe('Integrations worker static tests', () => {
       expect(next).toStrictEqual({
         endpoint: 'followers',
         page: 'p124',
-        endpoints: ['followers', 'mentions', 'hashtag/#1', 'hashtag/#2']
+        endpoints: ['followers', 'mentions', 'hashtag/#1', 'hashtag/#2'],
       })
     })
 
@@ -1472,7 +1472,7 @@ describe('Integrations worker static tests', () => {
       const iter = new TwitterIterator('tenant12345', 'profile12345', 'token', ['#1', '#2'], {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       })
       const date = iter.getAfterDate()
       expect(moment(date).unix()).toBeCloseTo(

--- a/backend/src/serverless/integrations/iterators/baseIterator.ts
+++ b/backend/src/serverless/integrations/iterators/baseIterator.ts
@@ -26,6 +26,7 @@ export default abstract class BaseIterator {
   startTimestamp: number
 
   static endState: State = {
+    endpoints: [],
     endpoint: '__finished',
     page: '__finished',
   }
@@ -50,7 +51,7 @@ export default abstract class BaseIterator {
   constructor(
     tenant: string,
     endPoints: Endpoints,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
     globalLimit: number = Infinity,
     limitCount: number = 0,
@@ -107,6 +108,7 @@ export default abstract class BaseIterator {
     while (this.state !== BaseIterator.endState) {
       // Get the current endpoint and page
       const { endpoint, page } = this.state
+
       // Get the response from the API and parse it.
       // We also get the date of the latest activity
       const response: IntegrationResponse = await this.get(endpoint, page)
@@ -237,8 +239,9 @@ export default abstract class BaseIterator {
     return lodash.isEqual(startState, {
       endpoint: '',
       page: '',
+      endpoints
     })
-      ? { endpoint: endpoints[0], page: '' }
+      ? { endpoint: endpoints[0], page: '', endpoints }
       : startState
   }
 
@@ -292,6 +295,7 @@ export default abstract class BaseIterator {
         : {
             endpoint: this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
             page: '',
+            endpoints: this.endpointsIterator.slice(1)
           }
     }
     // If we do not have a next page, return the next endpoint with an empty page and 0 for number
@@ -301,6 +305,7 @@ export default abstract class BaseIterator {
         ? currentEndpoint
         : this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
       page: nextPage || '',
+      endpoints: nextPage ? this.endpointsIterator : this.endpointsIterator.slice(1)
     }
   }
 

--- a/backend/src/serverless/integrations/iterators/baseIterator.ts
+++ b/backend/src/serverless/integrations/iterators/baseIterator.ts
@@ -57,7 +57,13 @@ export default abstract class BaseIterator {
     limitCount: number = 0,
   ) {
     this.tenant = tenant
-    this.endpoints = endPoints
+
+    if (state.endpoints.length > 0 ){
+      this.endpoints = state.endpoints
+    }
+    else{
+      this.endpoints = endPoints
+    }
     this.state = BaseIterator.initState(this.endpoints, state)
 
     this.startTimestamp = moment().utc().unix()
@@ -140,6 +146,7 @@ export default abstract class BaseIterator {
       }
       // Get the next state
       this.state = this.next(endpoint, response.nextPage, parseOutput)
+      this.endpoints = this.state.endpoints
 
       // If we are not done
       if (this.state !== BaseIterator.endState) {
@@ -239,7 +246,7 @@ export default abstract class BaseIterator {
     return lodash.isEqual(startState, {
       endpoint: '',
       page: '',
-      endpoints
+      endpoints: []
     })
       ? { endpoint: endpoints[0], page: '', endpoints }
       : startState
@@ -295,7 +302,7 @@ export default abstract class BaseIterator {
         : {
             endpoint: this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
             page: '',
-            endpoints: this.endpointsIterator.slice(1)
+            endpoints: this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1)
           }
     }
     // If we do not have a next page, return the next endpoint with an empty page and 0 for number
@@ -305,7 +312,7 @@ export default abstract class BaseIterator {
         ? currentEndpoint
         : this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
       page: nextPage || '',
-      endpoints: nextPage ? this.endpointsIterator : this.endpointsIterator.slice(1)
+      endpoints: nextPage ? this.endpoints : this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1)
     }
   }
 

--- a/backend/src/serverless/integrations/iterators/baseIterator.ts
+++ b/backend/src/serverless/integrations/iterators/baseIterator.ts
@@ -58,11 +58,12 @@ export default abstract class BaseIterator {
   ) {
     this.tenant = tenant
 
-    if (state.endpoints.length > 0) {
+    if (state.endpoints.length > 0 && state.endpoint) {
       this.endpoints = state.endpoints
     } else {
       this.endpoints = endPoints
     }
+
     this.state = BaseIterator.initState(this.endpoints, state)
 
     this.startTimestamp = moment().utc().unix()

--- a/backend/src/serverless/integrations/iterators/baseIterator.ts
+++ b/backend/src/serverless/integrations/iterators/baseIterator.ts
@@ -58,10 +58,9 @@ export default abstract class BaseIterator {
   ) {
     this.tenant = tenant
 
-    if (state.endpoints.length > 0 ){
+    if (state.endpoints.length > 0) {
       this.endpoints = state.endpoints
-    }
-    else{
+    } else {
       this.endpoints = endPoints
     }
     this.state = BaseIterator.initState(this.endpoints, state)
@@ -246,7 +245,7 @@ export default abstract class BaseIterator {
     return lodash.isEqual(startState, {
       endpoint: '',
       page: '',
-      endpoints: []
+      endpoints: [],
     })
       ? { endpoint: endpoints[0], page: '', endpoints }
       : startState
@@ -302,7 +301,7 @@ export default abstract class BaseIterator {
         : {
             endpoint: this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
             page: '',
-            endpoints: this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1)
+            endpoints: this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1),
           }
     }
     // If we do not have a next page, return the next endpoint with an empty page and 0 for number
@@ -312,7 +311,9 @@ export default abstract class BaseIterator {
         ? currentEndpoint
         : this.endpointsIterator[this.endpointsIterator.indexOf(currentEndpoint) + 1],
       page: nextPage || '',
-      endpoints: nextPage ? this.endpoints : this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1)
+      endpoints: nextPage
+        ? this.endpoints
+        : this.endpoints.slice(this.endpoints.indexOf(currentEndpoint) + 1),
     }
   }
 

--- a/backend/src/serverless/integrations/iterators/devtoIterator.ts
+++ b/backend/src/serverless/integrations/iterators/devtoIterator.ts
@@ -41,8 +41,6 @@ export default class DevtoIterator extends BaseIterator {
   ) {
     const endpoints: Endpoints = articles.map((a) => a.id.toString())
 
-    state.endpoints = endpoints
-
     super(tenant, endpoints, state, onboarding, DevtoIterator.globalLimit)
 
     this.userContext = userContext

--- a/backend/src/serverless/integrations/iterators/devtoIterator.ts
+++ b/backend/src/serverless/integrations/iterators/devtoIterator.ts
@@ -36,10 +36,12 @@ export default class DevtoIterator extends BaseIterator {
     articles: DevtoArticle[],
     userContext: IRepositoryOptions,
     integrationId: string,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
   ) {
     const endpoints: Endpoints = articles.map((a) => a.id.toString())
+
+    state.endpoints = endpoints
 
     super(tenant, endpoints, state, onboarding, DevtoIterator.globalLimit)
 

--- a/backend/src/serverless/integrations/iterators/discordIterator.ts
+++ b/backend/src/serverless/integrations/iterators/discordIterator.ts
@@ -65,8 +65,6 @@ export default class DiscordIterator extends BaseIterator {
       channels.map((channel) => channel.id),
     )
 
-    state.endpoints = endpoints
-
     super(tenant, endpoints, state, onboarding, DiscordIterator.globalLimit)
     this.guildId = guildId
     this.botToken = botToken

--- a/backend/src/serverless/integrations/iterators/discordIterator.ts
+++ b/backend/src/serverless/integrations/iterators/discordIterator.ts
@@ -20,6 +20,7 @@ import { PlatformType } from '../../../utils/platforms'
 
 export default class DiscordIterator extends BaseIterator {
   static limitReachedState: State = {
+    endpoints: [],
     endpoint: '__limit',
     page: '__limit',
   }
@@ -56,13 +57,15 @@ export default class DiscordIterator extends BaseIterator {
     guildId: string,
     botToken: string,
     channels: Channels,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
   ) {
     // Endpoints are the fixed endpoints plus the channels
     const endpoints: Endpoints = DiscordIterator.fixedEndpoints.concat(
       channels.map((channel) => channel.id),
     )
+
+    state.endpoints = endpoints
 
     super(tenant, endpoints, state, onboarding, DiscordIterator.globalLimit)
     this.guildId = guildId

--- a/backend/src/serverless/integrations/iterators/githubIterator.ts
+++ b/backend/src/serverless/integrations/iterators/githubIterator.ts
@@ -61,7 +61,7 @@ export default class GithubIterator extends BaseIterator {
     onboarding: boolean = false,
   ) {
     let endpoints: Endpoints
-    if (state.endpoints.length === 0){
+    if (state.endpoints.length === 0) {
       endpoints = repos.reduce((acc, repo) => {
         const repoEndpoints = GithubIterator.fixedEndpoints.map(
           (endpoint) => `${repo.name}|${endpoint}`,
@@ -71,8 +71,7 @@ export default class GithubIterator extends BaseIterator {
       }, [])
 
       state.endpoints = endpoints
-    }
-    else{
+    } else {
       endpoints = state.endpoints
     }
 

--- a/backend/src/serverless/integrations/iterators/githubIterator.ts
+++ b/backend/src/serverless/integrations/iterators/githubIterator.ts
@@ -69,8 +69,6 @@ export default class GithubIterator extends BaseIterator {
         acc.push(...repoEndpoints)
         return acc
       }, [])
-
-      state.endpoints = endpoints
     } else {
       endpoints = state.endpoints
     }

--- a/backend/src/serverless/integrations/iterators/slackIterator.ts
+++ b/backend/src/serverless/integrations/iterators/slackIterator.ts
@@ -27,6 +27,7 @@ import { PlatformType } from '../../../utils/platforms'
 
 export default class SlackIterator extends BaseIterator {
   static limitReachedState: State = {
+    endpoints: [],
     endpoint: '__limit',
     page: '__limit',
   }
@@ -72,13 +73,17 @@ export default class SlackIterator extends BaseIterator {
     members: Object,
     integrationId: string,
     userContext: IRepositoryOptions,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: []},
     onboarding: boolean = false,
   ) {
+    let endpoints: Endpoints = state.endpoints
     // Endpoints are the fixed endpoints plus the channels
-    const endpoints: Endpoints = SlackIterator.fixedEndpoints.concat(
-      channels.map((channel) => channel.id),
-    )
+    if (state.endpoints.length === 0){
+      endpoints = SlackIterator.fixedEndpoints.concat(
+        channels.map((channel) => channel.id),
+      )
+      state.endpoints = endpoints
+    }
 
     super(tenant, endpoints, state, onboarding, SlackIterator.globalLimit)
 

--- a/backend/src/serverless/integrations/iterators/slackIterator.ts
+++ b/backend/src/serverless/integrations/iterators/slackIterator.ts
@@ -73,15 +73,13 @@ export default class SlackIterator extends BaseIterator {
     members: Object,
     integrationId: string,
     userContext: IRepositoryOptions,
-    state: State = { endpoint: '', page: '', endpoints: []},
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
   ) {
     let endpoints: Endpoints = state.endpoints
     // Endpoints are the fixed endpoints plus the channels
-    if (state.endpoints.length === 0){
-      endpoints = SlackIterator.fixedEndpoints.concat(
-        channels.map((channel) => channel.id),
-      )
+    if (state.endpoints.length === 0) {
+      endpoints = SlackIterator.fixedEndpoints.concat(channels.map((channel) => channel.id))
       state.endpoints = endpoints
     }
 

--- a/backend/src/serverless/integrations/iterators/slackIterator.ts
+++ b/backend/src/serverless/integrations/iterators/slackIterator.ts
@@ -80,7 +80,6 @@ export default class SlackIterator extends BaseIterator {
     // Endpoints are the fixed endpoints plus the channels
     if (state.endpoints.length === 0) {
       endpoints = SlackIterator.fixedEndpoints.concat(channels.map((channel) => channel.id))
-      state.endpoints = endpoints
     }
 
     super(tenant, endpoints, state, onboarding, SlackIterator.globalLimit)

--- a/backend/src/serverless/integrations/iterators/twitterIterator.ts
+++ b/backend/src/serverless/integrations/iterators/twitterIterator.ts
@@ -67,8 +67,6 @@ export default class TwitterIterator extends BaseIterator {
       (hashtags || []).map((hashtag) => `hashtag/${hashtag}`),
     )
 
-    state.endpoints = endpoints
-
     let globalLimit = Number(process.env.TWITTER_GLOBAL_LIMIT || 10000)
 
     globalLimit = onboarding ? globalLimit * 0.7 : globalLimit

--- a/backend/src/serverless/integrations/iterators/twitterIterator.ts
+++ b/backend/src/serverless/integrations/iterators/twitterIterator.ts
@@ -25,6 +25,7 @@ import { PlatformType } from '../../../utils/platforms'
 
 export default class TwitterIterator extends BaseIterator {
   static limitReachedState: State = {
+    endpoints: [],
     endpoint: '__limit',
     page: '__limit',
   }
@@ -57,7 +58,7 @@ export default class TwitterIterator extends BaseIterator {
     profileId: string,
     accessToken: string,
     hashtags: Array<string>,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
     onboarding: boolean = false,
     tweetCount: number = 0,
     followers: Set<string> = new Set(),
@@ -65,6 +66,8 @@ export default class TwitterIterator extends BaseIterator {
     const endpoints: Endpoints = TwitterIterator.fixedEndpoints.concat(
       (hashtags || []).map((hashtag) => `hashtag/${hashtag}`),
     )
+
+    state.endpoints = endpoints
 
     let globalLimit = Number(process.env.TWITTER_GLOBAL_LIMIT || 10000)
 

--- a/backend/src/serverless/integrations/iterators/twitterReachIterator.ts
+++ b/backend/src/serverless/integrations/iterators/twitterReachIterator.ts
@@ -23,7 +23,7 @@ import { PlatformType } from '../../../utils/platforms'
 export default class TwitterReachIterator extends BaseIterator {
   static readonly TWITTER_API_MAX_USERNAME_LENGTH = 15
 
-  static limitReachedState: State = { endpoint: '__limit', page: '__limit' }
+  static limitReachedState: State = { endpoint: '__limit', page: '__limit', endpoints: [] }
 
   static maxRetrospect: number = Number(process.env.TWITTER_MAX_RETROSPECT_IN_SECONDS || 7380)
 
@@ -48,7 +48,7 @@ export default class TwitterReachIterator extends BaseIterator {
     profileId: string,
     accessToken: string,
     members: Array<any>,
-    state: State = { endpoint: '', page: '' },
+    state: State = { endpoint: '', page: '', endpoints: [] },
   ) {
     super(tenant, members, state, false)
 

--- a/backend/src/serverless/integrations/types/regularTypes.ts
+++ b/backend/src/serverless/integrations/types/regularTypes.ts
@@ -21,6 +21,7 @@ export type Endpoint = string
 export type Endpoints = Array<Endpoint>
 
 export type State = {
-  endpoint: Endpoint
+  endpoints: Endpoints
+  endpoint: string
   page: string
 }

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -185,7 +185,7 @@ export default class ActivityService {
     } else {
       // neither child nor parent is in a conversation, create one from parent
       const conversationTitle = await conversationService.generateTitle(
-        parent.crowdInfo.body,
+        parent.crowdInfo.title ? parent.crowdInfo.title : parent.crowdInfo.body,
         ActivityService.hasHtmlActivities(parent.platform),
       )
       const conversationSettings = await ConversationSettingsService.findOrCreateDefault(

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -262,7 +262,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -295,7 +295,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -366,7 +366,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -420,7 +420,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
-        endpoints: []
+        endpoints: [],
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -262,6 +262,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
+        endpoints: []
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -294,6 +295,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
+        endpoints: []
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -336,7 +338,7 @@ export default class IntegrationService {
       integrationId: integration.id,
       tenant: integration.tenantId.toString(),
       onboarding: true,
-      state: { endpoint: '', page: '' },
+      state: { endpoint: '', page: '', endpoints: [] },
       args: {},
     }
 
@@ -364,6 +366,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
+        endpoints: []
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,
@@ -417,6 +420,7 @@ export default class IntegrationService {
       state: {
         endpoint: '',
         page: '',
+        endpoints: []
       },
       tenant: integration.tenantId.toString(),
       sleep: 0,

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -249,8 +249,8 @@ const en = {
       },
       github: {
         fork: 'forked',
-        star: 'stared',
-        unstar: 'unstared',
+        star: 'starred',
+        unstar: 'unstarred',
         'pull_request-open': 'opened a new pull request',
         'pull_request-opened': 'opened a new pull request',
         'pull_request-close': 'closed a pull request',


### PR DESCRIPTION
# Changes proposed ✍️
- Currently, dynamic endpoints are lost when we spawn a new lambda on 15 min. limit reached.
-  Iterators now keep an endpoints state for parsing the remaining endpoints.
- This state is passed to new executions when lambda limit is reached. This helps retaining the dynamic endpoints during previous iterations
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [x] Environment variables have been updated
  - [x] Front-end: `frontend/.env.dist`
  - [x] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [x] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [x] Team members only: update environment variables in Password manager and update the team
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.