### PR TITLE
Bugfix for newly hosted webhook handler.

### DIFF
--- a/backend/src/api/apiResponseHandler.ts
+++ b/backend/src/api/apiResponseHandler.ts
@@ -15,6 +15,8 @@ export default class ApiResponseHandler {
   }
 
   static async error(_req, res, error) {
+    console.log('API ERROR', error)
+
     if (error && [400, 401, 403, 404].includes(error.code)) {
       res.status(error.code).send(error.message)
     } else {

--- a/backend/src/serverless/integrations/webhooks/github.ts
+++ b/backend/src/serverless/integrations/webhooks/github.ts
@@ -491,8 +491,10 @@ export default class GitHubWebhook {
     try {
       const signature = req.headers['x-hub-signature']
       const secret = GITHUB_CONFIG.webhookSecret
+
       console.log('Verifying webhook...')
-      const isVerified = verifyGithubWebhook(signature, req.body, secret) // Returns true if verification succeeds; otherwise, false.
+      const isVerified = verifyGithubWebhook(signature, JSON.stringify(req.body), secret) // Returns true if verification succeeds; otherwise, false.
+
       console.log('Verification', isVerified)
       if (!isVerified) {
         throw new Error('Webhook not verified')

--- a/backend/src/serverless/integrations/workers/githubWebhookWorker.ts
+++ b/backend/src/serverless/integrations/workers/githubWebhookWorker.ts
@@ -2,6 +2,6 @@ import GitHubWebhook from '../webhooks/github'
 
 export default async function githubWebhookWorker(req) {
   GitHubWebhook.verify(req)
-  const result = await new GitHubWebhook(req.headers['x-github-event'], JSON.parse(req.body)).main()
+  const result = await new GitHubWebhook(req.headers['x-github-event'], req.body).main()
   return result
 }


### PR DESCRIPTION
# Changes proposed ✍️
- Github webhook body was parsed as javascript object not like before when webhook was deployed as a serverless function REST API handler so a few lines had to be changed to make it work with the new `api` service hosted webhook endpoint
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation]~(https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.