### PR TITLE
added a check to use either docker-compose or docker compose

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -12,6 +12,8 @@ source $CLI_HOME/utils
 CONTAINERS=`ls $CLI_HOME/services | sed 's/\.[^.]*$//'`
 BUILDERS=`ls $CLI_HOME/builders | sed 's/\.[^.]*$//'`
 
+_DC="docker-compose"
+
 function prepare_dev_env() {
     if [[ ! -f "$CLI_HOME/../backend/.env.override.local" ]]; then
         echo "# Here you can put environment variables that you would like to override when using local environment" > "$CLI_HOME/../backend/.env.override.local"
@@ -27,6 +29,22 @@ function prepare_dev_env() {
     if [[ ! -f "$CLI_HOME/../frontend/.env.override.composed" ]]; then
         echo "# Here you can put environment variables that you would like to override when using local environment" > "$CLI_HOME/../frontend/.env.override.composed"
     fi
+
+    set +eo pipefail
+
+    which $_DC >> /dev/null 2>&1
+
+    if [[ ! $? -eq 0 ]]; then 
+        _DC="docker compose"
+        which $_DC >> /dev/null 2>&1
+
+        if [[ ! $? -eq 0 ]]; then
+            error "Docker compose not detected!" 
+            exit 1
+        fi
+    fi
+
+    set -eo pipefail
 }
 
 prepare_dev_env
@@ -174,14 +192,14 @@ function start_service() {
     export GROUP_ID=$(id -g)
 
     if [[ ${DEV} ]]; then
-        docker-compose --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" up --build -d ${1}-dev
+        $_DC --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" up --build -d ${1}-dev
     else
-        docker-compose --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" up --build -d ${1}
+        $_DC --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" up --build -d ${1}
     fi
 }
 
 function kill_containers() {
-    docker-compose --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" rm -fs ${1} ${1}-dev
+    $_DC --compatibility -p $PROJECT_NAME -f "$CLI_HOME/services/${1}.yaml" rm -fs ${1} ${1}-dev
 }
 
 function get_logs() {
@@ -239,14 +257,14 @@ function create_s3_buckets() {
 }
 
 function up_scaffold() {
-    scaffold_set_up_network && docker-compose --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml up -d --build
+    scaffold_set_up_network && $_DC --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml up -d --build
     wait_for_db
     apply_db_schema
     create_s3_buckets
 }
 
 function down_scaffold() {
-    docker-compose --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml down
+    $_DC --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml down
 }
 
 function scaffold_destroy() {
@@ -289,7 +307,7 @@ function kill_all_containers() {
 
 function scaffold_destroy_confirmed() {
     kill_all_containers
-    docker-compose --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml down
+    $_DC --compatibility -p $PROJECT_NAME -f $CLI_HOME/scaffold.yaml down
 
     # needed because if there are no volumes this might cause the script to exit
     set +eo pipefail


### PR DESCRIPTION
# Changes proposed ✍️
- added a check to cli so that it works both with `docker-compose` (standalone version) and with `docker compose` (docker plugin version).
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
  - [ ] ~Front-end: `frontend/.env.dist`~
  - [ ] ~Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] ~All changes have been tested in a staging site.~
- [x] All changes are working locally running crowd.dev's Docker local environment.