### PR TITLE
bug: Launch qa fixes

### DIFF
--- a/frontend/src/modules/activity/components/activity-dropdown.vue
+++ b/frontend/src/modules/activity/components/activity-dropdown.vue
@@ -31,6 +31,7 @@
 import { mapActions, mapGetters } from 'vuex'
 import { i18n } from '@/i18n'
 import { ActivityPermissions } from '@/modules/activity/activity-permissions'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppActivityDropdown',
@@ -62,7 +63,7 @@ export default {
   },
   methods: {
     ...mapActions({
-      doDestroy: 'activity/destroy/doDestroy'
+      doDestroy: 'activity/doDestroy'
     }),
     handleCommand(command) {
       if (command === 'activityDelete') {
@@ -78,15 +79,12 @@ export default {
     },
     async doDestroyWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await this.doDestroy(this.activity.id)
         this.$emit('activity-destroyed', this.activity.id)

--- a/frontend/src/modules/automation/components/automation-dropdown.vue
+++ b/frontend/src/modules/automation/components/automation-dropdown.vue
@@ -69,6 +69,7 @@ import { AutomationPermissions } from '@/modules/automation/automation-permissio
 import AppWebhookForm from './webhooks/webhook-form'
 import AppWebhookExecutionList from './webhooks/webhook-execution-list'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppAutomationDropdown',
@@ -109,15 +110,12 @@ export default {
     }),
     async doDestroyWithConfirm(id) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroy(id)
       } catch (error) {

--- a/frontend/src/modules/conversation/components/conversation-dropdown.vue
+++ b/frontend/src/modules/conversation/components/conversation-dropdown.vue
@@ -65,6 +65,7 @@ import { i18n } from '@/i18n'
 import { mapGetters, mapActions } from 'vuex'
 import Message from '@/shared/message/message'
 import config from '@/config'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppConversationDropdown',
@@ -96,15 +97,12 @@ export default {
     }),
     async doDestroyWithConfirm(id) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroy(id)
       } catch (error) {

--- a/frontend/src/modules/conversation/components/conversation-list-toolbar.vue
+++ b/frontend/src/modules/conversation/components/conversation-list-toolbar.vue
@@ -64,6 +64,7 @@
 import { mapGetters, mapActions } from 'vuex'
 import { ConversationPermissions } from '@/modules/conversation/conversation-permissions'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppConversationListToolbar',
@@ -153,15 +154,12 @@ export default {
 
     async doDestroyAllWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroyAll(
           this.selectedRows.map((item) => item.id)
@@ -175,15 +173,12 @@ export default {
         return this.doOpenSettingsModal()
       }
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await this.doPublishAll(
           this.selectedRows.map((item) => item.id)
@@ -195,15 +190,12 @@ export default {
 
     async doUnpublishAllWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await this.doUnpublishAll(
           this.selectedRows.map((item) => item.id)

--- a/frontend/src/modules/conversation/components/conversation-settings.vue
+++ b/frontend/src/modules/conversation/components/conversation-settings.vue
@@ -443,6 +443,7 @@ import authAxios from '@/shared/axios/auth-axios'
 import Message from '@/shared/message/message'
 import { ConversationPermissions } from '@/modules/conversation/conversation-permissions'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 const formSchema = new FormSchema([
   new UrlField('website', 'Website'),
@@ -616,19 +617,16 @@ export default {
         await this.$refs.form.validate()
 
         if (this.shouldConfirmAutoPublish) {
-          await this.$myConfirm(
-            `Are you sure you want to enable auto-publishing for ${
+          await ConfirmDialog({
+            title: i18n('common.confirm'),
+            message: `Are you sure you want to enable auto-publishing for ${
               this.model.autoPublish.status === 'all'
                 ? 'all channels'
                 : 'selected channels'
             }?`,
-            i18n('common.confirm'),
-            {
-              confirmButtonText: i18n('common.yes'),
-              cancelButtonText: i18n('common.no'),
-              type: 'warning'
-            }
-          )
+            confirmButtonText: i18n('common.yes'),
+            cancelButtonText: i18n('common.no')
+          })
         }
 
         await authAxios.post(

--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -33,6 +33,7 @@ import { mapActions, mapGetters } from 'vuex'
 import Banner from '@/shared/banner/banner.vue'
 import identify from '@/shared/segment/identify'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppLayout',
@@ -91,15 +92,13 @@ export default {
     }),
 
     async handleDeleteSampleDataClick() {
-      await this.$myConfirm(
-        i18n('common.areYouSure'),
-        i18n('common.confirm'),
-        {
-          confirmButtonText: i18n('common.yes'),
-          cancelButtonText: i18n('common.no'),
-          type: 'warning'
-        }
-      )
+      await ConfirmDialog({
+        title: i18n('common.confirm'),
+        message: i18n('common.areYouSure'),
+        confirmButtonText: i18n('common.yes'),
+        cancelButtonText: i18n('common.no')
+      })
+
       this.loading = true
       await TenantService.deleteSampleData(
         this.currentTenant.id

--- a/frontend/src/modules/member/components/form/member-form-identities.vue
+++ b/frontend/src/modules/member/components/form/member-form-identities.vue
@@ -5,7 +5,7 @@
         Identities <span class="text-brand-500">*</span>
       </h6>
       <p class="text-gray-500 text-2xs leading-normal mt-1">
-        Connect with members external data sources or
+        Connect with members' external data sources or
         profiles
       </p>
     </div>

--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -87,7 +87,7 @@
           </template>
         </el-table-column>
 
-        <el-table-column label="Identities" width="200">
+        <el-table-column label="Identities" width="220">
           <template #default="scope">
             <app-member-channels
               :member="scope.row"

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -57,6 +57,7 @@ import { mapGetters, mapActions, mapState } from 'vuex'
 import AppMemberListBulkUpdateTags from '@/modules/member/components/list/member-list-bulk-update-tags'
 import { i18n } from '@/i18n'
 import { MemberPermissions } from '@/modules/member/member-permissions'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppMemberListToolbar',
@@ -117,15 +118,12 @@ export default {
 
     async doDestroyAllWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await this.doDestroyAll(
           this.selectedRows.map((item) => item.id)

--- a/frontend/src/modules/member/components/member-channels.vue
+++ b/frontend/src/modules/member/components/member-channels.vue
@@ -35,7 +35,11 @@
           </span>
         </template>
         <a
-          :href="member.attributes?.url?.twitter || null"
+          :href="
+            member.attributes?.url?.twitter
+              ? `https://${member.attributes?.url?.twitter}`
+              : null
+          "
           target="_blank"
           class="btn p-2 text-base btn--twitter"
           :class="
@@ -67,7 +71,11 @@
           </span>
         </template>
         <a
-          :href="member.attributes?.url?.github || null"
+          :href="
+            member.attributes?.url?.github
+              ? `https://${member.attributes?.url?.github}`
+              : null
+          "
           target="_blank"
           class="btn p-2 text-base bg-gray-100 border border-gray-200"
           :class="
@@ -98,7 +106,11 @@
           </span>
         </template>
         <a
-          href="https://linkedin.com"
+          :href="
+            member.attributes?.url?.linkedin
+              ? `https://${member.attributes?.url?.linkedin}`
+              : null
+          "
           target="_blank"
           class="btn p-2 text-base btn--linkedin"
           :class="
@@ -129,7 +141,11 @@
           </span>
         </template>
         <a
-          :href="member.attributes?.url?.devto || null"
+          :href="
+            member.attributes?.url?.devto
+              ? `https://${member.attributes?.url?.devto}`
+              : null
+          "
           target="_blank"
           class="btn p-2 text-base bg-gray-100 border border-gray-200"
           :class="

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -74,6 +74,7 @@ import { mapActions, mapGetters } from 'vuex'
 import { MemberService } from '@/modules/member/member-service'
 import Message from '@/shared/message/message'
 import { MemberPermissions } from '@/modules/member/member-permissions'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppMemberDropdown',
@@ -109,15 +110,12 @@ export default {
     }),
     async doDestroyWithConfirm(id) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroy(id)
       } catch (error) {

--- a/frontend/src/modules/member/components/member-organizations.vue
+++ b/frontend/src/modules/member/components/member-organizations.vue
@@ -1,39 +1,71 @@
 <template>
-  <div v-if="props.member.organizations?.length > 0">
-    <div
-      v-for="organization of props.member.organizations"
-      :key="organization.id"
-      class="flex items-center"
-    >
+  <div v-if="orientation === 'vertical'">
+    <div v-if="props.member.organizations?.length > 0">
       <div
-        :class="{
-          'h-10': showTitle && member.attributes.jobTitle
-        }"
+        v-for="organization of props.member.organizations"
+        :key="organization.id"
+        class="flex items-start"
       >
-        <div v-if="organization.logo" class="w-5 h-5 mr-1">
-          <img :src="organization.logo" alt="Logo" />
+        <div v-if="organization.logo">
+          <div class="w-5 h-5 mr-1">
+            <img :src="organization.logo" alt="Logo" />
+          </div>
         </div>
-      </div>
-      <div
-        class="text-gray-900"
-        :class="{
-          'h-10': showTitle && member.attributes.jobTitle
-        }"
-      >
-        <p class="text-ellipsis truncate">
-          {{ organization.name }}
-        </p>
-        <div
-          v-if="
-            props.member.attributes.jobTitle &&
-            props.showTitle
-          "
-          class="text-gray-500 text-xs"
-        >
-          {{ props.member.attributes.jobTitle.default }}
+        <div>
+          <p
+            class="text-gray-900 text-sm text-ellipsis truncate"
+          >
+            {{ organization.name || '-' }}
+          </p>
+          <div
+            v-if="props.showTitle"
+            class="text-gray-500 text-2xs"
+          >
+            {{
+              props.member.attributes.jobTitle?.default ||
+              '-'
+            }}
+          </div>
         </div>
       </div>
     </div>
+    <div
+      v-else-if="props.member.attributes.jobTitle?.default"
+    >
+      <p class="text-gray-900 text-ellipsis truncate">-</p>
+      <div
+        v-if="props.showTitle"
+        class="text-gray-500 text-2xs"
+      >
+        {{
+          props.member.attributes.jobTitle?.default || '-'
+        }}
+      </div>
+    </div>
+    <div v-else class="text-gray-900">-</div>
+  </div>
+  <div v-else>
+    <div
+      v-if="
+        member.attributes.jobTitle?.default ||
+        props.member.organizations?.length
+      "
+      class="flex items-center mt-2"
+    >
+      <span
+        v-if="member.attributes?.jobTitle?.default"
+        class="text-gray-600 mr-1 text-2xs"
+        >{{ member.attributes.jobTitle.default }}
+        {{ member.organizations.length ? 'at' : '' }}</span
+      >
+      <p
+        v-if="member.organizations.length"
+        class="text-gray-900 text-sm text-ellipsis truncate"
+      >
+        {{ member.organizations[0].name || '-' }}
+      </p>
+    </div>
+    <div v-else class="text-gray-900">-</div>
   </div>
 </template>
 <script>
@@ -53,6 +85,10 @@ const props = defineProps({
   showTitle: {
     type: Boolean,
     default: true
+  },
+  orientation: {
+    type: String,
+    default: () => 'vertical'
   }
 })
 </script>

--- a/frontend/src/modules/member/components/member-platform-input.vue
+++ b/frontend/src/modules/member/components/member-platform-input.vue
@@ -69,6 +69,7 @@
 <script>
 import { i18n } from '@/i18n'
 import AppPlatformAutocompleteInput from '@/shared/form/platform-autocomplete-input'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppMemberPlatformInput',
@@ -118,15 +119,12 @@ export default {
     },
     async deletePlatform(index) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         this.platforms.splice(index, 1)
       } catch (error) {

--- a/frontend/src/modules/member/components/view/member-view-header.vue
+++ b/frontend/src/modules/member/components/view/member-view-header.vue
@@ -9,22 +9,11 @@
         />
         <div>
           <h5>{{ member.displayName }}</h5>
-          <div class="flex items-center mt-2">
-            <span
-              v-if="
-                member.attributes?.jobTitle?.default ||
-                false
-              "
-              class="text-gray-600 text-2xs"
-              >{{
-                member.attributes.jobTitle.default
-              }}</span
-            >
-            <app-member-organizations
-              :member="member"
-              :show-title="false"
-            />
-          </div>
+          <app-member-organizations
+            class="mt-2"
+            :member="member"
+            orientation="horizontal"
+          />
         </div>
       </div>
       <div class="flex items-center">

--- a/frontend/src/modules/member/pages/member-form-page.vue
+++ b/frontend/src/modules/member/pages/member-form-page.vue
@@ -259,7 +259,16 @@ watch(
   wasFormSubmittedSuccessfuly,
   (isFormSubmittedSuccessfuly) => {
     if (isFormSubmittedSuccessfuly) {
-      router.push({ name: 'member' })
+      if (isEditPage.value) {
+        return router.push({
+          name: 'memberView',
+          params: {
+            id: record.value.id
+          }
+        })
+      }
+
+      return router.push({ name: 'member' })
     }
   }
 )

--- a/frontend/src/modules/member/pages/member-merge-page.vue
+++ b/frontend/src/modules/member/pages/member-merge-page.vue
@@ -167,6 +167,7 @@ import MemberAutocompleteInput from '../components/member-autocomplete-input'
 import { MemberModel } from '@/modules/member/member-model'
 import { MemberService } from '@/modules/member/member-service'
 import ActivityItem from '@/modules/activity/components/activity-item'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 const { fields } = MemberModel
 
@@ -309,15 +310,12 @@ export default {
 
     async handleMergeSubmit() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         this.loadingSubmit = true
 

--- a/frontend/src/modules/report/components/report-dropdown.vue
+++ b/frontend/src/modules/report/components/report-dropdown.vue
@@ -64,6 +64,7 @@ import { mapActions, mapGetters } from 'vuex'
 import Message from '@/shared/message/message'
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant'
 import { ReportPermissions } from '@/modules/report/report-permissions'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppReportDropdown',
@@ -97,15 +98,12 @@ export default {
     }),
     async doDestroyWithConfirm(id) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroy(id)
       } catch (error) {

--- a/frontend/src/modules/report/components/report-grid-layout.vue
+++ b/frontend/src/modules/report/components/report-grid-layout.vue
@@ -133,6 +133,7 @@ import WidgetCubeRenderer from '@/modules/widget/components/cube/widget-cube-ren
 import WidgetCubeBuilder from '@/modules/widget/components/cube/widget-cube-builder'
 import { WidgetService } from '@/modules/widget/widget-service'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'ReportGridLayout',
@@ -272,15 +273,12 @@ export default {
     },
     async handleWidgetDelete(widget) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await WidgetService.destroyAll([widget.id])
         const index = this.model.widgets.findIndex(

--- a/frontend/src/modules/report/components/report-list-toolbar.vue
+++ b/frontend/src/modules/report/components/report-list-toolbar.vue
@@ -32,6 +32,7 @@
 import { mapGetters, mapActions } from 'vuex'
 import { ReportPermissions } from '@/modules/report/report-permissions'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppReportListToolbar',
@@ -76,15 +77,12 @@ export default {
 
     async doDestroyAllWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroyAll(
           this.selectedRows.map((item) => item.id)

--- a/frontend/src/modules/widget/components/dashboard/_settings/_benchmark-settings.vue
+++ b/frontend/src/modules/widget/components/dashboard/_settings/_benchmark-settings.vue
@@ -161,6 +161,7 @@
 import { mapGetters, mapActions } from 'vuex'
 import { Octokit } from '@octokit/core'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppGraphBenchmarkSettings',
@@ -258,15 +259,12 @@ export default {
     },
     async doDestroyWithConfirm(index) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         this.repositories.splice(index, 1)
       } catch (error) {

--- a/frontend/src/premium/user/components/user-dropdown.vue
+++ b/frontend/src/premium/user/components/user-dropdown.vue
@@ -56,6 +56,7 @@ import { i18n } from '@/i18n'
 import UserEditPage from './user-edit-page'
 import config from '@/config'
 import Message from '@/shared/message/message'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppUserDropdown',
@@ -107,15 +108,12 @@ export default {
     },
     async doDestroyWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         await this.doDestroy(this.user.id)
         this.$emit('user-destroyed', this.user.id)

--- a/frontend/src/premium/user/components/user-list-table.vue
+++ b/frontend/src/premium/user/components/user-list-table.vue
@@ -113,6 +113,7 @@ import UserListToolbar from '@/premium/user/components/user-list-toolbar.vue'
 import Roles from '@/security/roles'
 import { i18n } from '@/i18n'
 import AppUserDropdown from './user-dropdown'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 const { fields } = UserModel
 
@@ -185,15 +186,12 @@ export default {
 
     async doDestroyWithConfirm(id) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroy(id)
       } catch (error) {

--- a/frontend/src/premium/user/components/user-list-toolbar.vue
+++ b/frontend/src/premium/user/components/user-list-toolbar.vue
@@ -49,6 +49,7 @@ import { AuditLogPermissions } from '@/modules/audit-log/audit-log-permissions'
 import { mapGetters, mapActions } from 'vuex'
 import { UserPermissions } from '@/premium/user/user-permissions'
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppUserListToolbar',
@@ -115,15 +116,12 @@ export default {
 
     async doDestroyAllWithConfirm() {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         return this.doDestroyAll(
           this.selectedRows.map((item) => item.id)

--- a/frontend/src/shared/form/custom-attribute-input.vue
+++ b/frontend/src/shared/form/custom-attribute-input.vue
@@ -41,6 +41,7 @@
 
 <script>
 import { i18n } from '@/i18n'
+import ConfirmDialog from '@/shared/confirm-dialog/confirm-dialog.js'
 
 export default {
   name: 'AppCustomAttributeInput',
@@ -90,15 +91,12 @@ export default {
     },
     async deleteAttribute(index) {
       try {
-        await this.$myConfirm(
-          i18n('common.areYouSure'),
-          i18n('common.confirm'),
-          {
-            confirmButtonText: i18n('common.yes'),
-            cancelButtonText: i18n('common.no'),
-            type: 'warning'
-          }
-        )
+        await ConfirmDialog({
+          title: i18n('common.confirm'),
+          message: i18n('common.areYouSure'),
+          confirmButtonText: i18n('common.yes'),
+          cancelButtonText: i18n('common.no')
+        })
 
         this.attributes.splice(index, 1)
       } catch (error) {


### PR DESCRIPTION
# Changes proposed ✍️
- Profile view: When editing a member from profile view, you get back to the list view (but should get back to the members profile you edited)
- Identities: For Slack & Discord the links wont work
- Edit member: Tiny typo
- Member organization/job title is not matching the design both on members list (missing empty states) and on member profile (not matching design). Fix generic component 
- Make all confirmation dialogs UI consistent
- ### Screenshots (front-end changes only)  
		- ...  
        
## Checklist ✅
- [ ] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.