### PR TITLE
Fix store not being resetted on onboard page

### DIFF
--- a/frontend/src/modules/activity/store/state.js
+++ b/frontend/src/modules/activity/store/state.js
@@ -1,55 +1,57 @@
 import { INITIAL_PAGE_SIZE } from './constants'
 
-export default {
-  records: {
-    activities: {},
-    conversations: {}
-  },
-  views: [
-    {
-      id: 'activities',
-      type: 'activities',
-      label: 'Recent activities',
-      filter: {
-        operator: 'and',
-        attributes: {}
-      },
-      sorter: {
-        prop: 'timestamp',
-        order: 'descending'
-      },
-      active: true
+export default () => {
+  return {
+    records: {
+      activities: {},
+      conversations: {}
     },
-    {
-      id: 'conversations',
-      type: 'conversations',
-      label: 'Conversations',
-      filter: {
-        operator: 'and',
-        attributes: {}
+    views: [
+      {
+        id: 'activities',
+        type: 'activities',
+        label: 'Recent activities',
+        filter: {
+          operator: 'and',
+          attributes: {}
+        },
+        sorter: {
+          prop: 'timestamp',
+          order: 'descending'
+        },
+        active: true
       },
-      sorter: {
-        prop: 'activityCount',
-        order: 'descending'
-      },
-      active: false
+      {
+        id: 'conversations',
+        type: 'conversations',
+        label: 'Conversations',
+        filter: {
+          operator: 'and',
+          attributes: {}
+        },
+        sorter: {
+          prop: 'activityCount',
+          order: 'descending'
+        },
+        active: false
+      }
+    ],
+    list: {
+      ids: [],
+      loading: false
+    },
+    count: 0,
+    filter: {
+      operator: 'and',
+      attributes: {}
+    },
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
+    },
+    sorter: {
+      prop: 'timestamp',
+      order: 'descending'
     }
-  ],
-  list: {
-    ids: [],
-    loading: false
-  },
-  count: 0,
-  filter: {
-    operator: 'and',
-    attributes: {}
-  },
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {
-    prop: 'timestamp',
-    order: 'descending'
   }
 }

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -243,17 +243,11 @@ export default {
       tenantSubdomain.redirectAuthenticatedTo(tenant.url)
       return
     }
-    return Promise.all([
-      dispatch('widget/doResetStore', {}, { root: true }),
-      dispatch('report/doResetStore', {}, { root: true })
-    ])
-      .then(() => {
-        AuthCurrentTenant.set(tenant)
-        return dispatch('doRefreshCurrentUser')
-      })
-      .then(() => {
-        router.push('/')
-      })
+
+    AuthCurrentTenant.set(tenant)
+    await dispatch('doRefreshCurrentUser')
+
+    router.push('/')
   },
 
   clearTenant({ commit }) {

--- a/frontend/src/modules/auth/store/state.js
+++ b/frontend/src/modules/auth/store/state.js
@@ -1,12 +1,14 @@
-export default {
-  currentUser: null,
-  currentTenant: null,
-  loadingInit: true,
-  loadingEmailConfirmation: false,
-  loadingPasswordResetEmail: false,
-  loadingVerifyEmail: false,
-  loadingPasswordReset: false,
-  loadingPasswordChange: false,
-  loadingUpdateProfile: false,
-  loading: false
+export default () => {
+  return {
+    currentUser: null,
+    currentTenant: null,
+    loadingInit: true,
+    loadingEmailConfirmation: false,
+    loadingPasswordResetEmail: false,
+    loadingVerifyEmail: false,
+    loadingPasswordReset: false,
+    loadingPasswordChange: false,
+    loadingUpdateProfile: false,
+    loading: false
+  }
 }

--- a/frontend/src/modules/community-help-center/store/state.js
+++ b/frontend/src/modules/community-help-center/store/state.js
@@ -1,84 +1,86 @@
 import { INITIAL_PAGE_SIZE } from './constants'
 
-export default {
-  records: {},
-  views: [
-    {
-      id: 'all',
-      label: 'All conversations',
-      columns: [],
-      filter: {
-        operator: 'and',
-        attributes: {}
+export default () => {
+  return {
+    records: {},
+    views: [
+      {
+        id: 'all',
+        label: 'All conversations',
+        columns: [],
+        filter: {
+          operator: 'and',
+          attributes: {}
+        },
+        sorter: {
+          prop: 'activityCount',
+          order: 'descending'
+        },
+        active: true
       },
-      sorter: {
-        prop: 'activityCount',
-        order: 'descending'
-      },
-      active: true
-    },
-    {
-      id: 'published',
-      label: 'Published',
-      filter: {
-        operator: 'and',
-        attributes: {
-          published: {
-            name: 'published',
-            defaultOperator: 'eq',
-            operator: 'eq',
-            defaultValue: true,
-            value: true,
-            show: false
+      {
+        id: 'published',
+        label: 'Published',
+        filter: {
+          operator: 'and',
+          attributes: {
+            published: {
+              name: 'published',
+              defaultOperator: 'eq',
+              operator: 'eq',
+              defaultValue: true,
+              value: true,
+              show: false
+            }
           }
-        }
+        },
+        sorter: {
+          prop: 'activityCount',
+          order: 'descending'
+        },
+        active: false
       },
-      sorter: {
-        prop: 'activityCount',
-        order: 'descending'
-      },
-      active: false
-    },
-    {
-      id: 'unpublished',
-      label: 'Unpublished',
-      filter: {
-        operator: 'and',
-        attributes: {
-          published: {
-            name: 'published',
-            defaultOperator: 'eq',
-            operator: 'eq',
-            defaultValue: false,
-            value: false,
-            show: false
+      {
+        id: 'unpublished',
+        label: 'Unpublished',
+        filter: {
+          operator: 'and',
+          attributes: {
+            published: {
+              name: 'published',
+              defaultOperator: 'eq',
+              operator: 'eq',
+              defaultValue: false,
+              value: false,
+              show: false
+            }
           }
-        }
-      },
-      sorter: {
-        prop: 'activityCount',
-        order: 'descending'
-      },
-      active: false
-    }
-  ],
-  list: {
-    ids: [],
-    loading: false,
-    table: false
-  },
-  count: 0,
-  filter: {
-    operator: 'and',
-    attributes: {}
-  },
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {
-    prop: 'activityCount',
-    order: 'descending'
-  },
-  settingsVisible: false
+        },
+        sorter: {
+          prop: 'activityCount',
+          order: 'descending'
+        },
+        active: false
+      }
+    ],
+    list: {
+      ids: [],
+      loading: false,
+      table: false
+    },
+    count: 0,
+    filter: {
+      operator: 'and',
+      attributes: {}
+    },
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
+    },
+    sorter: {
+      prop: 'activityCount',
+      order: 'descending'
+    },
+    settingsVisible: false
+  }
 }

--- a/frontend/src/modules/dashboard/store/state.js
+++ b/frontend/src/modules/dashboard/store/state.js
@@ -1,30 +1,32 @@
-export default {
-  filters: {
-    period: 7,
-    platform: 'all'
-  },
-  conversations: {
-    loading: false,
-    trending: [],
-    total: 0
-  },
-  activities: {
-    loading: false,
-    recent: [],
-    total: 0
-  },
-  members: {
-    loadingActive: false,
-    loadingRecent: false,
-    active: [],
-    recent: [],
-    total: 0
-  },
-  organizations: {
-    loadingActive: false,
-    loadingRecent: false,
-    active: [],
-    recent: [],
-    total: 0
+export default () => {
+  return {
+    filters: {
+      period: 7,
+      platform: 'all'
+    },
+    conversations: {
+      loading: false,
+      trending: [],
+      total: 0
+    },
+    activities: {
+      loading: false,
+      recent: [],
+      total: 0
+    },
+    members: {
+      loadingActive: false,
+      loadingRecent: false,
+      active: [],
+      recent: [],
+      total: 0
+    },
+    organizations: {
+      loadingActive: false,
+      loadingRecent: false,
+      active: [],
+      recent: [],
+      total: 0
+    }
   }
 }

--- a/frontend/src/modules/member/store/state.js
+++ b/frontend/src/modules/member/store/state.js
@@ -9,108 +9,110 @@ import {
   NOT_TEAM_MEMBER_FILTER
 } from './constants'
 
-export default {
-  records: {},
-  views: [
-    {
-      id: 'all',
-      label: 'All members',
-      columns: [],
-      filter: {
-        operator: 'and',
-        attributes: {
-          ...ACTIVITY_COUNT_BIGGER_THAN_0_FILTER,
-          ...NOT_TEAM_MEMBER_FILTER
-        }
+export default () => {
+  return {
+    records: {},
+    views: [
+      {
+        id: 'all',
+        label: 'All members',
+        columns: [],
+        filter: {
+          operator: 'and',
+          attributes: {
+            ...ACTIVITY_COUNT_BIGGER_THAN_0_FILTER,
+            ...NOT_TEAM_MEMBER_FILTER
+          }
+        },
+        sorter: {
+          prop: 'lastActive',
+          order: 'descending'
+        },
+        active: true
       },
-      sorter: {
-        prop: 'lastActive',
-        order: 'descending'
+      {
+        id: 'recent',
+        label: 'New and active',
+        columns: [
+          {
+            name: 'joinedAt',
+            label: 'Joined at',
+            sortable: true,
+            formatter: (value) => {
+              return value
+                ? moment(value).format('DD-MM-YYYY')
+                : ''
+            },
+            width: 150
+          }
+        ],
+        filter: INITIAL_VIEW_RECENT_FILTER,
+        sorter: {
+          prop: 'joinedAt',
+          order: 'descending'
+        },
+        active: false
       },
-      active: true
+      {
+        id: 'slipping-away',
+        label: 'Slipping away',
+        columns: [],
+        filter: INITIAL_VIEW_SLIPPING_AWAY_FILTER,
+        sorter: {
+          prop: 'lastActive',
+          order: 'descending'
+        },
+        active: false
+      },
+      {
+        id: 'active',
+        label: 'Most engaged',
+        columns: [
+          {
+            name: 'activityCount',
+            label: '# of Activities',
+            sortable: true
+          }
+        ],
+        filter: INITIAL_VIEW_ACTIVE_FILTER,
+        sorter: {
+          prop: 'lastActive',
+          order: 'descending'
+        },
+        active: false
+      },
+      {
+        id: 'team',
+        label: 'Team members',
+        filter: INITIAL_VIEW_TEAM_MEMBERS_FILTER,
+        sorter: {
+          prop: 'lastActive',
+          order: 'descending'
+        },
+        active: false
+      }
+    ],
+    customAttributes: {},
+    list: {
+      ids: [],
+      loading: false,
+      table: false
     },
-    {
-      id: 'recent',
-      label: 'New and active',
-      columns: [
-        {
-          name: 'joinedAt',
-          label: 'Joined at',
-          sortable: true,
-          formatter: (value) => {
-            return value
-              ? moment(value).format('DD-MM-YYYY')
-              : ''
-          },
-          width: 150
-        }
-      ],
-      filter: INITIAL_VIEW_RECENT_FILTER,
-      sorter: {
-        prop: 'joinedAt',
-        order: 'descending'
-      },
-      active: false
+    count: 0,
+    filter: {
+      operator: 'and',
+      attributes: {
+        ...ACTIVITY_COUNT_BIGGER_THAN_0_FILTER,
+        ...NOT_TEAM_MEMBER_FILTER
+      }
     },
-    {
-      id: 'slipping-away',
-      label: 'Slipping away',
-      columns: [],
-      filter: INITIAL_VIEW_SLIPPING_AWAY_FILTER,
-      sorter: {
-        prop: 'lastActive',
-        order: 'descending'
-      },
-      active: false
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
     },
-    {
-      id: 'active',
-      label: 'Most engaged',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true
-        }
-      ],
-      filter: INITIAL_VIEW_ACTIVE_FILTER,
-      sorter: {
-        prop: 'lastActive',
-        order: 'descending'
-      },
-      active: false
-    },
-    {
-      id: 'team',
-      label: 'Team members',
-      filter: INITIAL_VIEW_TEAM_MEMBERS_FILTER,
-      sorter: {
-        prop: 'lastActive',
-        order: 'descending'
-      },
-      active: false
+    sorter: {
+      prop: 'lastActive',
+      order: 'descending'
     }
-  ],
-  customAttributes: {},
-  list: {
-    ids: [],
-    loading: false,
-    table: false
-  },
-  count: 0,
-  filter: {
-    operator: 'and',
-    attributes: {
-      ...ACTIVITY_COUNT_BIGGER_THAN_0_FILTER,
-      ...NOT_TEAM_MEMBER_FILTER
-    }
-  },
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {
-    prop: 'lastActive',
-    order: 'descending'
   }
 }

--- a/frontend/src/modules/onboard/onboard-routes.js
+++ b/frontend/src/modules/onboard/onboard-routes.js
@@ -1,3 +1,5 @@
+import { buildInitialState, store } from '@/store'
+
 const OnboardPage = () =>
   import('@/modules/onboard/pages/onboard-page.vue')
 
@@ -8,6 +10,12 @@ export default [
     component: OnboardPage,
     meta: {
       auth: true
+    },
+    beforeEnter: () => {
+      const initialState = buildInitialState(true)
+      console.log(initialState)
+      store.replaceState(initialState)
+      console.log('store replaced')
     }
   }
 ]

--- a/frontend/src/modules/organization/store/state.js
+++ b/frontend/src/modules/organization/store/state.js
@@ -1,16 +1,18 @@
 import { INITIAL_PAGE_SIZE } from './constants'
 
-export default {
-  records: {},
-  list: {
-    ids: [],
-    loading: false
-  },
-  count: 0,
-  filter: {},
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {}
+export default () => {
+  return {
+    records: {},
+    list: {
+      ids: [],
+      loading: false
+    },
+    count: 0,
+    filter: {},
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
+    },
+    sorter: {}
+  }
 }

--- a/frontend/src/modules/report/store/state.js
+++ b/frontend/src/modules/report/store/state.js
@@ -1,23 +1,25 @@
 import { INITIAL_PAGE_SIZE } from './constants'
 
-export default {
-  records: {},
-  list: {
-    ids: [],
-    loading: false,
-    table: false
-  },
-  count: 0,
-  filter: {
-    operator: 'and',
-    attributes: {}
-  },
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {
-    prop: 'createdAt',
-    order: 'descending'
+export default () => {
+  return {
+    records: {},
+    list: {
+      ids: [],
+      loading: false,
+      table: false
+    },
+    count: 0,
+    filter: {
+      operator: 'and',
+      attributes: {}
+    },
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
+    },
+    sorter: {
+      prop: 'createdAt',
+      order: 'descending'
+    }
   }
 }

--- a/frontend/src/modules/tenant/store/state.js
+++ b/frontend/src/modules/tenant/store/state.js
@@ -1,17 +1,19 @@
-export default {
-  records: {},
-  list: {
-    ids: [],
-    loading: false
-  },
-  saveLoading: false,
-  count: 0,
-  pagination: {
-    currentPage: 1,
-    pageSize: 20
-  },
-  sorter: {
-    prop: 'createdAt',
-    order: 'descending'
+export default () => {
+  return {
+    records: {},
+    list: {
+      ids: [],
+      loading: false
+    },
+    saveLoading: false,
+    count: 0,
+    pagination: {
+      currentPage: 1,
+      pageSize: 20
+    },
+    sorter: {
+      prop: 'createdAt',
+      order: 'descending'
+    }
   }
 }

--- a/frontend/src/premium/eagle-eye/store/state.js
+++ b/frontend/src/premium/eagle-eye/store/state.js
@@ -9,97 +9,99 @@ const savedKeywordsArray =
     ? savedKeywords.split(',')
     : []
 
-export default {
-  records: {},
-  views: [
-    {
-      id: 'inbox',
-      label: 'Inbox',
-      filter: {
-        operator: 'and',
-        attributes: {
-          keywords: {
-            name: 'keywords',
-            label: 'Keywords',
-            show: false,
-            operator: 'overlap',
-            defaultOperator: 'overlap',
-            type: 'custom',
-            value: savedKeywordsArray,
-            defaultValue: savedKeywordsArray
+export default () => {
+  return {
+    records: {},
+    views: [
+      {
+        id: 'inbox',
+        label: 'Inbox',
+        filter: {
+          operator: 'and',
+          attributes: {
+            keywords: {
+              name: 'keywords',
+              label: 'Keywords',
+              show: false,
+              operator: 'overlap',
+              defaultOperator: 'overlap',
+              type: 'custom',
+              value: savedKeywordsArray,
+              defaultValue: savedKeywordsArray
+            }
           }
-        }
+        },
+        sorter: {
+          prop: 'similarityScore',
+          order: 'descending'
+        },
+        active: true
       },
-      sorter: {
-        prop: 'similarityScore',
-        order: 'descending'
-      },
-      active: true
-    },
-    {
-      id: 'engaged',
-      label: 'Engaged',
-      filter: {
-        operator: 'and',
-        attributes: {
-          status: {
-            name: 'status',
-            operator: 'eq',
-            defaultOperator: 'eq',
-            defaultValue: 'engaged',
-            value: 'engaged',
-            show: false
+      {
+        id: 'engaged',
+        label: 'Engaged',
+        filter: {
+          operator: 'and',
+          attributes: {
+            status: {
+              name: 'status',
+              operator: 'eq',
+              defaultOperator: 'eq',
+              defaultValue: 'engaged',
+              value: 'engaged',
+              show: false
+            }
           }
-        }
+        },
+        sorter: {},
+        active: false
       },
-      sorter: {},
-      active: false
-    },
-    {
-      id: 'rejected',
-      label: 'Excluded',
-      filter: {
-        attributes: {
-          status: {
-            name: 'status',
-            operator: 'eq',
-            defaultOperator: 'eq',
-            defaultValue: 'rejected',
-            value: 'rejected',
-            show: false
+      {
+        id: 'rejected',
+        label: 'Excluded',
+        filter: {
+          attributes: {
+            status: {
+              name: 'status',
+              operator: 'eq',
+              defaultOperator: 'eq',
+              defaultValue: 'rejected',
+              value: 'rejected',
+              show: false
+            }
           }
-        }
-      },
-      sorter: {},
-      active: false
-    }
-  ],
-  list: {
-    ids: [],
-    loading: false
-  },
-  count: 0,
-  filter: {
-    operator: 'and',
-    attributes: {
-      keywords: {
-        name: 'keywords',
-        label: 'Keywords',
-        show: false,
-        operator: 'overlap',
-        defaultOperator: 'overlap',
-        type: 'custom',
-        value: savedKeywordsArray,
-        defaultValue: savedKeywordsArray
+        },
+        sorter: {},
+        active: false
       }
+    ],
+    list: {
+      ids: [],
+      loading: false
+    },
+    count: 0,
+    filter: {
+      operator: 'and',
+      attributes: {
+        keywords: {
+          name: 'keywords',
+          label: 'Keywords',
+          show: false,
+          operator: 'overlap',
+          defaultOperator: 'overlap',
+          type: 'custom',
+          value: savedKeywordsArray,
+          defaultValue: savedKeywordsArray
+        }
+      }
+    },
+    pagination: {
+      currentPage: 1,
+      pageSize: INITIAL_PAGE_SIZE
+    },
+    sorter: {
+      prop: 'similarityScore',
+      order: 'descending'
     }
-  },
-  pagination: {
-    currentPage: 1,
-    pageSize: INITIAL_PAGE_SIZE
-  },
-  sorter: {
-    prop: 'similarityScore',
-    order: 'descending'
   }
 }

--- a/frontend/src/premium/user/user-destroy-store.js
+++ b/frontend/src/premium/user/user-destroy-store.js
@@ -6,8 +6,10 @@ import { i18n } from '@/i18n'
 export default {
   namespaced: true,
 
-  state: {
-    loading: false
+  state: () => {
+    return {
+      loading: false
+    }
   },
 
   getters: {

--- a/frontend/src/premium/user/user-form-store.js
+++ b/frontend/src/premium/user/user-form-store.js
@@ -6,10 +6,12 @@ import { UserService } from '@/premium/user/user-service'
 export default {
   namespaced: true,
 
-  state: {
-    initLoading: false,
-    saveLoading: false,
-    record: null
+  state: () => {
+    return {
+      initLoading: false,
+      saveLoading: false,
+      record: null
+    }
   },
 
   getters: {

--- a/frontend/src/premium/user/user-list-store.js
+++ b/frontend/src/premium/user/user-list-store.js
@@ -9,19 +9,21 @@ const INITIAL_PAGE_SIZE = 20
 export default {
   namespaced: true,
 
-  state: {
-    rows: [],
-    count: 0,
-    loading: false,
-    filter: {},
-    rawFilter: {},
-    pagination: {
-      currentPage: 1,
-      pageSize: INITIAL_PAGE_SIZE
-    },
-    sorter: {},
+  state: () => {
+    return {
+      rows: [],
+      count: 0,
+      loading: false,
+      filter: {},
+      rawFilter: {},
+      pagination: {
+        currentPage: 1,
+        pageSize: INITIAL_PAGE_SIZE
+      },
+      sorter: {},
 
-    table: null
+      table: null
+    }
   },
 
   getters: {

--- a/frontend/src/premium/user/user-view-store.js
+++ b/frontend/src/premium/user/user-view-store.js
@@ -5,9 +5,11 @@ import { UserService } from '@/premium/user/user-service'
 export default {
   namespaced: true,
 
-  state: {
-    loading: false,
-    record: null
+  state: () => {
+    return {
+      loading: false,
+      record: null
+    }
   },
 
   getters: {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -38,11 +38,17 @@ const buildStores = () => {
  *
  * @returns {{}}
  */
-const buildInitialState = () => {
+const buildInitialState = (excludeAuth = false) => {
   const modules = buildStores()
+  console.log(buildStores())
   return Object.keys(modules).reduce((acc, moduleKey) => {
     acc[moduleKey] = {}
-    if (modules[moduleKey].state) {
+    if (
+      ['auth', 'tenant'].includes(moduleKey) &&
+      excludeAuth
+    ) {
+      acc[moduleKey] = store.state[moduleKey]
+    } else if (modules[moduleKey].state) {
       acc[moduleKey] = JSON.parse(
         JSON.stringify(modules[moduleKey].state)
       )

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -50,7 +50,7 @@ const buildInitialState = (excludeAuth = false) => {
       acc[moduleKey] = store.state[moduleKey]
     } else if (modules[moduleKey].state) {
       acc[moduleKey] = JSON.parse(
-        JSON.stringify(modules[moduleKey].state)
+        JSON.stringify(modules[moduleKey].state())
       )
     }
 
@@ -58,7 +58,7 @@ const buildInitialState = (excludeAuth = false) => {
     if (subModules) {
       for (const subModuleKey of Object.keys(subModules)) {
         acc[moduleKey][subModuleKey] = JSON.parse(
-          JSON.stringify(subModules[subModuleKey].state)
+          JSON.stringify(subModules[subModuleKey].state())
         )
       }
     }


### PR DESCRIPTION
# Changes proposed ✍️
- Refactored stores' states to be a factory
- Add replaceState/resetStore to onboard-page beforEnter route
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
  - [ ] ~Front-end: `frontend/.env.dist`~
  - [ ] ~Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [ ] ~[Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.~
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.