### PR TITLE
Fix Recent Actitivies tab in home

### DIFF
--- a/frontend/src/modules/dashboard/components/activity/dashboard-activity-list.vue
+++ b/frontend/src/modules/dashboard/components/activity/dashboard-activity-list.vue
@@ -32,7 +32,10 @@
     </div>
     <div class="pt-3 pb-2 flex justify-center">
       <router-link
-        :to="{ name: 'activity' }"
+        :to="{
+          name: 'activity',
+          query: { activeTab: 'activities' }
+        }"
         class="text-red font-medium text-center text-xs leading-5"
       >
         All activities


### PR DESCRIPTION
# Changes proposed ✍️
- Before in home, when clicking on the Recent Activities tab after the Trending Conversations, the app always redirected to the Conversations tab. This was fixed by passing the "activeTab" query param for the activities tab
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.