### PR TITLE
Keep old timestamp when upserting activities

### DIFF
--- a/backend/src/serverless/microservices/python/crowd-backend/crowd/backend/repository/repository.py
+++ b/backend/src/serverless/microservices/python/crowd-backend/crowd/backend/repository/repository.py
@@ -141,6 +141,13 @@ class Repository(object):
 
         return self.session.query(table).get(id)
 
+    def find_all_usernames(self):
+         with self.engine.connect() as con:
+
+            id = self.repository.tenant_id
+
+            self.mean_scores = con.execute(f"""SELECT "username" from "members" WHERE "tenantId" = '{self.tenant_id}'""" )
+
     def find_all(
         self, table, ignore_tenant: "bool" = False, query: "dict" = None, order: "dict" = None
     ) -> "list[dict]":

--- a/backend/src/serverless/microservices/python/crowd-backend/crowd/backend/repository/repository.py
+++ b/backend/src/serverless/microservices/python/crowd-backend/crowd/backend/repository/repository.py
@@ -142,11 +142,9 @@ class Repository(object):
         return self.session.query(table).get(id)
 
     def find_all_usernames(self):
-         with self.engine.connect() as con:
-
-            id = self.repository.tenant_id
-
-            self.mean_scores = con.execute(f"""SELECT "username" from "members" WHERE "tenantId" = '{self.tenant_id}'""" )
+        with self.engine.connect() as con:
+            return con.execute(
+                f"""SELECT "id", "username" from "members" WHERE "tenantId" = '{self.tenant_id}'""").fetchall()
 
     def find_all(
         self, table, ignore_tenant: "bool" = False, query: "dict" = None, order: "dict" = None
@@ -196,13 +194,6 @@ class Repository(object):
                     search_query = search_query.order_by(desc(key))
 
         return search_query.all()
-
-    def find_members(self, username):
-        return self.find_in_table(
-            Member,
-            {"username.crowdUsername": username, "tenantId": uuid.UUID(self.tenant_id)},
-            many=True,
-        )
 
     def find_activities(self, search_filters=None):
         if not search_filters:

--- a/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
+++ b/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
@@ -135,6 +135,7 @@ class MergeSuggestions:
         return cw, sw, lw
 
     def cosdis(self, ws):
+        logger.info("Calculating cosdis for: {}".format(ws))
         v1 = self.word2vec(ws[0])
         v2 = self.word2vec(ws[1])
         # which characters are common to the two words?

--- a/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
+++ b/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
@@ -37,7 +37,8 @@ class MergeSuggestions:
         self.sqs_sender = sqs_sender
 
         # Compute all members
-        self.comparison = self.repository.find_all_usernames(Member, query={})
+        self.comparison = self.repository.find_all_usernames()
+        print(f"Found {self.comparison} members to compare")
 
         self.test = test
 

--- a/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
+++ b/backend/src/serverless/microservices/python/crowd-check-merge-members/crowd/check_merge_members/merge_suggestions.py
@@ -37,7 +37,7 @@ class MergeSuggestions:
         self.sqs_sender = sqs_sender
 
         # Compute all members
-        self.comparison = self.repository.find_all(Member, query={})
+        self.comparison = self.repository.find_all_usernames(Member, query={})
 
         self.test = test
 

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -457,6 +457,43 @@ describe('ActivityService tests', () => {
       expect(activityCreated7.conversationId).toStrictEqual(conversationCreated2.id)
     })
 
+    it('Should create various conversations successfully with given parent-child relationships of activities [ascending timestamp order]', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const memberService = new MemberService(mockIRepositoryOptions)
+      const activityService = new ActivityService(mockIRepositoryOptions)
+
+      const cm = await memberService.upsert({
+        username: {
+          [PlatformType.DISCORD]: 'test',
+        },
+        platform: PlatformType.DISCORD,
+      })
+
+      const activity1 = {
+        type: 'message',
+        timestamp: '2020-05-27T15:13:30Z',
+        member: cm.id,
+        platform: PlatformType.DISCORD,
+        sourceId: 'sourceId#1',
+      }
+
+      const activityCreated1 = await activityService.upsert(activity1)
+
+      const activity2 = {
+        type: 'message',
+        timestamp: '2022-05-27T15:13:30Z',
+        member: cm.id,
+        platform: PlatformType.DISCORD,
+        sourceId: 'sourceId#1',
+        body: 'What is love?',
+      }
+
+      const activityCreated2 = await activityService.upsert(activity2)
+
+      expect(activityCreated2.timestamp).toBe(activityCreated1.timestamp)
+      expect(activityCreated2.body).toBe(activity2.body)
+    })
+
     it('Should create various conversations successfully with given parent-child relationships of activities [descending timestamp order]', async () => {
       const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
       const memberService = new MemberService(mockIRepositoryOptions)

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -457,7 +457,7 @@ describe('ActivityService tests', () => {
       expect(activityCreated7.conversationId).toStrictEqual(conversationCreated2.id)
     })
 
-    it('Should create various conversations successfully with given parent-child relationships of activities [ascending timestamp order]', async () => {
+    it('Should keep old timestamp', async () => {
       const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
       const memberService = new MemberService(mockIRepositoryOptions)
       const activityService = new ActivityService(mockIRepositoryOptions)
@@ -490,7 +490,7 @@ describe('ActivityService tests', () => {
 
       const activityCreated2 = await activityService.upsert(activity2)
 
-      expect(activityCreated2.timestamp).toBe(activityCreated1.timestamp)
+      expect(activityCreated2.timestamp).toStrictEqual(activityCreated1.timestamp)
       expect(activityCreated2.body).toBe(activity2.body)
     })
 

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -71,7 +71,10 @@ export default class ActivityService {
       if (existing) {
         const { id } = existing
         delete existing.id
-        const toUpdate = merge(existing, data)
+        const toUpdate = merge(existing, data, {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          timestamp: (oldValue, _newValue) => oldValue,
+        })
         record = await ActivityRepository.update(id, toUpdate, {
           ...this.options,
           transaction,


### PR DESCRIPTION
# Changes proposed ✍️
- Keeping old activity timestamp when upserting
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.