### PR TITLE
Skip starting premium services using normal cli commands

### DIFF
--- a/scripts/cli
+++ b/scripts/cli
@@ -403,8 +403,6 @@ function start() {
             for IGNORED_SERVICE in "${INGORED_SERVICES[@]}"
             do
                 if [[ "$SERVICE" == "${IGNORED_SERVICE}" ]]; then
-                    whisper "Skipping service $SERVICE!"
-                    nl
                     SKIP=1
                     break
                 fi
@@ -434,47 +432,68 @@ do
             exit;
         ;;
         start)
+            declare -a INGORED_SERVICES=("premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             start
             exit;
         ;;
         start-dev)
+            declare -a INGORED_SERVICES=("premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             DEV=1
             start
             exit;
         ;;
         clean-start) 
+            declare -a INGORED_SERVICES=("premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             CLEAN_START=1
             start
             exit;
         ;;
         clean-start-dev)
+            declare -a INGORED_SERVICES=("premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             CLEAN_START=1
             DEV=1
             start
             exit;
         ;;
         start-backend)
-            declare -a INGORED_SERVICES=("frontend")
+            declare -a INGORED_SERVICES=("frontend" "premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             start
             exit;
         ;;
         start-backend-dev)
-            declare -a INGORED_SERVICES=("frontend")
+            declare -a INGORED_SERVICES=("frontend" "premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             DEV=1
             start
             exit;
         ;;
         clean-start-backend)
-            declare -a INGORED_SERVICES=("frontend")
+            declare -a INGORED_SERVICES=("frontend" "premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             CLEAN_START=1
             start
             exit;
         ;;
         clean-start-backend-dev)
-            declare -a INGORED_SERVICES=("frontend")
+            declare -a INGORED_SERVICES=("frontend" "premium-api" "premium-job-generator" "premium-python-worker" "conversations")
             CLEAN_START=1
             DEV=1
             start
+            exit;
+        ;;
+        start-premium)
+            start
+            exit;
+        ;;
+        start-premium-dev)
+            DEV=1
+            exit;
+        ;;
+        clean-start-premium)
+            CLEAN_START=1
+            exit;
+        ;;
+        clean-start-premium-dev)
+            CLEAN_START=1
+            DEV=1
             exit;
         ;;
         build)

--- a/scripts/cli
+++ b/scripts/cli
@@ -418,7 +418,7 @@ function start() {
     done
 }
 
-SCRIPT_USAGE="${YELLOW}${PROJECT_NAME} CLI ${RESET}\n\nExample usage: ./cli [ start, start-dev, clean-start, clean-start-dev, start-backend, start-backend-dev, clean-start-backend, clean-start-backend-dev, scaffold =>, service =>, build =>, build-and-push ]"
+SCRIPT_USAGE="${YELLOW}${PROJECT_NAME} CLI ${RESET}\n\nExample usage: ./cli [ start, start-dev, clean-start, clean-start-dev, start-backend, start-backend-dev, clean-start-backend, clean-start-backend-dev, start-premium, start-premium-dev, clean-start-premium, clean-start-premium-dev, scaffold =>, service =>, build =>, build-and-push ]"
 
 [[ -z "$1" ]] && say "$SCRIPT_USAGE" && exit 1
 while test $# -gt 0


### PR DESCRIPTION
# Changes proposed ✍️
- Don't start premium services unless explicitly using `premium` commands.
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
  - [ ] ~Front-end: `frontend/.env.dist`~
  - [ ] ~Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] ~All changes have been tested in a staging site.~
- [x] All changes are working locally running crowd.dev's Docker local environment.