### PR TITLE
Update sentiment filter to number format

### DIFF
--- a/frontend/src/modules/activity/activity-sentiment-field.js
+++ b/frontend/src/modules/activity/activity-sentiment-field.js
@@ -16,15 +16,25 @@ export default class ActivitySentimentField extends StringField {
     return [
       {
         value: 'positive',
-        label: 'Positive'
+        label: 'Positive',
+        range: {
+          gte: 67
+        }
       },
       {
         value: 'neutral',
-        label: 'Neutral'
+        label: 'Neutral',
+        range: {
+          gt: 33,
+          lt: 67
+        }
       },
       {
         value: 'negative',
-        label: 'Negative'
+        label: 'Negative',
+        range: {
+          lte: 33
+        }
       }
     ]
   }

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -38,11 +38,16 @@ function _buildAttributeBlock(attribute) {
       })
     }
   } else if (attribute.name === 'sentiment') {
-    return {
-      'sentiment.label': {
-        eq: attribute.value.map((a) => a.value).join('/')
-      }
-    }
+    return attribute.value.reduce(
+      (obj, a) => {
+        obj.or.push({
+          sentiment: a.range
+        })
+
+        return obj
+      },
+      { or: [] }
+    )
   } else if (attribute.name === 'type') {
     return {
       and: [


### PR DESCRIPTION
# Changes proposed ✍️
- Add range property to `activity-sentiment-field` options
    - Use range property to build sentiment filter. Ranges placed inside an `or` condition
- Filter format for all three sentiments selected:
```
{
  "and": [
    {
      "or": [
        {
          "sentiment": {
            "gte": 67
          }
        },
        {
          "sentiment": {
            "gt": 33,
            "lt": 67
          }
        },
        {
          "sentiment": {
            "lte": 33
          }
        }
      ]
    }
  ]
}
``` 
- Filter format for positive sentiment selected:
```
{
  "and": [
    {
      "or": [
        {
          "sentiment": {
            "gte": 67
          }
        }
      ]
    }
  ]
}
```        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.