### PR TITLE
Fix reach column on members list

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -151,7 +151,12 @@
                 sortable="custom"
               >
                 <template #default="scope">
-                  <app-member-reach :member="scope.row" />
+                  <app-member-reach
+                    :member="{
+                      ...scope.row,
+                      reach: { total: scope.row.reach }
+                    }"
+                  />
                 </template>
               </el-table-column>
 

--- a/frontend/src/utils/number.js
+++ b/frontend/src/utils/number.js
@@ -14,6 +14,10 @@
  * 1,022,222,222 -> 1B
  */
 export const formatNumberToCompact = (number) => {
+  if (typeof number !== 'number') {
+    return '-'
+  }
+
   return Intl.NumberFormat('en-US', {
     notation: 'compact',
     maximumFractionDigits: 1


### PR DESCRIPTION
# Changes proposed ✍️
- On member list, pass the reach value in the same format as on the member profile to match the logic on `member-reach.vue`
- Protect `formatNumberToCompact` from non numbers
- ### Screenshots (front-end changes only)  
		- ...  
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.