### PR TITLE
Merge suggestions endpoint with pagination

### DIFF
--- a/backend/src/api/tenant/tenantMembersToMerge.ts
+++ b/backend/src/api/tenant/tenantMembersToMerge.ts
@@ -10,7 +10,7 @@ export default async (req, res) => {
 
     req.currentTenant = await new TenantService(req).findById(req.params.id)
 
-    const payload = await new TenantService(req).findMembersToMerge()
+    const payload = await new TenantService(req).findMembersToMerge(req.query)
 
     await ApiResponseHandler.success(req, res, payload)
   } catch (error) {

--- a/backend/src/database/repositories/filters/__tests__/queryParser.test.ts
+++ b/backend/src/database/repositories/filters/__tests__/queryParser.test.ts
@@ -291,7 +291,7 @@ describe('QueryParser tests', () => {
                 Sequelize.where(
                   Sequelize.literal(`"activities"."platform"`),
                   Op.in,
-                  Sequelize.literal(`(discord,github)`),
+                  Sequelize.literal(`('discord','github')`),
                 ),
               ],
             },
@@ -498,7 +498,7 @@ describe('QueryParser tests', () => {
                     Sequelize.where(
                       Sequelize.literal(`"activities"."platform"`),
                       Op.in,
-                      Sequelize.literal(`(discord,github)`),
+                      Sequelize.literal(`('discord','github')`),
                     ),
                   ],
                 },

--- a/backend/src/database/repositories/filters/queryParser.ts
+++ b/backend/src/database/repositories/filters/queryParser.ts
@@ -223,7 +223,11 @@ class QueryParser {
     // it to a postgres array.
     // This is not needed in `Op.in` queries. Simple lists are enough
     if (op === Op.in) {
-      where = Sequelize.where(left, op, Sequelize.literal(`(${right.map( i => `'${i}'`).toString()})`))
+      where = Sequelize.where(
+        left,
+        op,
+        Sequelize.literal(`(${right.map((i) => `'${i}'`).toString()})`),
+      )
     }
 
     if (query[Op.and]) {

--- a/backend/src/database/repositories/filters/queryParser.ts
+++ b/backend/src/database/repositories/filters/queryParser.ts
@@ -223,7 +223,7 @@ class QueryParser {
     // it to a postgres array.
     // This is not needed in `Op.in` queries. Simple lists are enough
     if (op === Op.in) {
-      where = Sequelize.where(left, op, Sequelize.literal(`(${right.toString()})`))
+      where = Sequelize.where(left, op, Sequelize.literal(`(${right.map( i => `'${i}'`).toString()})`))
     }
 
     if (query[Op.and]) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -76,7 +76,7 @@ class MemberRepository {
   }
 
   static async findMembersWithMergeSuggestions(
-    { limit = 10, offset = 0 },
+    { limit = 20, offset = 0 },
     options: IRepositoryOptions,
   ) {
     const currentTenant = SequelizeRepository.getCurrentTenant(options)

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -83,8 +83,8 @@ class MemberRepository {
 
     const mems = await options.database.sequelize.query(
       `
-    SELECT DISTINCT ON (Greatest(Hashtext(Concat(mem.id,
-      mtm."toMergeId")), Hashtext(Concat(mtm."toMergeId", mem.id)))) mem.id,
+    SELECT DISTINCT ON (Greatest(Hashtext(Concat(mem.id, mtm."toMergeId")), Hashtext(Concat(mtm."toMergeId", mem.id))))
+      mem.id,
       mtm."toMergeId",
       COUNT(*) OVER() AS total_count
       FROM   members mem

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -102,25 +102,23 @@ class MemberRepository {
       },
     )
 
-    if (mems.length > 0){
+    if (mems.length > 0) {
       const memberPromises = []
       const toMergePromises = []
-  
+
       for (const mem of mems) {
         memberPromises.push(MemberRepository.findById(mem.id, options))
         toMergePromises.push(MemberRepository.findById(mem.toMergeId, options))
       }
-  
+
       const memberResults = await Promise.all(memberPromises)
       const memberToMergeResults = await Promise.all(toMergePromises)
-  
-      const toRet = memberResults.map((i, idx) => [i, memberToMergeResults[idx]])
-      return  { rows: toRet, count: mems[0].total_count /2 }
+
+      const result = memberResults.map((i, idx) => [i, memberToMergeResults[idx]])
+      return { rows: result, count: mems[0].total_count / 2 }
     }
 
-    return { rows: [], count: 0}
-
-
+    return { rows: [], count: 0 }
   }
 
   static async addToMerge(id, toMergeId, options: IRepositoryOptions) {

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -67,7 +67,7 @@ describe('TenantService tests', () => {
       expect(member2.toMerge).toHaveLength(1)
       expect(member4.toMerge).toHaveLength(1)
 
-      const memberToMergeSuggestions = await tenantService.findMembersToMerge()
+      const memberToMergeSuggestions = await tenantService.findMembersToMerge({})
 
       console.log('mem sugs: ')
       console.log(memberToMergeSuggestions)
@@ -81,11 +81,11 @@ describe('TenantService tests', () => {
       // only two pairs: [m2, m1] and [m4, m3]
 
       expect(
-        memberToMergeSuggestions[0].sort((a, b) => a.createdAt > b.createdAt).map((m) => m.id),
+        memberToMergeSuggestions[0].sort((a, b) => a.createdAt > b.createdAt ? 1 : -1 ).map((m) => m.id),
       ).toStrictEqual([member1.id, member2.id])
 
       expect(
-        memberToMergeSuggestions[1].sort((a, b) => a.createdAt > b.createdAt).map((m) => m.id),
+        memberToMergeSuggestions[1].sort((a, b) => a.createdAt > b.createdAt ? 1 : -1).map((m) => m.id),
       ).toStrictEqual([member3.id, member4.id])
     })
   })

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -81,11 +81,15 @@ describe('TenantService tests', () => {
       // only two pairs: [m2, m1] and [m4, m3]
 
       expect(
-        memberToMergeSuggestions[0].sort((a, b) => a.createdAt > b.createdAt ? 1 : -1 ).map((m) => m.id),
+        memberToMergeSuggestions[0]
+          .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))
+          .map((m) => m.id),
       ).toStrictEqual([member1.id, member2.id])
 
       expect(
-        memberToMergeSuggestions[1].sort((a, b) => a.createdAt > b.createdAt ? 1 : -1).map((m) => m.id),
+        memberToMergeSuggestions[1]
+          .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))
+          .map((m) => m.id),
       ).toStrictEqual([member3.id, member4.id])
     })
   })

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -640,8 +640,8 @@ export default class MemberService {
     )
   }
 
-  async findMembersWithMergeSuggestions() {
-    return MemberRepository.findMembersWithMergeSuggestions(this.options)
+  async findMembersWithMergeSuggestions(args) {
+    return MemberRepository.findMembersWithMergeSuggestions(args, this.options)
   }
 
   async import(data, importHash) {

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -1,4 +1,3 @@
-import lodash from 'lodash'
 import { TENANT_MODE } from '../config/index'
 import TenantRepository from '../database/repositories/tenantRepository'
 import TenantUserRepository from '../database/repositories/tenantUserRepository'

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -500,21 +500,9 @@ export default class TenantService {
    * Return a list of all the memberToMerge suggestions available in the
    * tenant's members
    */
-  async findMembersToMerge() {
+  async findMembersToMerge(args) {
     const memberService = new MemberService(this.options)
-    const { rows } = await memberService.findMembersWithMergeSuggestions()
-
-    return rows.reduce((acc, item) => {
-      for (const toMergeMember of item.toMerge) {
-        const tp = [toMergeMember, item]
-        if (
-          lodash.find(acc, (pair) => pair[0].id === tp[0].id && pair[1].id === tp[1].id) ===
-          undefined
-        ) {
-          acc.push([item, toMergeMember])
-        }
-      }
-      return acc
-    }, [])
+    const { rows } = await memberService.findMembersWithMergeSuggestions(args)
+    return rows
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️
- merge suggestions endpoint is now paginated with limit and offset
- merge suggestions repo layer is now using a raw query that gets distinct possible member pairs and hydrating the members using Member.findById() method
- Fixed the problem in query parser that it was not parsing string type inputs in Op.in method properly
        
## Checklist ✅
- [ ] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.