### PR TITLE
Member list returns full reach object & Standardization of member endpoints' outputs

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -126,10 +126,10 @@ class MemberRepository {
       const memberToMergeResults = await Promise.all(toMergePromises)
 
       const result = memberResults.map((i, idx) => [i, memberToMergeResults[idx]])
-      return { rows: result, count: mems[0].total_count / 2 }
+      return { rows: result, count: mems[0].total_count / 2, limit, offset }
     }
 
-    return { rows: [], count: 0 }
+    return { rows: [], count: 0, limit, offset }
   }
 
   static async addToMerge(id, toMergeId, options: IRepositoryOptions) {
@@ -861,7 +861,7 @@ class MemberRepository {
 
     rows = await this._populateRelationsForRows(rows, attributesSettings)
 
-    return { rows, count: count.length }
+    return { rows, count: count.length, limit: limit ? Number(limit) : 50, offset:  offset ? Number(offset) : 0}
   }
 
   static async findAllAutocomplete(query, limit, options: IRepositoryOptions) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -861,7 +861,12 @@ class MemberRepository {
 
     rows = await this._populateRelationsForRows(rows, attributesSettings)
 
-    return { rows, count: count.length, limit: limit ? Number(limit) : 50, offset:  offset ? Number(offset) : 0}
+    return {
+      rows,
+      count: count.length,
+      limit: limit ? Number(limit) : 50,
+      offset: offset ? Number(offset) : 0,
+    }
   }
 
   static async findAllAutocomplete(query, limit, options: IRepositoryOptions) {

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -36,21 +36,21 @@ describe('TenantService tests', () => {
         username: 'member 2',
         platform: PlatformType.DISCORD,
         email: 'member.2@email.com',
-        joinedAt: '2020-05-27T15:13:30Z',
+        joinedAt: '2020-05-26T15:13:30Z',
       }
 
       const memberToCreate3 = {
         username: 'member 3',
         platform: PlatformType.GITHUB,
         email: 'member.3@email.com',
-        joinedAt: '2020-05-27T15:13:30Z',
+        joinedAt: '2020-05-25T15:13:30Z',
       }
 
       const memberToCreate4 = {
         username: 'member 4',
         platform: PlatformType.TWITTER,
         email: 'member.4@email.com',
-        joinedAt: '2020-05-27T15:13:30Z',
+        joinedAt: '2020-05-24T15:13:30Z',
       }
 
       const member1 = await memberService.upsert(memberToCreate1)
@@ -69,9 +69,6 @@ describe('TenantService tests', () => {
 
       const memberToMergeSuggestions = await tenantService.findMembersToMerge({})
 
-      console.log('mem sugs: ')
-      console.log(memberToMergeSuggestions)
-
       // In the DB there should be:
       // - Member 1 should have member 2 in toMerge
       // - Member 3 should have member 4 in toMerge
@@ -80,14 +77,16 @@ describe('TenantService tests', () => {
       // But this function should not return duplicates, so we should get
       // only two pairs: [m2, m1] and [m4, m3]
 
+      expect(memberToMergeSuggestions.count).toEqual(2)
+
       expect(
-        memberToMergeSuggestions[0]
+        memberToMergeSuggestions.rows[0]
           .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))
           .map((m) => m.id),
       ).toStrictEqual([member1.id, member2.id])
 
       expect(
-        memberToMergeSuggestions[1]
+        memberToMergeSuggestions.rows[1]
           .sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))
           .map((m) => m.id),
       ).toStrictEqual([member3.id, member4.id])

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -501,7 +501,6 @@ export default class TenantService {
    */
   async findMembersToMerge(args) {
     const memberService = new MemberService(this.options)
-    const { rows } = await memberService.findMembersWithMergeSuggestions(args)
-    return rows
+    return memberService.findMembersWithMergeSuggestions(args)
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️
- members returned by member.query endpoint had the reach as total number. Now it's returning the whole reach object
- Output standardized for endpoints member.query and merge-members endpoints. These are now returning rows, count, limit and offset
- Merge suggestions endpoint is now returning members sorted by their joinedAt date. Latest members are returned first
        
## Checklist ✅
- [ ] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.