### PR TITLE
Fix copy public url in CHC

### DIFF
--- a/frontend/src/modules/conversation/components/conversation-dropdown.vue
+++ b/frontend/src/modules/conversation/components/conversation-dropdown.vue
@@ -124,8 +124,10 @@ export default {
       } else if (
         command.action === 'conversationPublicUrl'
       ) {
-        const url = `${config.conversationPublicUrl}/${this.currentTenant.url}-c/${this.record.slug}`
+        const url = `${config.conversationPublicUrl}/${this.currentTenant.url}-c/${command.conversation.slug}`
+
         await navigator.clipboard.writeText(url)
+
         Message.success(
           'Conversation Public URL successfully copied to your clipboard'
         )


### PR DESCRIPTION
# Changes proposed ✍️
**Task**: [Copy public URL for published conversations not working](https://www.notion.so/crowddev/Copy-public-URL-for-published-conversations-not-working-66507e112fd244b693e9c2147e465ae4)

**Steps to reproduce**:
1. Community Help Center: When clicking on "Copy public URL" in published conversations, nothing happens
2. In the console, an error is being thrown: `Cannot read properties of undefined (reading 'slug')`

**Fix**:
- The slug was being used from an inexistent `record`. Get the slug from the conversation passed in the component
- ### Screenshots (front-end changes only)  
![Screenshot 2022-11-07 at 14 35 05](https://user-images.githubusercontent.com/20134207/200336296-e67724f5-c777-4814-b11f-3633ae393df9.png)

        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.