### PR TITLE
Fix reset view in Community Help Center and other modules

### DIFF
--- a/frontend/src/premium/community-help-center/components/community-help-center-tabs.vue
+++ b/frontend/src/premium/community-help-center/components/community-help-center-tabs.vue
@@ -53,6 +53,6 @@ const views = computed(() => {
 })
 
 const resetView = () => {
-  store.dispatch('member/doResetActiveView')
+  store.dispatch('communityHelpCenter/doResetActiveView')
 }
 </script>

--- a/frontend/src/shared/platform/platform.vue
+++ b/frontend/src/shared/platform/platform.vue
@@ -69,7 +69,7 @@ const props = defineProps({
   },
   trackEventName: {
     type: String,
-    required: true
+    default: () => null
   },
   hasTooltip: {
     type: Boolean,


### PR DESCRIPTION
# Changes proposed ✍️
- Fix reset view in Community Help Center. It was previously calling the reset method in members store
- Fix `trackEventName` default value in `app-platform` component. It is not required, console was throwing multiple warnings for when it was not being passed
- Fix `filter-type-search` component to reset its value when store is also reseted.
   -  Pass debounce/change method to `@input` handler instead of watching the value
   - Watch search value in store, if empty and different, set the input value to empty as well
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.