### PR TITLE
Bad tenant url on tenant creation

### DIFF
--- a/backend/src/database/repositories/__tests__/tenantRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/tenantRepository.test.ts
@@ -1,0 +1,49 @@
+import TenantRepository from '../tenantRepository'
+import SequelizeTestUtils from '../../utils/sequelizeTestUtils'
+import Plans from '../../../security/plans'
+
+const db = null
+
+describe('TenantRepository tests', () => {
+  beforeEach(async () => {
+    await SequelizeTestUtils.wipeDatabase(db)
+  })
+
+  afterAll((done) => {
+    // Closing the DB connection allows Jest to exit successfully.
+    SequelizeTestUtils.closeConnection(db)
+    done()
+  })
+
+  describe('generateTenantUrl method', () => {
+    it('Should generate a url from name - 0 existing tenants with same url', async () => {
+
+        const options = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+        const tenantName = 'some tenant Name with !@#_% non-alphanumeric characters'
+
+        const generatedUrl = await TenantRepository.generateTenantUrl(tenantName, options)
+        const expectedGeneratedUrl = 'some-tenant-name-with-non-alphanumeric-characters'
+
+        expect(generatedUrl).toStrictEqual(expectedGeneratedUrl)
+
+    })
+
+    it('Should generate a url from name - with existing tenant that has the same url', async () => {
+
+      const options = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const tenantName = 'a tenant name'
+
+      // create a tenant with url 'a-tenant-name'
+      await options.database.tenant.create({name: tenantName, url: 'a-tenant-name', plan: Plans.values.free})
+
+
+      // now generate function should return 'a-tenant-name-1' because it already exists
+      const generatedUrl = await TenantRepository.generateTenantUrl(tenantName, options)
+
+      const expectedGeneratedUrl = 'a-tenant-name-1'
+
+      expect(generatedUrl).toStrictEqual(expectedGeneratedUrl)
+
+  })
+  })
+})

--- a/backend/src/database/repositories/__tests__/tenantRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/tenantRepository.test.ts
@@ -17,25 +17,25 @@ describe('TenantRepository tests', () => {
 
   describe('generateTenantUrl method', () => {
     it('Should generate a url from name - 0 existing tenants with same url', async () => {
+      const options = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const tenantName = 'some tenant Name with !@#_% non-alphanumeric characters'
 
-        const options = await SequelizeTestUtils.getTestIRepositoryOptions(db)
-        const tenantName = 'some tenant Name with !@#_% non-alphanumeric characters'
+      const generatedUrl = await TenantRepository.generateTenantUrl(tenantName, options)
+      const expectedGeneratedUrl = 'some-tenant-name-with-non-alphanumeric-characters'
 
-        const generatedUrl = await TenantRepository.generateTenantUrl(tenantName, options)
-        const expectedGeneratedUrl = 'some-tenant-name-with-non-alphanumeric-characters'
-
-        expect(generatedUrl).toStrictEqual(expectedGeneratedUrl)
-
+      expect(generatedUrl).toStrictEqual(expectedGeneratedUrl)
     })
 
     it('Should generate a url from name - with existing tenant that has the same url', async () => {
-
       const options = await SequelizeTestUtils.getTestIRepositoryOptions(db)
       const tenantName = 'a tenant name'
 
       // create a tenant with url 'a-tenant-name'
-      await options.database.tenant.create({name: tenantName, url: 'a-tenant-name', plan: Plans.values.free})
-
+      await options.database.tenant.create({
+        name: tenantName,
+        url: 'a-tenant-name',
+        plan: Plans.values.free,
+      })
 
       // now generate function should return 'a-tenant-name-1' because it already exists
       const generatedUrl = await TenantRepository.generateTenantUrl(tenantName, options)
@@ -43,7 +43,6 @@ describe('TenantRepository tests', () => {
       const expectedGeneratedUrl = 'a-tenant-name-1'
 
       expect(generatedUrl).toStrictEqual(expectedGeneratedUrl)
-
-  })
+    })
   })
 })

--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -86,9 +86,12 @@ class TenantRepository {
     // remove trailing dash
     cleanedTenantUrl = cleanedTenantUrl.replace(/-$/gi, '')
 
+    const filterUser = false
+
     const checkTenantUrl = await TenantRepository.findAndCountAll(
       { filter: { url: cleanedTenantUrl } },
       options,
+      filterUser
     )
 
     if (checkTenantUrl.count > 0) {

--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -91,7 +91,7 @@ class TenantRepository {
     const checkTenantUrl = await TenantRepository.findAndCountAll(
       { filter: { url: cleanedTenantUrl } },
       options,
-      filterUser
+      filterUser,
     )
 
     if (checkTenantUrl.count > 0) {

--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -19,10 +19,7 @@ class TenantRepository {
 
     const transaction = SequelizeRepository.getTransaction(options)
 
-    // URL is required,
-    // in case of multi tenant without subdomain
-    // set a random uuid
-    console.log('data: ', data)
+    // name is required
     if (!data.name) {
       throw new Error400(options.language, 'tenant.errors.nameRequiredOnCreate')
     }
@@ -68,6 +65,13 @@ class TenantRepository {
     })
   }
 
+  /**
+   * Generates hyphen concataned tenant url from the tenant name
+   * If url already exists, appends a incremental number to the url
+   * @param name tenant name
+   * @param options repository options
+   * @returns slug like tenant name to be used in tenant.url
+   */
   static async generateTenantUrl(name: string, options: IRepositoryOptions): Promise<string> {
     const cleanedName = getCleanString(name)
 
@@ -86,9 +90,6 @@ class TenantRepository {
       { filter: { url: cleanedTenantUrl } },
       options,
     )
-
-    console.log('ctu')
-    console.log(checkTenantUrl)
 
     if (checkTenantUrl.count > 0) {
       cleanedTenantUrl += `-${checkTenantUrl.count}`

--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -1,6 +1,5 @@
 import lodash from 'lodash'
 import Sequelize, { QueryTypes } from 'sequelize'
-import { v4 as uuid } from 'uuid'
 import SequelizeRepository from './sequelizeRepository'
 import AuditLogRepository from './auditLogRepository'
 import SequelizeFilterUtils from '../utils/sequelizeFilterUtils'
@@ -8,6 +7,7 @@ import Error404 from '../../errors/Error404'
 import Error400 from '../../errors/Error400'
 import { isUserInTenant } from '../utils/userTenantUtils'
 import { IRepositoryOptions } from './IRepositoryOptions'
+import getCleanString from '../../utils/getCleanString'
 
 const { Op } = Sequelize
 
@@ -23,7 +23,11 @@ class TenantRepository {
     // in case of multi tenant without subdomain
     // set a random uuid
     console.log('data: ', data)
-    data.url = data.url || uuid()
+    if (!data.name) {
+      throw new Error400(options.language, 'tenant.errors.nameRequiredOnCreate')
+    }
+
+    data.url = data.url || (await TenantRepository.generateTenantUrl(data.name, options))
 
     const existsUrl = Boolean(
       await options.database.tenant.count({
@@ -62,6 +66,35 @@ class TenantRepository {
     return this.findById(record.id, {
       ...options,
     })
+  }
+
+  static async generateTenantUrl(name: string, options: IRepositoryOptions): Promise<string> {
+    const cleanedName = getCleanString(name)
+
+    const nameWordsArray = cleanedName.split(' ')
+
+    let cleanedTenantUrl = ''
+
+    for (let i = 0; i < nameWordsArray.length; i++) {
+      cleanedTenantUrl += `${nameWordsArray[i]}-`
+    }
+
+    // remove trailing dash
+    cleanedTenantUrl = cleanedTenantUrl.replace(/-$/gi, '')
+
+    const checkTenantUrl = await TenantRepository.findAndCountAll(
+      { filter: { url: cleanedTenantUrl } },
+      options,
+    )
+
+    console.log('ctu')
+    console.log(checkTenantUrl)
+
+    if (checkTenantUrl.count > 0) {
+      cleanedTenantUrl += `-${checkTenantUrl.count}`
+    }
+
+    return cleanedTenantUrl
   }
 
   static async update(id, data, options: IRepositoryOptions) {
@@ -272,6 +305,10 @@ class TenantRepository {
 
       if (filter.name) {
         whereAnd.push(SequelizeFilterUtils.ilikeIncludes('tenant', 'name', filter.name))
+      }
+
+      if (filter.url) {
+        whereAnd.push(SequelizeFilterUtils.ilikeIncludes('tenant', 'url', filter.url))
       }
 
       if (filter.createdAtRange) {

--- a/backend/src/database/utils/sequelizeTestUtils.ts
+++ b/backend/src/database/utils/sequelizeTestUtils.ts
@@ -106,24 +106,12 @@ export default class SequelizeTestUtils {
     const randomUser = await this.getRandomUser()
 
     let tenant = await db.tenant.create(randomTenant)
-    let user = await db.user.create(randomUser)
+    const user = await db.user.create(randomUser)
     await db.tenantUser.create({
       roles: ['admin'],
       status: 'active',
       tenantId: tenant.id,
       userId: user.id,
-    })
-
-    user = await db.user.findByPk(user.id, {
-      include: [
-        {
-          model: db.tenantUser,
-          as: 'tenants',
-          where: {
-            tenantId: tenant.id,
-          },
-        },
-      ],
     })
 
     await SettingsRepository.findOrCreateDefault({}, {

--- a/backend/src/database/utils/sequelizeTestUtils.ts
+++ b/backend/src/database/utils/sequelizeTestUtils.ts
@@ -106,12 +106,24 @@ export default class SequelizeTestUtils {
     const randomUser = await this.getRandomUser()
 
     let tenant = await db.tenant.create(randomTenant)
-    const user = await db.user.create(randomUser)
+    let user = await db.user.create(randomUser)
     await db.tenantUser.create({
       roles: ['admin'],
       status: 'active',
       tenantId: tenant.id,
       userId: user.id,
+    })
+
+    user = await db.user.findByPk(user.id, {
+      include: [
+        {
+          model: db.tenantUser,
+          as: 'tenants',
+          where: {
+            tenantId: tenant.id,
+          },
+        },
+      ],
     })
 
     await SettingsRepository.findOrCreateDefault({}, {

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -73,6 +73,7 @@ const en = {
     sampleDataDeletionCompleted: 'Sample data deletion completed.',
     errors: {
       publishedConversationExists: 'Update failed. Tenant already has published conversations.',
+      nameRequiredOnCreate: 'Name is required on tenant creation.',
     },
   },
 

--- a/backend/src/services/__tests__/conversationService.test.ts
+++ b/backend/src/services/__tests__/conversationService.test.ts
@@ -97,23 +97,6 @@ describe('ConversationService tests', () => {
     })
   })
 
-  describe('getCleanString method', () => {
-    it('Should clean a string with non alphanumeric characters', async () => {
-      const cleanedString = ConversationService.getCleanString('!@#$%^&*()_+abc    !@#$%123')
-      expect(cleanedString).toStrictEqual('abc 123')
-    })
-
-    it('Should return an empty string when an empty string is given', async () => {
-      const cleanedString = ConversationService.getCleanString('')
-      expect(cleanedString).toStrictEqual('')
-    })
-
-    it('Should return an empty string when no alphanumeric characters exist', async () => {
-      const cleanedString = ConversationService.getCleanString('ß!@#$%     ^&*()_+-')
-      expect(cleanedString).toStrictEqual('')
-    })
-  })
-
   describe('generateTitle method', () => {
     it('Should return the same title string if an alphanumeric character exists in title', async () => {
       const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db)

--- a/backend/src/services/conversationService.ts
+++ b/backend/src/services/conversationService.ts
@@ -19,6 +19,7 @@ import track from '../segment/track'
 import getStage from './helpers/getStage'
 import { s3 } from './aws'
 import { PlatformType } from '../types/integrationEnums'
+import getCleanString from '../utils/getCleanString'
 
 export default class ConversationService {
   static readonly MAX_SLUG_WORD_LENGTH = 10
@@ -502,7 +503,7 @@ export default class ConversationService {
    * @returns cleaned title
    */
   async generateTitle(title: string, isHtml: boolean = false): Promise<string> {
-    if (!title || ConversationService.getCleanString(title) === '') {
+    if (!title || getCleanString(title) === '') {
       return `conversation-${await ConversationRepository.count({}, this.options)}`
     }
 
@@ -562,9 +563,9 @@ export default class ConversationService {
    * @returns slug-like string
    *
    */
-  async generateSlug(title: String): Promise<String> {
+  async generateSlug(title: string): Promise<string> {
     // Remove non-standart characters and extra whitespaces
-    const cleanedTitle = ConversationService.getCleanString(title)
+    const cleanedTitle = getCleanString(title)
 
     const slugArray = cleanedTitle.split(' ')
     let cleanedSlug = ''

--- a/backend/src/utils/__tests__/getCleanString.test.ts
+++ b/backend/src/utils/__tests__/getCleanString.test.ts
@@ -1,0 +1,18 @@
+import getCleanString from '../getCleanString'
+
+describe('getCleanString method', () => {
+  it('Should clean a string with non alphanumeric characters', async () => {
+    const cleanedString = getCleanString('!@#$%^&*()_+abc    !@#$%123')
+    expect(cleanedString).toStrictEqual('abc 123')
+  })
+
+  it('Should return an empty string when an empty string is given', async () => {
+    const cleanedString = getCleanString('')
+    expect(cleanedString).toStrictEqual('')
+  })
+
+  it('Should return an empty string when no alphanumeric characters exist', async () => {
+    const cleanedString = getCleanString('ß!@#$%     ^&*()_+-')
+    expect(cleanedString).toStrictEqual('')
+  })
+})

--- a/backend/src/utils/getCleanString.ts
+++ b/backend/src/utils/getCleanString.ts
@@ -1,0 +1,16 @@
+/**
+ * Generates a cleaned string from given string by:
+ * Removing non alphanumeric characters from a string
+ * Converting dashes into spaces
+ * Removing extraneous whitespaces between words
+ * @param string string to be cleaned
+ * @returns cleaned string
+ *
+ */
+export default (string: string): string =>
+  string
+    .replace(/[^-0-9A-Z ]+/gi, '') // only get alphanumeric characters and dashes
+    .replace(/-+/gi, ' ') // convert dashes into spaces
+    .replace(/\s+/g, ' ') // get rid of excessive spaces between words
+    .toLowerCase()
+    .trim()


### PR DESCRIPTION
# Changes proposed ✍️
- On tenant create, we were setting the `tenant.url` as a random uuid when the data payload didn't have the url field. Now we're generating a tenant url from the tenant name and checking for duplication problems as well since url needs to be unique
- The previous uuid approach was creating a problem when publishing community help center of a tenant (The url comes populated with uuids)
- Also refactored out `getCleanString` function to utils, to also use it in `tenantRepository`
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [x] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.