### PR TITLE
Fix empty drawer after publish conversation

### DIFF
--- a/frontend/src/premium/community-help-center/components/community-help-center-conversation-drawer.vue
+++ b/frontend/src/premium/community-help-center/components/community-help-center-conversation-drawer.vue
@@ -189,6 +189,7 @@ const handleTogglePublished = async () => {
     conversation.published = true
   }
   loadingUpdate.value = false
+  isExpanded.value = false
 }
 
 const handleEditTitle = async () => {

--- a/frontend/src/premium/community-help-center/components/community-help-center-table.vue
+++ b/frontend/src/premium/community-help-center/components/community-help-center-table.vue
@@ -182,11 +182,6 @@
               />
             </div>
           </div>
-          <app-community-help-center-conversation-drawer
-            :expanded="drawerConversationId !== null"
-            :conversation-id="drawerConversationId"
-            @close="drawerConversationId = null"
-          ></app-community-help-center-conversation-drawer>
         </div>
       </div>
     </div>
@@ -206,13 +201,14 @@ import { useStore } from 'vuex'
 import { formatDateToTimeAgo } from '@/utils/date'
 import AppConversationDropdown from '@/modules/conversation/components/conversation-dropdown'
 import AppCommunityHelpCenterToolbar from './community-help-center-toolbar'
-import AppCommunityHelpCenterConversationDrawer from '@/premium/community-help-center/components/community-help-center-conversation-drawer'
 
 const store = useStore()
-defineEmits(['cta-click'])
+const emit = defineEmits([
+  'cta-click',
+  'open-conversation-drawer'
+])
 
 const table = ref(null)
-const drawerConversationId = ref(null)
 
 const loading = computed(
   () => store.state.communityHelpCenter.list.loading
@@ -311,7 +307,7 @@ function rowClass({ row }) {
 }
 
 function handleRowClick(row) {
-  drawerConversationId.value = row.id
+  emit('open-conversation-drawer', row.id)
 }
 
 function timeAgo(date) {

--- a/frontend/src/premium/community-help-center/pages/community-help-center-page.vue
+++ b/frontend/src/premium/community-help-center/pages/community-help-center-page.vue
@@ -32,7 +32,15 @@
     </div>
     <app-community-help-center-tabs />
     <app-community-help-center-filter />
-    <app-community-help-center-table />
+    <app-community-help-center-table
+      @open-conversation-drawer="onConversationDrawerOpen"
+    />
+
+    <app-community-help-center-conversation-drawer
+      :expanded="!!drawerConversationId"
+      :conversation-id="drawerConversationId"
+      @close="onConversationDrawerClose"
+    ></app-community-help-center-conversation-drawer>
   </app-page-wrapper>
 </template>
 
@@ -43,6 +51,7 @@ import AppCommunityHelpCenterTable from '@/premium/community-help-center/compone
 import AppCommunityHelpCenterTabs from '@/premium/community-help-center/components/community-help-center-tabs'
 import AppCommunityHelpCenterFilter from '@/premium/community-help-center/components/community-help-center-filter'
 import AppCommunityHelpCenterSettings from '@/premium/community-help-center/components/community-help-center-settings'
+import AppCommunityHelpCenterConversationDrawer from '@/premium/community-help-center/components/community-help-center-conversation-drawer'
 import config from '@/config'
 
 export default {
@@ -53,7 +62,14 @@ export default {
     AppCommunityHelpCenterTable,
     AppCommunityHelpCenterTabs,
     AppCommunityHelpCenterFilter,
-    AppCommunityHelpCenterSettings
+    AppCommunityHelpCenterSettings,
+    AppCommunityHelpCenterConversationDrawer
+  },
+
+  data() {
+    return {
+      drawerConversationId: null
+    }
   },
 
   computed: {
@@ -78,7 +94,13 @@ export default {
         'communityHelpCenter/doOpenSettingsDrawer',
       doCloseSettingsDrawer:
         'communityHelpCenter/doCloseSettingsDrawer'
-    })
+    }),
+    onConversationDrawerOpen(id) {
+      this.drawerConversationId = id
+    },
+    onConversationDrawerClose() {
+      this.drawerConversationId = null
+    }
   }
 }
 </script>


### PR DESCRIPTION
# Changes proposed ✍️
Issue: After publishing/unpublishing a conversation, the conversation drawer opens with no details inside - [Task](https://www.notion.so/crowddev/After-publishing-a-conversation-drawer-opens-with-no-information-2c229849d0d04ff4ae3572044a89dcee)

Approach:
- In the drawer component, close the drawer after request
- Remove Drawer logic from `community-help-center-table.vue`component. Prevent rerender of entire component when rows/conversations are updated after being fetched in the update request.
- Move Drawer logic to `community-help-center-page.vue`. In here, the drawer won't be affected by the table update after the most recent fetch of the table rows.

## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.