### PR TITLE
Add links to dashboard sentiment widget

### DIFF
--- a/frontend/src/modules/activity/components/list/activity-list-filter.vue
+++ b/frontend/src/modules/activity/components/list/activity-list-filter.vue
@@ -26,6 +26,7 @@ import { ActivityModel } from '@/modules/activity/activity-model'
 import { ConversationModel } from '@/modules/conversation/conversation-model'
 import { useStore } from 'vuex'
 import { onMounted, defineProps, computed } from 'vue'
+import SentimentField from '@/shared/fields/sentiment-field'
 
 const store = useStore()
 const props = defineProps({
@@ -75,6 +76,26 @@ onMounted(async () => {
   // Ob Conversations tab, the fetch is already done on the changeActiveView action
   if (activeView.value.type !== 'conversations') {
     await doFetch()
+  }
+
+  const params = new URLSearchParams(window.location.search)
+
+  if (
+    params.get('sentiment') &&
+    activeView.value.type === 'activities'
+  ) {
+    const sentimentField = new SentimentField(
+      'sentiment',
+      'Sentiment'
+    )
+    await store.dispatch(`activity/addFilterAttribute`, {
+      ...sentimentField.forFilter(),
+      value: [
+        sentimentField
+          .dropdownOptions()
+          .find((o) => o.value === params.get('sentiment'))
+      ]
+    })
   }
 })
 

--- a/frontend/src/modules/dashboard/components/activity/dashboard-activity-sentiment.vue
+++ b/frontend/src/modules/dashboard/components/activity/dashboard-activity-sentiment.vue
@@ -30,7 +30,7 @@
             <div
               v-for="data of compileData(resultSet)"
               :key="data.type"
-              class="h-2 border-l border-r rounded-sm transition"
+              class="h-2 border-l border-r rounded-sm transition cursor-pointer"
               :style="{
                 width: `${calculatePercentage(data.count)}%`
               }"
@@ -40,16 +40,18 @@
               ]"
               @mouseover="hoveredSentiment = data.type"
               @mouseleave="hoveredSentiment = ''"
+              @click="handleSentimentClick(data.type)"
             ></div>
           </div>
           <div>
             <div
               v-for="data of compileData(resultSet)"
               :key="data.type"
-              class="flex justify-between pb-2"
+              class="flex justify-between pb-2 cursor-pointer"
               :class="hoverSentimentClass(data.type)"
               @mouseover="hoveredSentiment = data.type"
               @mouseleave="hoveredSentiment = ''"
+              @click="handleSentimentClick(data.type)"
             >
               <p class="text-sm font-medium capitalize">
                 {{ data.type }}
@@ -150,6 +152,12 @@ export default {
       }, 0)
 
       return finalResult
+    },
+    handleSentimentClick(sentiment) {
+      this.$router.push({
+        name: 'activity',
+        query: { sentiment }
+      })
     }
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️
- Add links to dashboard sentiment widget (Negative, Neutral, Positive)
  - These links take the user to the `Activities` page with the Sentiment filter configured
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.