### PR TITLE
Check conversation publishable before loading into the search engine

### DIFF
--- a/backend/src/database/initializers/suggested-tasks.json
+++ b/backend/src/database/initializers/suggested-tasks.json
@@ -1,25 +1,26 @@
-[{
-        "name": "Engage with relevant content",
-        "body": "Engage with at least 5 posts on Eagle Eye today"
-    },
-    {
-        "name": "Reach out to influential members",
-        "body": "Connect with new members with over 10k followers"
-    },
-    {
-        "name": "Reach out to poorly engaged members",
-        "body": "Connect with members with low activity in the last 30 days"
-    },
-    {
-        "name": "Check for negative reactions",
-        "body": "React to activities with very negative sentiment"
-    },
-    {
-        "name": "Setup your workpace integrations",
-        "body": "Connect with at least 2 data sources that are relevant to your community"
-    },
-    {
-        "name": "Setup your team",
-        "body": "Invite colleagues to your community workspace"
-    }
+[
+  {
+    "name": "Engage with relevant content",
+    "body": "Engage with at least 5 posts on Eagle Eye today"
+  },
+  {
+    "name": "Reach out to influential members",
+    "body": "Connect with new members with over 10k followers"
+  },
+  {
+    "name": "Reach out to poorly engaged members",
+    "body": "Connect with members with low activity in the last 30 days"
+  },
+  {
+    "name": "Check for negative reactions",
+    "body": "React to activities with very negative sentiment"
+  },
+  {
+    "name": "Setup your workpace integrations",
+    "body": "Connect with at least 2 data sources that are relevant to your community"
+  },
+  {
+    "name": "Setup your team",
+    "body": "Invite colleagues to your community workspace"
+  }
 ]

--- a/backend/src/database/initializers/suggested-tasks.json
+++ b/backend/src/database/initializers/suggested-tasks.json
@@ -1,26 +1,25 @@
-[
-  {
-    "name": "Engage with relevant content",
-    "body": "Engage with at least 5 posts on Eagle today"
-  },
-  {
-    "name": "Reach out to influential members",
-    "body": "Connect with new members with over 10k followers"
-  },
-  {
-    "name": "Reach out to poorly engaged members",
-    "body": "Connect with members with low activity in the last 30 days"
-  },
-  {
-    "name": "Check for negative reactions",
-    "body": "React to activities with very negative sentiment"
-  },
-  {
-    "name": "Setup your workpace integrations",
-    "body": "Connect with at least 2 data sources that are relevant to your community"
-  },
-  {
-    "name": "Setup your team",
-    "body": "Invite colleagues to your community workspace"
-  }
+[{
+        "name": "Engage with relevant content",
+        "body": "Engage with at least 5 posts on Eagle Eye today"
+    },
+    {
+        "name": "Reach out to influential members",
+        "body": "Connect with new members with over 10k followers"
+    },
+    {
+        "name": "Reach out to poorly engaged members",
+        "body": "Connect with members with low activity in the last 30 days"
+    },
+    {
+        "name": "Check for negative reactions",
+        "body": "React to activities with very negative sentiment"
+    },
+    {
+        "name": "Setup your workpace integrations",
+        "body": "Connect with at least 2 data sources that are relevant to your community"
+    },
+    {
+        "name": "Setup your team",
+        "body": "Invite colleagues to your community workspace"
+    }
 ]


### PR DESCRIPTION
# Changes proposed ✍️
- We now check if a conversation has publishable activities before loading it into the search engine.
An activity is publishable if it has a body other then empty string, or if it has some attachments.
- Also fixes a typo in the suggested tasks json.
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.