### PR TITLE
Fix redirect after conversation/activity destroy on dashboard

### DIFF
--- a/frontend/src/modules/activity/store/actions.js
+++ b/frontend/src/modules/activity/store/actions.js
@@ -87,7 +87,9 @@ export default {
         i18n('entities.activity.destroy.success')
       )
 
-      router.push('/activities')
+      if (router.currentRoute.name === 'dashboard') {
+        router.push({ name: 'activity' })
+      }
 
       dispatch('doFetch', {
         keepPagination: true

--- a/frontend/src/modules/conversation/components/conversation-dropdown.vue
+++ b/frontend/src/modules/conversation/components/conversation-dropdown.vue
@@ -47,8 +47,10 @@
           action: 'conversationDelete',
           conversation: conversation
         }"
-        ><i class="ri-delete-bin-line mr-1 text-red" /><span
-          class="text-red"
+        class="!text-red-500"
+        ><i
+          class="ri-delete-bin-line mr-1 !text-red-500"
+        /><span class="text-red"
           >Delete conversation</span
         ></el-dropdown-item
       >

--- a/frontend/src/modules/dashboard/components/activity/dashboard-activity-list.vue
+++ b/frontend/src/modules/dashboard/components/activity/dashboard-activity-list.vue
@@ -51,11 +51,30 @@ export default {
   name: 'AppDashboardActivityList',
   components: { AppDashboardActivityItem },
   emits: { count: null },
+  data() {
+    return {
+      storeUnsubscribe: () => {}
+    }
+  },
   computed: {
     ...mapGetters('dashboard', [
       'recentActivities',
       'activities'
     ])
+  },
+  created() {
+    this.storeUnsubscribe = this.$store.subscribe(
+      (mutation) => {
+        if (mutation.type === 'activity/DESTROY_SUCCESS') {
+          this.$store.dispatch(
+            'dashboard/getRecentActivities'
+          )
+        }
+      }
+    )
+  },
+  beforeUnmount() {
+    this.storeUnsubscribe()
   }
 }
 </script>

--- a/frontend/src/modules/dashboard/components/conversations/dashboard-conversation-list.vue
+++ b/frontend/src/modules/dashboard/components/conversations/dashboard-conversation-list.vue
@@ -67,7 +67,8 @@ export default {
   },
   data() {
     return {
-      conversationId: null
+      conversationId: null,
+      storeUnsubscribe: () => {}
     }
   },
   computed: {
@@ -75,6 +76,23 @@ export default {
       'trendingConversations',
       'conversations'
     ])
+  },
+  created() {
+    this.storeUnsubscribe = this.$store.subscribe(
+      (mutation) => {
+        if (
+          mutation.type ===
+          'communityHelpCenter/DESTROY_SUCCESS'
+        ) {
+          this.$store.dispatch(
+            'dashboard/getTrendingConversations'
+          )
+        }
+      }
+    )
+  },
+  beforeUnmount() {
+    this.storeUnsubscribe()
   }
 }
 </script>

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -27,8 +27,29 @@ export default {
   // Fetch trending conversations
   async getTrendingConversations({ commit, state }) {
     state.conversations.loading = true
+    const { platform, period } = state.filters
     return ConversationService.query(
-      {},
+      {
+        and: [
+          {
+            lastActive: {
+              gte: moment()
+                .startOf('day')
+                .subtract(period - 1, 'day')
+                .toISOString()
+            }
+          },
+          ...(platform !== 'all'
+            ? [
+                {
+                  platform: {
+                    eq: platform
+                  }
+                }
+              ]
+            : [])
+        ]
+      },
       'lastActive_DESC',
       5,
       0

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -27,29 +27,8 @@ export default {
   // Fetch trending conversations
   async getTrendingConversations({ commit, state }) {
     state.conversations.loading = true
-    const { platform, period } = state.filters
     return ConversationService.query(
-      {
-        and: [
-          {
-            lastActive: {
-              gte: moment()
-                .startOf('day')
-                .subtract(period - 1, 'day')
-                .toISOString()
-            }
-          },
-          ...(platform !== 'all'
-            ? [
-                {
-                  platform: {
-                    eq: platform
-                  }
-                }
-              ]
-            : [])
-        ]
-      },
+      {},
       'lastActive_DESC',
       5,
       0

--- a/frontend/src/shared/store/actions.js
+++ b/frontend/src/shared/store/actions.js
@@ -57,7 +57,9 @@ export default (moduleName, moduleService = null) => {
               i18n(`entities.${moduleName}.destroy.success`)
             )
 
-            router.push({ name: moduleName })
+            if (router.currentRoute.name === 'dashboard') {
+              router.push({ name: moduleName })
+            }
 
             dispatch('doFetch', {
               keepPagination: true
@@ -86,7 +88,9 @@ export default (moduleName, moduleService = null) => {
               )
             )
 
-            router.push({ name: moduleName })
+            if (router.currentRoute.name === 'dashboard') {
+              router.push({ name: moduleName })
+            }
 
             dispatch('doFetch', {
               keepPagination: true


### PR DESCRIPTION
# Changes proposed ✍️
- Fix redirecting to module after destroy in Dashboard (for activities and conversations)
- Force refresh of these lists after mutation is commited
    
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
  - [ ] ~Front-end: `frontend/.env.dist`~
  - [ ] ~Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.