### PR TITLE
Average sentiment exclude zeros fix

### DIFF
--- a/backend/src/database/migrations/U1668615936__averageSentimentExcludeZeroFix.sql
+++ b/backend/src/database/migrations/U1668615936__averageSentimentExcludeZeroFix.sql
@@ -1,0 +1,36 @@
+drop materialized view "memberActivityAggregatesMVs";
+
+create materialized view "memberActivityAggregatesMVs" as
+(
+    select 
+        m.id,
+        max(a.timestamp) as "lastActive",
+        count(a.id)      as "activityCount",
+        array_agg(
+        distinct (a.platform)
+            ) filter (
+            where
+            a.platform is not null
+            )            AS "activeOn",
+        ROUND(
+                AVG(CASE
+                        WHEN
+                                COALESCE(
+                                            a."sentiment" ->> 'sentiment',
+                                            '0'
+                                    ):: float <> 0 THEN COALESCE(
+                                    a."sentiment" ->> 'sentiment',
+                                    '0'
+                            ):: float
+                        ELSE NULL end
+                    ):: numeric,
+                2
+            )            AS "averageSentiment"
+    from members m
+            left outer join activities a on m.id = a."memberId" and a."deletedAt" is null
+    group by m.id
+);
+
+
+create unique index ix_memberactivityaggregatesmvs_memberid
+    on "memberActivityAggregatesMVs" (id);

--- a/backend/src/database/migrations/V1668615936__averageSentimentExcludeZeroFix.sql
+++ b/backend/src/database/migrations/V1668615936__averageSentimentExcludeZeroFix.sql
@@ -23,7 +23,7 @@ create materialized view "memberActivityAggregatesMVs" as
            )            AS "averageSentiment"
     from members m
          left outer join activities a on m.id = a."memberId" and a."deletedAt" is null
-    group by m.id;
+    group by m.id
 );
 
 

--- a/backend/src/database/migrations/V1668615936__averageSentimentExcludeZeroFix.sql
+++ b/backend/src/database/migrations/V1668615936__averageSentimentExcludeZeroFix.sql
@@ -1,0 +1,31 @@
+drop materialized view "memberActivityAggregatesMVs";
+
+create materialized view "memberActivityAggregatesMVs" as
+(
+    select 
+       m.id,
+       max(a.timestamp) as "lastActive",
+       count(a.id)      as "activityCount",
+       array_agg(
+       distinct (a.platform)
+           ) filter (
+           where
+           a.platform is not null
+           )            AS "activeOn",
+       ROUND(
+               AVG(CASE
+                       WHEN
+                           a."sentiment" ->> 'sentiment' is not null then
+                           (a."sentiment" ->> 'sentiment')::float
+                       ELSE NULL end
+                   ):: numeric,
+               2
+           )            AS "averageSentiment"
+    from members m
+         left outer join activities a on m.id = a."memberId" and a."deletedAt" is null
+    group by m.id;
+);
+
+
+create unique index ix_memberactivityaggregatesmvs_memberid
+    on "memberActivityAggregatesMVs" (id);


### PR DESCRIPTION
# Changes proposed ✍️
- Unnecessary coalesce in the materialized view query was causing sentiment=0 activities to  be discarded from average calculation. Fixes this problem and also simplifies the calculation a bit. 
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.