### PR TITLE
Tweak tasks menu badge and active tab

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -22,9 +22,9 @@ export default {
     })
   },
 
-  created() {
-    this.doInit()
-    this.taskDoInit()
+  async created() {
+    await this.doInit()
+    await this.taskDoInit()
     window.addEventListener('resize', this.handleResize)
     this.handleResize()
   },

--- a/frontend/src/modules/layout/components/menu.vue
+++ b/frontend/src/modules/layout/components/menu.vue
@@ -103,7 +103,6 @@
               <div
                 v-if="!isCollapsed && myOpenTasksCount > 0"
                 class="task-badge"
-                :class="taskBadgeClass()"
               >
                 {{ myOpenTasksCount }}
               </div>
@@ -464,21 +463,6 @@ const classFor = (path, exact = false) => {
     routePath === path || routePath.startsWith(path + '/')
   return {
     'is-active': active
-  }
-}
-
-const taskBadgeClass = function () {
-  const overdue = computed(
-    () => store.getters['task/myOpenOverdueTasks']
-  )
-  const dueSoon = computed(
-    () => store.getters['task/myOpenDueSoonTasks']
-  )
-
-  if (overdue.value.length > 0) {
-    return 'text-red-900 bg-red-100'
-  } else if (dueSoon.value.length > 0) {
-    return 'text-yellow-900 bg-yellow-100'
   }
 }
 </script>

--- a/frontend/src/modules/layout/components/menu.vue
+++ b/frontend/src/modules/layout/components/menu.vue
@@ -101,10 +101,11 @@
                 </span>
               </div>
               <div
-                v-if="!isCollapsed && openTasksCount > 0"
-                class="h-5 flex items-center px-2 bg-brand-100 rounded-full text-2xs font-medium"
+                v-if="!isCollapsed && myOpenTasksCount > 0"
+                class="task-badge"
+                :class="taskBadgeClass()"
               >
-                {{ openTasksCount }}
+                {{ myOpenTasksCount }}
               </div>
             </div>
           </router-link>
@@ -349,7 +350,7 @@ function toggleMenu() {
   store.dispatch('layout/toggleMenu')
 }
 
-const { openTasksCount } = mapGetters('task')
+const { myOpenTasksCount } = mapGetters('task')
 
 const hasPermissionToSettings = computed(
   () =>
@@ -463,6 +464,21 @@ const classFor = (path, exact = false) => {
     routePath === path || routePath.startsWith(path + '/')
   return {
     'is-active': active
+  }
+}
+
+const taskBadgeClass = function () {
+  const overdue = computed(
+    () => store.getters['task/myOpenOverdueTasks']
+  )
+  const dueSoon = computed(
+    () => store.getters['task/myOpenDueSoonTasks']
+  )
+
+  if (overdue.value.length > 0) {
+    return 'text-red-900 bg-red-100'
+  } else if (dueSoon.value.length > 0) {
+    return 'text-yellow-900 bg-yellow-100'
   }
 }
 </script>
@@ -604,5 +620,13 @@ const classFor = (path, exact = false) => {
   & .plan {
     @apply text-brand-400;
   }
+}
+
+.task-badge {
+  @apply h-5 flex items-center px-2 bg-gray-100 rounded-full text-2xs font-medium;
+}
+
+.el-menu-item.is-active .task-badge {
+  @apply bg-brand-100;
 }
 </style>

--- a/frontend/src/modules/task/components/task-open.vue
+++ b/frontend/src/modules/task/components/task-open.vue
@@ -114,8 +114,11 @@ import { TaskPermissions } from '@/modules/task/task-permissions'
 const store = useStore()
 
 const { addTask } = mapActions('task')
-const { openTasksCount, closedTasksCount } =
-  mapGetters('task')
+const {
+  openTasksCount,
+  closedTasksCount,
+  myOpenTasksCount
+} = mapGetters('task')
 const { currentUser, currentTenant } = mapGetters('auth')
 
 const tabs = ref([
@@ -157,7 +160,10 @@ const taskCount = ref(0)
 const loading = ref(false)
 const intitialLoad = ref(false)
 
-const tab = ref(tabs.value[0])
+const tab =
+  myOpenTasksCount.value > 0
+    ? ref(tabs.value[1])
+    : ref(tabs.value[0])
 const order = ref('createdAt_DESC')
 
 const tabClasses = (tabName) => {

--- a/frontend/src/modules/task/store/actions.js
+++ b/frontend/src/modules/task/store/actions.js
@@ -2,7 +2,7 @@ import { TaskService } from '@/modules/task/task-service'
 
 export default {
   doInit({ dispatch }) {
-    dispatch('getOpenTaskCount')
+    dispatch('getMyOpenTasks')
   },
   getOpenTaskCount({ commit }) {
     return TaskService.list(
@@ -28,7 +28,7 @@ export default {
     return TaskService.list(
       {
         type: 'regular',
-        assignees: currentUser.id,
+        assignees: [currentUser.id],
         status: { eq: 'in-progress' }
       },
       '',

--- a/frontend/src/modules/task/store/getters.js
+++ b/frontend/src/modules/task/store/getters.js
@@ -1,7 +1,25 @@
+import moment from 'moment'
+
 export default {
   openTasksCount: (state) => state.openTasksCount,
   closedTasksCount: (state) => state.closedTasksCount,
   archivedTasksCount: (state) => state.archivedTasksCount,
   myOpenTasks: (state) => state.myOpenTasks,
-  myOpenTasksCount: (state) => state.myOpenTasksCount
+  myOpenTasksCount: (state) => state.myOpenTasksCount,
+  myOpenOverdueTasks: (state, getters) => {
+    return getters.myOpenTasks.filter(
+      (t) =>
+        t.dueDate &&
+        moment().startOf('day').isAfter(moment(t.dueDate))
+    )
+  },
+  myOpenDueSoonTasks: (state, getters) => {
+    return getters.myOpenTasks.filter((t) => {
+      t.dueDate &&
+        moment()
+          .add(1, 'day')
+          .startOf('day')
+          .isAfter(moment(t.dueDate))
+    })
+  }
 }

--- a/frontend/src/modules/task/store/getters.js
+++ b/frontend/src/modules/task/store/getters.js
@@ -7,19 +7,22 @@ export default {
   myOpenTasks: (state) => state.myOpenTasks,
   myOpenTasksCount: (state) => state.myOpenTasksCount,
   myOpenOverdueTasks: (state, getters) => {
-    return getters.myOpenTasks.filter(
-      (t) =>
+    return getters.myOpenTasks.filter((t) => {
+      return (
         t.dueDate &&
         moment().startOf('day').isAfter(moment(t.dueDate))
-    )
+      )
+    })
   },
   myOpenDueSoonTasks: (state, getters) => {
     return getters.myOpenTasks.filter((t) => {
-      t.dueDate &&
+      return (
+        t.dueDate &&
         moment()
           .add(1, 'day')
           .startOf('day')
           .isAfter(moment(t.dueDate))
+      )
     })
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️
- Tweak the Tasks badge within the menu item, now it will be rendered if there's at least one task assigned to the **currentUser**
- `Assigned to me` tab will be pre-selected if **currentUser** has at least 1 task, otherwise `All` tab will be pre-selected
     
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated~
  - [ ] ~Front-end: `frontend/.env.dist`~
  - [ ] ~Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.