### PR TITLE
New integrations should use the second bot token if available

### DIFF
--- a/backend/config/custom-environment-variables.json
+++ b/backend/config/custom-environment-variables.json
@@ -107,7 +107,8 @@
     "callbackUrl": "CROWD_GOOGLE_CALLBACK_URL"
   },
   "discord": {
-    "token": "CROWD_DISCORD_TOKEN"
+    "token": "CROWD_DISCORD_TOKEN",
+    "token2": "CROWD_DISCORD_TOKEN_2"
   },
   "github": {
     "appId": "CROWD_GITHUB_APP_ID",

--- a/backend/src/config/configTypes.ts
+++ b/backend/src/config/configTypes.ts
@@ -120,6 +120,7 @@ export interface GoogleConfiguration {
 
 export interface DiscordConfiguration {
   token: string
+  token2: string
   maxRetrospectInSeconds: number
   globalLimit?: number
   limitResetFrequencyDays?: number

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -163,6 +163,7 @@ export const DISCORD_CONFIG: DiscordConfiguration = KUBE_MODE
   ? config.get<DiscordConfiguration>('discord')
   : {
       token: process.env.DISCORD_TOKEN,
+      token2: process.env.DISCORD_TOKEN,
       maxRetrospectInSeconds: Number(process.env.DISCORD_MAX_RETROSPECT_IN_SECONDS || 3600),
       globalLimit: Number(process.env.DISCORD_GLOBAL_LIMIT || Infinity),
     }

--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -45,6 +45,14 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
     this.token = `Bot ${DISCORD_CONFIG.token}`
   }
 
+  private getToken(context: IStepContext): string {
+    if (context.integration.token) {
+      return `Bot ${context.integration.token}`
+    }
+
+    return this.token
+  }
+
   override async triggerIntegrationCheck(integrations: any[]): Promise<void> {
     let initialDelaySeconds = 0
     const batches = lodash.chunk(integrations, 2)
@@ -73,14 +81,14 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
     const threads: Channels = await getThreads(
       {
         guildId,
-        token: this.token,
+        token: this.getToken(context),
       },
       this.logger(context),
     )
     let channelsFromDiscordAPI: Channels = await getChannels(
       {
         guildId,
-        token: this.token,
+        token: this.getToken(context),
       },
       this.logger(context),
     )
@@ -160,7 +168,7 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
         const { records, nextPage, limit, timeUntilReset } = await fn(
           {
             ...arg,
-            token: this.token,
+            token: this.getToken(context),
             page: stream.metadata.page,
             perPage: 100,
           },

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -3,7 +3,7 @@ import { request } from '@octokit/request'
 import moment from 'moment'
 import axios from 'axios'
 import lodash from 'lodash'
-import { GITHUB_CONFIG, IS_TEST_ENV, KUBE_MODE } from '../config'
+import { DISCORD_CONFIG, GITHUB_CONFIG, IS_TEST_ENV, KUBE_MODE } from '../config/index'
 import Error400 from '../errors/Error400'
 import { IServiceOptions } from './IServiceOptions'
 import SequelizeRepository from '../database/repositories/sequelizeRepository'
@@ -14,6 +14,8 @@ import { IntegrationType, PlatformType } from '../types/integrationEnums'
 import { getInstalledRepositories } from '../serverless/integrations/usecases/github/rest/getInstalledRepositories'
 import { sendNodeWorkerMessage } from '../serverless/utils/nodeWorkerSQS'
 import { NodeWorkerIntegrationProcessMessage } from '../types/mq/nodeWorkerIntegrationProcessMessage'
+
+const discordToken = DISCORD_CONFIG.token2 || DISCORD_CONFIG.token
 
 export default class IntegrationService {
   options: IServiceOptions
@@ -292,6 +294,7 @@ export default class IntegrationService {
     const integration = await this.createOrUpdate({
       platform: PlatformType.DISCORD,
       integrationIdentifier: guildId,
+      token: discordToken,
       settings: { channels: [], updateMemberAttributes: true },
       status: 'in-progress',
     })


### PR DESCRIPTION
# Changes proposed ✍️
- Use the second bot token when available

## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [x] Environment variables have been updated
  - [x] Front-end: `frontend/.env.dist`
  - [x] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [x] ~Team members only: update environment variables in Password manager and update the team~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] ~All changes have been tested in a staging site.~
- [x] All changes are working locally running crowd.dev's Docker local environment.