### PR TITLE
Organization new filters

### DIFF
--- a/frontend/src/modules/organization/organization-employees-field.js
+++ b/frontend/src/modules/organization/organization-employees-field.js
@@ -1,0 +1,68 @@
+import IntegerRangeField from '@/shared/fields/integer-range-field'
+
+export default class OrganizationEmployeesField extends IntegerRangeField {
+  constructor(name, label, config = {}) {
+    super(name, label)
+
+    this.placeholder = config.placeholder
+    this.hint = config.hint
+    this.required = config.required
+    this.matches = config.matches
+    this.filterable = config.filterable || false
+    this.custom = config.custom || false
+  }
+
+  dropdownOptions() {
+    return [
+      {
+        value: [1, 10],
+        label: '1-10'
+      },
+      {
+        value: [11, 50],
+        label: '11-50'
+      },
+      {
+        value: [51, 200],
+        label: '51-200'
+      },
+      {
+        value: [201, 500],
+        label: '201-500'
+      },
+      {
+        value: [501, 1000],
+        label: '501-1000'
+      },
+      {
+        value: [1001, 5000],
+        label: '1001-5000'
+      },
+      {
+        value: [5001, 10000],
+        label: '5001-10000'
+      },
+      {
+        value: [10001, null],
+        label: '10001+'
+      }
+    ]
+  }
+
+  forFilter() {
+    return {
+      name: this.name,
+      label: this.label,
+      custom: this.custom,
+      props: {
+        options: this.dropdownOptions(),
+        multiple: true
+      },
+      defaultValue: null,
+      value: null,
+      defaultOperator: 'between',
+      operator: 'between',
+      type: 'select'
+    }
+  }
+}

--- a/frontend/src/modules/organization/organization-member-count-field.js
+++ b/frontend/src/modules/organization/organization-member-count-field.js
@@ -1,0 +1,28 @@
+import IntegerRangeField from '@/shared/fields/integer-range-field'
+
+export default class OrganizationMemberCountField extends IntegerRangeField {
+  constructor(name, label, config = {}) {
+    super(name, label)
+
+    this.placeholder = config.placeholder
+    this.hint = config.hint
+    this.required = config.required
+    this.matches = config.matches
+    this.filterable = config.filterable || false
+    this.custom = config.custom || false
+  }
+
+  forFilter() {
+    return {
+      name: this.name,
+      label: this.label,
+      custom: this.custom,
+      props: {},
+      defaultValue: [],
+      value: [],
+      defaultOperator: 'between',
+      operator: 'between',
+      type: 'number'
+    }
+  }
+}

--- a/frontend/src/modules/organization/organization-model.js
+++ b/frontend/src/modules/organization/organization-model.js
@@ -3,6 +3,8 @@ import IdField from '@/shared/fields/id-field'
 import { GenericModel } from '@/shared/model/generic-model'
 import DateTimeField from '@/shared/fields/date-time-field'
 import StringField from '@/shared/fields/string-field'
+import OrganizationMemberCountField from '@/modules/organization/organization-member-count-field'
+import OrganizationEmployeesField from '@/modules/organization/organization-employees-field'
 
 function label(name) {
   return i18n(`entities.member.fields.${name}`)
@@ -20,6 +22,18 @@ const fields = {
   updatedAt: new DateTimeField(
     'updatedAt',
     label('updatedAt')
+  ),
+  members: new OrganizationMemberCountField(
+    'memberCount',
+    '# of members',
+    { filterable: true }
+  ),
+  employees: new OrganizationEmployeesField(
+    'employees',
+    '# of employees',
+    {
+      filterable: true
+    }
   )
 }
 

--- a/frontend/src/shared/filter/components/filter-list-item.vue
+++ b/frontend/src/shared/filter/components/filter-list-item.vue
@@ -40,6 +40,7 @@
         v-bind="filter.props"
         v-model:value="model.value"
         v-model:operator="model.operator"
+        :default-operator="filter.defaultOperator"
         :is-expanded="filter.expanded"
       />
       <div
@@ -231,7 +232,7 @@ const clickOutsideListener = (event) => {
     // clicks outside
     !(
       component === event.target ||
-      component.contains(event.target) ||
+      component?.contains(event.target) ||
       // we need the following condition to validate clicks
       // on popovers that are not DOM children of this component,
       // since popper is adding fixed components to the body directly

--- a/frontend/src/shared/filter/components/type/filter-type-number.vue
+++ b/frontend/src/shared/filter/components/type/filter-type-number.vue
@@ -3,13 +3,14 @@
     class="filter-type-number filter-with-operator-and-input"
   >
     <app-inline-select-input
+      v-if="defaultOperator !== 'between'"
       v-model="operator"
       popper-placement="bottom-start"
       prefix="Number:"
       class="mb-2"
       :options="computedOperatorOptions"
     />
-    <div class="flex -mx-1">
+    <div class="flex -mx-1 gap-2">
       <el-input
         ref="inputRef"
         v-model="model"
@@ -21,7 +22,6 @@
           operator === 'is_empty' ||
           operator === 'is_not_empty'
         "
-        class="mx-1"
       ></el-input>
       <el-input
         v-if="operator === 'between'"
@@ -32,7 +32,6 @@
           operator === 'is_empty' ||
           operator === 'is_not_empty'
         "
-        class="mx-1"
       ></el-input>
     </div>
   </div>
@@ -57,6 +56,10 @@ import operators from '@/shared/filter/helpers/operators'
 const props = defineProps({
   value: {
     type: [Array, Number],
+    default: null
+  },
+  defaultOperator: {
+    type: String,
     default: null
   },
   operator: {
@@ -133,6 +136,7 @@ watch(expanded, async (newValue) => {
   input[type='number']::-webkit-inner-spin-button,
   input[type='number']::-webkit-outer-spin-button {
     -webkit-appearance: none;
+    appearance: none;
     margin: 0;
   }
 }

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -91,9 +91,22 @@ function _buildAttributeBlock(attribute) {
       }, [])
     }
   } else if (attribute.operator === 'between') {
-    // TODO: Chech if this exceptions is needed
+    const bottomLimit = attribute.value[0]
+    const topLimit = attribute.value[1]
+
     rule = {
-      between: attribute.value
+      // Range from ... to
+      ...(!!(topLimit && bottomLimit) && {
+        between: attribute.value
+      }),
+      // Range from ...
+      ...(!!(bottomLimit && !topLimit) && {
+        gte: bottomLimit
+      }),
+      // Range ... to
+      ...(!!(!bottomLimit && topLimit) && {
+        lte: topLimit
+      })
     }
   } else if (attribute.operator === null) {
     rule = Array.isArray(attribute.value)


### PR DESCRIPTION
# Changes proposed ✍️
- Create `# employees` and `# members` filter fields
- Add both fields to Organization model with filterable option set to true
- Add `defaultOperator` prop to Filter type number so that it does not show the operator selector if the defaultOperator is set to between.
- Refactor `between` logic in `build-api-payload`:
   - Prevent empty values to be sent as null
   - When both bottom and top limit are set, use the `between` operator
   - When only bottom limit is set, use the `gte` operator
   - When only top limit is set, use the `lte` operator

### Screenshots (front-end changes only)  
<img width="348" alt="Screenshot 2022-11-21 at 12 56 24" src="https://user-images.githubusercontent.com/20134207/203048872-e95fdeb5-b7fa-43a0-92be-3c4fdf234dcb.png">
<img width="349" alt="Screenshot 2022-11-21 at 12 56 31" src="https://user-images.githubusercontent.com/20134207/203048889-91134137-fa38-4e4e-bc7d-7bf9aff964f1.png">
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.