### PR TITLE
Fix custom scroll z-index

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -52,7 +52,7 @@
           <transition name="el-fade-in">
             <div
               v-show="isScrollbarVisible"
-              class="absolute z-10 top-0 left-0 w-full"
+              class="absolute z-20 top-0 left-0 w-full"
               @mouseover="onTableMouseover"
               @mouseleave="onTableMouseLeft"
             >


### PR DESCRIPTION
# Changes proposed ✍️
- When a member row is selected, the member toolbar gets on top of the custom scroll component -> Added `z-20` class so that scroll is on top of toolbar
- ### Screenshots (front-end changes only)  
<img width="1209" alt="Screenshot 2022-11-21 at 15 17 20" src="https://user-images.githubusercontent.com/20134207/203077314-6b94ffb4-21e7-4bdd-94d3-00a529044500.png">

        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.