### PR TITLE
Github integration paging problem

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -229,6 +229,10 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         throw new Error(`Unknown event '${event}'!`)
     }
 
+    const nextPageStream = result.hasPreviousPage
+    ? { value: stream.value, metadata: { repo:stream.metadata.repo,  page: result.startCursor } }
+    : undefined
+
     const activities = await GithubIntegrationService.parseActivities(result.data, stream, context)
 
     return {
@@ -239,6 +243,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         },
       ],
       newStreams,
+      nextPageStream
     }
   }
 

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -230,8 +230,8 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     }
 
     const nextPageStream = result.hasPreviousPage
-    ? { value: stream.value, metadata: { repo:stream.metadata.repo,  page: result.startCursor } }
-    : undefined
+      ? { value: stream.value, metadata: { repo: stream.metadata.repo, page: result.startCursor } }
+      : undefined
 
     const activities = await GithubIntegrationService.parseActivities(result.data, stream, context)
 
@@ -243,7 +243,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         },
       ],
       newStreams,
-      nextPageStream
+      nextPageStream,
     }
   }
 

--- a/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
@@ -16,7 +16,7 @@ const getOrganization = async (name: string, token: string): Promise<any> => {
       },
     })
 
-    const sanitizedName = name.replaceAll('\\','')
+    const sanitizedName = name.replaceAll('\\', '')
 
     const organizationsQuery = `{
       search(query: "type:org ${sanitizedName}", type: USER, first: 10) {

--- a/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
@@ -16,8 +16,10 @@ const getOrganization = async (name: string, token: string): Promise<any> => {
       },
     })
 
+    const sanitizedName = name.replaceAll('\\','')
+
     const organizationsQuery = `{
-      search(query: "type:org ${name}", type: USER, first: 10) {
+      search(query: "type:org ${sanitizedName}", type: USER, first: 10) {
         nodes {
           ... on Organization ${BaseQuery.ORGANIZATION_SELECT}
           }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "ES2021.String"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedLocals": false,


### PR DESCRIPTION
# Changes proposed ✍️
- Github integration service now passes the next page to processor
- Fixes an edge case for get organizations from github. When the organization name had backslashes in it, the string was not interpolating correctly resulting in an error. Now we sanitize the name from backslashes before sending it to the api.
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [ ] All changes are working locally running crowd.dev's Docker local environment.