### PR TITLE
Activity and organization entities new filters

### DIFF
--- a/backend/src/api/components/organization/examples.yaml
+++ b/backend/src/api/components/organization/examples.yaml
@@ -38,6 +38,8 @@ components:
         createdById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         updatedById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         memberCount: 2
+        activityCount: 4
+
 
     Organization:
       value:
@@ -84,6 +86,7 @@ components:
         createdById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         updatedById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         memberCount: 2
+        activityCount: 4
 
     Organization2:
       value:
@@ -130,6 +133,7 @@ components:
         createdById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         updatedById: debc3c7f-4c5d-4bec-9130-17bb0aea8b75
         memberCount: 0
+        activityCount: 0
 
     OrganizationList:
       value:

--- a/backend/src/api/components/organization/examples.yaml
+++ b/backend/src/api/components/organization/examples.yaml
@@ -40,7 +40,6 @@ components:
         memberCount: 2
         activityCount: 4
 
-
     Organization:
       value:
         id: 31bff99a-2eac-49f5-b015-cba95aa6e530

--- a/backend/src/api/components/organization/query.yaml
+++ b/backend/src/api/components/organization/query.yaml
@@ -23,6 +23,14 @@ components:
           enum:
             - createdAt_ASC
             - createdAt_DESC
+            - memberCount_ASC
+            - memberCount_DESC
+            - activityCount_ASC
+            - activityCount_DESC
+            - joinedAt_ASC
+            - joinedAt_DESC
+            - lastActive_ASC
+            - lastActive_DESC
 
         limit:
           description: >-

--- a/backend/src/database/repositories/__tests__/memberRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/memberRepository.test.ts
@@ -1531,12 +1531,14 @@ describe('MemberRepository tests', () => {
             'identities',
             'activeOn',
             'joinedAt',
+            'activityCount'
           ]),
           SequelizeTestUtils.objectWithoutKey(org2Plain, [
             'lastActive',
             'identities',
             'activeOn',
             'joinedAt',
+            'activityCount'
           ]),
         ],
         noMerge: [],

--- a/backend/src/database/repositories/__tests__/memberRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/memberRepository.test.ts
@@ -1531,14 +1531,14 @@ describe('MemberRepository tests', () => {
             'identities',
             'activeOn',
             'joinedAt',
-            'activityCount'
+            'activityCount',
           ]),
           SequelizeTestUtils.objectWithoutKey(org2Plain, [
             'lastActive',
             'identities',
             'activeOn',
             'joinedAt',
-            'activityCount'
+            'activityCount',
           ]),
         ],
         noMerge: [],

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -4,6 +4,7 @@ import SequelizeTestUtils from '../../utils/sequelizeTestUtils'
 import Error404 from '../../../errors/Error404'
 import MemberRepository from '../memberRepository'
 import { PlatformType } from '../../../types/integrationEnums'
+import ActivityRepository from '../activityRepository'
 
 const db = null
 
@@ -91,6 +92,7 @@ describe('OrganizationRepository tests', () => {
         id: organizationCreated.id,
         ...toCreate,
         memberCount: 0,
+        activityCount: 0,
         activeOn: [],
         identities: [],
         importHash: null,
@@ -136,6 +138,7 @@ describe('OrganizationRepository tests', () => {
         id: organizationCreated.id,
         ...toCreate,
         memberCount: 2,
+        activityCount: 0,
         lastActive: null,
         joinedAt: null,
         activeOn: [],
@@ -173,6 +176,7 @@ describe('OrganizationRepository tests', () => {
         id: organizationCreated.id,
         ...toCreate,
         memberCount: 0,
+        activityCount: 0,
         activeOn: [],
         identities: [],
         lastActive: null,
@@ -560,7 +564,17 @@ describe('OrganizationRepository tests', () => {
     async function createOrganization(organization: any, options, members = []) {
       const memberIds = []
       for (const member of members) {
-        const memberCreated = await MemberRepository.create(member, options)
+        const memberCreated = await MemberRepository.create(
+          SequelizeTestUtils.objectWithoutKey(member, 'activities'),
+          options,
+        )
+
+        if (member.activities) {
+          for (const activity of member.activities) {
+            await ActivityRepository.create({ ...activity, member: memberCreated.id }, options)
+          }
+        }
+
         memberIds.push(memberCreated.id)
       }
       organization.members = memberIds
@@ -777,6 +791,14 @@ describe('OrganizationRepository tests', () => {
           username: { github: 'joan' },
           displayName: 'Joan',
           joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-05-27T15:13:30Z',
+              platform: PlatformType.GITHUB,
+              sourceId: '#sourceId1',
+            },
+          ],
         },
       ])
       await createOrganization(piedpiper, mockIRepositoryOptions)
@@ -799,6 +821,193 @@ describe('OrganizationRepository tests', () => {
 
       expect(found.count).toEqual(1)
       expect(found.rows[0].name).toBe('crowd.dev')
+    })
+
+    it('Should filter by activityCount', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const org1 = await createOrganization(crowddev, mockIRepositoryOptions, [
+        {
+          username: { github: 'joan' },
+          displayName: 'Joan',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-05-27T15:13:30Z',
+              platform: PlatformType.GITHUB,
+              sourceId: '#sourceId1',
+            },
+          ],
+        },
+        {
+          username: { github: 'anil' },
+          displayName: 'anil',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-06-27T15:13:30Z',
+              platform: PlatformType.TWITTER,
+              sourceId: '#sourceId2',
+            },
+          ],
+        },
+      ])
+      await createOrganization(piedpiper, mockIRepositoryOptions)
+      await createOrganization(hooli, mockIRepositoryOptions)
+
+      const found = await OrganizationRepository.findAndCountAll(
+        {
+          advancedFilter: {
+            activityCount: {
+              gte: 2,
+            },
+          },
+        },
+        mockIRepositoryOptions,
+      )
+
+      expect(found.count).toBe(1)
+      expect(found.rows).toStrictEqual([org1])
+    })
+
+    it('Should filter by memberCount', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const org1 = await createOrganization(crowddev, mockIRepositoryOptions, [
+        {
+          username: { github: 'joan' },
+          displayName: 'Joan',
+          joinedAt: moment().toDate(),
+        },
+        {
+          username: { github: 'anil' },
+          displayName: 'anil',
+          joinedAt: moment().toDate(),
+        },
+        {
+          username: { github: 'uros' },
+          displayName: 'uros',
+          joinedAt: moment().toDate(),
+        },
+      ])
+      const org2 = await createOrganization(piedpiper, mockIRepositoryOptions, [
+        {
+          username: { github: 'mario' },
+          displayName: 'mario',
+          joinedAt: moment().toDate(),
+        },
+        {
+          username: { github: 'igor' },
+          displayName: 'igor',
+          joinedAt: moment().toDate(),
+        },
+      ])
+      await createOrganization(hooli, mockIRepositoryOptions)
+
+      const found = await OrganizationRepository.findAndCountAll(
+        {
+          advancedFilter: {
+            memberCount: {
+              gte: 2,
+            },
+          },
+        },
+        mockIRepositoryOptions,
+      )
+
+      expect(found.count).toBe(2)
+      expect(found.rows.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))).toStrictEqual([
+        org1,
+        org2,
+      ])
+    })
+
+    it('Should filter by joinedAt', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      await createOrganization(crowddev, mockIRepositoryOptions, [
+        {
+          username: { github: 'joan' },
+          displayName: 'Joan',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-05-27T15:13:30Z',
+              platform: PlatformType.GITHUB,
+              sourceId: '#sourceId1',
+            },
+          ],
+        },
+        {
+          username: { github: 'anil' },
+          displayName: 'anil',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-04-27T15:13:30Z',
+              platform: PlatformType.SLACK,
+              sourceId: '#sourceId2',
+            },
+          ],
+        },
+        {
+          username: { github: 'uros' },
+          displayName: 'uros',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2020-03-27T15:13:30Z',
+              platform: PlatformType.TWITTER,
+              sourceId: '#sourceId3',
+            },
+          ],
+        },
+      ])
+      const org2 = await createOrganization(piedpiper, mockIRepositoryOptions, [
+        {
+          username: { github: 'mario' },
+          displayName: 'mario',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2022-03-27T15:13:30Z',
+              platform: PlatformType.DEVTO,
+              sourceId: '#sourceId4',
+            },
+          ],
+        },
+        {
+          username: { github: 'igor' },
+          displayName: 'igor',
+          joinedAt: moment().toDate(),
+          activities: [
+            {
+              type: 'activity',
+              timestamp: '2022-02-27T15:13:30Z',
+              platform: PlatformType.DEVTO,
+              sourceId: '#sourceId4',
+            },
+          ],
+        },
+      ])
+      await createOrganization(hooli, mockIRepositoryOptions)
+
+      const found = await OrganizationRepository.findAndCountAll(
+        {
+          advancedFilter: {
+            joinedAt: {
+              gte: '2022-02-27',
+            },
+          },
+        },
+        mockIRepositoryOptions,
+      )
+
+      expect(found.count).toBe(1)
+      expect(found.rows.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))).toStrictEqual([org2])
     })
 
     it('Should work with advanced filters', async () => {
@@ -940,6 +1149,7 @@ describe('OrganizationRepository tests', () => {
         id: organizationCreated.id,
         ...toCreate,
         memberCount: 0,
+        activityCount: 0,
         activeOn: [],
         identities: [],
         lastActive: null,

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -507,6 +507,18 @@ class ActivityRepository {
         nestedFields: {
           sentiment: 'sentiment.sentiment',
         },
+        manyToMany: {
+          organizations: {
+            table: 'activities',
+            model: 'activity',
+            overrideJoinField: 'memberId',
+            relationTable: {
+              name: 'memberOrganizations',
+              from: 'memberId',
+              to: 'organizationId',
+            },
+          },
+        },
       },
       options,
     )

--- a/backend/src/database/repositories/filters/__tests__/queryParser.test.ts
+++ b/backend/src/database/repositories/filters/__tests__/queryParser.test.ts
@@ -376,14 +376,14 @@ describe('QueryParser tests', () => {
                   Sequelize.literal(`"task"."id"`),
                   Op.in,
                   Sequelize.literal(
-                    `(SELECT "tasks".id FROM "tasks" INNER JOIN "memberTasks" ON "memberTasks"."taskId" = "tasks".id WHERE  "memberTasks"."memberId"  = '${mid1}')`,
+                    `(SELECT "tasks"."id" FROM "tasks" INNER JOIN "memberTasks" ON "memberTasks"."taskId" = "tasks"."id" WHERE  "memberTasks"."memberId"  = '${mid1}')`,
                   ),
                 ),
                 Sequelize.where(
                   Sequelize.literal(`"task"."id"`),
                   Op.in,
                   Sequelize.literal(
-                    `(SELECT "tasks".id FROM "tasks" INNER JOIN "activityTasks" ON "activityTasks"."taskId" = "tasks".id WHERE  "activityTasks"."activityId"  = '${aid1}' OR "activityTasks"."activityId"  = '${aid2}')`,
+                    `(SELECT "tasks"."id" FROM "tasks" INNER JOIN "activityTasks" ON "activityTasks"."taskId" = "tasks"."id" WHERE  "activityTasks"."activityId"  = '${aid1}' OR "activityTasks"."activityId"  = '${aid2}')`,
                   ),
                 ),
               ],
@@ -522,7 +522,7 @@ describe('QueryParser tests', () => {
                   Sequelize.literal(`"task"."id"`),
                   Op.in,
                   Sequelize.literal(
-                    `(SELECT "tasks".id FROM "tasks" INNER JOIN "activityTasks" ON "activityTasks"."taskId" = "tasks".id WHERE  "activityTasks"."activityId"  = '${aid1}' OR "activityTasks"."activityId"  = '${aid2}')`,
+                    `(SELECT "tasks"."id" FROM "tasks" INNER JOIN "activityTasks" ON "activityTasks"."taskId" = "tasks"."id" WHERE  "activityTasks"."activityId"  = '${aid1}' OR "activityTasks"."activityId"  = '${aid2}')`,
                   ),
                 ),
               ],

--- a/backend/src/database/repositories/filters/queryParser.ts
+++ b/backend/src/database/repositories/filters/queryParser.ts
@@ -265,21 +265,23 @@ class QueryParser {
       }"  = '${QueryParser.uuid(item)}'`
     }, '')
 
+    const joinField = mapping.overrideJoinField ?? 'id'
+
     // Find all the rows in the table that have the items we are filtering on
     // For example, find all members that have the tags with id1 or id2
     const literal = Sequelize.literal(
-      `(SELECT "${mapping.table}".id FROM "${mapping.table}" INNER JOIN "${mapping.relationTable.name}" ON "${mapping.relationTable.name}"."${mapping.relationTable.from}" = "${mapping.table}".id WHERE ${items})`,
+      `(SELECT "${mapping.table}"."${joinField}" FROM "${mapping.table}" INNER JOIN "${mapping.relationTable.name}" ON "${mapping.relationTable.name}"."${mapping.relationTable.from}" = "${mapping.table}"."${joinField}" WHERE ${items})`,
     )
 
     // It coudl be that we have more than 1 many to many filter, so we could need to append. For example:
     // {tags: [id1, id2], organizations: [id3, id4]}
     if (query[Op.and]) {
       query[Op.and].push(
-        Sequelize.where(Sequelize.literal(`"${mapping.model}"."id"`), Op.in, literal),
+        Sequelize.where(Sequelize.literal(`"${mapping.model}"."${joinField}"`), Op.in, literal),
       )
     } else {
       query[Op.and] = [
-        Sequelize.where(Sequelize.literal(`"${mapping.model}"."id"`), Op.in, literal),
+        Sequelize.where(Sequelize.literal(`"${mapping.model}"."${joinField}"`), Op.in, literal),
       ]
     }
 

--- a/backend/src/database/repositories/filters/queryTypes.ts
+++ b/backend/src/database/repositories/filters/queryTypes.ts
@@ -20,6 +20,7 @@ export interface ManyToManyType {
   [key: string]: {
     table: string
     model?: string
+    overrideJoinField?: string
     relationTable: {
       name: string
       from: string

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -277,9 +277,6 @@ class OrganizationRepository {
             model: options.database.activity,
             as: 'activities',
             attributes: [],
-            // through: {
-            //   attributes: [],
-            // },
           },
         ],
       },

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1,5 +1,4 @@
 import lodash from 'lodash'
-import moment from 'moment'
 import Sequelize from 'sequelize'
 import SequelizeRepository from './sequelizeRepository'
 import AuditLogRepository from './auditLogRepository'
@@ -293,10 +292,14 @@ class OrganizationRepository {
     const identities = Sequelize.literal(
       `array( select distinct jsonb_object_keys(jsonb_array_elements(jsonb_agg( case when "members".username is not null then "members".username else '{}' end))))`,
     )
+
     const lastActive = Sequelize.literal(`MAX("members->activities".timestamp)`)
+
     const joinedAt = Sequelize.literal(`MIN("members->activities".timestamp)`)
 
     const memberCount = Sequelize.literal(`COUNT(DISTINCT "members".id)::integer`)
+
+    const activityCount = Sequelize.literal(`COUNT("members->activities".id)::integer`)
 
     // If the advanced filter is empty, we construct it from the query parameter filter
     if (!advancedFilter) {
@@ -466,6 +469,13 @@ class OrganizationRepository {
     customOrderBy = customOrderBy.concat(
       SequelizeFilterUtils.customOrderByIfExists('joinedAt', orderBy),
     )
+    customOrderBy = customOrderBy.concat(
+      SequelizeFilterUtils.customOrderByIfExists('activityCount', orderBy),
+    )
+
+    customOrderBy = customOrderBy.concat(
+      SequelizeFilterUtils.customOrderByIfExists('memberCount', orderBy),
+    )
 
     const parser = new QueryParser(
       {
@@ -509,6 +519,7 @@ class OrganizationRepository {
           lastActive,
           joinedAt,
           memberCount,
+          activityCount,
         },
         manyToMany: {
           members: {
@@ -578,6 +589,7 @@ class OrganizationRepository {
         [lastActive, 'lastActive'],
         [joinedAt, 'joinedAt'],
         [memberCount, 'memberCount'],
+        [activityCount, 'activityCount'],
       ],
       order,
       limit: parsed.limit,
@@ -685,13 +697,15 @@ class OrganizationRepository {
       ),
     ]
 
-    const activities = members
+    const activityTimestamps = members
       .reduce((acc, m) => acc.concat(...m.get({ plain: true }).activities), [])
       .map((i) => i.timestamp)
 
-    output.lastActive = activities.length > 0 ? moment(Math.max(activities)).toDate() : null
+    output.lastActive =
+      activityTimestamps.length > 0 ? new Date(Math.max(...activityTimestamps)) : null
 
-    output.joinedAt = activities.length > 0 ? moment(Math.min(activities)).toDate() : null
+    output.joinedAt =
+      activityTimestamps.length > 0 ? new Date(Math.min(...activityTimestamps)) : null
 
     output.identities = [
       ...new Set(
@@ -700,6 +714,8 @@ class OrganizationRepository {
     ]
 
     output.memberCount = members.length
+
+    output.activityCount = activityTimestamps.length
 
     return output
   }

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -1662,9 +1662,9 @@ describe('MemberService tests', () => {
       t3 = SequelizeTestUtils.objectWithoutKey(t3, 'members')
 
       // remove organizations->member relations as well (we should be only checking 1-deep relations)
-      o1 = SequelizeTestUtils.objectWithoutKey(o1, ['memberCount', 'joinedAt'])
-      o2 = SequelizeTestUtils.objectWithoutKey(o2, ['memberCount', 'joinedAt'])
-      o3 = SequelizeTestUtils.objectWithoutKey(o3, ['memberCount', 'joinedAt'])
+      o1 = SequelizeTestUtils.objectWithoutKey(o1, ['memberCount', 'joinedAt', 'activityCount'])
+      o2 = SequelizeTestUtils.objectWithoutKey(o2, ['memberCount', 'joinedAt', 'activityCount'])
+      o3 = SequelizeTestUtils.objectWithoutKey(o3, ['memberCount', 'joinedAt', 'activityCount'])
 
       // remove tasks->member and tasks->activity tasks->assignees relations as well (we should be only checking 1-deep relations)
       task1 = SequelizeTestUtils.objectWithoutKey(task1, ['members', 'activities', 'assignees'])


### PR DESCRIPTION
# Changes proposed ✍️
New fields and filters for the organization module:
- filter by activity count => field name: `activityCount`
- filter by member count => field name: `memberCount`
- filter by first activity time => field name: `joinedAt`
- filter by employee count => field name: `employees`

New filter for activity module
- filter by organizationId => filed name: `organizations`

Example payload:
```
{
   filter: {
       organizations: [organizationId1, organizationId2]
  }
}
```
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [x] Tests are passing.  
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.