### PR TITLE
Fix members export action

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -121,9 +121,7 @@
                       :member="scope.row"
                       class="ml-2"
                     />
-                     <app-member-badge
-                        :member="scope.row"
-                      />
+                    <app-member-badge :member="scope.row" />
                   </div>
                 </template>
               </el-table-column>

--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -12,7 +12,7 @@ import sharedActions from '@/shared/store/actions'
 export default {
   ...sharedActions('member', MemberService),
 
-  async doExport({ commit, state, getters }) {
+  async doExport({ commit, getters }) {
     try {
       if (
         !memberListExporterFields ||
@@ -25,10 +25,10 @@ export default {
 
       commit('EXPORT_STARTED')
 
-      const filter = state.filter
+      const activeView = getters.activeView
 
       const response = await MemberService.list(
-        filter,
+        activeView.filter,
         getters.orderBy,
         null,
         null
@@ -47,10 +47,9 @@ export default {
     }
   },
 
-  async doMarkAsTeamMember({ dispatch, state, getters }) {
+  async doMarkAsTeamMember({ dispatch, getters }) {
     try {
       const selectedRows = getters.selectedRows
-      const filter = state.filter
 
       for (const row of selectedRows) {
         await MemberService.update(row.id, {
@@ -65,7 +64,6 @@ export default {
       }
 
       dispatch('doFetch', {
-        filter,
         keepPagination: true
       })
 


### PR DESCRIPTION
# Changes proposed ✍️
- Remove `filter` from `doFetch` in `doMarkAsTeamMember`. It was not being used as the `doFetch` already uses the filters from the active view
- Fix `doExport` action from member's actions by getting the `filters` from the active view. There is no `state.filters`, so this value was undefined and when used in the `build-api-payload` brook the app
        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [x] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.