### PR TITLE
Add event tracking to organizations

### DIFF
--- a/backend/src/api/member/memberList.ts
+++ b/backend/src/api/member/memberList.ts
@@ -1,16 +1,10 @@
 import Permissions from '../../security/permissions'
-import track from '../../segment/track'
 import MemberService from '../../services/memberService'
 import PermissionChecker from '../../services/user/permissionChecker'
 
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberRead)
   const payload = await new MemberService(req).findAndCountAll(req.query)
-
-  if (req.query.filter && Object.keys(req.query.filter).length > 1) {
-    // the condition is length > 1 because we always use a filter here because of lookalike members
-    track('Members Filtered', { filter: req.query.filter }, { ...req })
-  }
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationCreate.ts
+++ b/backend/src/api/organization/organizationCreate.ts
@@ -1,4 +1,5 @@
 import Permissions from '../../security/permissions'
+import track from '../../segment/track'
 import OrganizationService from '../../services/organizationService'
 import PermissionChecker from '../../services/user/permissionChecker'
 
@@ -22,6 +23,8 @@ export default async (req, res) => {
 
   const enrichP = req.body?.shouldEnrich || false
   const payload = await new OrganizationService(req).findOrCreate(req.body, enrichP)
+
+  track('Organization Manually Created', { ...payload }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationList.ts
+++ b/backend/src/api/organization/organizationList.ts
@@ -1,4 +1,5 @@
 import Permissions from '../../security/permissions'
+import track from '../../segment/track'
 import OrganizationService from '../../services/organizationService'
 import PermissionChecker from '../../services/user/permissionChecker'
 
@@ -6,6 +7,10 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.organizationRead)
 
   const payload = await new OrganizationService(req).findAndCountAll(req.query)
+
+  if (req.query.filter) {
+    track('Organizations Filtered', { filter: req.query.filter }, { ...req })
+  }
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationList.ts
+++ b/backend/src/api/organization/organizationList.ts
@@ -1,5 +1,4 @@
 import Permissions from '../../security/permissions'
-import track from '../../segment/track'
 import OrganizationService from '../../services/organizationService'
 import PermissionChecker from '../../services/user/permissionChecker'
 
@@ -7,10 +6,6 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.organizationRead)
 
   const payload = await new OrganizationService(req).findAndCountAll(req.query)
-
-  if (req.query.filter) {
-    track('Organizations Filtered', { filter: req.query.filter }, { ...req })
-  }
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationQuery.ts
+++ b/backend/src/api/organization/organizationQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new OrganizationService(req).query(req.body)
 
   if (req.query.filter && Object.keys(req.query.filter).length > 0) {
-    track('Organizations Advanced Fitler', { ...payload }, { ...req })
+    track('Organizations Advanced Filter', { ...payload }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -176,9 +176,7 @@ export default class TenantService {
 
       if (data.integrationsRequired) {
         // Convert all to lowercase
-        data.integrationsRequired = data.integrationsRequired.map((item) =>
-          item.toLowerCase(),
-        )
+        data.integrationsRequired = data.integrationsRequired.map((item) => item.toLowerCase())
       }
 
       const record = await TenantRepository.create(data, {


### PR DESCRIPTION
# Changes proposed ✍️
Mimic events from members module:
- Add event to `organizationCreate`
- Fix typo in `organizationQuery`
- All other events were already in place

Removed `Members Filtered` event from `memberList`. @joanreyero could you check if this event is no longer needed? This seems to be overlapping with the other event we have, `Members Advanced Filter`.
However, in June, for `Members Filtered`  it has not triggered anything for the last 2 months. For `Members Advanced Filter` there is not one single record, do you know if both are being used at all? (We already have tracking events as well for filtering in the frontend)

        
## Checklist ✅
- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.  
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated
  - [ ] Front-end: `frontend/.env.dist`
  - [ ] Backend: `backend/.env.dist`, `backend/.env.dist.staging`, `backend/.env.dist.staging`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in Password manager and update the team
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).  
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.  
- [ ] All changes have been tested in a staging site.  
- [x] All changes are working locally running crowd.dev's Docker local environment.