### PR TITLE
Add links to source in member activities' list

### DIFF
--- a/frontend/src/integrations/github/components/activity/github-activity-message.vue
+++ b/frontend/src/integrations/github/components/activity/github-activity-message.vue
@@ -18,7 +18,7 @@
   >
   <a
     v-if="!short && activity.channel"
-    :href="activity.url"
+    :href="activity.channel"
     target="_blank"
     class="ml-1 text-brand-500"
   >

--- a/frontend/src/integrations/github/components/activity/github-activity-message.vue
+++ b/frontend/src/integrations/github/components/activity/github-activity-message.vue
@@ -18,7 +18,7 @@
   >
   <a
     v-if="!short && activity.channel"
-    :href="activity.channel"
+    :href="activity.url"
     target="_blank"
     class="ml-1 text-brand-500"
   >

--- a/frontend/src/modules/member/components/view/member-view-activities.vue
+++ b/frontend/src/modules/member/components/view/member-view-activities.vue
@@ -51,7 +51,11 @@
               class="text-sm bg-gray-50 rounded-lg p-4"
               :activity="activity"
               :show-more="true"
-            />
+              ><div v-if="activity.url" class="pt-6">
+                <app-activity-link
+                  :activity="activity"
+                /></div
+            ></app-activity-content>
           </div>
           <template #dot>
             <span
@@ -111,6 +115,7 @@ import debounce from 'lodash/debounce'
 import authAxios from '@/shared/axios/auth-axios'
 import { formatDateToTimeAgo } from '@/utils/date'
 import { CrowdIntegrations } from '@/integrations/integrations-config'
+import AppActivityLink from '@/modules/activity/components/activity-link'
 
 const SearchIcon = h(
   'i', // type


### PR DESCRIPTION
# Changes proposed ✍️
- Use activity `url` instead of `channel` to link github activity's source with member activities' list
- Relates to this issue https://github.com/CrowdDotDev/crowd.dev/issues/260

## Checklist ✅

- [x] Label appropriately with `type:feature 🚀`, `type:enhancement ✨`, `type:bug 🐞`, or `type:documentation 📜`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.
