### PR TITLE
Organization cache simplify enrichment

### DIFF
--- a/backend/src/database/migrations/U1669737732__organizationCacheEnrichedBoolean.sql
+++ b/backend/src/database/migrations/U1669737732__organizationCacheEnrichedBoolean.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."organizationCaches" DROP COLUMN "enriched";

--- a/backend/src/database/migrations/U1669802927__organizationCacheMissingFields.sql
+++ b/backend/src/database/migrations/U1669802927__organizationCacheMissingFields.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public."organizationCaches" DROP COLUMN "location";
+ALTER TABLE public."organizationCaches" DROP COLUMN "github";
+ALTER TABLE public."organizationCaches" DROP COLUMN "website";
+
+create unique index organizations_url_tenant_id
+    on "organizations" (url,"tenantId");

--- a/backend/src/database/migrations/V1669737732__organizationCacheEnrichedBoolean.sql
+++ b/backend/src/database/migrations/V1669737732__organizationCacheEnrichedBoolean.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."organizationCaches" ADD COLUMN "enriched" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/database/migrations/V1669802927__organizationCacheMissingFields.sql
+++ b/backend/src/database/migrations/V1669802927__organizationCacheMissingFields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public."organizationCaches" ADD "location" TEXT NULL;
+ALTER TABLE public."organizationCaches" ADD "github" JSONB NULL;
+ALTER TABLE public."organizationCaches" ADD "website" TEXT NULL;
+
+drop index public.organizations_url_tenant_id;

--- a/backend/src/database/models/organizationCache.ts
+++ b/backend/src/database/models/organizationCache.ts
@@ -52,6 +52,10 @@ export default (sequelize) => {
         type: DataTypes.JSONB,
         default: {},
       },
+      github: {
+        type: DataTypes.JSONB,
+        default: {},
+      },
       crunchbase: {
         type: DataTypes.JSONB,
         default: {},
@@ -70,6 +74,14 @@ export default (sequelize) => {
         validate: {
           len: [0, 255],
         },
+      },
+      location: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      website: {
+        type: DataTypes.TEXT,
+        allowNull: true,
       },
     },
     {

--- a/backend/src/database/repositories/__tests__/organizationCacheRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationCacheRepository.test.ts
@@ -13,6 +13,11 @@ const toCreate = {
   logo: 'https://logo.clearbit.com/crowd.dev',
   tags: ['community', 'growth', 'developer-first'],
   parentUrl: null,
+  website: 'https://crowd.dev',
+  location: 'Berlin',
+  github: {
+    handle: 'CrowdDotDev',
+  },
   twitter: {
     handle: 'CrowdDotDev',
     id: '1362101830923259908',

--- a/backend/src/database/repositories/organizationCacheRepository.ts
+++ b/backend/src/database/repositories/organizationCacheRepository.ts
@@ -25,6 +25,7 @@ class OrganizationCacheRepository {
           'employees',
           'revenueRange',
           'importHash',
+          'enriched',
         ]),
       },
       {
@@ -68,6 +69,7 @@ class OrganizationCacheRepository {
           'employees',
           'revenueRange',
           'importHash',
+          'enriched',
         ]),
       },
       {

--- a/backend/src/database/repositories/organizationCacheRepository.ts
+++ b/backend/src/database/repositories/organizationCacheRepository.ts
@@ -26,6 +26,9 @@ class OrganizationCacheRepository {
           'revenueRange',
           'importHash',
           'enriched',
+          'website',
+          'github',
+          'location',
         ]),
       },
       {
@@ -70,6 +73,9 @@ class OrganizationCacheRepository {
           'revenueRange',
           'importHash',
           'enriched',
+          'website',
+          'github',
+          'location',
         ]),
       },
       {

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -109,8 +109,8 @@ const en = {
     wrongEagleEyeSearch: {
       message: 'Wrong search parameters',
     },
-    OrganizationNameOrUrlRequired: {
-      message: 'Organization Name or Url is required',
+    OrganizationNameRequired: {
+      message: 'Organization Name is required',
     },
     projectNotFound: {
       message: 'Project not found',

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -596,6 +596,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
               logo: fromAPI.avatarUrl ?? null,
               url: fromAPI.url ?? null,
               twitter: fromAPI.twitterUsername ? { handle: fromAPI.twitterUsername } : null,
+              website: fromAPI.websiteUrl ?? null
             },
           ]
         } else {

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -596,7 +596,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
               logo: fromAPI.avatarUrl ?? null,
               url: fromAPI.url ?? null,
               twitter: fromAPI.twitterUsername ? { handle: fromAPI.twitterUsername } : null,
-              website: fromAPI.websiteUrl ?? null
+              website: fromAPI.websiteUrl ?? null,
             },
           ]
         } else {

--- a/backend/src/serverless/integrations/webhooks/github.ts
+++ b/backend/src/serverless/integrations/webhooks/github.ts
@@ -381,7 +381,7 @@ export default class GitHubWebhook {
               logo: fromAPI.avatarUrl ?? null,
               url: fromAPI.url ?? null,
               twitter: fromAPI.twitterUsername ? { handle: fromAPI.twitterUsername } : null,
-              website: fromAPI.websiteUrl ?? null
+              website: fromAPI.websiteUrl ?? null,
             },
           ]
         } else {

--- a/backend/src/serverless/integrations/webhooks/github.ts
+++ b/backend/src/serverless/integrations/webhooks/github.ts
@@ -381,6 +381,7 @@ export default class GitHubWebhook {
               logo: fromAPI.avatarUrl ?? null,
               url: fromAPI.url ?? null,
               twitter: fromAPI.twitterUsername ? { handle: fromAPI.twitterUsername } : null,
+              website: fromAPI.websiteUrl ?? null
             },
           ]
         } else {

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -674,7 +674,7 @@ describe('MemberService tests', () => {
 
       expect(o1).toStrictEqual({
         id: organization.id,
-        name: 'Crowd.dev',
+        name: 'crowd.dev',
         url: 'crowd.dev',
         description:
           'Understand, grow, and engage your developer community with zero hassle. With crowd.dev, you can build developer communities that drive your business forward.',

--- a/backend/src/services/__tests__/organizationService.test.ts
+++ b/backend/src/services/__tests__/organizationService.test.ts
@@ -72,50 +72,6 @@ describe('OrganizationService tests', () => {
       expect(added.url).toEqual(null)
     })
 
-    it('Should enrich and add an organization by URL', async () => {
-      const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
-      const service = new OrganizationService(mockIServiceOptions)
-
-      const toAdd = {
-        url: 'crowd.dev',
-      }
-
-      const added = await service.findOrCreate(toAdd)
-      expect(added.url).toEqual('crowd.dev')
-      expect(added.name).toEqual(expectedEnriched.name)
-      expect(added.description).toEqual(expectedEnriched.description)
-      expect(added.parentUrl).toEqual(expectedEnriched.parentUrl)
-      expect(added.emails).toEqual(expectedEnriched.emails)
-      expect(added.phoneNumbers).toEqual(expectedEnriched.phoneNumbers)
-      expect(added.logo).toEqual(expectedEnriched.logo)
-      expect(added.tags).toStrictEqual(expectedEnriched.tags)
-      expect(added.twitter).toStrictEqual(expectedEnriched.twitter)
-      expect(added.linkedin).toStrictEqual(expectedEnriched.linkedin)
-      expect(added.crunchbase).toStrictEqual(expectedEnriched.crunchbase)
-      expect(added.employees).toEqual(expectedEnriched.employees)
-      expect(added.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
-
-      // Check cache table was created
-      const foundCache = await organizationCacheRepository.findByUrl(
-        'crowd.dev',
-        mockIServiceOptions,
-      )
-
-      expect(foundCache.url).toEqual('crowd.dev')
-      expect(foundCache.name).toEqual(expectedEnriched.name)
-      expect(foundCache.description).toEqual(expectedEnriched.description)
-      expect(foundCache.parentUrl).toEqual(expectedEnriched.parentUrl)
-      expect(foundCache.emails).toEqual(expectedEnriched.emails)
-      expect(foundCache.phoneNumbers).toEqual(expectedEnriched.phoneNumbers)
-      expect(foundCache.logo).toEqual(expectedEnriched.logo)
-      expect(foundCache.tags).toStrictEqual(expectedEnriched.tags)
-      expect(foundCache.twitter).toStrictEqual(expectedEnriched.twitter)
-      expect(foundCache.linkedin).toStrictEqual(expectedEnriched.linkedin)
-      expect(foundCache.crunchbase).toStrictEqual(expectedEnriched.crunchbase)
-      expect(foundCache.employees).toEqual(expectedEnriched.employees)
-      expect(foundCache.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
-    })
-
     it('Should enrich and add an organization by name', async () => {
       const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
       const service = new OrganizationService(mockIServiceOptions)
@@ -126,7 +82,7 @@ describe('OrganizationService tests', () => {
 
       const added = await service.findOrCreate(toAdd)
       expect(added.url).toEqual('crowd.dev')
-      expect(added.name).toEqual(expectedEnriched.name)
+      expect(added.name).toEqual(toAdd.name)
       expect(added.description).toEqual(expectedEnriched.description)
       expect(added.parentUrl).toEqual(expectedEnriched.parentUrl)
       expect(added.emails).toEqual(expectedEnriched.emails)
@@ -140,13 +96,13 @@ describe('OrganizationService tests', () => {
       expect(added.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
 
       // Check cache table was created
-      const foundCache = await organizationCacheRepository.findByUrl(
+      const foundCache = await organizationCacheRepository.findByName(
         'crowd.dev',
         mockIServiceOptions,
       )
 
       expect(foundCache.url).toEqual('crowd.dev')
-      expect(foundCache.name).toEqual(expectedEnriched.name)
+      expect(foundCache.name).toEqual(toAdd.name)
       expect(foundCache.description).toEqual(expectedEnriched.description)
       expect(foundCache.parentUrl).toEqual(expectedEnriched.parentUrl)
       expect(foundCache.emails).toEqual(expectedEnriched.emails)
@@ -160,7 +116,7 @@ describe('OrganizationService tests', () => {
       expect(foundCache.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
     })
 
-    it('Should not re-enrich when the record is already in the cache table. By URL', async () => {
+    it('Should not re-enrich when the record is already in the cache table. By Name', async () => {
       const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
       const mockIServiceOptions2 = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
 
@@ -168,12 +124,12 @@ describe('OrganizationService tests', () => {
       const service2 = new OrganizationService(mockIServiceOptions2)
 
       const toAdd = {
-        url: 'https://crowd.dev',
+        name: 'crowd.dev',
       }
 
       const added = await service.findOrCreate(toAdd)
       expect(added.url).toEqual('crowd.dev')
-      expect(added.name).toEqual(expectedEnriched.name)
+      expect(added.name).toEqual(toAdd.name)
       expect(added.description).toEqual(expectedEnriched.description)
       expect(added.parentUrl).toEqual(expectedEnriched.parentUrl)
       expect(added.emails).toEqual(expectedEnriched.emails)
@@ -187,13 +143,12 @@ describe('OrganizationService tests', () => {
       expect(added.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
 
       // Check cache table was created
-      const foundCache = await organizationCacheRepository.findByUrl(
+      const foundCache = await organizationCacheRepository.findByName(
         'crowd.dev',
         mockIServiceOptions,
       )
 
-      expect(foundCache.url).toEqual('crowd.dev')
-      expect(foundCache.name).toEqual(expectedEnriched.name)
+      expect(foundCache.name).toEqual('crowd.dev')
       expect(foundCache.description).toEqual(expectedEnriched.description)
       expect(foundCache.parentUrl).toEqual(expectedEnriched.parentUrl)
       expect(foundCache.emails).toEqual(expectedEnriched.emails)
@@ -207,8 +162,7 @@ describe('OrganizationService tests', () => {
       expect(foundCache.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
 
       const added2 = await service2.findOrCreate(toAdd)
-      expect(added2.url).toEqual('crowd.dev')
-      expect(added2.name).toEqual(expectedEnriched.name)
+      expect(added2.name).toEqual('crowd.dev')
       expect(added2.description).toEqual(expectedEnriched.description)
       expect(added2.parentUrl).toEqual(expectedEnriched.parentUrl)
       expect(added2.emails).toEqual(expectedEnriched.emails)
@@ -223,21 +177,21 @@ describe('OrganizationService tests', () => {
       // Check they are indeed in different tenants
       expect(added2.tenantId).not.toBe(added.tenantId)
 
-      const foundCache2 = await organizationCacheRepository.findByUrl(
+      const foundCache2 = await organizationCacheRepository.findByName(
         'crowd.dev',
         mockIServiceOptions,
       )
       expect(foundCache2.id).toEqual(foundCache.id)
     })
 
-    it('Should throw an error when name and URL are not sent', async () => {
+    it('Should throw an error when name is not sent', async () => {
       const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
       const service = new OrganizationService(mockIServiceOptions)
 
       const toAdd = {}
 
       await expect(service.findOrCreate(toAdd)).rejects.toThrowError(
-        'Organization Name or Url is required',
+        'Organization Name is required',
       )
     })
 
@@ -258,35 +212,5 @@ describe('OrganizationService tests', () => {
       const foundAll = await service.findAndCountAll({ filter: {} })
       expect(foundAll.count).toBe(1)
     })
-
-    // it('Should not re-create when existing: enrich and name', async () => {
-    //   const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db, 'premium')
-    //   const service = new OrganizationService(mockIServiceOptions)
-    //
-    //   const toAdd = {
-    //     name: 'crowd.dev',
-    //   }
-    //
-    //   await service.findOrCreate(toAdd)
-    //
-    //
-    //   const added = await service.findOrCreate(SequelizeTestUtils.objectWithoutKey(toAdd, 'url'))
-    //   expect(added.url).toEqual('crowd.dev')
-    //   expect(added.name).toEqual(expectedEnriched.name)
-    //   expect(added.description).toEqual(expectedEnriched.description)
-    //   expect(added.parentUrl).toEqual(expectedEnriched.parentUrl)
-    //   expect(added.emails).toEqual(expectedEnriched.emails)
-    //   expect(added.phoneNumbers).toEqual(expectedEnriched.phoneNumbers)
-    //   expect(added.logo).toEqual(expectedEnriched.logo)
-    //   expect(added.tags).toStrictEqual(expectedEnriched.tags)
-    //   expect(added.twitter).toStrictEqual(expectedEnriched.twitter)
-    //   expect(added.linkedin).toStrictEqual(expectedEnriched.linkedin)
-    //   expect(added.crunchbase).toStrictEqual(expectedEnriched.crunchbase)
-    //   expect(added.employees).toEqual(expectedEnriched.employees)
-    //   expect(added.revenueRange).toStrictEqual(expectedEnriched.revenueRange)
-    //
-    //   const foundAll = await service.findAndCountAll({ filter: {} })
-    //   expect(foundAll.count).toBe(1)
-    // })
   })
 })


### PR DESCRIPTION
# Changes proposed ✍️

- `organizations` now only use name field as unique identifier
- `organizationCache` new boolean field: `enriched`. For clearbit enrichment, we now use this field to check if a cache entry was already enriched or not
- simplifies `organization.findOrCreate` function. Now we always check if an organization exists in cache:
if it exists in cache, we overwrite the cache with incoming data and save it to cache for future use
if it doesn't exist in cache, create cache with incoming data.
Then we use this cache entry to create organizations entity. 
If user is premium, data is also enriched using clearbit and `organizationCache.enriched` is set to true so that we don't query for same organization multiple times.
- Website is now successfully retrieved from github organization queries.

## Checklist ✅

- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.
