### PR TITLE
Fix average sentiment filter throwing a 500 error

### DIFF
--- a/frontend/src/shared/fields/sentiment-field.js
+++ b/frontend/src/shared/fields/sentiment-field.js
@@ -25,8 +25,7 @@ export default class SentimentField extends GenericField {
         value: 'neutral',
         label: 'Neutral',
         range: {
-          gt: 33,
-          lt: 67
+          between: [33, 67]
         }
       },
       {

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -48,8 +48,7 @@ function _buildAttributeBlock(attribute) {
       },
       { or: [] }
     )
-  }
-  else if (attribute.name === 'averageSentiment') {
+  } else if (attribute.name === 'averageSentiment') {
     return attribute.value.reduce(
       (obj, a) => {
         obj.or.push({

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -48,7 +48,19 @@ function _buildAttributeBlock(attribute) {
       },
       { or: [] }
     )
-  } else if (attribute.name === 'type') {
+  }
+  else if (attribute.name === 'averageSentiment') {
+    return attribute.value.reduce(
+      (obj, a) => {
+        obj.or.push({
+          averageSentiment: a.range
+        })
+
+        return obj
+      },
+      { or: [] }
+    )
+  }else if (attribute.name === 'type') {
     return {
       and: [
         {

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -59,7 +59,7 @@ function _buildAttributeBlock(attribute) {
       },
       { or: [] }
     )
-  }else if (attribute.name === 'type') {
+  } else if (attribute.name === 'type') {
     return {
       and: [
         {


### PR DESCRIPTION
# Changes proposed ✍️

- Changed `averageSentiment` to use range.
- For neutral, we were using `{gt: 33, lt: 66}`. This was not working, it was only getting greater-than. I changed it to `between: [33, 66]`. 

## Checklist ✅

- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.
