### PR TITLE
Github organization enrichment: name sanitization

### DIFF
--- a/backend/src/database/migrations/U1669832400__organizationCacheIndexUpdates.sql
+++ b/backend/src/database/migrations/U1669832400__organizationCacheIndexUpdates.sql
@@ -1,0 +1,4 @@
+create unique index organization_caches_url
+    on "organizationCaches" (url);
+
+drop index public.organization_caches_name;

--- a/backend/src/database/migrations/V1669832400__organizationCacheIndexUpdates.sql
+++ b/backend/src/database/migrations/V1669832400__organizationCacheIndexUpdates.sql
@@ -1,0 +1,4 @@
+create unique index organization_caches_name
+    on "organizationCaches" (name);
+
+drop index public.organization_caches_url;

--- a/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
@@ -16,7 +16,7 @@ const getOrganization = async (name: string, token: string): Promise<any> => {
       },
     })
 
-    const sanitizedName = name.replaceAll('\\', '').replaceAll('\\"', '')
+    const sanitizedName = name.replaceAll('\\', '').replaceAll('"', '')
 
     const organizationsQuery = `{
       search(query: "type:org ${sanitizedName}", type: USER, first: 10) {

--- a/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/organizations.ts
@@ -16,7 +16,7 @@ const getOrganization = async (name: string, token: string): Promise<any> => {
       },
     })
 
-    const sanitizedName = name.replaceAll('\\', '')
+    const sanitizedName = name.replaceAll('\\', '').replaceAll('\\"', '')
 
     const organizationsQuery = `{
       search(query: "type:org ${sanitizedName}", type: USER, first: 10) {


### PR DESCRIPTION
# Changes proposed ✍️
- Removes url unique index from organizationCaches (so it has same indexes with organization entity)
- Cleans organization name from double quotes before sending it for enrichment to gh api

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.