### PR TITLE
Stop processing if there are no posts with such hashtag

### DIFF
--- a/backend/src/serverless/integrations/usecases/twitter/getPostsByHashtag.ts
+++ b/backend/src/serverless/integrations/usecases/twitter/getPostsByHashtag.ts
@@ -39,6 +39,18 @@ const getPostsByHashtag = async (
 
   try {
     const response = await axios(config)
+    const limit = parseInt(response.headers['x-rate-limit-remaining'], 10)
+    const resetTs = parseInt(response.headers['x-rate-limit-reset'], 10) * 1000
+    const timeUntilReset = moment(resetTs).diff(moment(), 'seconds')
+
+    if (response.data?.meta?.result_count === 0) {
+      return {
+        records: [],
+        limit,
+        timeUntilReset,
+        nextPage: '',
+      }
+    }
 
     const posts = response.data.data
     const media = response.data.includes.media
@@ -58,9 +70,6 @@ const getPostsByHashtag = async (
       postsOut.push(post)
     }
 
-    const limit = parseInt(response.headers['x-rate-limit-remaining'], 10)
-    const resetTs = parseInt(response.headers['x-rate-limit-reset'], 10) * 1000
-    const timeUntilReset = moment(resetTs).diff(moment(), 'seconds')
     return {
       records: postsOut,
       nextPage: response.data?.meta?.next_token || '',


### PR DESCRIPTION
# Changes proposed ✍️
- If no posts are returned there is no data except `meta.result_count` property that shows 0 posts returned. We have to check this and ignore processing because other properties won't be there in case there are no results.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.