### PR TITLE
Preserve old member email if we receive empty string from an integration

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -439,7 +439,13 @@ export default class MemberService extends LoggingBase {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       displayName: (oldValue, _newValue) => oldValue,
       reach: (oldReach, newReach) => MemberService.calculateReach(oldReach, newReach),
+      email: (oldEmail, newEmail) => {
+        if (newEmail && newEmail.strip().length > 0) {
+          return newEmail.strip()
+        }
 
+        return oldEmail
+      },
       // Get rid of activities that are the same and were in both members
       activities: (oldActivities, newActivities) => {
         oldActivities = oldActivities || []


### PR DESCRIPTION
# Changes proposed ✍️
- If we already have an email in the database and we received an empty string from an integration we shouldn't use that empty string to upsert the member but we should keep the old email.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.