### PR TITLE
Ensure index attributes call removed while creating a document

### DIFF
--- a/backend/src/search-engine/repositories/indexable.ts
+++ b/backend/src/search-engine/repositories/indexable.ts
@@ -57,7 +57,6 @@ export default abstract class Indexable {
    * @param {Document} document document to be created
    */
   async createOrReplace(document: Document): Promise<void> {
-    await this.ensureIndexAttributes()
     await this.index.addDocuments([document])
   }
 


### PR DESCRIPTION
# Changes proposed ✍️
- Ensuring index properties on each creates is unnecessary, removed the `ensureIndexSettings` call on create a document.
- I'll provide util functions to change these settings in a migration manner, tho this needs to be merged so the task queue can process the already existing tasks in the queue 

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.