### PR TITLE
Show "-" in engagement level for team members

### DIFF
--- a/frontend/src/modules/member/components/member-engagement-level.vue
+++ b/frontend/src/modules/member/components/member-engagement-level.vue
@@ -10,6 +10,12 @@
           >Computing</span
         >
       </div>
+      <div v-else-if="member.attributes.isTeamMember?.crowd">
+      <span
+          class="block mr-2 text-xs font-semibold text-gray-500"
+          >-</span
+        >
+      </div>
       <div
         v-else
         class="member-engagement-level"


### PR DESCRIPTION
# Changes proposed ✍️
- Showing _-_ for engagement level in team members

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.