### PR TITLE
Tenants created after the 18th of December only had trial for 14 days. It should be until the 15th of January.

### DIFF
--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -50,7 +50,7 @@ class TenantRepository {
         ]),
         plan: 'Growth',
         isTrialPlan: true,
-        trialEndsAt: moment().add(14, 'days').isAfter('2023-01-01')
+        trialEndsAt: moment().add(14, 'days').isAfter('2023-01-15')
           ? moment().add(14, 'days').toISOString()
           : '2023-01-15',
         createdById: currentUser.id,

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import SequelizeTestUtils from '../../database/utils/sequelizeTestUtils'
 import TenantService from '../tenantService'
 import MemberService from '../memberService'
@@ -152,7 +153,9 @@ describe('TenantService tests', () => {
         url: 'testUrl',
         plan: Plans.values.growth,
         isTrialPlan: true,
-        trialEndsAt: new Date('2023-01-15T00:00:00.000Z'),
+        trialEndsAt: moment().add(14, 'days').isAfter('2023-01-15')
+          ? moment().add(14, 'days').toISOString()
+          : new Date('2023-01-15T00:00:00.000Z'),
         planStatus: 'active',
         planStripeCustomerId: null,
         planUserId: null,


### PR DESCRIPTION
# Changes proposed ✍️
- Tenants created after the 18th of December only had trial for 14 days. It should be until the 15th of January.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.