### PR TITLE
Change "Read more" URL for custom integrations

### DIFF
--- a/frontend/src/modules/integration/components/integration-connect.vue
+++ b/frontend/src/modules/integration/components/integration-connect.vue
@@ -19,7 +19,7 @@
   </component>
   <a
     v-else-if="props.integration.platform === 'custom'"
-    href="https://docs.crowd.dev/v0/reference/"
+    href="https://crowd.dev/integration-framework"
     target="_blank"
     class="btn btn-brand btn-brand--primary btn--md"
     >Read more</a


### PR DESCRIPTION
from "https://docs.crowd.dev/v0/reference/" to "https://crowd.dev/integration-framework"

# Changes proposed ✍️
- The old URL contains a versioned link to v0 of the docs which do not contain information about the integration framework.

  
- ### Screenshots (front-end changes only)
      - ...

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.