### PR TITLE
Fix most engaged view sorter

### DIFF
--- a/frontend/src/modules/member/store/state.js
+++ b/frontend/src/modules/member/store/state.js
@@ -114,7 +114,7 @@ export default () => {
           order: 'descending'
         },
         sorter: {
-          prop: 'lastActive',
+          prop: 'score',
           order: 'descending'
         },
         active: false


### PR DESCRIPTION
# Changes proposed ✍️
- Update sorter from `lastActive` to `score`
  
### Screenshots (front-end changes only)
![Screenshot 2022-12-21 at 17 16 55](https://user-images.githubusercontent.com/20134207/208965246-bdedb046-56a7-4a2f-824c-d54358383ee0.png)


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.