### PR TITLE
Fix joined date filter organization

### DIFF
--- a/frontend/src/modules/organization/store/constants.js
+++ b/frontend/src/modules/organization/store/constants.js
@@ -1,6 +1,5 @@
 import { formatDate } from '@/utils/date'
 import OrganizationEmployeesField from '@/modules/organization/organization-employees-field'
-import ActivityDateField from '@/shared/fields/activity-date-field'
 
 export const INITIAL_PAGE_SIZE = 20
 
@@ -11,19 +10,16 @@ export const INITIAL_VIEW_NEW_AND_ACTIVE_FILTER = {
       name: 'joinedAt',
       label: 'Joined date',
       custom: false,
-      props: {
-        options: new ActivityDateField().dropdownOptions(),
-        multiple: false
-      },
+      props: {},
       defaultValue: formatDate({
         subtractDays: 30
       }),
       value: formatDate({
         subtractDays: 30
       }),
-      defaultOperator: 'gte',
-      operator: 'gte',
-      type: 'select',
+      defaultOperator: 'eq',
+      operator: 'eq',
+      type: 'date',
       expanded: false
     }
   }

--- a/frontend/src/modules/organization/store/constants.js
+++ b/frontend/src/modules/organization/store/constants.js
@@ -17,8 +17,8 @@ export const INITIAL_VIEW_NEW_AND_ACTIVE_FILTER = {
       value: formatDate({
         subtractDays: 30
       }),
-      defaultOperator: 'eq',
-      operator: 'eq',
+      defaultOperator: 'gt',
+      operator: 'gt',
       type: 'date',
       expanded: false
     }


### PR DESCRIPTION
# Changes proposed ✍️
- The default "Joined at" filter in "New and active" tab in the Organizations module was not updated. It was still a dropdown filter. This PR updates it to a date time picker, matching all other joined at filters
  
### Screenshots (front-end changes only)
![Screenshot 2022-12-22 at 17 12 15](https://user-images.githubusercontent.com/20134207/209189505-e6ad57a3-d270-46ae-9a69-3bed7fb985ef.png)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.