### PR TITLE
Cubejs preaggregations dimension updates

### DIFF
--- a/backend/src/cubejs/schema/Activities.js
+++ b/backend/src/cubejs/schema/Activities.js
@@ -1,149 +1,149 @@
 cube(`Activities`, {
-    sql: `SELECT * FROM public.activities`,
+  sql: `SELECT * FROM public.activities`,
 
-    preAggregations: {
-        Activities: {
-            measures: [Activities.count],
-            dimensions: [
-                Activities.platform,
-                Activities.type,
-                Members.score,
-                Members.location,
-                Members.tenantId,
-                Members.isTeamMember,
-                Members.isBot,
-                Activities.tenantId,
-            ],
-            timeDimension: Activities.date,
-            granularity: `day`,
-            refreshKey: {
-                every: `10 minute`,
-            },
-        },
+  preAggregations: {
+    Activities: {
+      measures: [Activities.count],
+      dimensions: [
+        Activities.platform,
+        Activities.type,
+        Members.score,
+        Members.location,
+        Members.tenantId,
+        Members.isTeamMember,
+        Members.isBot,
+        Activities.tenantId,
+      ],
+      timeDimension: Activities.date,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
+    },
+  },
+
+  joins: {
+    Members: {
+      sql: `${CUBE}."memberId" = ${Members}."id"`,
+      relationship: `belongsTo`,
+    },
+  },
+
+  measures: {
+    count: {
+      type: `count`,
+      drillMembers: [
+        memberId,
+        sourceid,
+        tenantId,
+        id,
+        updatedbyid,
+        parentid,
+        createdbyid,
+        createdat,
+        updatedat,
+        date,
+      ],
+    },
+  },
+
+  dimensions: {
+    memberId: {
+      sql: `${CUBE}."memberId"`,
+      type: `string`,
+      shown: false,
     },
 
-    joins: {
-        Members: {
-            sql: `${CUBE}."memberId" = ${Members}."id"`,
-            relationship: `belongsTo`,
-        },
+    sentimentMood: {
+      case: {
+        when: [
+          { sql: `${CUBE}.sentiment->>'sentiment' is null`, label: `no data` },
+          { sql: `(${CUBE}.sentiment->>'sentiment')::integer < 34`, label: `negative` },
+          { sql: `(${CUBE}.sentiment->>'sentiment')::integer > 66`, label: `positive` },
+        ],
+        else: { label: `neutral` },
+      },
+      type: `string`,
     },
 
-    measures: {
-        count: {
-            type: `count`,
-            drillMembers: [
-                memberId,
-                sourceid,
-                tenantId,
-                id,
-                updatedbyid,
-                parentid,
-                createdbyid,
-                createdat,
-                updatedat,
-                date,
-            ],
-        },
+    sourceid: {
+      sql: `${CUBE}."sourceId"`,
+      type: `string`,
+      shown: false,
     },
 
-    dimensions: {
-        memberId: {
-            sql: `${CUBE}."memberId"`,
-            type: `string`,
-            shown: false,
-        },
-
-        sentimentMood: {
-            case: {
-                when: [
-                    { sql: `${CUBE}.sentiment->>'sentiment' is null`, label: `no data` },
-                    { sql: `(${CUBE}.sentiment->>'sentiment')::integer < 34`, label: `negative` },
-                    { sql: `(${CUBE}.sentiment->>'sentiment')::integer > 66`, label: `positive` },
-                ],
-                else: { label: `neutral` },
-            },
-            type: `string`,
-        },
-
-        sourceid: {
-            sql: `${CUBE}."sourceId"`,
-            type: `string`,
-            shown: false,
-        },
-
-        platform: {
-            sql: `platform`,
-            type: `string`,
-        },
-
-        channel: {
-            sql: `channel`,
-            type: `string`,
-        },
-
-        tenantId: {
-            sql: `${CUBE}."tenantId"`,
-            type: `string`,
-            shown: false,
-        },
-
-        id: {
-            sql: `id`,
-            type: `string`,
-            primaryKey: true,
-        },
-
-        type: {
-            sql: `type`,
-            type: `string`,
-        },
-
-        updatedbyid: {
-            sql: `${CUBE}."updatedById"`,
-            type: `string`,
-            shown: false,
-        },
-
-        iskeyaction: {
-            sql: `${CUBE}."isKeyAction"`,
-            type: `string`,
-            shown: false,
-        },
-
-        parentid: {
-            sql: `${CUBE}."parentId"`,
-            type: `string`,
-            shown: false,
-        },
-
-        createdbyid: {
-            sql: `${CUBE}."createdById"`,
-            type: `string`,
-            shown: false,
-        },
-
-        createdat: {
-            sql: `${CUBE}."createdAt"`,
-            type: `time`,
-            shown: false,
-        },
-
-        updatedat: {
-            sql: `${CUBE}."updatedAt"`,
-            type: `time`,
-            shown: false,
-        },
-
-        date: {
-            sql: `timestamp`,
-            type: `time`,
-        },
-
-        deletedat: {
-            sql: `${CUBE}."deletedAt"`,
-            type: `time`,
-            shown: false,
-        },
+    platform: {
+      sql: `platform`,
+      type: `string`,
     },
+
+    channel: {
+      sql: `channel`,
+      type: `string`,
+    },
+
+    tenantId: {
+      sql: `${CUBE}."tenantId"`,
+      type: `string`,
+      shown: false,
+    },
+
+    id: {
+      sql: `id`,
+      type: `string`,
+      primaryKey: true,
+    },
+
+    type: {
+      sql: `type`,
+      type: `string`,
+    },
+
+    updatedbyid: {
+      sql: `${CUBE}."updatedById"`,
+      type: `string`,
+      shown: false,
+    },
+
+    iskeyaction: {
+      sql: `${CUBE}."isKeyAction"`,
+      type: `string`,
+      shown: false,
+    },
+
+    parentid: {
+      sql: `${CUBE}."parentId"`,
+      type: `string`,
+      shown: false,
+    },
+
+    createdbyid: {
+      sql: `${CUBE}."createdById"`,
+      type: `string`,
+      shown: false,
+    },
+
+    createdat: {
+      sql: `${CUBE}."createdAt"`,
+      type: `time`,
+      shown: false,
+    },
+
+    updatedat: {
+      sql: `${CUBE}."updatedAt"`,
+      type: `time`,
+      shown: false,
+    },
+
+    date: {
+      sql: `timestamp`,
+      type: `time`,
+    },
+
+    deletedat: {
+      sql: `${CUBE}."deletedAt"`,
+      type: `time`,
+      shown: false,
+    },
+  },
 })

--- a/backend/src/cubejs/schema/Activities.js
+++ b/backend/src/cubejs/schema/Activities.js
@@ -1,147 +1,149 @@
 cube(`Activities`, {
-  sql: `SELECT * FROM public.activities`,
+    sql: `SELECT * FROM public.activities`,
 
-  preAggregations: {
-    Activities: {
-      measures: [Activities.count],
-      dimensions: [
-        Activities.platform,
-        Activities.type,
-        Members.score,
-        Members.location,
-        Members.tenantId,
-        Activities.tenantId,
-      ],
-      timeDimension: Activities.date,
-      granularity: `day`,
-      refreshKey: {
-        every: `10 minute`,
-      },
-    },
-  },
-
-  joins: {
-    Members: {
-      sql: `${CUBE}."memberId" = ${Members}."id"`,
-      relationship: `belongsTo`,
-    },
-  },
-
-  measures: {
-    count: {
-      type: `count`,
-      drillMembers: [
-        memberId,
-        sourceid,
-        tenantId,
-        id,
-        updatedbyid,
-        parentid,
-        createdbyid,
-        createdat,
-        updatedat,
-        date,
-      ],
-    },
-  },
-
-  dimensions: {
-    memberId: {
-      sql: `${CUBE}."memberId"`,
-      type: `string`,
-      shown: false,
+    preAggregations: {
+        Activities: {
+            measures: [Activities.count],
+            dimensions: [
+                Activities.platform,
+                Activities.type,
+                Members.score,
+                Members.location,
+                Members.tenantId,
+                Members.isTeamMember,
+                Members.isBot,
+                Activities.tenantId,
+            ],
+            timeDimension: Activities.date,
+            granularity: `day`,
+            refreshKey: {
+                every: `10 minute`,
+            },
+        },
     },
 
-    sentimentMood: {
-      case: {
-        when: [
-          { sql: `${CUBE}.sentiment->>'sentiment' is null`, label: `no data` },
-          { sql: `(${CUBE}.sentiment->>'sentiment')::integer < 34`, label: `negative` },
-          { sql: `(${CUBE}.sentiment->>'sentiment')::integer > 66`, label: `positive` },
-        ],
-        else: { label: `neutral` },
-      },
-      type: `string`,
+    joins: {
+        Members: {
+            sql: `${CUBE}."memberId" = ${Members}."id"`,
+            relationship: `belongsTo`,
+        },
     },
 
-    sourceid: {
-      sql: `${CUBE}."sourceId"`,
-      type: `string`,
-      shown: false,
+    measures: {
+        count: {
+            type: `count`,
+            drillMembers: [
+                memberId,
+                sourceid,
+                tenantId,
+                id,
+                updatedbyid,
+                parentid,
+                createdbyid,
+                createdat,
+                updatedat,
+                date,
+            ],
+        },
     },
 
-    platform: {
-      sql: `platform`,
-      type: `string`,
-    },
+    dimensions: {
+        memberId: {
+            sql: `${CUBE}."memberId"`,
+            type: `string`,
+            shown: false,
+        },
 
-    channel: {
-      sql: `channel`,
-      type: `string`,
-    },
+        sentimentMood: {
+            case: {
+                when: [
+                    { sql: `${CUBE}.sentiment->>'sentiment' is null`, label: `no data` },
+                    { sql: `(${CUBE}.sentiment->>'sentiment')::integer < 34`, label: `negative` },
+                    { sql: `(${CUBE}.sentiment->>'sentiment')::integer > 66`, label: `positive` },
+                ],
+                else: { label: `neutral` },
+            },
+            type: `string`,
+        },
 
-    tenantId: {
-      sql: `${CUBE}."tenantId"`,
-      type: `string`,
-      shown: false,
-    },
+        sourceid: {
+            sql: `${CUBE}."sourceId"`,
+            type: `string`,
+            shown: false,
+        },
 
-    id: {
-      sql: `id`,
-      type: `string`,
-      primaryKey: true,
-    },
+        platform: {
+            sql: `platform`,
+            type: `string`,
+        },
 
-    type: {
-      sql: `type`,
-      type: `string`,
-    },
+        channel: {
+            sql: `channel`,
+            type: `string`,
+        },
 
-    updatedbyid: {
-      sql: `${CUBE}."updatedById"`,
-      type: `string`,
-      shown: false,
-    },
+        tenantId: {
+            sql: `${CUBE}."tenantId"`,
+            type: `string`,
+            shown: false,
+        },
 
-    iskeyaction: {
-      sql: `${CUBE}."isKeyAction"`,
-      type: `string`,
-      shown: false,
-    },
+        id: {
+            sql: `id`,
+            type: `string`,
+            primaryKey: true,
+        },
 
-    parentid: {
-      sql: `${CUBE}."parentId"`,
-      type: `string`,
-      shown: false,
-    },
+        type: {
+            sql: `type`,
+            type: `string`,
+        },
 
-    createdbyid: {
-      sql: `${CUBE}."createdById"`,
-      type: `string`,
-      shown: false,
-    },
+        updatedbyid: {
+            sql: `${CUBE}."updatedById"`,
+            type: `string`,
+            shown: false,
+        },
 
-    createdat: {
-      sql: `${CUBE}."createdAt"`,
-      type: `time`,
-      shown: false,
-    },
+        iskeyaction: {
+            sql: `${CUBE}."isKeyAction"`,
+            type: `string`,
+            shown: false,
+        },
 
-    updatedat: {
-      sql: `${CUBE}."updatedAt"`,
-      type: `time`,
-      shown: false,
-    },
+        parentid: {
+            sql: `${CUBE}."parentId"`,
+            type: `string`,
+            shown: false,
+        },
 
-    date: {
-      sql: `timestamp`,
-      type: `time`,
-    },
+        createdbyid: {
+            sql: `${CUBE}."createdById"`,
+            type: `string`,
+            shown: false,
+        },
 
-    deletedat: {
-      sql: `${CUBE}."deletedAt"`,
-      type: `time`,
-      shown: false,
+        createdat: {
+            sql: `${CUBE}."createdAt"`,
+            type: `time`,
+            shown: false,
+        },
+
+        updatedat: {
+            sql: `${CUBE}."updatedAt"`,
+            type: `time`,
+            shown: false,
+        },
+
+        date: {
+            sql: `timestamp`,
+            type: `time`,
+        },
+
+        deletedat: {
+            sql: `${CUBE}."deletedAt"`,
+            type: `time`,
+            shown: false,
+        },
     },
-  },
 })

--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -1,5 +1,5 @@
 cube(`Members`, {
-    sql: `SELECT M.*, 
+  sql: `SELECT M.*, 
 		  CASE 
 		 	    WHEN DATE_PART('day', MIN(a.timestamp)::timestamp - M."joinedAt"::TIMESTAMP) < 0 THEN 0
 		 	    WHEN MIN(M."joinedAt") < '1980-01-01' THEN 0
@@ -12,171 +12,184 @@ cube(`Members`, {
       LEFT JOIN activities a ON (a."memberId" = m.id AND a."isKeyAction"=TRUE)
       GROUP BY m.id`,
 
-    preAggregations: {
-        ActiveMembers: {
-            measures: [Members.count],
-            dimensions: [Members.score, Members.location, Members.tenantId, Tags.name, Members.isTeamMember, Members.isBot],
-            timeDimension: Members.joinedAt,
-            granularity: `day`,
-            refreshKey: {
-                every: `10 minute`,
-            },
-        },
-
-        MembersActivities: {
-            measures: [Members.count],
-            dimensions: [Members.tenantId, Activities.platform, Activities.type, Members.isTeamMember, Members.isBot],
-            timeDimension: Members.joinedAt,
-            granularity: `day`,
-            refreshKey: {
-                every: `10 minute`,
-            },
-        },
-
-        MembersTags: {
-            measures: [Members.count],
-            dimensions: [Members.tenantId, Tags.name, Members.isTeamMember, Members.isBot],
-            timeDimension: Members.joinedAt,
-            granularity: `day`,
-            refreshKey: {
-                every: `10 minute`,
-            },
-        },
+  preAggregations: {
+    ActiveMembers: {
+      measures: [Members.count],
+      dimensions: [
+        Members.score,
+        Members.location,
+        Members.tenantId,
+        Tags.name,
+        Members.isTeamMember,
+        Members.isBot,
+      ],
+      timeDimension: Members.joinedAt,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
     },
 
-    joins: {
-        Activities: {
-            sql: `${CUBE}.id = ${Activities}."memberId"`,
-            relationship: `hasMany`,
-        },
-
-        MemberTags: {
-            sql: `${CUBE}.id = ${MemberTags}."memberId"`,
-            relationship: `belongsTo`,
-        },
-
-        MemberOrganizations: {
-            sql: `${CUBE}.id = ${MemberOrganizations}."memberId"`,
-            relationship: `belongsTo`,
-        },
-
-        MemberIdentities: {
-            sql: `${CUBE}.id = ${MemberIdentities}."memberId"`,
-            relationship: `belongsTo`,
-        },
+    MembersActivities: {
+      measures: [Members.count],
+      dimensions: [
+        Members.tenantId,
+        Activities.platform,
+        Activities.type,
+        Members.isTeamMember,
+        Members.isBot,
+      ],
+      timeDimension: Members.joinedAt,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
     },
 
-    measures: {
-        count: {
-            type: `count`,
-        },
+    MembersTags: {
+      measures: [Members.count],
+      dimensions: [Members.tenantId, Tags.name, Members.isTeamMember, Members.isBot],
+      timeDimension: Members.joinedAt,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
+    },
+  },
 
-        earliestJoinedAt: {
-            type: `min`,
-            sql: `${Members}."joinedAt"`,
-            shown: false,
-        },
-
-        averageTimeToFirstInteraction: {
-            type: 'avg',
-            sql: `time_to_first_interaction`,
-            shown: false,
-        },
+  joins: {
+    Activities: {
+      sql: `${CUBE}.id = ${Activities}."memberId"`,
+      relationship: `hasMany`,
     },
 
-    dimensions: {
-        email: {
-            sql: `email`,
-            type: `string`,
-            shown: false,
-        },
-
-        tenantId: {
-            sql: `${CUBE}."tenantId"`,
-            type: `string`,
-            shown: false,
-        },
-
-        location: {
-            sql: `COALESCE(${CUBE}.attributes->'location'->>'default', '')`,
-            type: `string`,
-        },
-
-        bio: {
-            sql: `COALESCE(${CUBE}.attributes->'bio'->>'default', '')`,
-            type: `string`,
-        },
-
-        info: {
-            sql: `info`,
-            type: `string`,
-            shown: false,
-        },
-
-        isTeamMember: {
-            sql: `COALESCE((${CUBE}.attributes->'isTeamMember'->'default')::boolean, false)`,
-            type: `boolean`,
-        },
-
-        isBot: {
-            sql: `COALESCE((${CUBE}.attributes->'isBot'->'default')::boolean, false)`,
-            type: `boolean`,
-        },
-
-        id: {
-            sql: `id`,
-            type: `string`,
-            primaryKey: true,
-        },
-
-        updatedbyid: {
-            sql: `${CUBE}."updatedById"`,
-            type: `string`,
-            shown: false,
-        },
-
-        username: {
-            sql: `${CUBE}."displayName"`,
-            type: `string`,
-            shown: false,
-        },
-
-        createdbyid: {
-            sql: `${CUBE}."createdById"`,
-            type: `string`,
-            shown: false,
-        },
-
-        createdat: {
-            sql: `${CUBE}."createdAt"`,
-            type: `time`,
-            shown: false,
-        },
-
-        updatedat: {
-            sql: `${CUBE}."updatedAt"`,
-            type: `time`,
-            shown: false,
-        },
-
-        deletedat: {
-            sql: `${CUBE}."deletedAt"`,
-            type: `time`,
-            shown: false,
-        },
-
-        joinedAt: {
-            sql: `${CUBE}."joinedAt"`,
-            type: `time`,
-        },
-        score: {
-            sql: `${CUBE}."score"`,
-            type: `number`,
-        },
-
-        identities: {
-            sql: `${CUBE}."identities"`,
-            type: `string`,
-        },
+    MemberTags: {
+      sql: `${CUBE}.id = ${MemberTags}."memberId"`,
+      relationship: `belongsTo`,
     },
+
+    MemberOrganizations: {
+      sql: `${CUBE}.id = ${MemberOrganizations}."memberId"`,
+      relationship: `belongsTo`,
+    },
+
+    MemberIdentities: {
+      sql: `${CUBE}.id = ${MemberIdentities}."memberId"`,
+      relationship: `belongsTo`,
+    },
+  },
+
+  measures: {
+    count: {
+      type: `count`,
+    },
+
+    earliestJoinedAt: {
+      type: `min`,
+      sql: `${Members}."joinedAt"`,
+      shown: false,
+    },
+
+    averageTimeToFirstInteraction: {
+      type: 'avg',
+      sql: `time_to_first_interaction`,
+      shown: false,
+    },
+  },
+
+  dimensions: {
+    email: {
+      sql: `email`,
+      type: `string`,
+      shown: false,
+    },
+
+    tenantId: {
+      sql: `${CUBE}."tenantId"`,
+      type: `string`,
+      shown: false,
+    },
+
+    location: {
+      sql: `COALESCE(${CUBE}.attributes->'location'->>'default', '')`,
+      type: `string`,
+    },
+
+    bio: {
+      sql: `COALESCE(${CUBE}.attributes->'bio'->>'default', '')`,
+      type: `string`,
+    },
+
+    info: {
+      sql: `info`,
+      type: `string`,
+      shown: false,
+    },
+
+    isTeamMember: {
+      sql: `COALESCE((${CUBE}.attributes->'isTeamMember'->'default')::boolean, false)`,
+      type: `boolean`,
+    },
+
+    isBot: {
+      sql: `COALESCE((${CUBE}.attributes->'isBot'->'default')::boolean, false)`,
+      type: `boolean`,
+    },
+
+    id: {
+      sql: `id`,
+      type: `string`,
+      primaryKey: true,
+    },
+
+    updatedbyid: {
+      sql: `${CUBE}."updatedById"`,
+      type: `string`,
+      shown: false,
+    },
+
+    username: {
+      sql: `${CUBE}."displayName"`,
+      type: `string`,
+      shown: false,
+    },
+
+    createdbyid: {
+      sql: `${CUBE}."createdById"`,
+      type: `string`,
+      shown: false,
+    },
+
+    createdat: {
+      sql: `${CUBE}."createdAt"`,
+      type: `time`,
+      shown: false,
+    },
+
+    updatedat: {
+      sql: `${CUBE}."updatedAt"`,
+      type: `time`,
+      shown: false,
+    },
+
+    deletedat: {
+      sql: `${CUBE}."deletedAt"`,
+      type: `time`,
+      shown: false,
+    },
+
+    joinedAt: {
+      sql: `${CUBE}."joinedAt"`,
+      type: `time`,
+    },
+    score: {
+      sql: `${CUBE}."score"`,
+      type: `number`,
+    },
+
+    identities: {
+      sql: `${CUBE}."identities"`,
+      type: `string`,
+    },
+  },
 })

--- a/backend/src/cubejs/schema/Organizations.js
+++ b/backend/src/cubejs/schema/Organizations.js
@@ -1,118 +1,118 @@
 /* eslint-disable no-restricted-globals */
 cube(`Organizations`, {
-    sql: `SELECT * FROM public.organizations`,
-    preAggregations: {
-        activeOrganizations: {
-            measures: [Organizations.count],
-            dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
-            timeDimension: Activities.date,
-            granularity: `day`,
-        },
-        newOrganizations: {
-            measures: [Organizations.count],
-            dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
-            timeDimension: Organizations.joinedAt,
-            granularity: `day`,
-        },
+  sql: `SELECT * FROM public.organizations`,
+  preAggregations: {
+    activeOrganizations: {
+      measures: [Organizations.count],
+      dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
+      timeDimension: Activities.date,
+      granularity: `day`,
     },
-    joins: {
-        MemberOrganizations: {
-            sql: `${CUBE}.id = ${MemberOrganizations}."organizationId"`,
-            relationship: `hasMany`,
-        },
+    newOrganizations: {
+      measures: [Organizations.count],
+      dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
+      timeDimension: Organizations.joinedAt,
+      granularity: `day`,
     },
-    measures: {
-        count: {
-            type: `count`,
-            drillMembers: [updatedbyid, id, name, createdbyid, tenantId, createdat, updatedat],
-        },
+  },
+  joins: {
+    MemberOrganizations: {
+      sql: `${CUBE}.id = ${MemberOrganizations}."organizationId"`,
+      relationship: `hasMany`,
     },
-    dimensions: {
-        emails: {
-            sql: `emails`,
-            type: `string`,
-        },
-        logo: {
-            sql: `logo`,
-            type: `string`,
-        },
-        phonenumbers: {
-            sql: `${CUBE}."phoneNumbers"`,
-            type: `string`,
-        },
-        twitter: {
-            sql: `twitter`,
-            type: `string`,
-        },
-        importhash: {
-            sql: `${CUBE}."importHash"`,
-            type: `string`,
-        },
-        updatedbyid: {
-            sql: `${CUBE}."updatedById"`,
-            type: `string`,
-        },
-        revenuerange: {
-            sql: `${CUBE}."revenueRange"`,
-            type: `string`,
-        },
-        url: {
-            sql: `url`,
-            type: `string`,
-        },
-        tags: {
-            sql: `tags`,
-            type: `string`,
-        },
-        description: {
-            sql: `description`,
-            type: `string`,
-        },
-        id: {
-            sql: `id`,
-            type: `string`,
-            primaryKey: true,
-        },
-        linkedin: {
-            sql: `linkedin`,
-            type: `string`,
-        },
-        name: {
-            sql: `name`,
-            type: `string`,
-        },
-        crunchbase: {
-            sql: `crunchbase`,
-            type: `string`,
-        },
-        createdbyid: {
-            sql: `${CUBE}."createdById"`,
-            type: `string`,
-        },
-        tenantId: {
-            sql: `${CUBE}."tenantId"`,
-            type: `string`,
-        },
-        parenturl: {
-            sql: `${CUBE}."parentUrl"`,
-            type: `string`,
-        },
-        createdat: {
-            sql: `${CUBE}."createdAt"`,
-            type: `time`,
-        },
-        updatedat: {
-            sql: `${CUBE}."updatedAt"`,
-            type: `time`,
-        },
-        deletedat: {
-            sql: `${CUBE}."deletedAt"`,
-            type: `time`,
-        },
-        joinedAt: {
-            sql: `${Members.earliestJoinedAt}`,
-            type: `time`,
-            subQuery: true,
-        },
+  },
+  measures: {
+    count: {
+      type: `count`,
+      drillMembers: [updatedbyid, id, name, createdbyid, tenantId, createdat, updatedat],
     },
+  },
+  dimensions: {
+    emails: {
+      sql: `emails`,
+      type: `string`,
+    },
+    logo: {
+      sql: `logo`,
+      type: `string`,
+    },
+    phonenumbers: {
+      sql: `${CUBE}."phoneNumbers"`,
+      type: `string`,
+    },
+    twitter: {
+      sql: `twitter`,
+      type: `string`,
+    },
+    importhash: {
+      sql: `${CUBE}."importHash"`,
+      type: `string`,
+    },
+    updatedbyid: {
+      sql: `${CUBE}."updatedById"`,
+      type: `string`,
+    },
+    revenuerange: {
+      sql: `${CUBE}."revenueRange"`,
+      type: `string`,
+    },
+    url: {
+      sql: `url`,
+      type: `string`,
+    },
+    tags: {
+      sql: `tags`,
+      type: `string`,
+    },
+    description: {
+      sql: `description`,
+      type: `string`,
+    },
+    id: {
+      sql: `id`,
+      type: `string`,
+      primaryKey: true,
+    },
+    linkedin: {
+      sql: `linkedin`,
+      type: `string`,
+    },
+    name: {
+      sql: `name`,
+      type: `string`,
+    },
+    crunchbase: {
+      sql: `crunchbase`,
+      type: `string`,
+    },
+    createdbyid: {
+      sql: `${CUBE}."createdById"`,
+      type: `string`,
+    },
+    tenantId: {
+      sql: `${CUBE}."tenantId"`,
+      type: `string`,
+    },
+    parenturl: {
+      sql: `${CUBE}."parentUrl"`,
+      type: `string`,
+    },
+    createdat: {
+      sql: `${CUBE}."createdAt"`,
+      type: `time`,
+    },
+    updatedat: {
+      sql: `${CUBE}."updatedAt"`,
+      type: `time`,
+    },
+    deletedat: {
+      sql: `${CUBE}."deletedAt"`,
+      type: `time`,
+    },
+    joinedAt: {
+      sql: `${Members.earliestJoinedAt}`,
+      type: `time`,
+      subQuery: true,
+    },
+  },
 })

--- a/backend/src/cubejs/schema/Organizations.js
+++ b/backend/src/cubejs/schema/Organizations.js
@@ -1,118 +1,118 @@
 /* eslint-disable no-restricted-globals */
 cube(`Organizations`, {
-  sql: `SELECT * FROM public.organizations`,
-  preAggregations: {
-    activeOrganizations: {
-      measures: [Organizations.count],
-      dimensions: [Organizations.tenantId],
-      timeDimension: Activities.date,
-      granularity: `day`,
+    sql: `SELECT * FROM public.organizations`,
+    preAggregations: {
+        activeOrganizations: {
+            measures: [Organizations.count],
+            dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
+            timeDimension: Activities.date,
+            granularity: `day`,
+        },
+        newOrganizations: {
+            measures: [Organizations.count],
+            dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
+            timeDimension: Organizations.joinedAt,
+            granularity: `day`,
+        },
     },
-    newOrganizations: {
-      measures: [Organizations.count],
-      dimensions: [Organizations.tenantId],
-      timeDimension: Organizations.joinedAt,
-      granularity: `day`,
+    joins: {
+        MemberOrganizations: {
+            sql: `${CUBE}.id = ${MemberOrganizations}."organizationId"`,
+            relationship: `hasMany`,
+        },
     },
-  },
-  joins: {
-    MemberOrganizations: {
-      sql: `${CUBE}.id = ${MemberOrganizations}."organizationId"`,
-      relationship: `hasMany`,
+    measures: {
+        count: {
+            type: `count`,
+            drillMembers: [updatedbyid, id, name, createdbyid, tenantId, createdat, updatedat],
+        },
     },
-  },
-  measures: {
-    count: {
-      type: `count`,
-      drillMembers: [updatedbyid, id, name, createdbyid, tenantId, createdat, updatedat],
+    dimensions: {
+        emails: {
+            sql: `emails`,
+            type: `string`,
+        },
+        logo: {
+            sql: `logo`,
+            type: `string`,
+        },
+        phonenumbers: {
+            sql: `${CUBE}."phoneNumbers"`,
+            type: `string`,
+        },
+        twitter: {
+            sql: `twitter`,
+            type: `string`,
+        },
+        importhash: {
+            sql: `${CUBE}."importHash"`,
+            type: `string`,
+        },
+        updatedbyid: {
+            sql: `${CUBE}."updatedById"`,
+            type: `string`,
+        },
+        revenuerange: {
+            sql: `${CUBE}."revenueRange"`,
+            type: `string`,
+        },
+        url: {
+            sql: `url`,
+            type: `string`,
+        },
+        tags: {
+            sql: `tags`,
+            type: `string`,
+        },
+        description: {
+            sql: `description`,
+            type: `string`,
+        },
+        id: {
+            sql: `id`,
+            type: `string`,
+            primaryKey: true,
+        },
+        linkedin: {
+            sql: `linkedin`,
+            type: `string`,
+        },
+        name: {
+            sql: `name`,
+            type: `string`,
+        },
+        crunchbase: {
+            sql: `crunchbase`,
+            type: `string`,
+        },
+        createdbyid: {
+            sql: `${CUBE}."createdById"`,
+            type: `string`,
+        },
+        tenantId: {
+            sql: `${CUBE}."tenantId"`,
+            type: `string`,
+        },
+        parenturl: {
+            sql: `${CUBE}."parentUrl"`,
+            type: `string`,
+        },
+        createdat: {
+            sql: `${CUBE}."createdAt"`,
+            type: `time`,
+        },
+        updatedat: {
+            sql: `${CUBE}."updatedAt"`,
+            type: `time`,
+        },
+        deletedat: {
+            sql: `${CUBE}."deletedAt"`,
+            type: `time`,
+        },
+        joinedAt: {
+            sql: `${Members.earliestJoinedAt}`,
+            type: `time`,
+            subQuery: true,
+        },
     },
-  },
-  dimensions: {
-    emails: {
-      sql: `emails`,
-      type: `string`,
-    },
-    logo: {
-      sql: `logo`,
-      type: `string`,
-    },
-    phonenumbers: {
-      sql: `${CUBE}."phoneNumbers"`,
-      type: `string`,
-    },
-    twitter: {
-      sql: `twitter`,
-      type: `string`,
-    },
-    importhash: {
-      sql: `${CUBE}."importHash"`,
-      type: `string`,
-    },
-    updatedbyid: {
-      sql: `${CUBE}."updatedById"`,
-      type: `string`,
-    },
-    revenuerange: {
-      sql: `${CUBE}."revenueRange"`,
-      type: `string`,
-    },
-    url: {
-      sql: `url`,
-      type: `string`,
-    },
-    tags: {
-      sql: `tags`,
-      type: `string`,
-    },
-    description: {
-      sql: `description`,
-      type: `string`,
-    },
-    id: {
-      sql: `id`,
-      type: `string`,
-      primaryKey: true,
-    },
-    linkedin: {
-      sql: `linkedin`,
-      type: `string`,
-    },
-    name: {
-      sql: `name`,
-      type: `string`,
-    },
-    crunchbase: {
-      sql: `crunchbase`,
-      type: `string`,
-    },
-    createdbyid: {
-      sql: `${CUBE}."createdById"`,
-      type: `string`,
-    },
-    tenantId: {
-      sql: `${CUBE}."tenantId"`,
-      type: `string`,
-    },
-    parenturl: {
-      sql: `${CUBE}."parentUrl"`,
-      type: `string`,
-    },
-    createdat: {
-      sql: `${CUBE}."createdAt"`,
-      type: `time`,
-    },
-    updatedat: {
-      sql: `${CUBE}."updatedAt"`,
-      type: `time`,
-    },
-    deletedat: {
-      sql: `${CUBE}."deletedAt"`,
-      type: `time`,
-    },
-    joinedAt: {
-      sql: `${Members.earliestJoinedAt}`,
-      type: `time`,
-      subQuery: true,
-    },
-  },
 })

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -154,7 +154,7 @@ describe('TenantService tests', () => {
         url: 'testUrl',
         plan: Plans.values.growth,
         isTrialPlan: true,
-        trialEndsAt:  moment().add(14, 'days').toISOString().split('T')[0],
+        trialEndsAt: moment().add(14, 'days').toISOString().split('T')[0],
         planStatus: 'active',
         planStripeCustomerId: null,
         planUserId: null,

--- a/backend/src/services/__tests__/tenantService.test.ts
+++ b/backend/src/services/__tests__/tenantService.test.ts
@@ -146,6 +146,7 @@ describe('TenantService tests', () => {
 
       tenantCreatedPlain.createdAt = tenantCreatedPlain.createdAt.toISOString().split('T')[0]
       tenantCreatedPlain.updatedAt = tenantCreatedPlain.updatedAt.toISOString().split('T')[0]
+      tenantCreatedPlain.trialEndsAt = tenantCreatedPlain.trialEndsAt.toISOString().split('T')[0]
 
       const tenantExpected = {
         id: tenantCreatedPlain.id,
@@ -153,9 +154,7 @@ describe('TenantService tests', () => {
         url: 'testUrl',
         plan: Plans.values.growth,
         isTrialPlan: true,
-        trialEndsAt: moment().add(14, 'days').isAfter('2023-01-15')
-          ? moment().add(14, 'days').toISOString()
-          : new Date('2023-01-15T00:00:00.000Z'),
+        trialEndsAt:  moment().add(14, 'days').toISOString().split('T')[0],
         planStatus: 'active',
         planStripeCustomerId: null,
         planUserId: null,


### PR DESCRIPTION
# Changes proposed ✍️
- After introducing `isTeamMember` and `isBot` as universal filters to all cubes, preaggregations were not matching their definitions anymore, resulting in a long query response time. This pr aims to add these dimensions also to preaggregations.
  
## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [x] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.