### PR TITLE
Get GitHub user emails with GitHub app token instead of user token

### DIFF
--- a/backend/src/serverless/integrations/services/integrationProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationProcessor.ts
@@ -264,7 +264,6 @@ export class IntegrationProcessor extends LoggingBase {
 
       // delay for retries/continuing with the remaining streams (in seconds)
       let delay: number = 5
-      let stopProcessing = false
 
       let exit = false
 
@@ -304,15 +303,16 @@ export class IntegrationProcessor extends LoggingBase {
             } catch (err) {
               if (err.rateLimitResetSeconds) {
                 delay = err.rateLimitResetSeconds + 5
-                stopProcessing = true
+                logger.warn(
+                  err,
+                  { stream: stream.value, delay },
+                  'Rate limit reached while processing stream! Delaying...',
+                )
+                failedStreams.push(stream)
+                break
               } else {
                 throw err
               }
-            }
-
-            if (stopProcessing) {
-              failedStreams.push(stream)
-              break
             }
 
             if (processStreamResult.newStreams && processStreamResult.newStreams.length > 0) {

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -1,4 +1,5 @@
 import moment from 'moment/moment'
+import { createAppAuth } from '@octokit/auth-app'
 import { Repo, Repos } from '../../types/regularTypes'
 import { IntegrationType, PlatformType } from '../../../../types/integrationEnums'
 import {
@@ -27,6 +28,9 @@ import { GithubActivityType } from '../../../../types/activityTypes'
 import { GitHubGrid } from '../../grid/githubGrid'
 import getOrganization from '../../usecases/github/graphql/organizations'
 import { singleOrDefault } from '../../../../utils/arrays'
+import { AppTokenResponse, getAppToken } from '../../usecases/github/rest/getAppToken'
+import getMember from '../../usecases/github/graphql/members'
+import { createRedisClient, RedisCache } from '../../../../utils/redis'
 
 /* eslint class-methods-use-this: 0 */
 
@@ -45,7 +49,16 @@ enum GithubStreamType {
   DISCUSSION_COMMENTS = 'discussion-comments',
 }
 
+const privateKey = Buffer.from(GITHUB_CONFIG.privateKey, 'base64').toString('ascii')
+
 export class GithubIntegrationService extends IntegrationServiceBase {
+  private static githubAuthenticator = createAppAuth({
+    appId: GITHUB_CONFIG.appId,
+    clientId: GITHUB_CONFIG.clientId,
+    clientSecret: GITHUB_CONFIG.clientSecret,
+    privateKey,
+  })
+
   constructor() {
     super(IntegrationType.GITHUB, -1)
 
@@ -65,6 +78,9 @@ export class GithubIntegrationService extends IntegrationServiceBase {
 
   async preprocess(context: IStepContext): Promise<void> {
     const log = this.logger(context)
+
+    const redis = await createRedisClient(true)
+    const emailCache = new RedisCache('github-emails', redis)
 
     const repos: Repos = []
     const unavailableRepos: Repos = []
@@ -98,6 +114,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     context.pipelineData = {
       repos,
       unavailableRepos,
+      emailCache,
     }
   }
 
@@ -566,7 +583,61 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     return out
   }
 
+  private static async getAppToken(context: IStepContext): Promise<string> {
+    let appToken: AppTokenResponse
+    if (context.pipelineData.appToken) {
+      // check expiration
+      const expiration = moment(context.pipelineData.appToken.expiration)
+      if (expiration.isAfter(moment())) {
+        // need to refresh
+        const authResponse = await this.githubAuthenticator({ type: 'app' })
+        const jwtToken = authResponse.token
+        appToken = await getAppToken(jwtToken, context.integration.integrationIdentifier)
+      } else {
+        appToken = context.pipelineData.appToken
+      }
+    } else {
+      const authResponse = await this.githubAuthenticator({ type: 'app' })
+      const jwtToken = authResponse.token
+      appToken = await getAppToken(jwtToken, context.integration.integrationIdentifier)
+    }
+
+    context.pipelineData.appToken = appToken
+
+    return appToken.token
+  }
+
+  private static async getMemberData(context: IStepContext, login: string): Promise<any> {
+    const appToken = await this.getAppToken(context)
+    return getMember(login, appToken)
+  }
+
+  private static async getMemberEmail(context: IStepContext, login: string): Promise<string> {
+    const cache: RedisCache = context.pipelineData.emailCache
+
+    const existing = await cache.getValue(login)
+    if (existing) {
+      if (existing === 'null') {
+        return ''
+      }
+
+      return existing
+    }
+
+    const member = await this.getMemberData(context, login)
+    const email = (member.email || '').trim()
+    if (email && email.length > 0) {
+      await cache.setValue(login, email, 60 * 60)
+      return email
+    }
+
+    await cache.setValue(login, 'null', 60 * 60)
+    return ''
+  }
+
   private static async parseMember(memberFromApi: any, context: IStepContext): Promise<Member> {
+    const email = await this.getMemberEmail(context, memberFromApi.login)
+
     const member: Member = {
       username: { [PlatformType.GITHUB]: memberFromApi.login },
       displayName: memberFromApi.name,
@@ -587,7 +658,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           [PlatformType.GITHUB]: memberFromApi.avatarUrl || '',
         },
       },
-      email: memberFromApi.email || '',
+      email,
     }
 
     if (memberFromApi.company) {

--- a/backend/src/serverless/integrations/usecases/github/rest/getAppToken.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getAppToken.ts
@@ -1,0 +1,37 @@
+import axios, { AxiosRequestConfig } from 'axios'
+import { createServiceChildLogger } from '../../../../../utils/logging'
+
+const log = createServiceChildLogger('getAppToken')
+
+export interface AppTokenResponse {
+  token: string
+  expiresAt: string
+}
+
+export const getAppToken = async (
+  jwt: string,
+  installationId: number,
+): Promise<AppTokenResponse> => {
+  try {
+    const config = {
+      method: 'post',
+      url: `https://api.github.com/app/installations/${installationId}/access_tokens`,
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github+json',
+      },
+    } as AxiosRequestConfig
+
+    const response = await axios(config)
+
+    const data = response.data as any
+
+    return {
+      token: data.token,
+      expiresAt: data.expires_at,
+    }
+  } catch (err: any) {
+    log.error(err, { installationId }, 'Error fetching app token!')
+    throw err
+  }
+}


### PR DESCRIPTION
# Changes proposed ✍️
- We had to use installation app token to fetch GitHub user public email
 

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.