### PR TITLE
Bugfix/comprehend text too big

### DIFF
--- a/backend/src/services/aws.ts
+++ b/backend/src/services/aws.ts
@@ -1,5 +1,4 @@
 import AWS, { SQS } from 'aws-sdk'
-import { Blob } from 'buffer'
 import { COMPREHEND_CONFIG, IS_DEV_ENV, KUBE_MODE, S3_CONFIG, SQS_CONFIG } from '../config'
 
 let sqsInstance

--- a/backend/src/services/aws.ts
+++ b/backend/src/services/aws.ts
@@ -109,7 +109,6 @@ const ALLOWED_MAX_BYTE_LENGTH = 200000
 export async function detectSentiment(text) {
   // Only if we have proper credentials
   if (comprehendInstance) {
-
     // make text maximum 250000 bytes
     if (Buffer.byteLength(text, 'utf8') > ALLOWED_MAX_BYTE_LENGTH) {
       text = text.slice(0, ALLOWED_MAX_BYTE_LENGTH)

--- a/backend/src/services/aws.ts
+++ b/backend/src/services/aws.ts
@@ -101,7 +101,7 @@ if (KUBE_MODE) {
       : undefined
 }
 
-const ALLOWED_MAX_BYTE_LENGTH = 4500
+const ALLOWED_MAX_BYTE_LENGTH = 200000
 /**
  * Get sentiment for a text using AWS Comprehend
  * @param text Text to detect sentiment on
@@ -110,15 +110,11 @@ const ALLOWED_MAX_BYTE_LENGTH = 4500
 export async function detectSentiment(text) {
   // Only if we have proper credentials
   if (comprehendInstance) {
-    // Check text byte size
-    let blob = new Blob([text])
-    if (blob.size > ALLOWED_MAX_BYTE_LENGTH) {
-      blob = blob.slice(0, ALLOWED_MAX_BYTE_LENGTH)
-      text = await blob.text()
-    }
 
-    // convert to utf-8
-    text = Buffer.from(text).toString('utf-8')
+    // make text maximum 250000 bytes
+    if (Buffer.byteLength(text, 'utf8') > ALLOWED_MAX_BYTE_LENGTH) {
+      text = text.slice(0, ALLOWED_MAX_BYTE_LENGTH)
+    }
 
     const params = {
       LanguageCode: 'en',


### PR DESCRIPTION
# Changes proposed ✍️
- Fixed a bug where the text we were sending to comprehend was too big

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.