### PR TITLE
Improved copy for widget tooltips

### DIFF
--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -510,22 +510,10 @@ const en = {
   widget: {
     cubejs: {
       tooltip: {
-        Activities: {
-          singular: 'Activity',
-          plural: 'Activities'
-        },
-        Members: {
-          singular: 'Member',
-          plural: 'Members'
-        },
-        Conversations: {
-          singular: 'Conversation',
-          plural: 'Conversations'
-        },
-        Organizations: {
-          singular: 'Organization',
-          plural: 'Organizations'
-        }
+        Activities: 'Activity',
+        Members: 'Member',
+        Conversations: 'Conversation',
+        Organizations: 'Organization'
       },
       cubes: {
         Activities: 'Activities',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -509,11 +509,29 @@ const en = {
 
   widget: {
     cubejs: {
+      tooltip: {
+        Activities: {
+          singular: 'Activity',
+          plural: 'Activities'
+        },
+        Members: {
+          singular: 'Member',
+          plural: 'Members'
+        },
+        Conversations: {
+          singular: 'Conversation',
+          plural: 'Conversations'
+        },
+        Organizations: {
+          singular: 'Organization',
+          plural: 'Organizations'
+        }
+      },
       cubes: {
-        Activities: '[Activities] Count',
-        Members: '[Members] Count',
-        Conversations: '[Conversations] Count',
-        Organizations: '[Organizations] Count'
+        Activities: 'Activities',
+        Members: 'Members',
+        Conversations: 'Conversations',
+        Organizations: 'Organizations'
       },
       Activities: {
         count: '[Activities] Count',

--- a/frontend/src/modules/dashboard/components/dashboard-members.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-members.vue
@@ -60,7 +60,10 @@
           :show-subtitle="false"
           :chart-options="{
             ...chartOptions,
-            library: hideLabels
+            library: {
+              ...chartOptions.library,
+              ...hideLabels
+            }
           }"
         ></app-widget-cube-renderer>
       </div>
@@ -148,7 +151,10 @@
           :show-subtitle="false"
           :chart-options="{
             ...chartOptions,
-            library: hideLabels
+            library: {
+              ...chartOptions.library,
+              ...hideLabels
+            }
           }"
         ></app-widget-cube-renderer>
       </div>

--- a/frontend/src/modules/dashboard/components/dashboard-organizations.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-organizations.vue
@@ -59,7 +59,10 @@
           :show-subtitle="false"
           :chart-options="{
             ...chartOptions,
-            library: hideLabels
+            library: {
+              ...chartOptions.library,
+              ...hideLabels
+            }
           }"
         ></app-widget-cube-renderer>
       </div>
@@ -133,7 +136,10 @@
           :show-subtitle="false"
           :chart-options="{
             ...chartOptions,
-            library: hideLabels
+            library: {
+              ...chartOptions.library,
+              ...hideLabels
+            }
           }"
         ></app-widget-cube-renderer>
       </div>

--- a/frontend/src/modules/dashboard/dashboard.cube.js
+++ b/frontend/src/modules/dashboard/dashboard.cube.js
@@ -1,3 +1,4 @@
+import { i18n } from '@/i18n'
 import moment from 'moment'
 
 export const chartOptions = {
@@ -8,6 +9,30 @@ export const chartOptions = {
   backgroundColor: 'pink',
   loading: 'Loading...',
   empty: 'Loading...',
+  library: {
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const translationSuffix =
+              context.dataset.data[context.dataIndex] > 1
+                ? 'plural'
+                : 'singular'
+
+            return (
+              context.dataset.data[context.dataIndex] +
+              ' ' +
+              i18n(
+                'widget.cubejs.tooltip.' +
+                  context.dataset.label +
+                  `.${translationSuffix}`
+              )
+            )
+          }
+        }
+      }
+    }
+  },
   computeDataset: (canvas) => {
     const ctx = canvas.getContext('2d')
     const gradient = ctx.createLinearGradient(0, 0, 0, 150)

--- a/frontend/src/modules/dashboard/dashboard.cube.js
+++ b/frontend/src/modules/dashboard/dashboard.cube.js
@@ -1,5 +1,6 @@
 import { i18n } from '@/i18n'
 import moment from 'moment'
+import pluralize from 'pluralize'
 
 export const chartOptions = {
   legend: false,
@@ -13,22 +14,14 @@ export const chartOptions = {
     plugins: {
       tooltip: {
         callbacks: {
-          label: (context) => {
-            const translationSuffix =
-              context.dataset.data[context.dataIndex] > 1
-                ? 'plural'
-                : 'singular'
-
-            return (
-              context.dataset.data[context.dataIndex] +
-              ' ' +
+          label: (context) =>
+            pluralize(
               i18n(
-                'widget.cubejs.tooltip.' +
-                  context.dataset.label +
-                  `.${translationSuffix}`
-              )
+                `widget.cubejs.tooltip.${context.dataset.label}`
+              ),
+              context.dataset.data[context.dataIndex],
+              true
             )
-          }
         }
       }
     }

--- a/frontend/src/modules/report/report-charts.js
+++ b/frontend/src/modules/report/report-charts.js
@@ -1,4 +1,5 @@
 import { i18n } from '@/i18n'
+import pluralize from 'pluralize'
 
 const defaultChartOptions = {
   legend: false,
@@ -15,31 +16,26 @@ const defaultChartOptions = {
     '#06B6D4',
     '#F97316'
   ],
+  loading: 'Loading...'
+}
+
+const formatTooltipOptions = {
   library: {
     plugins: {
       tooltip: {
         callbacks: {
-          label: (context) => {
-            const translationSuffix =
-              context.dataset.data[context.dataIndex] > 1
-                ? 'plural'
-                : 'singular'
-
-            return (
-              context.dataset.data[context.dataIndex] +
-              ' ' +
+          label: (context) =>
+            pluralize(
               i18n(
-                'widget.cubejs.tooltip.' +
-                  context.dataset.label +
-                  `.${translationSuffix}`
-              )
+                `widget.cubejs.tooltip.${context.dataset.label}`
+              ),
+              context.dataset.data[context.dataIndex],
+              true
             )
-          }
         }
       }
     }
-  },
-  loading: 'Loading...'
+  }
 }
 
 const platformColors = {
@@ -148,9 +144,23 @@ export function chartOptions(widget, resultSet) {
       colors: [...mappedColors, ...restColors]
     }
   }
+
+  // When there's a dimension, we don't want custom format in tooltips,
+  // instead we'll use the default format `dimension: value`
+  if (
+    widget.settings.query.dimensions &&
+    widget.settings.query.dimensions.length
+  ) {
+    return {
+      ...defaultChartOptions,
+      ...chartTypeOptions
+    }
+  }
+
   return {
     ...defaultChartOptions,
-    ...chartTypeOptions
+    ...chartTypeOptions,
+    ...formatTooltipOptions
   }
 }
 

--- a/frontend/src/modules/report/report-charts.js
+++ b/frontend/src/modules/report/report-charts.js
@@ -1,3 +1,5 @@
+import { i18n } from '@/i18n'
+
 const defaultChartOptions = {
   legend: false,
   curve: false,
@@ -13,6 +15,30 @@ const defaultChartOptions = {
     '#06B6D4',
     '#F97316'
   ],
+  library: {
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (context) => {
+            const translationSuffix =
+              context.dataset.data[context.dataIndex] > 1
+                ? 'plural'
+                : 'singular'
+
+            return (
+              context.dataset.data[context.dataIndex] +
+              ' ' +
+              i18n(
+                'widget.cubejs.tooltip.' +
+                  context.dataset.label +
+                  `.${translationSuffix}`
+              )
+            )
+          }
+        }
+      }
+    }
+  },
   loading: 'Loading...'
 }
 

--- a/frontend/src/modules/widget/components/cube/widget-cube.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube.vue
@@ -320,7 +320,7 @@ export default {
     seriesPairs(resultSet) {
       // For bar charts
       return resultSet.series().map((seriesItem) => {
-        let { dimension, measure } = this.deconstructLabel(
+        let { dimension } = this.deconstructLabel(
           seriesItem.title
         )
 
@@ -333,14 +333,13 @@ export default {
           )
         }
 
-        measure = measure
-          ? measure
-          : i18n('widget.cubejs.' + this.query.measures[0])
-
         const seriesName =
           dimension && dimension !== 'unknown'
             ? dimension
-            : measure
+            : i18n(
+                'widget.cubejs.cubes.' +
+                  this.query.measures[0].split('.')[0]
+              )
         return {
           name: seriesName,
           data: seriesItem.series.map((item) => {


### PR DESCRIPTION
# Changes proposed ✍️
- Changes the tooltip of the widgets without dimensions from format `[Cube] Count: {value}` to `{value} [Plural or Singular Cube Name]`
eg: Changes `[Activities] Count: 5` to `5 Activities`

  
- ### Screenshots (front-end changes only)
![tooltip-update](https://user-images.githubusercontent.com/12017738/210559688-bacbf4bc-d91e-4f8e-908a-abe7d68a2320.png)


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [x] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.