### PR TITLE
Engagement score was weighting too much activities at the beginning of the month

### DIFF
--- a/backend/src/serverless/microservices/python/crowd-members-score/crowd/members_score/members_score.py
+++ b/backend/src/serverless/microservices/python/crowd-members-score/crowd/members_score/members_score.py
@@ -1,3 +1,4 @@
+import decimal
 from crowd.backend.infrastructure.logging import get_logger
 from crowd.backend.repository import Repository
 from crowd.backend.repository.keys import DBKeys as dbk
@@ -103,7 +104,7 @@ class MembersScore:
         year = int(row[6])
 
         if month == current_month:
-            average_monthly_score = average_monthly_score * (current_day / 30)
+            average_monthly_score = average_monthly_score * decimal.Decimal(current_day / 30)
 
         sm = float(average_monthly_score) / float(1 + stddev_score_activities)
 

--- a/backend/src/serverless/microservices/python/crowd-members-score/crowd/members_score/members_score.py
+++ b/backend/src/serverless/microservices/python/crowd-members-score/crowd/members_score/members_score.py
@@ -94,9 +94,16 @@ class MembersScore:
         m = 13  # Number of months to take into account
 
         average_monthly_score = row[2]
+
+        current_month = datetime.now().month
+        current_day = datetime.now().day
+
         stddev_score_activities = row[4]
         month = int(row[5])
         year = int(row[6])
+
+        if month == current_month:
+            average_monthly_score = average_monthly_score * (current_day / 30)
 
         sm = float(average_monthly_score) / float(1 + stddev_score_activities)
 


### PR DESCRIPTION
# Changes proposed ✍️
- Divide by the number of remaining days into the month when calculating the average monthly score for the current month.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.