### PR TITLE
Don't log github webhook event type not supported as error

### DIFF
--- a/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
+++ b/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
@@ -377,8 +377,8 @@ describe('Github webhooks tests', () => {
           await gh.main()
           fail('Should have thrown an error')
         } catch (err) {
-          expect(err.message).toBe(
-            `Activity not supported! Event was issues of type  string. Action was ${action}, with a payload type of object.`,
+          expect(err.action).toBe(
+            `GitHub WebHook processing of event 'issues' of type 'string' with action '${action}', with a payload type of 'object'.`,
           )
         }
       }
@@ -710,8 +710,8 @@ describe('Github webhooks tests', () => {
           await gh.main()
           fail('Should have thrown an error')
         } catch (err) {
-          expect(err.message).toBe(
-            `Activity not supported! Event was pull_request of type  string. Action was ${action}, with a payload type of object.`,
+          expect(err.action).toBe(
+            `GitHub WebHook processing of event 'pull_request' of type 'string' with action '${action}', with a payload type of 'object'.`,
           )
         }
       }
@@ -1042,7 +1042,7 @@ describe('Github webhooks tests', () => {
           fail('Should have thrown error')
         } catch (err) {
           expect(err.message).toBe(
-            'Activity not supported! Event was issue_comment of type  string. Action was deleted, with a payload type of object.',
+            `GitHub WebHook processing of event 'issue_comment' of type 'string' with action '${action}', with a payload type of 'object'.`,
           )
         }
       }

--- a/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
+++ b/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
@@ -1041,7 +1041,7 @@ describe('Github webhooks tests', () => {
           await gh.main()
           fail('Should have thrown error')
         } catch (err) {
-          expect(err.actions).toBe(
+          expect(err.action).toBe(
             `GitHub WebHook processing of event 'issue_comment' of type 'string' with action '${action}', with a payload type of 'object'.`,
           )
         }

--- a/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
+++ b/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
@@ -1041,7 +1041,7 @@ describe('Github webhooks tests', () => {
           await gh.main()
           fail('Should have thrown error')
         } catch (err) {
-          expect(err.message).toBe(
+          expect(err.actions).toBe(
             `GitHub WebHook processing of event 'issue_comment' of type 'string' with action '${action}', with a payload type of 'object'.`,
           )
         }

--- a/backend/src/serverless/integrations/webhooks/github.ts
+++ b/backend/src/serverless/integrations/webhooks/github.ts
@@ -541,8 +541,8 @@ export default class GitHubWebhook {
     }
 
     throw new NotSupportedError(
-      `GitHub WebHook processing of event '${this.event}' of type  ${typeof this
-        .event} with action '${this.payload.action}', with a payload type of '${typeof this
+      `GitHub WebHook processing of event '${this.event}' of type '${typeof this
+        .event}' with action '${this.payload.action}', with a payload type of '${typeof this
         .payload}'.`,
     )
   }

--- a/backend/src/serverless/integrations/webhooks/github.ts
+++ b/backend/src/serverless/integrations/webhooks/github.ts
@@ -14,6 +14,7 @@ import { MemberAttributeName } from '../../../database/attributes/member/enums'
 import getOrganization from '../usecases/github/graphql/organizations'
 import { IntegrationServiceBase } from '../services/integrationServiceBase'
 import { createServiceChildLogger } from '../../../utils/logging'
+import { NotSupportedError } from '../../../types/integration/notSupportedError'
 
 type EventOutput = Promise<AddActivitiesSingle | null>
 
@@ -539,10 +540,10 @@ export default class GitHubWebhook {
       return new ActivityService(userContext).createWithMember(activity)
     }
 
-    throw new Error(
-      `Activity not supported! Event was ${this.event} of type  ${typeof this.event}. Action was ${
-        this.payload.action
-      }, with a payload type of ${typeof this.payload}.`,
+    throw new NotSupportedError(
+      `GitHub WebHook processing of event '${this.event}' of type  ${typeof this
+        .event} with action '${this.payload.action}', with a payload type of '${typeof this
+        .payload}'.`,
     )
   }
 }

--- a/backend/src/serverless/integrations/workers/githubWebhookWorker.ts
+++ b/backend/src/serverless/integrations/workers/githubWebhookWorker.ts
@@ -85,7 +85,12 @@ export const processWebhook = async (
       await repo.markCompleted(webhook.id)
       logger.info('Webhook processed successfully!')
     } catch (err) {
-      logger.error(err, 'Error processing webhook!')
+      if (err.action) {
+        logger.warn({ action: err.action }, 'Action not supported!')
+      } else {
+        logger.error(err, 'Error processing webhook!')
+      }
+
       await repo.markError(
         webhook.id,
         new WebhookError(webhook.id, 'Error processing webhook!', err),

--- a/backend/src/types/integration/notSupportedError.ts
+++ b/backend/src/types/integration/notSupportedError.ts
@@ -1,0 +1,10 @@
+import { BaseError } from '../baseError'
+
+export class NotSupportedError extends BaseError {
+  public action: string
+
+  constructor(action: string, originalError?: any) {
+    super(`Action '${action}' is not supported!`, originalError)
+    this.action = action
+  }
+}


### PR DESCRIPTION
# Changes proposed ✍️
- We are already storing error information in the database in `incomingWebhooks` table and this error log is causing a lot of spam with alerts so we can switch to warn log level.
  
## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.