### PR TITLE
Fix merging members twice

### DIFF
--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -258,6 +258,13 @@ export default {
           memberToKeep: this.primaryMember,
           memberToMerge: this.memberToMerge
         })
+
+        this.isMergeDialogOpen = false
+
+        // If in member view, fetch member newly merged member
+        if (this.$route.name === 'memberView') {
+          this.doFind(this.primaryMember.id)
+        }
       } catch (error) {
         console.log(error)
         Message.error('There was an error merging members')


### PR DESCRIPTION
# Changes proposed ✍️
- Bug: When in a member detailed view page, if the user tried to merge that member with another one the merge dialog wouldn't close after a successful merge operation. So if the user clicked on the merge button again the app would break

Fix: close dialog after successfully merging members and fetch newly merged member so that the detailed page view is updated

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.