### PR TITLE
Wrong hash generated for star activities

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -343,7 +343,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         sourceId: IntegrationServiceBase.generateSourceIdHash(
           record.node.login,
           GithubActivityType.STAR,
-          moment(record.starredAt).utc().toDate().toString(),
+          moment(record.starredAt).utc().unix().toString(),
           PlatformType.GITHUB,
         ),
         sourceParentId: '',

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -13,6 +13,8 @@ import { prepareMemberPayload } from './newMemberWorker'
 import { createServiceChildLogger } from '../../../../../utils/logging'
 import AutomationExecutionRepository from '../../../../../database/repositories/automationExecutionRepository'
 import SequelizeRepository from '../../../../../database/repositories/sequelizeRepository'
+import { PlatformType } from '../../../../../types/integrationEnums'
+import { GithubActivityType } from '../../../../../types/activityTypes'
 
 const log = createServiceChildLogger('newActivityWorker')
 
@@ -28,6 +30,11 @@ export const shouldProcessActivity = async (
   const settings = automation.settings as NewActivitySettings
 
   let process = true
+
+  // TODO ANIL - remove this temp if
+  if (activity.platform === PlatformType.GITHUB && activity.type === GithubActivityType.STAR) {
+    return false
+  }
 
   // check whether activity type matches
   if (settings.types && settings.types.length > 0) {


### PR DESCRIPTION
# Changes proposed ✍️
- Webhooks and onboardings were generating different hashes because webhooks were using the UNIX timestamp string, but onboardings were using the date string when generating the `sourceId` hash.
- Now, onboardings also use the UNIX timestamp when generating the hash.
- Also, there's a temp fix in automations, where we discard the star activities temporarily (Will onboard GitHub integrations and remove this part)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.