### PR TITLE
Github integration service should handle github settings not being available

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -49,15 +49,19 @@ enum GithubStreamType {
   DISCUSSION_COMMENTS = 'discussion-comments',
 }
 
-const privateKey = Buffer.from(GITHUB_CONFIG.privateKey, 'base64').toString('ascii')
+const privateKey = GITHUB_CONFIG.privateKey
+  ? Buffer.from(GITHUB_CONFIG.privateKey, 'base64').toString('ascii')
+  : undefined
 
 export class GithubIntegrationService extends IntegrationServiceBase {
-  private static githubAuthenticator = createAppAuth({
-    appId: GITHUB_CONFIG.appId,
-    clientId: GITHUB_CONFIG.clientId,
-    clientSecret: GITHUB_CONFIG.clientSecret,
-    privateKey,
-  })
+  private static githubAuthenticator = privateKey
+    ? createAppAuth({
+        appId: GITHUB_CONFIG.appId,
+        clientId: GITHUB_CONFIG.clientId,
+        clientSecret: GITHUB_CONFIG.clientSecret,
+        privateKey,
+      })
+    : undefined
 
   constructor() {
     super(IntegrationType.GITHUB, -1)
@@ -584,27 +588,31 @@ export class GithubIntegrationService extends IntegrationServiceBase {
   }
 
   private static async getAppToken(context: IStepContext): Promise<string> {
-    let appToken: AppTokenResponse
-    if (context.pipelineData.appToken) {
-      // check expiration
-      const expiration = moment(context.pipelineData.appToken.expiration).add(5, 'minutes')
-      if (expiration.isAfter(moment())) {
-        // need to refresh
+    if (this.githubAuthenticator) {
+      let appToken: AppTokenResponse
+      if (context.pipelineData.appToken) {
+        // check expiration
+        const expiration = moment(context.pipelineData.appToken.expiration).add(5, 'minutes')
+        if (expiration.isAfter(moment())) {
+          // need to refresh
+          const authResponse = await this.githubAuthenticator({ type: 'app' })
+          const jwtToken = authResponse.token
+          appToken = await getAppToken(jwtToken, context.integration.integrationIdentifier)
+        } else {
+          appToken = context.pipelineData.appToken
+        }
+      } else {
         const authResponse = await this.githubAuthenticator({ type: 'app' })
         const jwtToken = authResponse.token
         appToken = await getAppToken(jwtToken, context.integration.integrationIdentifier)
-      } else {
-        appToken = context.pipelineData.appToken
       }
-    } else {
-      const authResponse = await this.githubAuthenticator({ type: 'app' })
-      const jwtToken = authResponse.token
-      appToken = await getAppToken(jwtToken, context.integration.integrationIdentifier)
+
+      context.pipelineData.appToken = appToken
+
+      return appToken.token
     }
 
-    context.pipelineData.appToken = appToken
-
-    return appToken.token
+    throw new Error('GitHub integration is not configured!')
   }
 
   private static async getMemberData(context: IStepContext, login: string): Promise<any> {


### PR DESCRIPTION

# Changes proposed ✍️
- If github integration is not configured `nodejs-worker` should not crash.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] ~All changes have been tested in a staging site.~
- [x] All changes are working locally running crowd.dev's Docker local environment.