### PR TITLE
Truncate tenant name in workspace-dropdown

### DIFF
--- a/frontend/src/modules/layout/components/workspace-dropdown.vue
+++ b/frontend/src/modules/layout/components/workspace-dropdown.vue
@@ -38,7 +38,7 @@
                   class="text-sm account-btn-info"
                 >
                   <div
-                    class="text-gray-900 whitespace-nowrap"
+                    class="text-gray-900 whitespace-nowrap truncate max-w-3.5xs"
                   >
                     {{ currentTenant.name }}
                   </div>
@@ -95,7 +95,9 @@
           <div
             class="flex grow justify-between items-center"
           >
-            <div class="text-gray-900 text-xs flex-grow">
+            <div
+              class="text-gray-900 text-xs w-full truncate max-w-3xs"
+            >
               {{ tenant.name }}
             </div>
             <div

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -774,6 +774,8 @@ module.exports = {
     maxWidth: ({ theme, breakpoints }) => ({
       none: 'none',
       0: '0rem',
+      '3.5xs': '10rem',
+      '3xs': '12rem',
       '2xs': '16rem',
       xs: '20rem',
       sm: '24rem',


### PR DESCRIPTION
# Changes proposed ✍️
- Force max-width and truncate tenant name in workspace-dropdown.vue
  
- ### Screenshots (front-end changes only)

<img width="614" alt="Screenshot 2023-01-09 at 17 33 34" src="https://user-images.githubusercontent.com/4289045/211371026-a78eb0f8-b8e7-404b-99c3-c02244a00d58.png">

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.