### PR TITLE
Add formbricks feedback

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -40,6 +40,10 @@ const defaultConfig = {
   posthog: {
     apiKey: process.env.VUE_APP_POSTHOG_API_KEY,
     host: process.env.VUE_APP_POSTHOG_HOST
+  },
+  formbricks: {
+    url: process.env.VUE_APP_FORMBRICKS_URL,
+    formId: process.env.VUE_APP_FORMBRICKS_FORM_ID
   }
 }
 

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -822,6 +822,9 @@ const en = {
       yellow: 'Yellow'
     }
   },
+  feedback: {
+    menu: 'Feedback'
+  },
   integrations: {
     menu: 'Integrations'
   },

--- a/frontend/src/modules/layout/components/menu.vue
+++ b/frontend/src/modules/layout/components/menu.vue
@@ -370,17 +370,17 @@
 <script>
 export default {
   name: 'AppMenu',
-  methods: {
-    openFeedbackWidget: function (event) {
-      window.formbricks.open(event)
-    },
-  },
   mounted() {
     const store = useStore()
-    let formbricksFeedbackWidget = document.createElement('script')
-    formbricksFeedbackWidget.setAttribute('src', 'https://cdn.jsdelivr.net/npm/@formbricks/feedback@0.1.5/dist/index.umd.js')
+    let formbricksFeedbackWidget =
+      document.createElement('script')
+    formbricksFeedbackWidget.setAttribute(
+      'src',
+      'https://cdn.jsdelivr.net/npm/@formbricks/feedback@0.1.5/dist/index.umd.js'
+    )
     document.head.appendChild(formbricksFeedbackWidget)
-    let formbricksFeedbackConfig = document.createElement('script')
+    let formbricksFeedbackConfig =
+      document.createElement('script')
     formbricksFeedbackConfig.innerHTML = `
     window.formbricks = {
       config: {
@@ -406,8 +406,13 @@ export default {
       },
       ...window.formbricks,
     };
-    `;
+    `
     document.head.appendChild(formbricksFeedbackConfig)
+  },
+  methods: {
+    openFeedbackWidget: function (event) {
+      window.formbricks.open(event)
+    }
   }
 }
 </script>
@@ -447,7 +452,10 @@ function toggleMenu() {
 }
 
 const formbricksEnabled = computed(
-  () => (i18n('feedback.menu') !== "feedback.menu" && config.formbricks.url && config.formbricks.formId)
+  () =>
+    i18n('feedback.menu') !== 'feedback.menu' &&
+    config.formbricks.url &&
+    config.formbricks.formId
 )
 
 const { myOpenTasksCount } = mapGetters('task')

--- a/frontend/src/modules/layout/components/menu.vue
+++ b/frontend/src/modules/layout/components/menu.vue
@@ -332,6 +332,29 @@
           </router-link>
         </el-tooltip>
 
+        <!-- Feedback -->
+        <el-tooltip
+          :disabled="!isCollapsed"
+          :hide-after="50"
+          effect="dark"
+          placement="right"
+          raw-content
+          popper-class="custom-menu-tooltip"
+          :content="i18n('feedback.menu')"
+        >
+          <button
+            v-if="formbricksEnabled"
+            id="menu-feedback"
+            class="el-menu-item"
+            @click="openFeedbackWidget"
+          >
+            <i class="ri-feedback-line"></i>
+            <span v-if="!isCollapsed">
+              <app-i18n code="feedback.menu"></app-i18n
+            ></span>
+          </button>
+        </el-tooltip>
+
         <!-- Support popover -->
         <app-support-dropdown />
       </div>
@@ -346,7 +369,46 @@
 
 <script>
 export default {
-  name: 'AppMenu'
+  name: 'AppMenu',
+  methods: {
+    openFeedbackWidget: function (event) {
+      window.formbricks.open(event)
+    },
+  },
+  mounted() {
+    const store = useStore()
+    let formbricksFeedbackWidget = document.createElement('script')
+    formbricksFeedbackWidget.setAttribute('src', 'https://cdn.jsdelivr.net/npm/@formbricks/feedback@0.1.5/dist/index.umd.js')
+    document.head.appendChild(formbricksFeedbackWidget)
+    let formbricksFeedbackConfig = document.createElement('script')
+    formbricksFeedbackConfig.innerHTML = `
+    window.formbricks = {
+      config: {
+        hqUrl: "${config.formbricks.url}",
+        formId: "${config.formbricks.formId}",
+        contact: {
+          name: "Jonathan",
+          position: "Co-Founder",
+          imgUrl: "https://avatars.githubusercontent.com/u/41432658?v=4",
+        },
+        customer: {
+          id: "${store.getters['auth/currentUser'].id}",
+          name: "${store.getters['auth/currentUser'].fullName}",
+          email: "${store.getters['auth/currentUser'].email}",
+        },
+        style: {
+          brandColor: "#e94f2e",
+          headerBGColor: "#F9FAFB",
+          boxBGColor: "#ffffff",
+          textColor: "#140505",
+          buttonHoverColor: "#F9FAFB",
+        },
+      },
+      ...window.formbricks,
+    };
+    `;
+    document.head.appendChild(formbricksFeedbackConfig)
+  }
 }
 </script>
 
@@ -362,6 +424,7 @@ import AppSupportDropdown from './support-dropdown'
 import AppWorkspaceDropdown from './workspace-dropdown'
 import { computed } from 'vue'
 import { i18n } from '@/i18n'
+import config from '@/config'
 
 import { RouterLink, useLink } from 'vue-router'
 import { mapGetters } from '@/shared/vuex/vuex.helpers'
@@ -382,6 +445,10 @@ const currentTenant = computed(
 function toggleMenu() {
   store.dispatch('layout/toggleMenu')
 }
+
+const formbricksEnabled = computed(
+  () => (i18n('feedback.menu') !== "feedback.menu" && config.formbricks.url && config.formbricks.formId)
+)
 
 const { myOpenTasksCount } = mapGetters('task')
 


### PR DESCRIPTION
# Changes proposed ✍️
Add Formbricks Feedback Widget to crowd.dev to improve feedback submissions.
* Adds a new menu entry "Feedback" to side menu (if environment variables set && language set (TODO: good way to disable for non-english)
* Adds Feedback Widget with customized colors and customer information
* Sends Feedback to Formbricks Cloud or a self-hosted instance of Formbricks to manage Feedback and receive notifications on new submissions

These new environment variables got introduced:
```
VUE_APP_FORMBRICKS_URL=https://xm.formbricks.com
VUE_APP_FORMBRICKS_FORM_ID=clcq5n4h80000l808jyrdx82i
```

To test, go to (Formbricks XM)[https://xm.formbricks.com], create a new account, create a new form and copy the form ID from "Setup Instructions" to your env variables. Start the crowd.dev server, send a feedback and view feedback in Formbricks. If you like to receive email notifications on new submissions you can also setup a "Data Pipeline" for E-Mail in Formbricks.
  
- ### Screenshots (front-end changes only)
<img width="1559" alt="Screenshot 2023-01-10 at 11 10 05" src="https://user-images.githubusercontent.com/675065/211553010-7e45bc83-d4ee-496a-b04a-9fedab6dd0b4.png">
<img width="1559" alt="Screenshot 2023-01-10 at 11 10 12" src="https://user-images.githubusercontent.com/675065/211553298-53eff1d8-b1f3-47b7-8f91-be80144d1c56.png">
<img width="301" alt="Screenshot 2023-01-10 at 13 35 06" src="https://user-images.githubusercontent.com/675065/211553203-1922f347-67c0-4ba6-92ae-de261c1e04de.png">
<img width="299" alt="Screenshot 2023-01-10 at 13 35 11" src="https://user-images.githubusercontent.com/675065/211553217-105f8966-e685-4576-8478-70704a68b0d2.png">
<img width="307" alt="Screenshot 2023-01-10 at 13 35 29" src="https://user-images.githubusercontent.com/675065/211553227-d7b18995-b1be-40ef-af20-fc65aa884313.png">

