### PR TITLE
Activity filters using member attributes

### DIFF
--- a/backend/src/database/repositories/__tests__/activityRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/activityRepository.test.ts
@@ -1507,7 +1507,7 @@ describe('ActivityRepository tests', () => {
       }
 
       const activityCreated1 = await ActivityRepository.create(activity1, mockIRepositoryOptions)
-      await ActivityRepository.create(activity2, mockIRepositoryOptions)
+      const activityCreated2 = await ActivityRepository.create(activity2, mockIRepositoryOptions)
 
       // Control
       expect(
@@ -1515,7 +1515,7 @@ describe('ActivityRepository tests', () => {
       ).toBe(2)
 
       // Filter by member.isTeamMember
-      const filteredActivities = await ActivityRepository.findAndCountAll(
+      let filteredActivities = await ActivityRepository.findAndCountAll(
         {
           advancedFilter: {
             member: {
@@ -1531,6 +1531,25 @@ describe('ActivityRepository tests', () => {
 
       expect(filteredActivities.count).toBe(1)
       expect(filteredActivities.rows[0].id).toBe(activityCreated1.id)
+
+
+
+      filteredActivities = await ActivityRepository.findAndCountAll(
+        {
+          advancedFilter: {
+            member: {
+              'attributes.location.slack': 'New York',
+            },
+          },
+          attributesSettings: memberAttributeSettings,
+        },
+        mockIRepositoryOptions,
+      )
+
+      expect(filteredActivities.count).toBe(1)
+      expect(filteredActivities.rows[0].id).toBe(activityCreated2.id)
+
+
     })
   })
 })

--- a/backend/src/database/repositories/__tests__/activityRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/activityRepository.test.ts
@@ -1444,7 +1444,7 @@ describe('ActivityRepository tests', () => {
             [MemberAttributeName.LOCATION]: {
               default: 'Berlin',
               [PlatformType.GITHUB]: 'Berlin',
-              [PlatformType.SLACK]: 'Turkey'
+              [PlatformType.SLACK]: 'Turkey',
             },
           },
           joinedAt: '2020-05-27T15:13:30Z',
@@ -1466,7 +1466,7 @@ describe('ActivityRepository tests', () => {
             [MemberAttributeName.LOCATION]: {
               default: 'Scranton',
               [PlatformType.GITHUB]: 'Scranton',
-              [PlatformType.SLACK]: 'New York'
+              [PlatformType.SLACK]: 'New York',
             },
           },
           joinedAt: '2020-05-27T15:13:30Z',
@@ -1520,18 +1520,17 @@ describe('ActivityRepository tests', () => {
           advancedFilter: {
             member: {
               isTeamMember: {
-                not: false
-              }
-            }
+                not: false,
+              },
+            },
           },
-          attributesSettings: memberAttributeSettings
+          attributesSettings: memberAttributeSettings,
         },
         mockIRepositoryOptions,
       )
 
       expect(filteredActivities.count).toBe(1)
       expect(filteredActivities.rows[0].id).toBe(activityCreated1.id)
-
     })
   })
 })

--- a/backend/src/database/repositories/__tests__/activityRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/activityRepository.test.ts
@@ -1532,8 +1532,6 @@ describe('ActivityRepository tests', () => {
       expect(filteredActivities.count).toBe(1)
       expect(filteredActivities.rows[0].id).toBe(activityCreated1.id)
 
-
-
       filteredActivities = await ActivityRepository.findAndCountAll(
         {
           advancedFilter: {
@@ -1548,8 +1546,6 @@ describe('ActivityRepository tests', () => {
 
       expect(filteredActivities.count).toBe(1)
       expect(filteredActivities.rows[0].id).toBe(activityCreated2.id)
-
-
     })
   })
 })

--- a/backend/src/database/repositories/__tests__/activityRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/activityRepository.test.ts
@@ -4,6 +4,10 @@ import Error404 from '../../../errors/Error404'
 import ActivityRepository from '../activityRepository'
 import { PlatformType } from '../../../types/integrationEnums'
 import TaskRepository from '../taskRepository'
+import { MemberAttributeName } from '../../attributes/member/enums'
+import MemberAttributeSettingsRepository from '../memberAttributeSettingsRepository'
+import MemberAttributeSettingsService from '../../../services/memberAttributeSettingsService'
+import { DefaultMemberAttributes } from '../../attributes/member/default'
 
 const db = null
 
@@ -1344,6 +1348,7 @@ describe('ActivityRepository tests', () => {
 
     it('Overall sentiment filter and sort', async () => {
       const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
       const memberCreated = await MemberRepository.create(
         {
           username: {
@@ -1413,6 +1418,120 @@ describe('ActivityRepository tests', () => {
       expect(filteredActivities3.rows[0].sentiment.positive).toBeGreaterThan(
         filteredActivities3.rows[1].sentiment.positive,
       )
+    })
+
+    it('Member related attributes filters', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const mas = new MemberAttributeSettingsService(mockIRepositoryOptions)
+
+      await mas.createPredefined(DefaultMemberAttributes)
+
+      const memberAttributeSettings = (
+        await MemberAttributeSettingsRepository.findAndCountAll({}, mockIRepositoryOptions)
+      ).rows
+
+      const memberCreated1 = await MemberRepository.create(
+        {
+          username: {
+            [PlatformType.GITHUB]: 'test',
+          },
+          displayName: 'Anil',
+          attributes: {
+            [MemberAttributeName.IS_TEAM_MEMBER]: {
+              default: true,
+              [PlatformType.CROWD]: true,
+            },
+            [MemberAttributeName.LOCATION]: {
+              default: 'Berlin',
+              [PlatformType.GITHUB]: 'Berlin',
+              [PlatformType.SLACK]: 'Turkey'
+            },
+          },
+          joinedAt: '2020-05-27T15:13:30Z',
+        },
+        mockIRepositoryOptions,
+      )
+
+      const memberCreated2 = await MemberRepository.create(
+        {
+          username: {
+            [PlatformType.GITHUB]: 'Michael',
+          },
+          displayName: 'Michael',
+          attributes: {
+            [MemberAttributeName.IS_TEAM_MEMBER]: {
+              default: false,
+              [PlatformType.CROWD]: false,
+            },
+            [MemberAttributeName.LOCATION]: {
+              default: 'Scranton',
+              [PlatformType.GITHUB]: 'Scranton',
+              [PlatformType.SLACK]: 'New York'
+            },
+          },
+          joinedAt: '2020-05-27T15:13:30Z',
+        },
+        mockIRepositoryOptions,
+      )
+
+      const activity1 = {
+        type: 'activity',
+        timestamp: '2020-05-27T15:13:30Z',
+        platform: PlatformType.GITHUB,
+        sentiment: {
+          positive: 0.98,
+          negative: 0.0,
+          neutral: 0.02,
+          mixed: 0.0,
+          label: 'positive',
+          sentiment: 0.98,
+        },
+        member: memberCreated1.id,
+        sourceId: '#sourceId1',
+      }
+
+      const activity2 = {
+        type: 'activity',
+        timestamp: '2020-05-27T15:13:30Z',
+        platform: PlatformType.GITHUB,
+        sentiment: {
+          positive: 0.55,
+          negative: 0.0,
+          neutral: 0.45,
+          mixed: 0.0,
+          label: 'neutral',
+          sentiment: 0.55,
+        },
+        member: memberCreated2.id,
+        sourceId: '#sourceId2',
+      }
+
+      const activityCreated1 = await ActivityRepository.create(activity1, mockIRepositoryOptions)
+      await ActivityRepository.create(activity2, mockIRepositoryOptions)
+
+      // Control
+      expect(
+        (await ActivityRepository.findAndCountAll({ filter: {} }, mockIRepositoryOptions)).count,
+      ).toBe(2)
+
+      // Filter by member.isTeamMember
+      const filteredActivities = await ActivityRepository.findAndCountAll(
+        {
+          advancedFilter: {
+            member: {
+              isTeamMember: {
+                not: false
+              }
+            }
+          },
+          attributesSettings: memberAttributeSettings
+        },
+        mockIRepositoryOptions,
+      )
+
+      expect(filteredActivities.count).toBe(1)
+      expect(filteredActivities.rows[0].id).toBe(activityCreated1.id)
+
     })
   })
 })

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -500,20 +500,16 @@ class ActivityRepository {
       }
     }
 
-
     const memberSequelizeInclude = {
       model: options.database.member,
       as: 'member',
-      where: {}
+      where: {},
     }
 
+    if (advancedFilter.member) {
+      const { dynamicAttributesDefaultNestedFields, dynamicAttributesPlatformNestedFields } =
+        await MemberRepository.getDynamicAttributesLiterals(attributesSettings, options)
 
-    if (advancedFilter.member){
-      const {
-        dynamicAttributesDefaultNestedFields,
-        dynamicAttributesPlatformNestedFields
-      } = await MemberRepository.getDynamicAttributesLiterals(attributesSettings, options)
-  
       const memberQueryParser = new QueryParser(
         {
           nestedFields: {
@@ -554,7 +550,7 @@ class ActivityRepository {
         },
         options,
       )
-  
+
       const parsedMemberQuery: QueryOutput = memberQueryParser.parse({
         filter: advancedFilter.member,
         orderBy: orderBy || ['joinedAt_DESC'],
@@ -562,12 +558,10 @@ class ActivityRepository {
         offset,
       })
 
-      memberSequelizeInclude.where =  parsedMemberQuery.where ?? {}
+      memberSequelizeInclude.where = parsedMemberQuery.where ?? {}
       delete advancedFilter.member
-
     }
 
-    
     const include = [
       memberSequelizeInclude,
       {

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -9,6 +9,8 @@ import Error404 from '../../errors/Error404'
 import { IRepositoryOptions } from './IRepositoryOptions'
 import QueryParser from './filters/queryParser'
 import { QueryOutput } from './filters/queryTypes'
+import { AttributeData } from '../attributes/attribute'
+import MemberRepository from './memberRepository'
 
 const { Op } = Sequelize
 
@@ -282,7 +284,14 @@ class ActivityRepository {
   }
 
   static async findAndCountAll(
-    { filter = {} as any, advancedFilter = null as any, limit = 0, offset = 0, orderBy = '' },
+    {
+      filter = {} as any,
+      advancedFilter = null as any,
+      limit = 0,
+      offset = 0,
+      orderBy = '',
+      attributesSettings = [] as AttributeData[],
+    },
     options: IRepositoryOptions,
   ) {
     // If the advanced filter is empty, we construct it from the query parameter filter
@@ -491,11 +500,76 @@ class ActivityRepository {
       }
     }
 
+
+    const memberSequelizeInclude = {
+      model: options.database.member,
+      as: 'member',
+      where: {}
+    }
+
+
+    if (advancedFilter.member){
+      const {
+        dynamicAttributesDefaultNestedFields,
+        dynamicAttributesPlatformNestedFields
+      } = await MemberRepository.getDynamicAttributesLiterals(attributesSettings, options)
+  
+      const memberQueryParser = new QueryParser(
+        {
+          nestedFields: {
+            ...dynamicAttributesDefaultNestedFields,
+            ...dynamicAttributesPlatformNestedFields,
+            reach: 'reach.total',
+          },
+          manyToMany: {
+            tags: {
+              table: 'members',
+              model: 'member',
+              relationTable: {
+                name: 'memberTags',
+                from: 'memberId',
+                to: 'tagId',
+              },
+            },
+            organizations: {
+              table: 'members',
+              model: 'member',
+              relationTable: {
+                name: 'memberOrganizations',
+                from: 'memberId',
+                to: 'organizationId',
+              },
+            },
+          },
+          customOperators: {
+            username: {
+              model: 'member',
+              column: 'username',
+            },
+            platform: {
+              model: 'member',
+              column: 'username',
+            },
+          },
+        },
+        options,
+      )
+  
+      const parsedMemberQuery: QueryOutput = memberQueryParser.parse({
+        filter: advancedFilter.member,
+        orderBy: orderBy || ['joinedAt_DESC'],
+        limit,
+        offset,
+      })
+
+      memberSequelizeInclude.where =  parsedMemberQuery.where ?? {}
+      delete advancedFilter.member
+
+    }
+
+    
     const include = [
-      {
-        model: options.database.member,
-        as: 'member',
-      },
+      memberSequelizeInclude,
       {
         model: options.database.activity,
         as: 'parent',
@@ -535,6 +609,15 @@ class ActivityRepository {
       count, // eslint-disable-line prefer-const
     } = await options.database.activity.findAndCountAll({
       include,
+      attributes: [
+        ...SequelizeFilterUtils.getLiteralProjectionsOfModel('activity', options.database),
+        // ...SequelizeFilterUtils.getLiteralProjectionsOfModel(
+        //   'activity',
+        //   options.database,
+        //   'parent',
+        // ),
+        // ...SequelizeFilterUtils.getLiteralProjectionsOfModel('member', options.database),
+      ],
       ...(parsed.where ? { where: parsed.where } : {}),
       ...(parsed.having ? { having: parsed.having } : {}),
       order: parsed.order,

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -611,12 +611,6 @@ class ActivityRepository {
       include,
       attributes: [
         ...SequelizeFilterUtils.getLiteralProjectionsOfModel('activity', options.database),
-        // ...SequelizeFilterUtils.getLiteralProjectionsOfModel(
-        //   'activity',
-        //   options.database,
-        //   'parent',
-        // ),
-        // ...SequelizeFilterUtils.getLiteralProjectionsOfModel('member', options.database),
       ],
       ...(parsed.where ? { where: parsed.where } : {}),
       ...(parsed.having ? { having: parsed.having } : {}),

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -717,7 +717,7 @@ class MemberRepository {
     const activeDaysCount = Sequelize.literal(`"memberActivityAggregatesMVs"."activeDaysCount"`)
     const lastActive = Sequelize.literal(`"memberActivityAggregatesMVs"."lastActive"`)
     const activeOn = Sequelize.literal(`"memberActivityAggregatesMVs"."activeOn"`)
-    
+
     const averageSentiment = Sequelize.literal(`"memberActivityAggregatesMVs"."averageSentiment"`)
     const identities = Sequelize.literal(`ARRAY(SELECT jsonb_object_keys("member"."username"))`)
 
@@ -895,28 +895,31 @@ class MemberRepository {
       {},
     )
 
-    const dynamicAttributesPlatformNestedFields = memberAttributeSettings.reduce((acc, attribute) => {
-      for (const key of availableDynamicAttributePlatformKeys) {
-        if (attribute.type === AttributeType.NUMBER) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `("member"."attributes"#>>'{${attribute.name},${key}}')::integer`,
-          )
-        } else if (attribute.type === AttributeType.BOOLEAN) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `("member"."attributes"#>>'{${attribute.name},${key}}')::boolean`,
-          )
-        } else if (attribute.type === AttributeType.MULTI_SELECT) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `ARRAY( SELECT jsonb_array_elements_text("member"."attributes"#>'{${attribute.name},${key}}'))`,
-          )
-        } else {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `"member"."attributes"#>>'{${attribute.name},${key}}'`,
-          )
+    const dynamicAttributesPlatformNestedFields = memberAttributeSettings.reduce(
+      (acc, attribute) => {
+        for (const key of availableDynamicAttributePlatformKeys) {
+          if (attribute.type === AttributeType.NUMBER) {
+            acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+              `("member"."attributes"#>>'{${attribute.name},${key}}')::integer`,
+            )
+          } else if (attribute.type === AttributeType.BOOLEAN) {
+            acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+              `("member"."attributes"#>>'{${attribute.name},${key}}')::boolean`,
+            )
+          } else if (attribute.type === AttributeType.MULTI_SELECT) {
+            acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+              `ARRAY( SELECT jsonb_array_elements_text("member"."attributes"#>'{${attribute.name},${key}}'))`,
+            )
+          } else {
+            acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+              `"member"."attributes"#>>'{${attribute.name},${key}}'`,
+            )
+          }
         }
-      }
-      return acc
-    }, {})
+        return acc
+      },
+      {},
+    )
 
     const dynamicAttributesProjection = memberAttributeSettings.reduce((acc, attribute) => {
       for (const key of availableDynamicAttributePlatformKeys) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -474,16 +474,6 @@ class MemberRepository {
       },
     ]
 
-    // get possible platforms for a tenant
-    const availableDynamicAttributePlatformKeys = [
-      'default',
-      'custom',
-      'enrichment',
-      ...(await TenantRepository.getAvailablePlatforms(options.currentTenant.id, options)).map(
-        (p) => p.platform,
-      ),
-    ]
-
     customOrderBy = customOrderBy.concat(
       SequelizeFilterUtils.customOrderByIfExists('activityCount', orderBy),
     )
@@ -716,67 +706,28 @@ class MemberRepository {
       }
     }
 
-    const dynamicAttributesNestedFields = attributesSettings.reduce((acc, attribute) => {
-      acc[attribute.name] = `attributes.${attribute.name}.default`
-      return acc
-    }, {})
-
-    const dynamicAttributesLiterals = attributesSettings.reduce((acc, attribute) => {
-      for (const key of availableDynamicAttributePlatformKeys) {
-        if (attribute.type === AttributeType.NUMBER) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `("member"."attributes"#>>'{${attribute.name},${key}}')::integer`,
-          )
-        } else if (attribute.type === AttributeType.BOOLEAN) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `("member"."attributes"#>>'{${attribute.name},${key}}')::boolean`,
-          )
-        } else if (attribute.type === AttributeType.MULTI_SELECT) {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `ARRAY( SELECT jsonb_array_elements_text("member"."attributes"#>'{${attribute.name},${key}}'))`,
-          )
-        } else {
-          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
-            `"member"."attributes"#>>'{${attribute.name},${key}}'`,
-          )
-        }
-      }
-      return acc
-    }, {})
-
-    const dynamicAttributesProjection = attributesSettings.reduce((acc, attribute) => {
-      for (const key of availableDynamicAttributePlatformKeys) {
-        if (key === 'default') {
-          acc.push([
-            Sequelize.literal(`"member"."attributes"#>>'{${attribute.name},default}'`),
-            attribute.name,
-          ])
-        } else {
-          acc.push([
-            Sequelize.literal(`"member"."attributes"#>>'{${attribute.name},${key}}'`),
-            `${attribute.name}.${key}`,
-          ])
-        }
-      }
-      return acc
-    }, [])
+    const {
+      dynamicAttributesDefaultNestedFields,
+      dynamicAttributesPlatformNestedFields,
+      dynamicAttributesProjection,
+    } = await MemberRepository.getDynamicAttributesLiterals(attributesSettings, options)
 
     const activityCount = Sequelize.literal(`"memberActivityAggregatesMVs"."activityCount"`)
     const activityTypes = Sequelize.literal(`"memberActivityAggregatesMVs"."activityTypes"`)
     const activeDaysCount = Sequelize.literal(`"memberActivityAggregatesMVs"."activeDaysCount"`)
     const lastActive = Sequelize.literal(`"memberActivityAggregatesMVs"."lastActive"`)
     const activeOn = Sequelize.literal(`"memberActivityAggregatesMVs"."activeOn"`)
+    
     const averageSentiment = Sequelize.literal(`"memberActivityAggregatesMVs"."averageSentiment"`)
     const identities = Sequelize.literal(`ARRAY(SELECT jsonb_object_keys("member"."username"))`)
 
     const toMergeArray = Sequelize.literal(`STRING_AGG( distinct "toMerge"."id"::text, ',')`)
-
     const noMergeArray = Sequelize.literal(`STRING_AGG( distinct "noMerge"."id"::text, ',')`)
 
     const parser = new QueryParser(
       {
         nestedFields: {
-          ...dynamicAttributesNestedFields,
+          ...dynamicAttributesDefaultNestedFields,
           reach: 'reach.total',
         },
         aggregators: {
@@ -787,7 +738,7 @@ class MemberRepository {
           averageSentiment,
           activeOn,
           identities,
-          ...dynamicAttributesLiterals,
+          ...dynamicAttributesPlatformNestedFields,
           'reach.total': Sequelize.literal(`("member".reach->'total')::int`),
           ...SequelizeFilterUtils.getNativeTableFieldAggregations(
             [
@@ -920,6 +871,75 @@ class MemberRepository {
       count: count.length,
       limit: limit ? Number(limit) : 50,
       offset: offset ? Number(offset) : 0,
+    }
+  }
+
+  static async getDynamicAttributesLiterals(
+    memberAttributeSettings: AttributeData[],
+    options: IRepositoryOptions,
+  ) {
+    // get possible platforms for a tenant
+    const availableDynamicAttributePlatformKeys = [
+      'default',
+      'custom',
+      ...(await TenantRepository.getAvailablePlatforms(options.currentTenant.id, options)).map(
+        (p) => p.platform,
+      ),
+    ]
+
+    const dynamicAttributesDefaultNestedFields = memberAttributeSettings.reduce(
+      (acc, attribute) => {
+        acc[attribute.name] = `attributes.${attribute.name}.default`
+        return acc
+      },
+      {},
+    )
+
+    const dynamicAttributesPlatformNestedFields = memberAttributeSettings.reduce((acc, attribute) => {
+      for (const key of availableDynamicAttributePlatformKeys) {
+        if (attribute.type === AttributeType.NUMBER) {
+          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+            `("member"."attributes"#>>'{${attribute.name},${key}}')::integer`,
+          )
+        } else if (attribute.type === AttributeType.BOOLEAN) {
+          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+            `("member"."attributes"#>>'{${attribute.name},${key}}')::boolean`,
+          )
+        } else if (attribute.type === AttributeType.MULTI_SELECT) {
+          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+            `ARRAY( SELECT jsonb_array_elements_text("member"."attributes"#>'{${attribute.name},${key}}'))`,
+          )
+        } else {
+          acc[`attributes.${attribute.name}.${key}`] = Sequelize.literal(
+            `"member"."attributes"#>>'{${attribute.name},${key}}'`,
+          )
+        }
+      }
+      return acc
+    }, {})
+
+    const dynamicAttributesProjection = memberAttributeSettings.reduce((acc, attribute) => {
+      for (const key of availableDynamicAttributePlatformKeys) {
+        if (key === 'default') {
+          acc.push([
+            Sequelize.literal(`"member"."attributes"#>>'{${attribute.name},default}'`),
+            attribute.name,
+          ])
+        } else {
+          acc.push([
+            Sequelize.literal(`"member"."attributes"#>>'{${attribute.name},${key}}'`),
+            `${attribute.name}.${key}`,
+          ])
+        }
+      }
+      return acc
+    }, [])
+
+    return {
+      dynamicAttributesDefaultNestedFields,
+      dynamicAttributesPlatformNestedFields,
+      availableDynamicAttributePlatformKeys,
+      dynamicAttributesProjection,
     }
   }
 

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -874,6 +874,12 @@ class MemberRepository {
     }
   }
 
+  /**
+   * Returns sequelize literals for dynamic member attributes.
+   * @param memberAttributeSettings
+   * @param options
+   * @returns
+   */
   static async getDynamicAttributesLiterals(
     memberAttributeSettings: AttributeData[],
     options: IRepositoryOptions,

--- a/backend/src/database/utils/sequelizeFilterUtils.ts
+++ b/backend/src/database/utils/sequelizeFilterUtils.ts
@@ -61,22 +61,22 @@ export default class SequelizeFilterUtils {
     return []
   }
 
-  static getFieldLiteral(field:string, model:string): Col {
+  static getFieldLiteral(field: string, model: string): Col {
     return Sequelize.col(`"${model}"."${field}"`)
   }
 
-  static getLiteralProjections(fields:any, model:string): string[] {
+  static getLiteralProjections(fields: any, model: string): string[] {
     return fields.reduce((acc, field) => {
       acc.push([SequelizeFilterUtils.getFieldLiteral(field, model), field])
       return acc
     }, [])
   }
 
-  static getLiteralProjectionsOfModel(model:string, models:any, modelAlias: string = null) {
-      return SequelizeFilterUtils.getLiteralProjections(
-        Object.keys(models[model].rawAttributes),
-        modelAlias ?? model,
-      )
+  static getLiteralProjectionsOfModel(model: string, models: any, modelAlias: string = null) {
+    return SequelizeFilterUtils.getLiteralProjections(
+      Object.keys(models[model].rawAttributes),
+      modelAlias ?? model,
+    )
   }
 
   static getNativeTableFieldAggregations(fields, model) {

--- a/backend/src/database/utils/sequelizeFilterUtils.ts
+++ b/backend/src/database/utils/sequelizeFilterUtils.ts
@@ -1,6 +1,7 @@
 import validator from 'validator'
 import { v4 as uuid } from 'uuid'
 import Sequelize from 'sequelize'
+import { Col } from 'sequelize/types/utils'
 
 /**
  * Utilities to use on Sequelize queries.
@@ -60,15 +61,22 @@ export default class SequelizeFilterUtils {
     return []
   }
 
-  static getFieldLiteral(field, model) {
+  static getFieldLiteral(field:string, model:string): Col {
     return Sequelize.col(`"${model}"."${field}"`)
   }
 
-  static getLiteralProjections(fields, model) {
+  static getLiteralProjections(fields:any, model:string): string[] {
     return fields.reduce((acc, field) => {
       acc.push([SequelizeFilterUtils.getFieldLiteral(field, model), field])
       return acc
     }, [])
+  }
+
+  static getLiteralProjectionsOfModel(model:string, models:any, modelAlias: string = null) {
+      return SequelizeFilterUtils.getLiteralProjections(
+        Object.keys(models[model].rawAttributes),
+        modelAlias ?? model,
+      )
   }
 
   static getNativeTableFieldAggregations(fields, model) {

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -16,6 +16,7 @@ import { IS_TEST_ENV, IS_DEV_ENV } from '../config'
 import { logExecutionTime } from '../utils/logging'
 import { sendNewActivityNodeSQSMessage } from '../serverless/utils/nodeWorkerSQS'
 import { LoggingBase } from './loggingBase'
+import MemberAttributeSettingsRepository from '../database/repositories/memberAttributeSettingsRepository'
 
 export default class ActivityService extends LoggingBase {
   options: IServiceOptions
@@ -470,12 +471,15 @@ export default class ActivityService extends LoggingBase {
   }
 
   async query(data) {
+    const memberAttributeSettings = (
+      await MemberAttributeSettingsRepository.findAndCountAll({}, this.options)
+    ).rows
     const advancedFilter = data.filter
     const orderBy = data.orderBy
     const limit = data.limit
     const offset = data.offset
     return ActivityRepository.findAndCountAll(
-      { advancedFilter, orderBy, limit, offset },
+      { advancedFilter, orderBy, limit, offset, attributesSettings: memberAttributeSettings },
       this.options,
     )
   }

--- a/frontend/src/modules/activity/activity-service.js
+++ b/frontend/src/modules/activity/activity-service.js
@@ -86,10 +86,16 @@ export class ActivityService {
     offset,
     buildFilter = true
   ) {
+    let builtFilter = buildFilter
+      ? buildApiPayload(filter)
+      : filter
+    builtFilter = {
+      ...builtFilter,
+      member: { isTeamMember: { not: true } }
+    }
+
     const body = {
-      filter: buildFilter
-        ? buildApiPayload(filter)
-        : filter,
+      filter: builtFilter,
       orderBy,
       limit,
       offset

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -98,11 +98,6 @@ export default {
     const { platform, period } = state.filters
     return ActivityService.list(
       {
-        member: {
-          isTeamMember: {
-            not: true
-          }
-        },
         and: [
           {
             timestamp: {

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -98,6 +98,11 @@ export default {
     const { platform, period } = state.filters
     return ActivityService.list(
       {
+        member: {
+          isTeamMember: {
+            not: true
+          }
+        },
         and: [
           {
             timestamp: {


### PR DESCRIPTION
# Changes proposed ✍️
- Refactor of dynamic member attributes.
- `Activity.query` endpoint now supports advanced filters regarding members.
- It can be sent using the following syntax:
```
filter : {
 member: {
      isTeamMember: true
  }
 ...activityRelatedFilters
}
```
- By default now we're excluding team member activities from dashboard -> recent activities and activityList module -> Recent activities
## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.