### PR TITLE
Fix organization urls

### DIFF
--- a/frontend/src/modules/organization/components/list/organization-list-table.vue
+++ b/frontend/src/modules/organization/components/list/organization-list-table.vue
@@ -115,7 +115,7 @@
                     <a
                       v-if="scope.row.website"
                       class="text-gray-500 hover:!text-brand-500"
-                      :href="scope.row.website || null"
+                      :href="withHttp(scope.row.website)"
                       target="_blank"
                       @click.stop
                       >{{ scope.row.website }}</a
@@ -277,6 +277,7 @@ import {
 } from '@/shared/vuex/vuex.helpers'
 import { formatDateToTimeAgo } from '@/utils/date'
 import { formatNumberToCompact } from '@/utils/number'
+import { withHttp } from '@/utils/string'
 import AppOrganizationIdentities from '../organization-identities'
 import AppOrganizationListToolbar from './organization-list-toolbar'
 import AppOrganizationName from '../organization-name'

--- a/frontend/src/modules/organization/components/view/organization-view-header.vue
+++ b/frontend/src/modules/organization/components/view/organization-view-header.vue
@@ -21,7 +21,7 @@
             >
               <i class="ri-link mr-1"></i>
               <a
-                :href="organization.website"
+                :href="withHttp(organization.website)"
                 target="_blank"
                 class="text-gray-600"
                 >{{ organization.website }}</a
@@ -159,6 +159,7 @@ import {
   formatNumberToCompact,
   formatRevenueRange
 } from '@/utils/number'
+import { withHttp } from '@/utils/string'
 
 defineProps({
   organization: {

--- a/frontend/src/utils/string.js
+++ b/frontend/src/utils/string.js
@@ -1,3 +1,3 @@
 export const withHttp = (url) => {
-  return !/^https?:\/\//i.test(url) ? `http://${url}` : url
+  return !/^https?:\/\//i.test(url) ? `https://${url}` : url
 }

--- a/frontend/src/utils/string.js
+++ b/frontend/src/utils/string.js
@@ -1,0 +1,3 @@
+export const withHttp = (url) => {
+  return !/^https?:\/\//i.test(url) ? `http://${url}` : url
+}


### PR DESCRIPTION
# Changes proposed ✍️
- Add `http` to urls that do not have it both on Organizations list and Organizations profile

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.