### PR TITLE
Show todays value graphs differently

### DIFF
--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -532,6 +532,7 @@ const en = {
       },
       Members: {
         count: '[Members] Count',
+        cumulativeCount: '[Members] Cumulative Count',
         score: '[Members] Engagement Level',
         location: '[Members] Location',
         organization: '[Members] Organization',

--- a/frontend/src/modules/report/report-charts.js
+++ b/frontend/src/modules/report/report-charts.js
@@ -157,16 +157,21 @@ export function chartOptions(widget, resultSet) {
     }
   }
 
-  return {
+  const options = {
     ...defaultChartOptions,
-    ...{
-      ...chartTypeOptions,
-      ...formatTooltipOptions,
-      library: {
-        ...chartTypeOptions.library,
-        plugins: {
-          ...chartTypeOptions?.library?.plugins,
-          tooltipAnnotationLine: false
+    ...chartTypeOptions,
+    ...formatTooltipOptions
+  }
+
+  return {
+    ...options,
+    library: {
+      ...options.library,
+      plugins: {
+        ...options.library.plugins,
+        tooltipAnnotationLine: false,
+        verticalTodayLine: {
+          bottomMargin: 11
         }
       }
     }

--- a/frontend/src/modules/report/templates/template-report-charts.js
+++ b/frontend/src/modules/report/templates/template-report-charts.js
@@ -52,6 +52,9 @@ const defaultChartOptions = {
       intersect: false
     },
     plugins: {
+      verticalTodayLine: {
+        bottomMargin: 14
+      },
       tooltip: {
         position: 'nearest',
         enabled: false,
@@ -66,7 +69,7 @@ const defaultChartOptions = {
         display: true,
         position: 'bottom',
         align: 'center',
-        onClick: (click, legendItem, legend) => {
+        onClick: (_click, legendItem, legend) => {
           const datasets = legend.legendItems.map(
             (dataset) => dataset.text
           )
@@ -138,7 +141,8 @@ export function chartOptions(type) {
           pointBackgroundColor: 'transparent',
           pointHoverBorderColor: '#E94F2E',
           pointHoverBackgroundColor: '#fff',
-          pointHoverBorderWidth: '2'
+          pointHoverBorderWidth: '2',
+          spanGaps: true
         }
       }
     }

--- a/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
@@ -371,18 +371,23 @@ export default {
         return []
       }
 
-      return JSON.parse(JSON.stringify(this.filters)).map(
-        (f) => {
-          const filter = f
+      return (
+        JSON.parse(JSON.stringify(this.filters))
+          .map((f) => {
+            const filter = f
 
-          filter.value = f.values[0]
-          filter.select = f.member.name
+            filter.value = f.values[0]
+            filter.select = f.member.name
 
-          delete filter.member
-          delete filter.values
+            delete filter.member
+            delete filter.values
 
-          return filter
-        }
+            return filter
+          })
+          // Remove this filter from options for now
+          .filter(
+            (f) => f.select !== 'Members.isTeamMember'
+          )
       )
     },
     syncFilters(option, value, index) {


### PR DESCRIPTION
# Changes proposed ✍️
- Fix label in custom reports to have translation for [Members] Cumulative Count
- Remove Members.isTeamMember filter from Custom Reports
- Add a method to `widget-area` to build dataset style according to datapoint position
- Create a new plugin in chartkick to draw both a line and a background on today/week/month's time span
  
### Screenshots (front-end changes only)
![Screenshot 2023-01-20 at 12 14 56](https://user-images.githubusercontent.com/20134207/213692768-46beba0d-afb0-46f2-97cb-852fe0809299.png)
![Screenshot 2023-01-20 at 12 14 54](https://user-images.githubusercontent.com/20134207/213692772-b0b5e79f-9a1f-4d58-9fc9-b9807eee933f.png)


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.