### PR TITLE
Member enrichment feature flagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.17.0 - 2023-01-23
+
+### Changes
+
+### 🚀 Features
+
+#### LinkedIn integration
+
+Introduction the LinkedIn integration! With it, you can bring the comments and reactions to your organization's LinkedIn posts into crowd.dev. This integration is only available for Growth and Custom plans.
+
+<img width="1727" alt="Linkedin" src="https://user-images.githubusercontent.com/37874460/214154195-3e3ba24e-ba70-4eae-9f65-c22f3bd9042e.png">
+- Linkedin integration @mariobalca (#442)
+
+### ✨ Improvements
+
+- Add global filters to Default Reports. @joanagmaia (#425)
+- Added a Stripe integration for payment so we can automatically upgrade new Growth workspaces. @epipav (#419)
+- Show the current date's value differently in reports. @joanagmaia (#443)
+- Make the email independent from the identities in the members' list. @joanagmaia (#440)
+- Refactor the UI of public reports. @joanagmaia (#437)
+- Remove activities performed by team members. @epipav (#427)
+
+### 🐞 Bug Fixes
+
+- Fix a bug that kept redirecting from `auth/signup` to `augh/signin`. @themarolt (#445)
+- Fix an error when unpublishing conversations in bulk. @epipav (#438)
+- Modified the Community help center's `robots.txt` so Google will index it again. @epipav (#434)
+- Fix URLs in organizations @joanagmaia (#430)
+- Add the Job Title to the members list view @mariobalca (#428)
+
 ## v0.16.0 - 2023-01-16
 
 ### Changes
@@ -18,7 +48,6 @@ Introducing our newest feature: Default Reports! These specially crafted reports
 
 <img width="1727" alt="Reports 1" src="https://user-images.githubusercontent.com/37874460/212732237-8e46b294-8d60-433a-b76b-a3f45c1bf895.png">
 #### Formbricks feedback
-
 Our first external code contribution! @mattinannt and the [Formbricks](https://formbricks.com/) team added an in-app feedback box to our menu. If you have an idea, something needs to be fixed, or want to point out which features you like, you can leave us feedback there!
 <img width="200" alt="Screenshot 2023-01-16 at 14 04 37" src="https://user-images.githubusercontent.com/37874460/212684851-8edd5ee7-1f40-4b48-9556-78190249707e.png">
 
@@ -56,7 +85,6 @@ For example, imagine you want to search for content that talks about *generatice
 <img width="1067" alt="Screenshot 2023-01-09 at 13 14 50" src="https://user-images.githubusercontent.com/37874460/211305723-24aec737-7edf-4c4d-bcd4-deab5e64a968.png">
 - EagleEye exact keyword matching @mariobalca @joanreyero (#383)
 #### Discord forum channels
-
 Forum channels are now supported as part of the Discord integration. We will get posts and all comments on those channels. If you already have a Discord integration connected, we will get posts in public forum channels automatically. You'll need to add the bot to the forum channels that you want if they are private.
 
 - Get forum channels from Discord @joanreyero (#405)
@@ -97,7 +125,6 @@ You can now export your community members as CSV. You can export all members or 
 - Update the call to action layout when a workspace is in the trial. @joanagmaia (#371)
 - When a Kubernetes pod is restarted while performing a job, retake the job when the pod is back up. @themarolt (#365 and #368)
 - Update the logos and images on the app. @joanagmaia (#367)
-
 ### 🐞 Bug Fixes
 
 - Fixed the sorting in the *Most engaged* view on the member's page. @joanagmaia (#375)
@@ -136,7 +163,6 @@ We are advancing in making premium plans possible. This week we introduced a *Pl
 - Do not show the engagement level for team members in the members' list, as it does not make sense. @joanreyero (#349)
 - Added the infrastructure so we can display a banner with in-app TypeForm surveys. @joanreyero (#348)
 ### 🐞 Bug Fixes
-
 - Add a missing interaction to the *Trial* tag. @joanagmaia (#366)
 - Tenants created after the 18th of December only had a trial for 14 days. It should be until the 15th of January. @joanreyero (#363)
 - Fix EagleEye's API throwing a 500 when sending posts to exclude @joanreyero (#359)
@@ -208,7 +234,6 @@ The Hacker News integration will detect any post that mentions your community in
 - Disable range filters in the frontend if one value is empty @joanagmaia (#290)
 ## v0.10.1 - 2022-11-30
 ### Changes
-
 This release introduces three new features: organizations, tasks, and notes. Furthermore, we added a bunch of bug fixes and improvements based on your feedback.
 
 ### :rocket: Features
@@ -254,7 +279,6 @@ Use our custom attribute function to add specific to you details as well as extr
 :key: Social Sign in with Google
 We’ve added social sign-in to make signing up and logging into [crowd.dev](http://crowd.dev/) a breeze. You can now use your Google account.
 #### Breaking changes
-
 This version introduces breaking API changes. While the API has vastly improved and it is now much more powerful, previous scripts written with the API will need to be adjusted. For more information, refer to the [API docs](https://docs.crowd.dev/reference).
 
 ## v0.8.0 - 2022-10-07
@@ -293,7 +317,9 @@ This version introduces breaking API changes. While the API has vastly improved 
 - 
 - 
 - 
+- 
 - - When a new activity is created
+- 
 - 
 - 
 - 
@@ -367,7 +393,6 @@ This version introduces breaking API changes. While the API has vastly improved 
 - Simplified start of development environment @joanreyero (#5)
 ### 🐞 Bug Fixes
 - EagleEye events @joanreyero (#6)
-
 ## v0.0.3 - 2022-08-24
 
 ### Changes

--- a/backend/config/default.json
+++ b/backend/config/default.json
@@ -33,5 +33,6 @@
   "discord": {
     "maxRetrospectInSeconds": 3600
   },
-  "github": {}
+  "github": {},
+  "enrichment": {}
 }

--- a/backend/src/api/auth/authMe.ts
+++ b/backend/src/api/auth/authMe.ts
@@ -1,4 +1,6 @@
+import AutomationRepository from '../../database/repositories/automationRepository'
 import Error403 from '../../errors/Error403'
+import { FeatureFlagRedisKey } from '../../types/common'
 import { RedisCache } from '../../utils/redis/redisCache'
 
 export default async (req, res) => {
@@ -9,16 +11,21 @@ export default async (req, res) => {
 
   const payload = req.currentUser
 
-  const csvExportCountCache = new RedisCache('csvExportCount', req.redis)
-  const automationCountCache = new RedisCache('automation', req.redis)
+  const csvExportCountCache = new RedisCache(FeatureFlagRedisKey.CSV_EXPORT_COUNT, req.redis)
+  const memberEnrichmentCountCache = new RedisCache(
+    FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+    req.redis,
+  )
 
-  // TODO: We should probably revisit this later
   payload.tenants = await Promise.all(
     payload.tenants.map(async (tenantUser) => {
       tenantUser.tenant.dataValues = {
         ...tenantUser.tenant.dataValues,
         csvExportCount: Number(await csvExportCountCache.getValue(tenantUser.tenant.id)) || 0,
-        automationCount: Number(await automationCountCache.getValue(tenantUser.tenant.id)) || 0,
+        automationCount:
+          Number(await AutomationRepository.countAll(req.database, tenantUser.tenant.id)) || 0,
+        memberEnrichmentCount:
+          Number(await memberEnrichmentCountCache.getValue(tenantUser.tenant.id)) || 0,
       }
       return tenantUser
     }),

--- a/backend/src/api/member/memberExport.ts
+++ b/backend/src/api/member/memberExport.ts
@@ -4,6 +4,7 @@ import identifyTenant from '../../segment/identifyTenant'
 import track from '../../segment/track'
 import MemberService from '../../services/memberService'
 import PermissionChecker from '../../services/user/permissionChecker'
+import { FeatureFlagRedisKey } from '../../types/common'
 import { RedisCache } from '../../utils/redis/redisCache'
 
 /**
@@ -24,7 +25,7 @@ export default async (req, res) => {
 
   const payload = await new MemberService(req).export(req.body)
 
-  const csvCountCache = new RedisCache('csvExportCount', req.redis)
+  const csvCountCache = new RedisCache(FeatureFlagRedisKey.CSV_EXPORT_COUNT, req.redis)
 
   const csvCount = await csvCountCache.getValue(req.currentTenant.id)
 

--- a/backend/src/api/premium/enrichment/index.ts
+++ b/backend/src/api/premium/enrichment/index.ts
@@ -5,7 +5,12 @@ import { FeatureFlag } from '../../../types/common'
 export default (app) => {
   app.put(
     `/tenant/:tenantId/enrichment/member/bulk`,
+    featureFlagMiddleware(FeatureFlag.MEMBER_ENRICHMENT, 'enrichment.errors.planLimitExceeded'),
     safeWrap(require('./memberEnrichBulk').default),
   )
-  app.put(`/tenant/:tenantId/enrichment/member/:id/`, safeWrap(require('./memberEnrich').default))
+  app.put(
+    `/tenant/:tenantId/enrichment/member/:id/`,
+    featureFlagMiddleware(FeatureFlag.MEMBER_ENRICHMENT, 'enrichment.errors.planLimitExceeded'),
+    safeWrap(require('./memberEnrich').default),
+  )
 }

--- a/backend/src/api/premium/enrichment/memberEnrich.ts
+++ b/backend/src/api/premium/enrichment/memberEnrich.ts
@@ -1,6 +1,10 @@
+import moment from 'moment'
 import Permissions from '../../../security/permissions'
+import identifyTenant from '../../../segment/identifyTenant'
 import MemberEnrichmentService from '../../../services/premium/enrichment/memberEnrichmentService'
 import PermissionChecker from '../../../services/user/permissionChecker'
+import { FeatureFlagRedisKey } from '../../../types/common'
+import { RedisCache } from '../../../utils/redis/redisCache'
 
 // /**
 //  * PUT /tenant/{tenantId}/member/{id}
@@ -21,5 +25,34 @@ import PermissionChecker from '../../../services/user/permissionChecker'
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberEdit)
   const payload = await new MemberEnrichmentService(req).enrichOne(req.params.id)
+
+  const memberEnrichmentCountCache = new RedisCache(
+    FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+    req.redis,
+  )
+
+  const memberEnrichmentCount = await memberEnrichmentCountCache.getValue(req.currentTenant.id)
+
+  const endTime = moment().endOf('month')
+  const startTime = moment()
+
+  const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+
+  if (!memberEnrichmentCount) {
+    await memberEnrichmentCountCache.setValue(
+      req.currentTenant.id,
+      '0',
+      secondsRemainingUntilEndOfMonth,
+    )
+  } else {
+    await memberEnrichmentCountCache.setValue(
+      req.currentTenant.id,
+      (parseInt(memberEnrichmentCount, 10) + 1).toString(),
+      secondsRemainingUntilEndOfMonth,
+    )
+  }
+
+  identifyTenant(req)
+
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/premium/enrichment/memberEnrichBulk.ts
+++ b/backend/src/api/premium/enrichment/memberEnrichBulk.ts
@@ -40,7 +40,7 @@ export default async (req, res) => {
   // send the message
   await sendBulkEnrichMessage(tenant, membersToEnrich)
 
-  // update enrichment count
+  // update enrichment count, we'll also check failed enrichments and deduct these from grand total in bulkEnrichmentWorker
   const endTime = moment().endOf('month')
   const startTime = moment()
 

--- a/backend/src/api/premium/enrichment/memberEnrichBulk.ts
+++ b/backend/src/api/premium/enrichment/memberEnrichBulk.ts
@@ -1,12 +1,66 @@
+import moment from 'moment'
+import Error403 from '../../../errors/Error403'
+import { PLAN_LIMITS } from '../../../feature-flags/ensureFlagUpdated'
 import Permissions from '../../../security/permissions'
+import identifyTenant from '../../../segment/identifyTenant'
 import { sendBulkEnrichMessage } from '../../../serverless/utils/nodeWorkerSQS'
 import PermissionChecker from '../../../services/user/permissionChecker'
+import { FeatureFlag, FeatureFlagRedisKey } from '../../../types/common'
+import { createServiceLogger } from '../../../utils/logging'
+import { RedisCache } from '../../../utils/redis/redisCache'
+
+const log = createServiceLogger()
 
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberEdit)
   const membersToEnrich = req.body.members
   const tenant = req.currentTenant.id
 
+  const memberEnrichmentCountCache = new RedisCache(
+    FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+    req.redis,
+  )
+  const memberEnrichmentCount = await memberEnrichmentCountCache.getValue(req.currentTenant.id)
+
+  log.info(parseInt(memberEnrichmentCount, 10) + membersToEnrich.length, 'Total: ')
+
+  // Check if requested enrich count is over limit
+  if (
+    parseInt(memberEnrichmentCount, 10) + membersToEnrich.length >
+    PLAN_LIMITS[req.currentTenant.plan][FeatureFlag.MEMBER_ENRICHMENT]
+  ) {
+    await req.responseHandler.error(
+      req,
+      res,
+      new Error403(req.language, 'enrichment.errors.requestedEnrichmentMoreThanLimit'),
+    )
+    return
+  }
+
+  // send the message
   await sendBulkEnrichMessage(tenant, membersToEnrich)
+
+  // update enrichment count
+  const endTime = moment().endOf('month')
+  const startTime = moment()
+
+  const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+
+  if (!memberEnrichmentCount) {
+    await memberEnrichmentCountCache.setValue(
+      req.currentTenant.id,
+      '0',
+      secondsRemainingUntilEndOfMonth,
+    )
+  } else {
+    await memberEnrichmentCountCache.setValue(
+      req.currentTenant.id,
+      (parseInt(memberEnrichmentCount, 10) + membersToEnrich.length).toString(),
+      secondsRemainingUntilEndOfMonth,
+    )
+  }
+
+  identifyTenant(req)
+
   await req.responseHandler.success(req, res, membersToEnrich)
 }

--- a/backend/src/feature-flags/ensureFlagUpdated.ts
+++ b/backend/src/feature-flags/ensureFlagUpdated.ts
@@ -6,6 +6,18 @@ import { timeout } from '../utils/timing'
 
 const log = getServiceLogger()
 
+export const PLAN_LIMITS = {
+  [Plans.values.essential]: {
+    [FeatureFlag.AUTOMATIONS]: 2,
+    [FeatureFlag.CSV_EXPORT]: 2,
+    [FeatureFlag.MEMBER_ENRICHMENT]: 5,
+  },
+  [Plans.values.growth]: {
+    [FeatureFlag.AUTOMATIONS]: 10,
+    [FeatureFlag.CSV_EXPORT]: 10,
+    [FeatureFlag.MEMBER_ENRICHMENT]: 1000,
+  },
+}
 export default async (
   featureFlag: FeatureFlag,
   tenantId: string,
@@ -17,14 +29,28 @@ export default async (
   switch (featureFlag) {
     case FeatureFlag.AUTOMATIONS: {
       expectedFlag =
-        payload.plan === Plans.values.growth ||
-        (payload.plan === Plans.values.essential && payload.automationCount < 2)
+        (payload.plan === Plans.values.growth &&
+          payload.automationCount < PLAN_LIMITS[Plans.values.growth][FeatureFlag.AUTOMATIONS]) ||
+        (payload.plan === Plans.values.essential &&
+          payload.automationCount < PLAN_LIMITS[Plans.values.essential][FeatureFlag.AUTOMATIONS])
       break
     }
     case FeatureFlag.CSV_EXPORT: {
       expectedFlag =
-        payload.plan === Plans.values.growth ||
-        (payload.plan === Plans.values.essential && payload.csvExportCount < 2)
+        (payload.plan === Plans.values.growth &&
+          payload.csvExportCount < PLAN_LIMITS[Plans.values.growth][FeatureFlag.CSV_EXPORT]) ||
+        (payload.plan === Plans.values.essential &&
+          payload.csvExportCount < PLAN_LIMITS[Plans.values.essential][FeatureFlag.CSV_EXPORT])
+      break
+    }
+    case FeatureFlag.MEMBER_ENRICHMENT: {
+      expectedFlag =
+        (payload.plan === Plans.values.growth &&
+          payload.memberEnrichmentCount <
+            PLAN_LIMITS[Plans.values.growth][FeatureFlag.MEMBER_ENRICHMENT]) ||
+        (payload.plan === Plans.values.essential &&
+          payload.memberEnrichmentCount <
+            PLAN_LIMITS[Plans.values.essential][FeatureFlag.MEMBER_ENRICHMENT])
       break
     }
     case FeatureFlag.EAGLE_EYE:

--- a/backend/src/feature-flags/setTenantProperties.ts
+++ b/backend/src/feature-flags/setTenantProperties.ts
@@ -2,7 +2,7 @@ import moment from 'moment'
 import { PostHog } from 'posthog-node'
 import { API_CONFIG, POSTHOG_CONFIG } from '../config'
 import AutomationRepository from '../database/repositories/automationRepository'
-import { Edition } from '../types/common'
+import { Edition, FeatureFlagRedisKey } from '../types/common'
 import { RedisClient } from '../utils/redis'
 import { RedisCache } from '../utils/redis/redisCache'
 
@@ -14,9 +14,15 @@ export default async function setPosthogTenantProperties(
 ) {
   if (POSTHOG_CONFIG.apiKey && API_CONFIG.edition === Edition.CROWD_HOSTED) {
     const automationCount = await AutomationRepository.countAll(database, tenant.id)
-    const csvExportCountCache = new RedisCache('csvExportCount', redis)
+    const csvExportCountCache = new RedisCache(FeatureFlagRedisKey.CSV_EXPORT_COUNT, redis)
+    const memberEnrichmentCountCache = new RedisCache(
+      FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+      redis,
+    )
 
     let csvExportCount = await csvExportCountCache.getValue(tenant.id)
+    let memberEnrichmentCount = await memberEnrichmentCountCache.getValue(tenant.id)
+
     const endTime = moment().endOf('month')
     const startTime = moment()
 
@@ -27,6 +33,11 @@ export default async function setPosthogTenantProperties(
       csvExportCount = '0'
     }
 
+    if (!memberEnrichmentCount) {
+      await memberEnrichmentCountCache.setValue(tenant.id, '0', secondsRemainingUntilEndOfMonth)
+      memberEnrichmentCount = '0'
+    }
+
     const payload = {
       groupType: 'tenant',
       groupKey: tenant.id,
@@ -35,6 +46,7 @@ export default async function setPosthogTenantProperties(
         plan: tenant.plan,
         automationCount: automationCount.toString(),
         csvExportCount,
+        memberEnrichmentCount,
       },
     }
 

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -207,6 +207,7 @@ const en = {
       enrichmentFailed: 'Failed to call the enrichment API',
       noGithubHandleOrEmail:
         'No GitHub handle or email found. We can only enrich profiles with GitHub handles or emails.',
+      memberNotFound: 'Member not found in enrichment remote. Failed to enrich.',
     },
   },
 }

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -200,6 +200,10 @@ const en = {
 
   enrichment: {
     errors: {
+      planLimitExceeded:
+        'You have exceeded # of member enrichments you can have per month in your plan.',
+      requestedEnrichmentMoreThanLimit:
+        'You have requested more member enrichments than your available limit.',
       enrichmentFailed: 'Failed to call the enrichment API',
       noGithubHandleOrEmail:
         'No GitHub handle or email found. We can only enrich profiles with GitHub handles or emails.',

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -207,7 +207,8 @@ const en = {
       enrichmentFailed: 'Failed to call the enrichment API',
       noGithubHandleOrEmail:
         'No GitHub handle or email found. We can only enrich profiles with GitHub handles or emails.',
-      memberNotFound: 'Member not found in enrichment remote. Failed to enrich.',
+      memberNotFound:
+        'Member not found in the enrichment database. This did not affect your quota.',
     },
   },
 }

--- a/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
@@ -36,7 +36,6 @@ async function bulkEnrichmentWorker(tenantId: string, memberIds: string[]) {
       userContext.currentTenant.id,
     )
 
-    // update enrichment count, we'll also check failed enrichments and deduct these from grand total in bulkEnrichmentWorker
     const endTime = moment().endOf('month')
     const startTime = moment()
     const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400

--- a/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
@@ -52,7 +52,7 @@ async function bulkEnrichmentWorker(tenantId: string, memberIds: string[]) {
     } else {
       // Before sending the queue message, we increase the memberEnrichmentCount with all member Ids that are sent,
       // assuming that we'll be able to enrich all.
-      // If any of enrichments failed, we should deduct these credits from memberEnrichmentCount
+      // If any of enrichments failed, we should add these credits back, reducing memberEnrichmentCount
       await memberEnrichmentCountCache.setValue(
         userContext.currentTenant.id,
         (parseInt(memberEnrichmentCount, 10) - failedEnrichmentRequests).toString(),

--- a/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
@@ -1,5 +1,12 @@
+import moment from 'moment-timezone'
+import { PostHog } from 'posthog-node'
+import { POSTHOG_CONFIG } from '../../../../config'
 import getUserContext from '../../../../database/utils/getUserContext'
+import setPosthogTenantProperties from '../../../../feature-flags/setTenantProperties'
 import MemberEnrichmentService from '../../../../services/premium/enrichment/memberEnrichmentService'
+import { FeatureFlagRedisKey } from '../../../../types/common'
+import { createRedisClient } from '../../../../utils/redis'
+import { RedisCache } from '../../../../utils/redis/redisCache'
 
 /**
  * Sends weekly analytics emails of a given tenant
@@ -9,7 +16,50 @@ import MemberEnrichmentService from '../../../../services/premium/enrichment/mem
  */
 async function bulkEnrichmentWorker(tenantId: string, memberIds: string[]) {
   const userContext = await getUserContext(tenantId)
+
   const memberEnrichmentService = new MemberEnrichmentService(userContext)
-  await memberEnrichmentService.bulkEnrich(memberIds)
+
+  const { enrichedMemberCount } = await memberEnrichmentService.bulkEnrich(memberIds)
+
+  const failedEnrichmentRequests = memberIds.length - enrichedMemberCount
+
+  // if there are failed enrichments, deduct these from total memberEnrichmentCount credits
+  if (failedEnrichmentRequests > 0) {
+    const redis = await createRedisClient(true)
+
+    const memberEnrichmentCountCache = new RedisCache(
+      FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+      redis,
+    )
+
+    const memberEnrichmentCount = await memberEnrichmentCountCache.getValue(
+      userContext.currentTenant.id,
+    )
+
+    // update enrichment count, we'll also check failed enrichments and deduct these from grand total in bulkEnrichmentWorker
+    const endTime = moment().endOf('month')
+    const startTime = moment()
+    const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+
+    if (!memberEnrichmentCount) {
+      await memberEnrichmentCountCache.setValue(
+        userContext.currentTenant.id,
+        '0',
+        secondsRemainingUntilEndOfMonth,
+      )
+    } else {
+      await memberEnrichmentCountCache.setValue(
+        userContext.currentTenant.id,
+        (parseInt(memberEnrichmentCount, 10) - failedEnrichmentRequests).toString(),
+        secondsRemainingUntilEndOfMonth,
+      )
+    }
+    setPosthogTenantProperties(
+      userContext.currentTenant,
+      new PostHog(POSTHOG_CONFIG.apiKey, { flushAt: 1, flushInterval: 1 }),
+      userContext.database,
+      redis,
+    )
+  }
 }
 export { bulkEnrichmentWorker }

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -187,6 +187,8 @@ export default class MemberEnrichmentService extends LoggingBase {
         this.options.currentTenant.id,
       ),
     )
+
+    return { enrichedMemberCount: enrichedMembers }
   }
 
   /**

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -449,11 +449,16 @@ export default class MemberEnrichmentService extends LoggingBase {
       }
       // Make the GET request and extract the profile data from the response
       const response: EnrichmentAPIResponse = (await axios(config)).data
+
+      if (response.error) {
+        this.log.error(githubHandle, `Member not found using github handle.`)
+        throw new Error400(this.options.language, 'enrichment.errors.memberNotFound')
+      }
       return response.profile
     } catch (error) {
       // Log the error and throw a custom error
       this.log.error({ error, githubHandle }, 'Enrichment failed')
-      throw new Error400(this.options.language, 'enrichment.errors.enrichmentFailed')
+      throw error
     }
   }
 
@@ -481,11 +486,15 @@ export default class MemberEnrichmentService extends LoggingBase {
       }
       // Make the GET request and extract the profile data from the response
       const response: EnrichmentAPIResponse = (await axios(config)).data
+      if (response.error) {
+        this.log.error(email, `Member not found using email.`)
+        throw new Error400(this.options.language, 'enrichment.errors.memberNotFound')
+      }
       return response.profile
     } catch (error) {
       // Log the error and throw a custom error
       this.log.error({ error, email }, 'Enrichment failed')
-      throw new Error400(this.options.language, 'enrichment.errors.enrichmentFailed')
+      throw error
     }
   }
 }

--- a/backend/src/services/premium/enrichment/types/memberEnrichmentTypes.ts
+++ b/backend/src/services/premium/enrichment/types/memberEnrichmentTypes.ts
@@ -79,4 +79,5 @@ export interface EnrichmentAPIMember {
 
 export interface EnrichmentAPIResponse {
   profile: EnrichmentAPIMember
+  error?: any
 }

--- a/backend/src/types/common.ts
+++ b/backend/src/types/common.ts
@@ -17,6 +17,12 @@ export enum FeatureFlag {
   ORGANIZATIONS = 'organizations',
   CSV_EXPORT = 'csv-export',
   LINKEDIN = 'linkedin',
+  MEMBER_ENRICHMENT = 'member-enrichment',
+}
+
+export enum FeatureFlagRedisKey {
+  CSV_EXPORT_COUNT = 'csvExportCount',
+  MEMBER_ENRICHMENT_COUNT = 'memberEnrichmentCount',
 }
 
 export enum Edition {

--- a/frontend/src/modules/member/components/member-channels.vue
+++ b/frontend/src/modules/member/components/member-channels.vue
@@ -109,6 +109,7 @@ const hasSocialIdentities = computed(
     !!props.member.username?.discord ||
     !!props.member.username?.slack ||
     !!props.member.username?.hackernews ||
-    !!props.member.username?.reddit
+    !!props.member.username?.reddit ||
+    !!props.member.username?.linkedin
 )
 </script>


### PR DESCRIPTION
# Changes proposed ✍️
- Feature flagging logic for member enrichment. We also keep the current enrichment count in Redis just like CSV exports.
- For single enrichment, we use the feature flags from Posthog to see if we still have credits.
- For bulk enrichment, we calculate the remaining credits with the value from Redis and allow enrichment if the tenant has enough credits to bulk enrich.
- Also we decided not to use `ensureFeatureFlags` function not to keep the frontend waiting for Posthog processing. Instead, frontend will use returned `memberEnrichmentCount` value in the tenant object to determine if a tenant still has some enrichment credits or not

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.