### PR TITLE
Member enrichment cache

### DIFF
--- a/backend/src/database/migrations/U1674663701__memberEnrichmentCache.sql
+++ b/backend/src/database/migrations/U1674663701__memberEnrichmentCache.sql
@@ -1,0 +1,1 @@
+drop table "memberEnrichmentCache";

--- a/backend/src/database/migrations/V1674663701__memberEnrichmentCache.sql
+++ b/backend/src/database/migrations/V1674663701__memberEnrichmentCache.sql
@@ -1,0 +1,11 @@
+CREATE TABLE public."memberEnrichmentCache" (
+	"createdAt" timestamptz NOT NULL,
+	"updatedAt" timestamptz NOT NULL,
+	"memberId" uuid NOT NULL,
+    "data" jsonb NOT NULL,
+	CONSTRAINT "memberEnrichmentCache_pkey" PRIMARY KEY ("memberId")
+);
+
+
+-- public."taskAssignees" foreign keys
+ALTER TABLE public."memberEnrichmentCache" ADD CONSTRAINT "memberEnrichmentCache_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES public.members(id) ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/backend/src/database/repositories/__tests__/memberEnrichmentCache.test.ts
+++ b/backend/src/database/repositories/__tests__/memberEnrichmentCache.test.ts
@@ -8,136 +8,147 @@ import MemberEnrichmentCacheRepository from '../memberEnrichmentCacheRepository'
 const db = null
 
 describe('MemberEnrichmentCacheRepository tests', () => {
-    beforeEach(async () => {
-        await SequelizeTestUtils.wipeDatabase(db)
+  beforeEach(async () => {
+    await SequelizeTestUtils.wipeDatabase(db)
+  })
+
+  afterAll((done) => {
+    // Closing the DB connection allows Jest to exit successfully.
+    SequelizeTestUtils.closeConnection(db)
+    done()
+  })
+
+  describe('upsert method', () => {
+    it('Should create non existing item successfully', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+      const member2add = {
+        username: {
+          [PlatformType.GITHUB]: 'michael_scott',
+        },
+        displayName: 'Member 1',
+        email: 'michael@dd.com',
+        score: 10,
+        attributes: {},
+        joinedAt: '2020-05-27T15:13:30Z',
+      }
+
+      const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+      const enrichmentData = {
+        enrichmentField1: 'string',
+        enrichmentField2: 24,
+        arrayEnrichmentField: [1, 2, 3],
+      }
+
+      const cache = await MemberEnrichmentCacheRepository.upsert(
+        member.id,
+        enrichmentData,
+        mockIRepositoryOptions,
+      )
+
+      expect(cache.memberId).toEqual(member.id)
+      expect(cache.data).toStrictEqual(enrichmentData)
     })
 
-    afterAll((done) => {
-        // Closing the DB connection allows Jest to exit successfully.
-        SequelizeTestUtils.closeConnection(db)
-        done()
+    it('Should update the data of existing cache item with incoming data', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+      const member2add = {
+        username: {
+          [PlatformType.GITHUB]: 'michael_scott',
+        },
+        displayName: 'Member 1',
+        email: 'michael@dd.com',
+        score: 10,
+        attributes: {},
+        joinedAt: '2020-05-27T15:13:30Z',
+      }
+
+      const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+      const enrichmentData = {
+        enrichmentField1: 'string',
+        enrichmentField2: 24,
+        arrayEnrichmentField: [1, 2, 3],
+      }
+
+      let cache = await MemberEnrichmentCacheRepository.upsert(
+        member.id,
+        enrichmentData,
+        mockIRepositoryOptions,
+      )
+
+      const newerEnrichmentData = {
+        enrichmentField1: 'anotherString',
+        enrichmentField2: 99,
+        arrayEnrichmentField: ['a', 'b', 'c'],
+      }
+
+      // should overwrite with new cache data
+      cache = await MemberEnrichmentCacheRepository.upsert(
+        member.id,
+        newerEnrichmentData,
+        mockIRepositoryOptions,
+      )
+
+      expect(cache.memberId).toEqual(member.id)
+      expect(cache.data).toStrictEqual(newerEnrichmentData)
+
+      // when we send an empty object, it shouldn't overwrite
+      cache = await MemberEnrichmentCacheRepository.upsert(member.id, {}, mockIRepositoryOptions)
+
+      expect(cache.memberId).toEqual(member.id)
+      expect(cache.data).toStrictEqual(newerEnrichmentData)
+    })
+  })
+
+  describe('findByMemberId method', () => {
+    it('Should find enrichment cache by memberId', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+      const member2add = {
+        username: {
+          [PlatformType.GITHUB]: 'michael_scott',
+        },
+        displayName: 'Member 1',
+        email: 'michael@dd.com',
+        score: 10,
+        attributes: {},
+        joinedAt: '2020-05-27T15:13:30Z',
+      }
+
+      const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+      const enrichmentData = {
+        enrichmentField1: 'string',
+        enrichmentField2: 24,
+        arrayEnrichmentField: [1, 2, 3],
+      }
+
+      await MemberEnrichmentCacheRepository.upsert(
+        member.id,
+        enrichmentData,
+        mockIRepositoryOptions,
+      )
+
+      const cache = await MemberEnrichmentCacheRepository.findByMemberId(
+        member.id,
+        mockIRepositoryOptions,
+      )
+
+      expect(cache.memberId).toEqual(member.id)
+      expect(cache.data).toEqual(enrichmentData)
     })
 
-    describe('upsert method', () => {
-        it('Should create non existing item successfully', async () => {
-            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+    it('Should return null for non-existing cache entry', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
 
-            const member2add = {
-                username: {
-                    [PlatformType.GITHUB]: 'michael_scott',
-                },
-                displayName: 'Member 1',
-                email: 'michael@dd.com',
-                score: 10,
-                attributes: {},
-                joinedAt: '2020-05-27T15:13:30Z',
-            }
-
-            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
-
-            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
-
-            const cache = await MemberEnrichmentCacheRepository.upsert(
-                member.id,
-                enrichmentData,
-                mockIRepositoryOptions,
-            )
-
-            expect(cache.memberId).toEqual(member.id)
-            expect(cache.data).toStrictEqual(enrichmentData)
-        })
-
-        it('Should update the data of existing cache item with incoming data', async () => {
-            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
-
-            const member2add = {
-                username: {
-                    [PlatformType.GITHUB]: 'michael_scott',
-                },
-                displayName: 'Member 1',
-                email: 'michael@dd.com',
-                score: 10,
-                attributes: {},
-                joinedAt: '2020-05-27T15:13:30Z',
-            }
-
-            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
-
-            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
-
-            let cache = await MemberEnrichmentCacheRepository.upsert(
-                member.id,
-                enrichmentData,
-                mockIRepositoryOptions,
-            )
-
-            const newerEnrichmentData = { enrichmentField1: 'anotherString', enrichmentField2: 99, arrayEnrichmentField: ['a', 'b', 'c'] }
-
-            // should overwrite with new cache data
-            cache = await MemberEnrichmentCacheRepository.upsert(
-                member.id,
-                newerEnrichmentData,
-                mockIRepositoryOptions,
-            )
-
-            expect(cache.memberId).toEqual(member.id)
-            expect(cache.data).toStrictEqual(newerEnrichmentData)
-
-            // when we send an empty object, it shouldn't overwrite
-            cache = await MemberEnrichmentCacheRepository.upsert(
-                member.id,
-                {},
-                mockIRepositoryOptions,
-            )
-
-            expect(cache.memberId).toEqual(member.id)
-            expect(cache.data).toStrictEqual(newerEnrichmentData)
-
-
-
-        })
+      const cache = await MemberEnrichmentCacheRepository.findByMemberId(
+        randomUUID(),
+        mockIRepositoryOptions,
+      )
+      expect(cache).toBeNull()
     })
-
-    describe('findByMemberId method', () => {
-        it('Should find enrichment cache by memberId', async () => {
-
-            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
-
-            const member2add = {
-                username: {
-                    [PlatformType.GITHUB]: 'michael_scott',
-                },
-                displayName: 'Member 1',
-                email: 'michael@dd.com',
-                score: 10,
-                attributes: {},
-                joinedAt: '2020-05-27T15:13:30Z',
-            }
-
-            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
-
-            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
-
-            await MemberEnrichmentCacheRepository.upsert(
-                member.id,
-                enrichmentData,
-                mockIRepositoryOptions,
-            )
-
-            const cache = await MemberEnrichmentCacheRepository.findByMemberId(member.id, mockIRepositoryOptions)
-
-            expect(cache.memberId).toEqual(member.id)
-            expect(cache.data).toEqual(enrichmentData)
-
-        })
-
-        it('Should return null for non-existing cache entry', async () => {
-            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
-
-            const cache = await MemberEnrichmentCacheRepository.findByMemberId(randomUUID(), mockIRepositoryOptions)
-            expect(cache).toBeNull()
-
-        })
-
-    })
+  })
 })

--- a/backend/src/database/repositories/__tests__/memberEnrichmentCache.test.ts
+++ b/backend/src/database/repositories/__tests__/memberEnrichmentCache.test.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'crypto'
+
+import MemberRepository from '../memberRepository'
+import SequelizeTestUtils from '../../utils/sequelizeTestUtils'
+import { PlatformType } from '../../../types/integrationEnums'
+import MemberEnrichmentCacheRepository from '../memberEnrichmentCacheRepository'
+
+const db = null
+
+describe('MemberEnrichmentCacheRepository tests', () => {
+    beforeEach(async () => {
+        await SequelizeTestUtils.wipeDatabase(db)
+    })
+
+    afterAll((done) => {
+        // Closing the DB connection allows Jest to exit successfully.
+        SequelizeTestUtils.closeConnection(db)
+        done()
+    })
+
+    describe('upsert method', () => {
+        it('Should create non existing item successfully', async () => {
+            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+            const member2add = {
+                username: {
+                    [PlatformType.GITHUB]: 'michael_scott',
+                },
+                displayName: 'Member 1',
+                email: 'michael@dd.com',
+                score: 10,
+                attributes: {},
+                joinedAt: '2020-05-27T15:13:30Z',
+            }
+
+            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
+
+            const cache = await MemberEnrichmentCacheRepository.upsert(
+                member.id,
+                enrichmentData,
+                mockIRepositoryOptions,
+            )
+
+            expect(cache.memberId).toEqual(member.id)
+            expect(cache.data).toStrictEqual(enrichmentData)
+        })
+
+        it('Should update the data of existing cache item with incoming data', async () => {
+            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+            const member2add = {
+                username: {
+                    [PlatformType.GITHUB]: 'michael_scott',
+                },
+                displayName: 'Member 1',
+                email: 'michael@dd.com',
+                score: 10,
+                attributes: {},
+                joinedAt: '2020-05-27T15:13:30Z',
+            }
+
+            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
+
+            let cache = await MemberEnrichmentCacheRepository.upsert(
+                member.id,
+                enrichmentData,
+                mockIRepositoryOptions,
+            )
+
+            const newerEnrichmentData = { enrichmentField1: 'anotherString', enrichmentField2: 99, arrayEnrichmentField: ['a', 'b', 'c'] }
+
+            // should overwrite with new cache data
+            cache = await MemberEnrichmentCacheRepository.upsert(
+                member.id,
+                newerEnrichmentData,
+                mockIRepositoryOptions,
+            )
+
+            expect(cache.memberId).toEqual(member.id)
+            expect(cache.data).toStrictEqual(newerEnrichmentData)
+
+            // when we send an empty object, it shouldn't overwrite
+            cache = await MemberEnrichmentCacheRepository.upsert(
+                member.id,
+                {},
+                mockIRepositoryOptions,
+            )
+
+            expect(cache.memberId).toEqual(member.id)
+            expect(cache.data).toStrictEqual(newerEnrichmentData)
+
+
+
+        })
+    })
+
+    describe('findByMemberId method', () => {
+        it('Should find enrichment cache by memberId', async () => {
+
+            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+            const member2add = {
+                username: {
+                    [PlatformType.GITHUB]: 'michael_scott',
+                },
+                displayName: 'Member 1',
+                email: 'michael@dd.com',
+                score: 10,
+                attributes: {},
+                joinedAt: '2020-05-27T15:13:30Z',
+            }
+
+            const member = await MemberRepository.create(member2add, mockIRepositoryOptions)
+
+            const enrichmentData = { enrichmentField1: 'string', enrichmentField2: 24, arrayEnrichmentField: [1, 2, 3] }
+
+            await MemberEnrichmentCacheRepository.upsert(
+                member.id,
+                enrichmentData,
+                mockIRepositoryOptions,
+            )
+
+            const cache = await MemberEnrichmentCacheRepository.findByMemberId(member.id, mockIRepositoryOptions)
+
+            expect(cache.memberId).toEqual(member.id)
+            expect(cache.data).toEqual(enrichmentData)
+
+        })
+
+        it('Should return null for non-existing cache entry', async () => {
+            const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+
+            const cache = await MemberEnrichmentCacheRepository.findByMemberId(randomUUID(), mockIRepositoryOptions)
+            expect(cache).toBeNull()
+
+        })
+
+    })
+})

--- a/backend/src/database/repositories/memberEnrichmentCacheRepository.ts
+++ b/backend/src/database/repositories/memberEnrichmentCacheRepository.ts
@@ -1,0 +1,75 @@
+import { QueryTypes } from 'sequelize'
+import { EnrichmentCache } from '../../services/premium/enrichment/types/memberEnrichmentTypes'
+import { IRepositoryOptions } from './IRepositoryOptions'
+
+class MemberEnrichmentCacheRepository {
+  /**
+   * Inserts enrichment data into cache. If a member
+   * already has an enrichment entry, row is updated with the latest given data.
+   * Returns null if data is falsy or an empty object.
+   * @param memberId enriched member's id
+   * @param data enrichment data
+   * @param options
+   * @returns
+   */
+  static async upsert(
+    memberId: string,
+    data: any,
+    options: IRepositoryOptions,
+  ): Promise<EnrichmentCache> {
+    if (data && Object.keys(data).length > 0) {
+      await options.database.sequelize.query(
+        `INSERT INTO "memberEnrichmentCache" ("createdAt", "updatedAt", "memberId", "data")
+          VALUES
+              (now(), now(), :memberId, :data)
+          ON CONFLICT ("memberId") DO UPDATE
+          SET data = :data, "updatedAt" = now()
+        `,
+        {
+          replacements: {
+            memberId,
+            data: JSON.stringify(data),
+          },
+          type: QueryTypes.UPSERT,
+        },
+      )
+
+    }
+
+    const cacheUpserted = await MemberEnrichmentCacheRepository.findByMemberId(memberId, options)
+    return cacheUpserted
+  }
+
+  /**
+   * Finds member enrichment cache given memberId
+   * Returns null if not found.
+   * @param memberId enriched member's id
+   * @param options
+   * @returns
+   */
+  static async findByMemberId(
+    memberId: string,
+    options: IRepositoryOptions,
+  ): Promise<EnrichmentCache> {
+    const records = await options.database.sequelize.query(
+      `select *
+       from "memberEnrichmentCache"
+       where "memberId" = :memberId;
+    `,
+      {
+        replacements: {
+          memberId,
+        },
+        type: QueryTypes.SELECT,
+      },
+    )
+
+    if (records.length === 0) {
+      return null
+    }
+
+    return records[0]
+  }
+}
+
+export default MemberEnrichmentCacheRepository

--- a/backend/src/database/repositories/memberEnrichmentCacheRepository.ts
+++ b/backend/src/database/repositories/memberEnrichmentCacheRepository.ts
@@ -33,7 +33,6 @@ class MemberEnrichmentCacheRepository {
           type: QueryTypes.UPSERT,
         },
       )
-
     }
 
     const cacheUpserted = await MemberEnrichmentCacheRepository.findByMemberId(memberId, options)

--- a/backend/src/database/utils/sequelizeTestUtils.ts
+++ b/backend/src/database/utils/sequelizeTestUtils.ts
@@ -34,7 +34,8 @@ export default class SequelizeTestUtils {
         files,
         microservices,
         "eagleEyeContents",
-        "auditLogs"
+        "auditLogs",
+        "memberEnrichmentCache"
       cascade;
     `)
   }

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -28,6 +28,7 @@ import { i18n } from '../../../i18n'
 import RedisPubSubEmitter from '../../../utils/redis/pubSubEmitter'
 import { createRedisClient } from '../../../utils/redis'
 import { ApiWebsocketMessage } from '../../../types/mq/apiWebsocketMessage'
+import MemberEnrichmentCacheRepository from '../../../database/repositories/memberEnrichmentCacheRepository'
 
 export default class MemberEnrichmentService extends LoggingBase {
   options: IServiceOptions
@@ -228,6 +229,9 @@ export default class MemberEnrichmentService extends LoggingBase {
     }
 
     if (enrichmentData) {
+      // save raw data to cache
+      await MemberEnrichmentCacheRepository.upsert(memberId, enrichmentData, this.options)
+
       const normalized = await this.normalize(member, enrichmentData)
 
       // We are updating the displayName only if the existing one has one word only

--- a/backend/src/services/premium/enrichment/types/memberEnrichmentTypes.ts
+++ b/backend/src/services/premium/enrichment/types/memberEnrichmentTypes.ts
@@ -81,3 +81,10 @@ export interface EnrichmentAPIResponse {
   profile: EnrichmentAPIMember
   error?: any
 }
+
+export interface EnrichmentCache {
+  memberId: string
+  data: any
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
# Changes proposed ✍️
- Enrichment cache table to store raw data from enrichment database. Before normalizing the data we save the incoming data to this table first.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.