### PR TITLE
Fixing discord joined_guild activity generation

### DIFF
--- a/backend/src/serverless/integrations/services/integrationProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationProcessor.ts
@@ -320,7 +320,7 @@ export class IntegrationProcessor extends LoggingBase {
           // surround with try catch so if one stream fails we try all of them as well just in case
           try {
             logger.trace(
-              { stream: stream.value },
+              { stream: JSON.stringify(stream) },
               `Processing stream! Still have ${streams.length} streams left to process!`,
             )
             let processStreamResult
@@ -330,7 +330,7 @@ export class IntegrationProcessor extends LoggingBase {
               if (err.rateLimitResetSeconds) {
                 delay = err.rateLimitResetSeconds + 5
                 logger.warn(
-                  { stream: stream.value, delay, message: err.message },
+                  { stream: JSON.stringify(stream), delay, message: err.message },
                   'Rate limit reached while processing stream! Delaying...',
                 )
                 failedStreams.push(stream)
@@ -372,7 +372,7 @@ export class IntegrationProcessor extends LoggingBase {
                 logger.warn('Integration processing finished because of service implementation!')
               } else {
                 logger.trace(
-                  { currentStream: stream },
+                  { currentStream: JSON.stringify(stream) },
                   `Detected next page stream! Now we have ${streams.length} left to process!`,
                 )
                 streams.push(processStreamResult.nextPageStream)
@@ -421,7 +421,7 @@ export class IntegrationProcessor extends LoggingBase {
               notifyCount = 0
             }
           } catch (err) {
-            logger.error(err, { stream }, 'Error processing a stream!')
+            logger.error(err, { stream: JSON.stringify(stream) }, 'Error processing a stream!')
             failedStreams.push(stream)
           }
         }
@@ -454,7 +454,7 @@ export class IntegrationProcessor extends LoggingBase {
 
             if (retryCount > MAX_STREAM_RETRIES) {
               logger.warn(
-                { failedStream },
+                { failedStream: JSON.stringify(failedStream) },
                 'Failed stream will not be retried because it reached retry limit!',
               )
               streamRetryLimitReached = true

--- a/backend/src/serverless/integrations/services/integrationServiceBase.ts
+++ b/backend/src/serverless/integrations/services/integrationServiceBase.ts
@@ -144,7 +144,7 @@ export abstract class IntegrationServiceBase {
     timestamp: string,
     platform: string,
   ) {
-    if (uniqueRemoteId === '' || type === '' || timestamp === '' || platform === '') {
+    if (!uniqueRemoteId || !type || !timestamp || !platform) {
       throw new Error('Bad hash input')
     }
 

--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -343,22 +343,21 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
         if (record.user.avatar !== null && record.user.avatar !== undefined) {
           avatarUrl = `https://cdn.discordapp.com/avatars/${record.user.id}/${record.user.avatar}.png`
         }
+
+        const joinedAt = moment(record.joined_at).utc().toDate()
+        const sourceId = `gen-${record.user.id}-${joinedAt.toISOString()}`
+
         acc.push({
           tenant: context.integration.tenantId,
           platform: PlatformType.DISCORD,
           type: 'joined_guild',
-          sourceId: IntegrationServiceBase.generateSourceIdHash(
-            record.id,
-            'joined_guild',
-            moment(record.joined_at).utc().unix().toString(),
-            PlatformType.DISCORD,
-          ),
-          timestamp: moment(record.joined_at).utc().toDate(),
+          sourceId,
+          timestamp: joinedAt,
           member: {
             username: record.user.username,
             attributes: {
               [MemberAttributeName.SOURCE_ID]: {
-                [PlatformType.DISCORD]: record.id,
+                [PlatformType.DISCORD]: record.user.id,
               },
               ...(avatarUrl && {
                 [MemberAttributeName.AVATAR_URL]: {

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -2326,10 +2326,6 @@ describe('MemberService tests', () => {
 
   describe('getHighestPriorityPlatformForAttributes method', () => {
     it('Should return the highest priority platform from a priority array, handling the exceptions', async () => {
-      const mockIServiceOptions = await SequelizeTestUtils.getTestIServiceOptions(db)
-
-      const memberService = new MemberService(mockIServiceOptions)
-
       const priorityArray = [
         PlatformType.TWITTER,
         PlatformType.CROWD,
@@ -2340,7 +2336,7 @@ describe('MemberService tests', () => {
       ]
 
       let inputPlatforms = [PlatformType.GITHUB, PlatformType.DEVTO]
-      let highestPriorityPlatform = memberService.getHighestPriorityPlatformForAttributes(
+      let highestPriorityPlatform = MemberService.getHighestPriorityPlatformForAttributes(
         inputPlatforms,
         priorityArray,
       )
@@ -2348,7 +2344,7 @@ describe('MemberService tests', () => {
       expect(highestPriorityPlatform).toBe(PlatformType.DEVTO)
 
       inputPlatforms = [PlatformType.GITHUB, 'someOtherPlatform'] as any
-      highestPriorityPlatform = memberService.getHighestPriorityPlatformForAttributes(
+      highestPriorityPlatform = MemberService.getHighestPriorityPlatformForAttributes(
         inputPlatforms,
         priorityArray,
       )
@@ -2358,7 +2354,7 @@ describe('MemberService tests', () => {
       inputPlatforms = ['somePlatform1', 'somePlatform2'] as any
 
       // if no match in the priority array, it should return the first platform it finds
-      highestPriorityPlatform = memberService.getHighestPriorityPlatformForAttributes(
+      highestPriorityPlatform = MemberService.getHighestPriorityPlatformForAttributes(
         inputPlatforms,
         priorityArray,
       )
@@ -2367,10 +2363,12 @@ describe('MemberService tests', () => {
 
       inputPlatforms = []
 
-      // if no platforms are sent to choose from, it should throw a 400 Error
-      expect(() =>
-        memberService.getHighestPriorityPlatformForAttributes(inputPlatforms, priorityArray),
-      ).toThrowError(new Error400('en', 'settings.memberAttributes.noPlatformSent'))
+      // if no platforms are sent to choose from, it should return undefined
+      highestPriorityPlatform = MemberService.getHighestPriorityPlatformForAttributes(
+        inputPlatforms,
+        priorityArray,
+      )
+      expect(highestPriorityPlatform).not.toBeDefined()
     })
   })
 

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -123,11 +123,16 @@ export default class MemberService extends LoggingBase {
       .attributeSettings.priorities
 
     for (const attributeName of Object.keys(attributes)) {
-      const highestPriorityPlatform = this.getHighestPriorityPlatformForAttributes(
+      const highestPriorityPlatform = MemberService.getHighestPriorityPlatformForAttributes(
         Object.keys(attributes[attributeName]),
         priorityArray,
       )
-      attributes[attributeName].default = attributes[attributeName][highestPriorityPlatform]
+
+      if (highestPriorityPlatform !== undefined) {
+        attributes[attributeName].default = attributes[attributeName][highestPriorityPlatform]
+      } else {
+        delete attributes[attributeName]
+      }
     }
 
     return attributes
@@ -139,11 +144,14 @@ export default class MemberService extends LoggingBase {
    * the first platform sent as the highest priority platform.
    * @param platforms Array of platforms to select the highest priority platform
    * @param priorityArray zero indexed priority array. Lower index means higher priority
-   * @returns the highest priority platform
+   * @returns the highest priority platform or undefined if values are incorrect
    */
-  getHighestPriorityPlatformForAttributes(platforms: string[], priorityArray: string[]): string {
+  public static getHighestPriorityPlatformForAttributes(
+    platforms: string[],
+    priorityArray: string[],
+  ): string | undefined {
     if (platforms.length <= 0) {
-      throw new Error400(this.options.language, 'settings.memberAttributes.noPlatformSent')
+      return undefined
     }
     const filteredPlatforms = priorityArray.filter((i) => platforms.includes(i))
     return filteredPlatforms.length > 0 ? filteredPlatforms[0] : platforms[0]


### PR DESCRIPTION
# Changes proposed ✍️
- Discord `joined_guild` activity had a broken `SOURCE_ID` member attribute and hash generation for `sourceId` property - this is now fixed.
- Because of that there are a lot of members in the database that have broken attributes that are saved like this:
  ```json
  { "sourceId": {} }
  ```
  and it breaks our code in MemberService - this is why the change there so that it will slowly fix the database data to be of the correct format.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.