### PR TITLE
LinkedIn integration service optimization

### DIFF
--- a/backend/src/serverless/integrations/types/linkedinTypes.ts
+++ b/backend/src/serverless/integrations/types/linkedinTypes.ts
@@ -14,6 +14,12 @@ export interface ILinkedInOrganizationPost {
   authorUrn: string
   body?: string
   originalUrnId?: string
+  timestamp: number
+}
+
+export enum LinkedInAuthorType {
+  ORGANIZATION = 'organization',
+  USER = 'user',
 }
 
 export interface ILinkedInPostReaction {

--- a/backend/src/serverless/integrations/usecases/linkedin/getPost.ts
+++ b/backend/src/serverless/integrations/usecases/linkedin/getPost.ts
@@ -33,6 +33,7 @@ export const getPost = async (
       authorUrn: e.author,
       body: e.commentary,
       originalUrnId: e.reshareContext?.parent,
+      timestamp: e.createdAt,
     }
   } catch (err) {
     const newErr = handleLinkedinError(err, config, { pizzlyId, postId }, logger)

--- a/backend/src/serverless/integrations/usecases/linkedin/utils.ts
+++ b/backend/src/serverless/integrations/usecases/linkedin/utils.ts
@@ -1,0 +1,21 @@
+import { LinkedInAuthorType } from '../../types/linkedinTypes'
+
+export const isLinkedInOrganization = (urn: string): boolean =>
+  urn.startsWith('urn:li:organization:') || urn.startsWith('urn:li:company:')
+
+export const isLinkedInUser = (urn: string): boolean => urn.startsWith('urn:li:person:')
+
+export const getLinkedInMemberType = (urn: string): LinkedInAuthorType => {
+  if (isLinkedInOrganization(urn)) {
+    return LinkedInAuthorType.ORGANIZATION
+  }
+  if (isLinkedInUser(urn)) {
+    return LinkedInAuthorType.USER
+  }
+  throw new Error(`Unknown LinkedIn member type: ${urn}`)
+}
+
+export const getLinkedInUserId = (urn: string): string => urn.replace('urn:li:person:', '')
+
+export const getLinkedInOrganizationId = (urn: string): string =>
+  urn.replace('urn:li:organization:', '').replace('urn:li:company:', '')

--- a/backend/src/utils/redis/redisCache.ts
+++ b/backend/src/utils/redis/redisCache.ts
@@ -96,7 +96,7 @@ return count`
 
   public async getOrAdd(
     key: string,
-    provider: (key: string) => Promise<string> | string,
+    provider: () => Promise<string> | string,
     ttlSeconds?: number,
   ): Promise<string> {
     const value = await this.getValue(key)
@@ -104,8 +104,8 @@ return count`
       return value
     }
 
-    const generatedValue = await provider(key)
-    await this.setValue(key, value, ttlSeconds)
+    const generatedValue = await provider()
+    await this.setValue(key, generatedValue, ttlSeconds)
     return generatedValue
   }
 


### PR DESCRIPTION
# Changes proposed ✍️
- We spam GET /member linkedin API endpoint quite hard so I added redis cache because a lot of the reactions and comments are done by the same people over and over again and this reduced API calls by more than 50%
- For non-onboarding integration triggers I added a check so that we don't look for comments and reactions beyond those that we already looked for or 1 month back. This should optimize request count for reactions and comments as well - the only downside is that we might miss some nested comments with this... 

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.