### PR TITLE
Prevent the same integration from being processed multiple times at once

### DIFF
--- a/backend/src/bin/worker/integrations.ts
+++ b/backend/src/bin/worker/integrations.ts
@@ -13,7 +13,9 @@ export const processIntegrationCheck = async (
   const options = (await SequelizeRepository.getDefaultIRepositoryOptions()) as IServiceOptions
   options.log = messageLogger
 
-  const processor = new IntegrationProcessor(options)
+  const redisEmitter = await createRedisClient(true)
+
+  const processor = new IntegrationProcessor(options, redisEmitter)
 
   await processor.processCheck(msg.integrationType)
 }

--- a/backend/src/serverless/integrations/services/integrationServiceBase.ts
+++ b/backend/src/serverless/integrations/services/integrationServiceBase.ts
@@ -18,6 +18,8 @@ import { IS_TEST_ENV } from '../../../config'
 import { sendNodeWorkerMessage } from '../../utils/nodeWorkerSQS'
 import { NodeWorkerIntegrationProcessMessage } from '../../../types/mq/nodeWorkerIntegrationProcessMessage'
 
+const logger = createServiceChildLogger('integrationService')
+
 /* eslint class-methods-use-this: 0 */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -55,7 +57,7 @@ export abstract class IntegrationServiceBase {
 
   async triggerIntegrationCheck(integrations: any[]): Promise<void> {
     for (const integration of integrations) {
-      console.log('Triggering integration check for', integration.id)
+      logger.info({ integrationId: integration.id }, 'Triggering integration processing!')
       await sendNodeWorkerMessage(
         integration.tenantId,
         new NodeWorkerIntegrationProcessMessage(


### PR DESCRIPTION
# Changes proposed ✍️
- Added a tag in the redis while integration is being processed and checking that tag to see whether to trigger an integration check or not so we don't get a case where the same integration would be processed by multiple workers at once (for example - a check takes 1h but we trigger checks every 20 minutes...)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.