### PR TITLE
Non existing member attributes in settings

### DIFF
--- a/backend/src/api/member/memberExport.ts
+++ b/backend/src/api/member/memberExport.ts
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import Permissions from '../../security/permissions'
 import identifyTenant from '../../segment/identifyTenant'
 import track from '../../segment/track'
@@ -6,6 +5,7 @@ import MemberService from '../../services/memberService'
 import PermissionChecker from '../../services/user/permissionChecker'
 import { FeatureFlagRedisKey } from '../../types/common'
 import { RedisCache } from '../../utils/redis/redisCache'
+import { getSecondsTillEndOfMonth } from '../../utils/timing'
 
 /**
  * POST /tenant/{tenantId}/member/export
@@ -29,10 +29,7 @@ export default async (req, res) => {
 
   const csvCount = await csvCountCache.getValue(req.currentTenant.id)
 
-  const endTime = moment().endOf('month')
-  const startTime = moment()
-
-  const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+  const secondsRemainingUntilEndOfMonth = getSecondsTillEndOfMonth()
 
   if (!csvCount) {
     await csvCountCache.setValue(req.currentTenant.id, '0', secondsRemainingUntilEndOfMonth)

--- a/backend/src/api/premium/enrichment/memberEnrich.ts
+++ b/backend/src/api/premium/enrichment/memberEnrich.ts
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import Permissions from '../../../security/permissions'
 import identifyTenant from '../../../segment/identifyTenant'
 import MemberEnrichmentService from '../../../services/premium/enrichment/memberEnrichmentService'
@@ -6,6 +5,10 @@ import PermissionChecker from '../../../services/user/permissionChecker'
 import { FeatureFlagRedisKey } from '../../../types/common'
 import { RedisCache } from '../../../utils/redis/redisCache'
 import track from '../../../segment/track'
+import { createServiceLogger } from '../../../utils/logging'
+import { getSecondsTillEndOfMonth } from '../../../utils/timing'
+
+const log = createServiceLogger()
 
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberEdit)
@@ -21,10 +24,9 @@ export default async (req, res) => {
 
   const memberEnrichmentCount = await memberEnrichmentCountCache.getValue(req.currentTenant.id)
 
-  const endTime = moment().endOf('month')
-  const startTime = moment()
+  const secondsRemainingUntilEndOfMonth = getSecondsTillEndOfMonth()
 
-  const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+  log.info(secondsRemainingUntilEndOfMonth, 'Seconds remaining')
 
   if (!memberEnrichmentCount) {
     await memberEnrichmentCountCache.setValue(

--- a/backend/src/api/premium/enrichment/memberEnrichBulk.ts
+++ b/backend/src/api/premium/enrichment/memberEnrichBulk.ts
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import Error403 from '../../../errors/Error403'
 import { PLAN_LIMITS } from '../../../feature-flags/ensureFlagUpdated'
 import Permissions from '../../../security/permissions'
@@ -9,6 +8,7 @@ import { FeatureFlag, FeatureFlagRedisKey } from '../../../types/common'
 import { createServiceLogger } from '../../../utils/logging'
 import { RedisCache } from '../../../utils/redis/redisCache'
 import track from '../../../segment/track'
+import { getSecondsTillEndOfMonth } from '../../../utils/timing'
 
 const log = createServiceLogger()
 
@@ -54,10 +54,7 @@ export default async (req, res) => {
   await sendBulkEnrichMessage(tenant, membersToEnrich)
 
   // update enrichment count, we'll also check failed enrichments and deduct these from grand total in bulkEnrichmentWorker
-  const endTime = moment().endOf('month')
-  const startTime = moment()
-
-  const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+  const secondsRemainingUntilEndOfMonth = getSecondsTillEndOfMonth()
 
   if (!memberEnrichmentCount) {
     await memberEnrichmentCountCache.setValue(

--- a/backend/src/feature-flags/setTenantProperties.ts
+++ b/backend/src/feature-flags/setTenantProperties.ts
@@ -1,10 +1,10 @@
-import moment from 'moment'
 import { PostHog } from 'posthog-node'
 import { API_CONFIG, POSTHOG_CONFIG } from '../config'
 import AutomationRepository from '../database/repositories/automationRepository'
 import { Edition, FeatureFlagRedisKey } from '../types/common'
 import { RedisClient } from '../utils/redis'
 import { RedisCache } from '../utils/redis/redisCache'
+import { getSecondsTillEndOfMonth } from '../utils/timing'
 
 export default async function setPosthogTenantProperties(
   tenant: any,
@@ -23,10 +23,7 @@ export default async function setPosthogTenantProperties(
     let csvExportCount = await csvExportCountCache.getValue(tenant.id)
     let memberEnrichmentCount = await memberEnrichmentCountCache.getValue(tenant.id)
 
-    const endTime = moment().endOf('month')
-    const startTime = moment()
-
-    const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+    const secondsRemainingUntilEndOfMonth = getSecondsTillEndOfMonth()
 
     if (!csvExportCount) {
       await csvExportCountCache.setValue(tenant.id, '0', secondsRemainingUntilEndOfMonth)

--- a/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkEnrichmentWorker.ts
@@ -1,4 +1,3 @@
-import moment from 'moment-timezone'
 import { PostHog } from 'posthog-node'
 import { POSTHOG_CONFIG } from '../../../../config'
 import getUserContext from '../../../../database/utils/getUserContext'
@@ -7,6 +6,7 @@ import MemberEnrichmentService from '../../../../services/premium/enrichment/mem
 import { FeatureFlagRedisKey } from '../../../../types/common'
 import { createRedisClient } from '../../../../utils/redis'
 import { RedisCache } from '../../../../utils/redis/redisCache'
+import { getSecondsTillEndOfMonth } from '../../../../utils/timing'
 
 /**
  * Sends weekly analytics emails of a given tenant
@@ -39,9 +39,7 @@ async function bulkEnrichmentWorker(tenantId: string, memberIds: string[]) {
     )
 
     // calculate remaining seconds for the end of the month, to set TTL for redis keys
-    const endTime = moment().endOf('month')
-    const startTime = moment()
-    const secondsRemainingUntilEndOfMonth = endTime.diff(startTime, 'days') * 86400
+    const secondsRemainingUntilEndOfMonth = getSecondsTillEndOfMonth()
 
     if (!memberEnrichmentCount) {
       await memberEnrichmentCountCache.setValue(

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -2511,10 +2511,18 @@ describe('MemberService tests', () => {
           [PlatformType.TWITTER]: 'some value',
         },
       }
+      const validateAttributes = await memberService.validateAttributes(attributes)
 
-      await expect(() => memberService.validateAttributes(attributes)).rejects.toThrowError(
-        new Error400('en', 'settings.memberAttributes.notFound', 'non-existing-attribute'),
-      )
+      // member attribute that is non existing in settings, should be omitted after validate
+      const expectedValidatedAttributes = {
+        [MemberAttributeName.URL]: {
+          [PlatformType.GITHUB]: 'https://some-github-url',
+        },
+        [MemberAttributeName.AVATAR_URL]: {
+          [PlatformType.TWITTER]: 'https://some-image-url',
+        },
+      }
+      expect(validateAttributes).toEqual(expectedValidatedAttributes)
     })
 
     it('Should throw a 400 Error when the type of an attribute does not match the type in member attribute settings', async () => {

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-continue */
+
 import moment from 'moment-timezone'
 import lodash from 'lodash'
 import validator from 'validator'
@@ -80,11 +82,8 @@ export default class MemberService extends LoggingBase {
           attributeName,
           attributes,
         })
-        throw new Error400(
-          this.options.language,
-          'settings.memberAttributes.notFound',
-          attributeName,
-        )
+        delete attributes[attributeName]
+        continue
       }
       if (typeof attributes[attributeName] !== 'object') {
         attributes[attributeName] = {

--- a/backend/src/utils/timing.ts
+++ b/backend/src/utils/timing.ts
@@ -1,4 +1,13 @@
+import moment from 'moment'
+
 export const timeout = async (delayMilliseconds: number): Promise<void> =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, delayMilliseconds)
   })
+
+export const getSecondsTillEndOfMonth = () => {
+  const endTime = moment().endOf('month')
+  const startTime = moment()
+
+  return endTime.diff(startTime, 'seconds')
+}


### PR DESCRIPTION
We have some attributes in some members that are non existing in member attribute settings.
This is probably happened after migrating data to dynamic attributes. 
- Now instead of throwing a 400 error, we're deleting the non-existing attribute from the payload before upserting the member. This will also enable us to clear up the already existing member attributes data.
- Also fixes the wrong calculation of `seconds until end of month` when it's the last day of the month.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.