### PR TITLE
Fix global attributes not showing in Edit attributes drawer

### DIFF
--- a/frontend/src/modules/member/components/form/member-form-attributes.vue
+++ b/frontend/src/modules/member/components/form/member-form-attributes.vue
@@ -198,23 +198,25 @@ const customAttributes = computed(() =>
   props.attributes
     .filter((attribute) => {
       return (
-        attribute.show &&
-        ![
-          'bio',
-          'url',
-          'location',
-          'jobTitle',
-          'emails',
-          'workExperiences', // we render them in _aside-enriched
-          'certifications', // we render them in _aside-enriched
-          'education', // we render them in _aside-enriched
-          'awards' // we render them in _aside-enriched
-        ].includes(attribute.name) &&
-        props.record.attributes[attribute.name]
+        (attribute.show &&
+          ![
+            'bio',
+            'url',
+            'location',
+            'jobTitle',
+            'emails',
+            'workExperiences', // we render them in _aside-enriched
+            'certifications', // we render them in _aside-enriched
+            'education', // we render them in _aside-enriched
+            'awards' // we render them in _aside-enriched
+          ].includes(attribute.name) &&
+          props.record.attributes[attribute.name]) ||
+        // Global attributes
+        attribute.canDelete
       )
     })
     .sort((a, b) => {
-      if (props.record.attributes[a.name].enrich) {
+      if (props.record.attributes[a.name]?.enrich) {
         return props.record.attributes[b.name].enrich
           ? 0
           : -1


### PR DESCRIPTION
# Changes proposed ✍️
- Allow for attributes that have `canDelete` set to false (custom global attributes) to appear on the form
  
### Screenshots (front-end changes only)
![Screenshot 2023-02-07 at 15 45 34](https://user-images.githubusercontent.com/20134207/217292767-b23c5351-9ca3-4eff-bce9-0c221ca8ee4f.png)
![Screenshot 2023-02-07 at 15 45 39](https://user-images.githubusercontent.com/20134207/217292785-385c249d-9941-4f10-acdd-0e91df86d124.png)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.