### PR TITLE
Fix filters for custom attributes

### DIFF
--- a/frontend/src/modules/member/member-array-attributes-field.js
+++ b/frontend/src/modules/member/member-array-attributes-field.js
@@ -1,0 +1,42 @@
+import StringField from '@/shared/fields/string-field'
+
+export default class MemberArrayAttributesField extends StringField {
+  constructor(name, label, config = {}) {
+    super(name, label)
+
+    this.placeholder = config.placeholder
+    this.hint = config.hint
+    this.required = config.required
+    this.matches = config.matches
+    this.filterable = config.filterable || false
+    this.custom = config.custom || false
+    this.options = config.options
+  }
+
+  dropdownOptions() {
+    return this.options.sort((x, y) => {
+      return x.label < y.label
+        ? -1
+        : x.label > y.label
+        ? 1
+        : 0
+    })
+  }
+
+  forFilter() {
+    return {
+      name: this.name,
+      label: this.label,
+      custom: this.custom,
+      props: {
+        options: this.dropdownOptions(),
+        multiple: true
+      },
+      defaultValue: [],
+      value: [],
+      defaultOperator: 'contains',
+      operator: 'contains',
+      type: 'select-multi'
+    }
+  }
+}

--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -366,7 +366,7 @@ export default {
     }
   },
 
-  async doBulkEnrich({ rootGetters }, ids) {
+  async doBulkEnrich({ rootGetters, dispatch }, ids) {
     try {
       const currentTenant =
         rootGetters['auth/currentTenant']
@@ -403,6 +403,8 @@ export default {
       showEnrichmentLoadingMessage({ isBulk: true })
 
       await MemberService.enrichMemberBulk(ids)
+
+      await dispatch('doFetchCustomAttributes')
     } catch (error) {
       Message.closeAll()
       Errors.handle(error)

--- a/frontend/src/shared/fields/get-custom-attributes.js
+++ b/frontend/src/shared/fields/get-custom-attributes.js
@@ -7,7 +7,17 @@ import MemberArrayAttributesField from '@/modules/member/member-array-attributes
 export default (customAttributes) => {
   return (
     Object.values(customAttributes)
-      .filter((a) => a.show)
+      .filter((a) => {
+        // Don't render special filters that do not have available options
+        if (
+          a.type === 'multiSelect' ||
+          a.type === 'special'
+        ) {
+          return a.options.length && a.show
+        }
+
+        return a.show
+      })
       .map((customAttribute) => {
         switch (customAttribute.type) {
           case 'boolean':
@@ -31,12 +41,12 @@ export default (customAttributes) => {
 
           case 'multiSelect':
           case 'special': {
-            const options = customAttributes[
-              customAttribute.name
-            ].options.map((o) => ({
-              value: o,
-              label: o
-            }))
+            const options = customAttribute.options.map(
+              (o) => ({
+                value: o,
+                label: o
+              })
+            )
 
             return new MemberArrayAttributesField(
               customAttribute.name,

--- a/frontend/src/shared/fields/get-custom-attributes.js
+++ b/frontend/src/shared/fields/get-custom-attributes.js
@@ -2,7 +2,7 @@ import StringField from '@/shared/fields/string-field'
 import BooleanField from '@/shared/fields/boolean-field'
 import IntegerField from '@/shared/fields/integer-field'
 import DateField from '@/shared/fields/date-field'
-import ArrayField from '@/shared/fields/array-field'
+import MemberArrayAttributesField from '@/modules/member/member-array-attributes-field'
 
 export default (customAttributes) => {
   return (
@@ -30,12 +30,20 @@ export default (customAttributes) => {
             )
 
           case 'multiSelect':
-          case 'special':
-            return new ArrayField(
-              customAttribute.name,
-              customAttribute.label
-            )
+          case 'special': {
+            const options = customAttributes[
+              customAttribute.name
+            ].options.map((o) => ({
+              value: o,
+              label: o
+            }))
 
+            return new MemberArrayAttributesField(
+              customAttribute.name,
+              customAttribute.label,
+              { options }
+            )
+          }
           default:
             return new StringField(
               customAttribute.name,


### PR DESCRIPTION
# Changes proposed ✍️
- Create a new field to handle multi-select filter with pre-existent options. Sort options alphabetically
- After bulk enrichment, fetch attributes to get the latest attributes and options
- For "multi-select" and "special" render the new filter component. For "multi-select" and "special" that do not have available options, do not render as a filter
  
### Screenshots (front-end changes only)
<img width="1261" alt="Screenshot 2023-02-08 at 10 03 28" src="https://user-images.githubusercontent.com/20134207/217504244-f49b8753-28e0-43d1-b84e-86d00cc952d1.png">


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.