### PR TITLE
Removed left server activity type for filters

### DIFF
--- a/backend/src/types/prettyActivityTypes.ts
+++ b/backend/src/types/prettyActivityTypes.ts
@@ -29,8 +29,7 @@ export const prettyActivityTypes = {
     replied_thread: 'replied to a thread',
     thread_started: 'started a new thread',
     started_thread: 'started a new thread',
-    joined_guild: 'joined server',
-    left_guild: 'left server',
+    joined_guild: 'joined server'
   },
   [PlatformType.SLACK]: {
     contributed_to_community: 'contributed to community',

--- a/backend/src/types/prettyActivityTypes.ts
+++ b/backend/src/types/prettyActivityTypes.ts
@@ -29,7 +29,7 @@ export const prettyActivityTypes = {
     replied_thread: 'replied to a thread',
     thread_started: 'started a new thread',
     started_thread: 'started a new thread',
-    joined_guild: 'joined server'
+    joined_guild: 'joined server',
   },
   [PlatformType.SLACK]: {
     contributed_to_community: 'contributed to community',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -351,8 +351,7 @@ const en = {
         replied: 'replied to a message',
         replied_thread: 'replied to a thread',
         started_thread: 'started a new thread',
-        joined_guild: 'joined server',
-        left_guild: 'left server'
+        joined_guild: 'joined server'
       },
       slack: {
         contributed_to_community:

--- a/frontend/src/jsons/activity-types.json
+++ b/frontend/src/jsons/activity-types.json
@@ -16,8 +16,7 @@
     "message",
     "replied",
     "replied_thread",
-    "joined_guild",
-    "left_guild"
+    "joined_guild"
   ],
   "slack": [
     "message",


### PR DESCRIPTION
# Changes proposed ✍️
- Remove Left Server from Discord filters

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.