### PR TITLE
Fix settings update action

### DIFF
--- a/frontend/src/premium/eagle-eye/store/actions.js
+++ b/frontend/src/premium/eagle-eye/store/actions.js
@@ -231,19 +231,17 @@ export default {
   async doUpdateSettings({ commit, dispatch }, data) {
     commit('UPDATE_EAGLE_EYE_SETTINGS_STARTED')
     return EagleEyeService.updateSettings(data)
-      .then(() =>
+      .then(() => {
         dispatch(`auth/doRefreshCurrentUser`, null, {
           root: true
+        }).then(() => {
+          commit('UPDATE_EAGLE_EYE_SETTINGS_SUCCESS')
+
+          dispatch(`doFetch`, {
+            resetStorage: true
+          })
+          return Promise.resolve()
         })
-      )
-      .then(() =>
-        dispatch(`doFetch`, {
-          resetStorage: true
-        })
-      )
-      .then(() => {
-        commit('UPDATE_EAGLE_EYE_SETTINGS_SUCCESS')
-        return Promise.resolve()
       })
       .catch((error) => {
         Errors.handle(error)


### PR DESCRIPTION
# Changes proposed ✍️
- When updating settings (drawer, onboarding), the drawer should only be while the settings/user is being updated. It should not have to wait for fetching

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.