### PR TITLE
Fixed discord message activity URL building.

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -505,7 +505,7 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
           body: record.content
             ? DiscordIntegrationService.replaceMentions(record.content, record.mentions)
             : '',
-          url: `https://discordapp.com/channels/${context.pipelineData.guildId}/${channel.id}/${record.id}`,
+          url: `https://discordapp.com/channels/${channel.guild_id}/${channel.id}/${record.id}`,
           channel: channel.name,
           attributes: {
             parentChannel,


### PR DESCRIPTION
# Changes proposed ✍️
- Currently for websocket activities we are not building URL correctly - guild_id was not set.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.