### PR TITLE
Fix discord websocket message duplication issue when server has both crowd.dev apps connected

### DIFF
--- a/backend/src/bin/discord-ws.ts
+++ b/backend/src/bin/discord-ws.ts
@@ -1,5 +1,6 @@
 import { Client, Events, GatewayIntentBits, MessageType } from 'discord.js'
 import moment from 'moment'
+import { timeout } from '../utils/timing'
 import { DISCORD_CONFIG } from '../config'
 import { createChildLogger, getServiceLogger } from '../utils/logging'
 import SequelizeRepository from '../database/repositories/sequelizeRepository'
@@ -15,7 +16,16 @@ import { DiscordIntegrationService } from '../serverless/integrations/services/i
 
 const log = getServiceLogger()
 
-async function executeIfNotExists(key: string, cache: RedisCache, fn: () => Promise<void>) {
+async function executeIfNotExists(
+  key: string,
+  cache: RedisCache,
+  fn: () => Promise<void>,
+  delayMilliseconds?: number,
+) {
+  if (delayMilliseconds) {
+    await timeout(delayMilliseconds)
+  }
+
   const exists = await cache.getValue(key)
   if (!exists) {
     await fn()
@@ -23,7 +33,12 @@ async function executeIfNotExists(key: string, cache: RedisCache, fn: () => Prom
   }
 }
 
-async function spawnClient(name: string, token: string, cache: RedisCache) {
+async function spawnClient(
+  name: string,
+  token: string,
+  cache: RedisCache,
+  delayMilliseconds?: number,
+) {
   const logger = createChildLogger('discord-ws', log, { clientName: name })
 
   const repoOptions = await SequelizeRepository.getDefaultIRepositoryOptions()
@@ -104,18 +119,28 @@ async function spawnClient(name: string, token: string, cache: RedisCache) {
 
   // listen to discord events
   client.on(Events.GuildMemberAdd, async (member) => {
-    await executeIfNotExists(`member-${(member as any).userId}`, cache, async () => {
-      logger.debug({ member }, 'Member joined guild!')
-      await processPayload(DiscordWebsocketEvent.MEMBER_ADDED, member, member.guild.id)
-    })
+    await executeIfNotExists(
+      `member-${(member as any).userId}`,
+      cache,
+      async () => {
+        logger.debug({ member }, 'Member joined guild!')
+        await processPayload(DiscordWebsocketEvent.MEMBER_ADDED, member, member.guild.id)
+      },
+      delayMilliseconds,
+    )
   })
 
   client.on(Events.MessageCreate, async (message) => {
     if (message.type === MessageType.Default || message.type === MessageType.Reply) {
-      await executeIfNotExists(`msg-${message.id}`, cache, async () => {
-        logger.debug({ message }, 'Message created!')
-        await processPayload(DiscordWebsocketEvent.MESSAGE_CREATED, message, message.guildId)
-      })
+      await executeIfNotExists(
+        `msg-${message.id}`,
+        cache,
+        async () => {
+          logger.debug({ message }, 'Message created!')
+          await processPayload(DiscordWebsocketEvent.MESSAGE_CREATED, message, message.guildId)
+        },
+        delayMilliseconds,
+      )
     }
   })
 
@@ -135,6 +160,7 @@ async function spawnClient(name: string, token: string, cache: RedisCache) {
             newMessage.guildId,
           )
         },
+        delayMilliseconds,
       )
     }
   })
@@ -176,7 +202,12 @@ setImmediate(async () => {
     }
   }
 
-  await spawnClient('first-app', DISCORD_CONFIG.token, cache)
+  await spawnClient(
+    'first-app',
+    DISCORD_CONFIG.token,
+    cache,
+    DISCORD_CONFIG.token2 ? 1000 : undefined,
+  )
 
   if (DISCORD_CONFIG.token2) {
     await spawnClient('second-app', DISCORD_CONFIG.token2, cache)


### PR DESCRIPTION
# Changes proposed ✍️
- When we are receiving messages for the first crowd discord bot we are waiting for a second before we are actually processing the message to avoid concurrent redis access when we check for duplicated message ids

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.