### PR TITLE
Fixing guild id being passed incorrectly in some cases.

### DIFF
--- a/backend/src/services/eagleEyeContentService.ts
+++ b/backend/src/services/eagleEyeContentService.ts
@@ -87,13 +87,13 @@ export default class EagleEyeContentService extends LoggingBase {
     )
   }
 
-  static trackPostClicked(url: string, platform: string, req: any, source:string = 'app'): void {
+  static trackPostClicked(url: string, platform: string, req: any, source: string = 'app'): void {
     track(
       'Eagle Eye post clicked',
       {
         url,
         platform,
-        source
+        source,
       },
       { ...req },
     )

--- a/backend/src/types/integrationEnums.ts
+++ b/backend/src/types/integrationEnums.ts
@@ -14,7 +14,7 @@ export enum PlatformType {
   MEDIUM = 'medium',
   PRODUCTHUNT = 'producthunt',
   YOUTUBE = 'youtube',
-  STACKOVERFLOW = 'stackoverflow'
+  STACKOVERFLOW = 'stackoverflow',
 }
 
 export enum IntegrationType {


### PR DESCRIPTION
# Changes proposed ✍️
- Discord sometimes sends `member.guildId` and sometimes `member.guild.id` not really clear when it will be which so we have to check both.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.