### PR TITLE
Community help center - send delete task even document doesn't exist

### DIFF
--- a/backend/src/search-engine/repositories/indexable.ts
+++ b/backend/src/search-engine/repositories/indexable.ts
@@ -65,6 +65,6 @@ export default abstract class Indexable {
    * @param {string} id
    */
   async delete(id: string) {
-      await this.index.deleteDocument(id)
+    await this.index.deleteDocument(id)
   }
 }

--- a/backend/src/search-engine/repositories/indexable.ts
+++ b/backend/src/search-engine/repositories/indexable.ts
@@ -65,9 +65,6 @@ export default abstract class Indexable {
    * @param {string} id
    */
   async delete(id: string) {
-    const doc = await this.findById(id)
-    if (doc) {
-      await this.index.deleteDocument(doc.id)
-    }
+      await this.index.deleteDocument(id)
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️
- We were finding the document first and were sending the delete request if it existed. This was causing sync problems between the search engine and database in some edge cases when using the auto-publishing feature.
- Now we send the delete request even if the document does not exist.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.