### PR TITLE
Allow to unmark team members

### DIFF
--- a/frontend/src/modules/member/components/member-badge.vue
+++ b/frontend/src/modules/member/components/member-badge.vue
@@ -47,7 +47,7 @@ const props = defineProps({
 })
 
 const isTeam = computed(() => {
-  return props.member.attributes.isTeamMember
+  return props.member.attributes.isTeamMember?.default
 })
 
 const isBot = computed(() => {

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -72,12 +72,27 @@
           class="h-10"
           :command="{
             action: 'memberMarkAsTeamMember',
-            member: member
+            member: member,
+            value: true
           }"
           ><i
             class="ri-bookmark-line text-base mr-2"
           /><span class="text-xs text-gray-900"
             >Mark as team member</span
+          ></el-dropdown-item
+        >
+        <el-dropdown-item
+          v-if="member.attributes.isTeamMember?.default"
+          class="h-10"
+          :command="{
+            action: 'memberMarkAsTeamMember',
+            member: member,
+            value: false
+          }"
+          ><i
+            class="ri-bookmark-2-line text-base mr-2"
+          /><span class="text-xs text-gray-900"
+            >Unmark as team member</span
           ></el-dropdown-item
         >
         <el-dropdown-item
@@ -263,7 +278,7 @@ export default {
           attributes: {
             ...command.member.attributes,
             isTeamMember: {
-              default: true
+              default: command.value
             }
           }
         })

--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -125,7 +125,7 @@ export default {
     }
   },
 
-  async doMarkAsTeamMember({ dispatch, getters }) {
+  async doMarkAsTeamMember({ dispatch, getters }, value) {
     try {
       const selectedRows = getters.selectedRows
 
@@ -134,8 +134,7 @@ export default {
           attributes: {
             ...row.attributes,
             isTeamMember: {
-              crowd: true,
-              default: true
+              default: value
             }
           }
         })


### PR DESCRIPTION
# Changes proposed ✍️
- Refactor `member-list-toolbar` to have a new option "Unmark as team member" if the selected view in members is `Team members`
- In `member-badge`, verify if member is team member through the `default` property and not the object itself
- Refactor `member-dropdown` to have a new option "Unmark as team member" if the selected member is a team member
  
### Screenshots (front-end changes only)
<img width="354" alt="Screenshot 2023-02-23 at 11 37 08" src="https://user-images.githubusercontent.com/20134207/220895334-eb916194-2d73-432b-9aac-4e40e88dca7d.png">
<img width="459" alt="Screenshot 2023-02-23 at 11 37 19" src="https://user-images.githubusercontent.com/20134207/220895344-77f39dd7-5846-4663-aeda-a3cc020ce553.png">



## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.