### PR TITLE
Organization endpoints only returns organizations with members

### DIFF
--- a/backend/src/cubejs/schema/Organizations.js
+++ b/backend/src/cubejs/schema/Organizations.js
@@ -2,16 +2,16 @@
 cube(`Organizations`, {
   sql: `SELECT * FROM public.organizations`,
   preAggregations: {
-    activeOrganizations: {
-      measures: [Organizations.count],
-      dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
-      timeDimension: Activities.date,
-      granularity: `day`,
-    },
     newOrganizations: {
       measures: [Organizations.count],
       dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
       timeDimension: Organizations.joinedAt,
+      granularity: `day`,
+    },
+    activeOrganizations: {
+      measures: [Organizations.count],
+      dimensions: [Organizations.tenantId, Members.isTeamMember, Members.isBot],
+      timeDimension: Activities.date,
       granularity: `day`,
     },
   },

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -607,6 +607,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             name: 'Pied Piper',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -626,6 +627,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             url: 'crowd.dev',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -645,6 +647,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             description: 'community',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -664,6 +667,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             emails: 'richard@piedpiper.io,jonathan@crowd.dev',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -675,6 +679,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             emails: ['richard@piedpiper.io', 'jonathan@crowd.dev'],
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -693,6 +698,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             tags: 'new-internet,not-google,new',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -704,6 +710,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             tags: ['new-internet', 'not-google', 'new'],
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -722,6 +729,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             twitter: 'crowdDotDev',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -741,6 +749,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             linkedin: 'crowddevhq',
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -760,6 +769,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             employeesRange: [90, 120],
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -780,6 +790,7 @@ describe('OrganizationRepository tests', () => {
             revenueMin: 0,
             revenueMax: 1,
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -792,6 +803,7 @@ describe('OrganizationRepository tests', () => {
           filter: {
             revenueMin: 9,
           },
+          includeOrganizationsWithoutMembers: true,
         },
         mockIRepositoryOptions,
       )
@@ -1053,6 +1065,7 @@ describe('OrganizationRepository tests', () => {
                   gte: 9,
                 },
               },
+              includeOrganizationsWithoutMembers: true,
             },
             mockIRepositoryOptions,
           )
@@ -1069,6 +1082,7 @@ describe('OrganizationRepository tests', () => {
                   textContains: 'world a better place',
                 },
               },
+              includeOrganizationsWithoutMembers: true,
             },
             mockIRepositoryOptions,
           )
@@ -1102,6 +1116,7 @@ describe('OrganizationRepository tests', () => {
                   },
                 ],
               },
+              includeOrganizationsWithoutMembers: true,
             },
             mockIRepositoryOptions,
           )
@@ -1133,6 +1148,7 @@ describe('OrganizationRepository tests', () => {
                   },
                 ],
               },
+              includeOrganizationsWithoutMembers: true,
             },
             mockIRepositoryOptions,
           )

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -274,6 +274,7 @@ class OrganizationRepository {
       {
         model: options.database.member,
         as: 'members',
+        required:true,
         attributes: [],
         through: {
           attributes: [],

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -265,7 +265,14 @@ class OrganizationRepository {
   }
 
   static async findAndCountAll(
-    { filter = {} as any, advancedFilter = null as any, limit = 0, offset = 0, orderBy = '' },
+    {
+      filter = {} as any,
+      advancedFilter = null as any,
+      limit = 0,
+      offset = 0,
+      orderBy = '',
+      includeOrganizationsWithoutMembers = false,
+    },
     options: IRepositoryOptions,
   ) {
     let customOrderBy: Array<any> = []
@@ -274,7 +281,7 @@ class OrganizationRepository {
       {
         model: options.database.member,
         as: 'members',
-        required: true,
+        required: !includeOrganizationsWithoutMembers,
         attributes: [],
         through: {
           attributes: [],

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -274,7 +274,7 @@ class OrganizationRepository {
       {
         model: options.database.member,
         as: 'members',
-        required:true,
+        required: true,
         attributes: [],
         through: {
           attributes: [],

--- a/backend/src/services/__tests__/organizationService.test.ts
+++ b/backend/src/services/__tests__/organizationService.test.ts
@@ -225,7 +225,10 @@ describe('OrganizationService tests', () => {
       expect(added.name).toEqual(toAdd.name)
       expect(added.url).toBeNull()
 
-      const foundAll = await service.findAndCountAll({ filter: {} })
+      const foundAll = await service.findAndCountAll({
+        filter: {},
+        includeOrganizationsWithoutMembers: true,
+      })
       expect(foundAll.count).toBe(1)
     })
   })


### PR DESCRIPTION
# Changes proposed ✍️
- Changing the organization name in GitHub results in orphaned organizations in Crowd. To ignore these, we stop returning organizations without members from respective endpoints using the new parameter in `OrganizationRepository.findAndCountAll -> includeOrganizationsWithoutMembers`

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.