### PR TITLE
Cumulative measures all time date range

### DIFF
--- a/backend/src/cubejs/cube.js
+++ b/backend/src/cubejs/cube.js
@@ -32,6 +32,18 @@ module.exports = {
       })
     }
 
+    // Cubejs doesn't support all time dateranges with cumulative measures yet.
+    // If a cumulative measure is selected
+    // without time dimension daterange(all time),
+    // send a long daterange
+    if (
+      query.measures[0] === 'Members.cumulativeCount' &&
+      query.timeDimensions[0] &&
+      !query.timeDimensions[0].dateRange
+    ) {
+      query.timeDimensions[0].dateRange = ['2020-01-01', new Date().toISOString()]
+    }
+
     query.filters.push({
       member: `Members.isBot`,
       operator: 'equals',


### PR DESCRIPTION
# Changes proposed ✍️
- Cubejs doesn't support all-time date ranges with cumulative measures yet. It returns `Time series queries without dateRange aren't supported`
- To overcome this, when members cumulative count is requested without date range, we send the date range as 
```
from: 2022-01-01
to: now
```

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.