### PR TITLE
Sentiment exceptions result in empty sentiment object

### DIFF
--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -204,8 +204,8 @@ export default class ActivityService extends LoggingBase {
 
       return text === '' ? {} : await detectSentiment(text)
     } catch (err) {
-      this.log.error(err, 'Error getting sentiment of activity')
-      throw err
+      this.log.error({err, data}, 'Error getting sentiment of activity - Setting sentiment to empty object.')
+      return {}
     }
   }
 

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -204,7 +204,10 @@ export default class ActivityService extends LoggingBase {
 
       return text === '' ? {} : await detectSentiment(text)
     } catch (err) {
-      this.log.error({err, data}, 'Error getting sentiment of activity - Setting sentiment to empty object.')
+      this.log.error(
+        { err, data },
+        'Error getting sentiment of activity - Setting sentiment to empty object.',
+      )
       return {}
     }
   }


### PR DESCRIPTION
# Changes proposed ✍️
- Instead of throwing an error on sentiment calls, we're setting it to empty object and printing the text that failed for future debugging.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.