### PR TITLE
Cascading to member enrichment cache on member delete

### DIFF
--- a/backend/src/database/migrations/V1677596354__fixOnDeleteCascadeMemberEnrichment.sql
+++ b/backend/src/database/migrations/V1677596354__fixOnDeleteCascadeMemberEnrichment.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public."memberEnrichmentCache" DROP CONSTRAINT "memberEnrichmentCache_memberId_fkey";
+
+ALTER TABLE public."memberEnrichmentCache" ADD CONSTRAINT "memberEnrichmentCache_memberId_fkey" FOREIGN KEY ("memberId") REFERENCES public.members(id) ON DELETE CASCADE ON UPDATE NO ACTION;


### PR DESCRIPTION
# Changes proposed ✍️
- adds `ON DELETE CASCADE` to member enrichment cache on `memberId`. This was preventing enriched members to be merged with some other member

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.