### PR TITLE
Allow to reenrich members

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -146,7 +146,7 @@ export default {
       ) {
         return `Re-enrich ${pluralize(
           'member',
-          this.selectedIds,
+          this.selectedIds.length,
           false
         )}`
       }

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -140,8 +140,9 @@ export default {
     },
     enrichmentLabel() {
       if (
+        this.enrichedMembers &&
         this.enrichedMembers ===
-        this.elegibleEnrichmentMembersIds.length
+          this.elegibleEnrichmentMembersIds.length
       ) {
         return `Re-enrich ${pluralize(
           'member',

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -25,7 +25,6 @@
           Merge members
         </el-dropdown-item>
         <el-tooltip
-          v-if="areSelectedMembersNotEnriched"
           placement="top"
           content="Selected members lack an associated GitHub profile or Email"
           :disabled="elegibleEnrichmentMembersIds.length"
@@ -44,7 +43,9 @@
                 class="max-w-[16px] h-4"
                 color="#9CA3AF"
               />
-              <span class="ml-2">Enrich members</span>
+              <span class="ml-2">{{
+                enrichmentLabel
+              }}</span>
             </el-dropdown-item>
           </span>
         </el-tooltip>
@@ -130,22 +131,33 @@ export default {
     },
     elegibleEnrichmentMembersIds() {
       return this.selectedRows
-        .filter(
-          (r) =>
-            (r.username?.github || r.email) &&
-            !r.lastEnriched
-        )
+        .filter((r) => r.username?.github || r.email)
         .map((item) => item.id)
+    },
+    enrichedMembers() {
+      return this.selectedRows.filter((r) => r.lastEnriched)
+        .length
+    },
+    enrichmentLabel() {
+      if (
+        this.enrichedMembers ===
+        this.elegibleEnrichmentMembersIds.length
+      ) {
+        return `Re-enrich ${pluralize(
+          'member',
+          this.selectedIds,
+          false
+        )}`
+      }
+
+      return `Enrich ${pluralize(
+        'member',
+        this.selectedIds.length,
+        false
+      )}`
     },
     selectedIds() {
-      return this.selectedRows
-        .filter((item) => !item.lastEnriched)
-        .map((item) => item.id)
-    },
-    areSelectedMembersNotEnriched() {
-      return this.selectedRows.some(
-        (item) => !item.lastEnriched
-      )
+      return this.selectedRows.map((item) => item.id)
     },
     markAsTeamMemberOptions() {
       const isTeamView = this.activeView.id === 'team'
@@ -192,16 +204,45 @@ export default {
       } else if (command.action === 'destroyAll') {
         await this.doDestroyAllWithConfirm()
       } else if (command.action === 'enrichMember') {
+        const enrichments =
+          this.elegibleEnrichmentMembersIds.length
+        let doEnrich = false
+        let reEnrichmentMessage = null
+
+        if (this.enrichedMembers) {
+          reEnrichmentMessage =
+            this.enrichedMembers === 1
+              ? `You selected 1 member that was already enriched. If you proceed, this member will be re-enriched and counted towards your quota.`
+              : `You selected ${this.enrichedMembers} members that were already enriched. If you proceed, these members will be re-enriched and counted towards your quota.`
+        }
+
         // All members are elegible for enrichment
-        if (
-          this.elegibleEnrichmentMembersIds.length ===
-          this.selectedIds.length
-        ) {
-          await this.doBulkEnrich(
-            this.elegibleEnrichmentMembersIds
-          )
-        } else {
+        if (enrichments === this.selectedIds.length) {
+          // If there are already enriched members, show a warning dialog
+          if (this.enrichedMembers) {
+            try {
+              await ConfirmDialog({
+                type: 'warning',
+                title: 'Some members were already enriched',
+                message: reEnrichmentMessage,
+                confirmButtonText: `Proceed with enrichment (${pluralize(
+                  'member',
+                  enrichments,
+                  true
+                )})`,
+                cancelButtonText: 'Cancel',
+                icon: 'ri-alert-line'
+              })
+
+              doEnrich = true
+            } catch (error) {
+              // no
+            }
+          } else {
+            doEnrich = true
+          }
           // Only a few members are elegible for enrichment
+        } else {
           try {
             await ConfirmDialog({
               type: 'warning',
@@ -211,19 +252,24 @@ export default {
                 'Member enrichment requires an associated GitHub profile or Email. If you proceed, only the members who fulfill this requirement will be enriched and counted towards your quota.',
               confirmButtonText: `Proceed with enrichment (${pluralize(
                 'member',
-                this.elegibleEnrichmentMembersIds.length,
+                enrichments,
                 true
               )})`,
+              highlightedInfo: reEnrichmentMessage,
               cancelButtonText: 'Cancel',
               icon: 'ri-alert-line'
             })
 
-            await this.doBulkEnrich(
-              this.elegibleEnrichmentMembersIds
-            )
+            doEnrich = true
           } catch (error) {
             // no
           }
+        }
+
+        if (doEnrich) {
+          await this.doBulkEnrich(
+            this.elegibleEnrichmentMembersIds
+          )
         }
       }
     },

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -22,7 +22,7 @@
             }
           }"
         >
-          <el-dropdown-item class="h-10"
+          <el-dropdown-item class="h-10 mb-1"
             ><i
               class="ri-pencil-line text-base mr-2"
             /><span class="text-xs text-gray-900"
@@ -31,7 +31,6 @@
           >
         </router-link>
         <el-tooltip
-          v-if="!member.lastEnriched"
           placement="top"
           content="Member enrichment requires an associated GitHub profile or Email"
           :disabled="!isEnrichmentDisabled"
@@ -56,7 +55,11 @@
                 :class="{
                   'text-gray-400': isEnrichmentDisabled
                 }"
-                >Enrich member</span
+                >{{
+                  member.lastEnriched
+                    ? 'Re-enrich member'
+                    : 'Enrich member'
+                }}</span
               >
             </el-dropdown-item>
           </span>

--- a/frontend/src/shared/dialog/confirm-dialog.js
+++ b/frontend/src/shared/dialog/confirm-dialog.js
@@ -52,10 +52,26 @@ export default ({
           )
         ]
       ),
-      h('p', {
-        innerHTML: message,
-        class: 'text-gray-500 text-sm'
-      })
+      h('div', [
+        h('p', {
+          innerHTML: message,
+          class: 'text-gray-500 text-sm'
+        }),
+        highlightedInfo
+          ? h(
+              'div',
+              {
+                class:
+                  'text-2xs text-yellow-600 flex items-center mt-4'
+              },
+              [
+                h('div', {
+                  innerHTML: highlightedInfo
+                })
+              ]
+            )
+          : undefined
+      ])
     ]
   )
 


### PR DESCRIPTION
# Changes proposed ✍️
- Support `highlightedInfo` in horizontal dialogs
- Refactor `member-dropdown`. If member was already enriched, show `Re-enrich member`
- Refactor `member-list-toolbar`:
   -  Add computed label for enrichment option. `Re-enrich members` if all selected members were already enriched. `Enrich members` for all other scenarios
   - If all selected members we already enrich, trigger the action immediately after click
   - If all selected members were not enriched and are elegible, trigger the action immediately after click
   - If some of the selected members are not elegible and were already enriched, show modal with warning regarding both constraints
   - If some of the selected members were already enriched, show modal with warning

### Screenshots (front-end changes only)
![Screenshot 2023-03-01 at 17 41 47](https://user-images.githubusercontent.com/20134207/222219395-2a2f6dad-82b7-4e35-91fa-923557709632.png)
![Screenshot 2023-03-01 at 17 41 39](https://user-images.githubusercontent.com/20134207/222219401-130522e5-0ed3-424a-b2e4-96782d0df9c0.png)
![Screenshot 2023-03-01 at 17 41 24](https://user-images.githubusercontent.com/20134207/222219405-f6590fcc-a6fc-4000-b795-97600693e092.png)
![Screenshot 2023-03-01 at 17 41 19](https://user-images.githubusercontent.com/20134207/222219407-f363cbde-eff4-4120-97ea-3ac8f028af55.png)
![Screenshot 2023-03-01 at 17 41 10](https://user-images.githubusercontent.com/20134207/222219411-818f0400-d3ee-4b5e-8fc7-bc74e46aabc5.png)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.