### PR TITLE
Fix members search pagination

### DIFF
--- a/frontend/src/modules/activity/store/actions.js
+++ b/frontend/src/modules/activity/store/actions.js
@@ -15,7 +15,12 @@ export default {
     { keepPagination = false }
   ) {
     try {
-      commit('FETCH_STARTED', { keepPagination })
+      const activeView = getters.activeView
+
+      commit('FETCH_STARTED', {
+        keepPagination,
+        activeView
+      })
 
       let response
 

--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -147,6 +147,7 @@
     aria-modal="true"
   >
     <div
+      id="#formbricksPmf-0-0"
       class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
     ></div>
 

--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -147,7 +147,6 @@
     aria-modal="true"
   >
     <div
-      id="#formbricksPmf-0-0"
       class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
     ></div>
 

--- a/frontend/src/premium/eagle-eye/store/mutations.js
+++ b/frontend/src/premium/eagle-eye/store/mutations.js
@@ -9,13 +9,14 @@ export default {
       state.views[activeView].list.posts.length = 0
     }
 
-    state.pagination = keepPagination
-      ? state.pagination
-      : {
-          currentPage: 1,
-          pageSize:
-            state.pagination && state.pagination.pageSize
-        }
+    if (activeView.pagination) {
+      activeView.pagination = keepPagination
+        ? activeView.pagination
+        : {
+            currentPage: 1,
+            pageSize: activeView.pagination.pageSize
+          }
+    }
   },
 
   FETCH_SUCCESS(

--- a/frontend/src/shared/store/actions.js
+++ b/frontend/src/shared/store/actions.js
@@ -13,7 +13,10 @@ export default (moduleName, moduleService = null) => {
         ) {
           try {
             const activeView = getters.activeView
-            commit('FETCH_STARTED', { keepPagination })
+            commit('FETCH_STARTED', {
+              keepPagination,
+              activeView
+            })
 
             const response = await moduleService.list(
               activeView.filter,

--- a/frontend/src/shared/store/mutations.js
+++ b/frontend/src/shared/store/mutations.js
@@ -34,15 +34,27 @@ export default () => {
         state.list.ids.length = 0
       }
 
-      state.pagination =
-        payload && payload.keepPagination
-          ? state.pagination
-          : {
-              currentPage: 1,
-              pageSize:
-                state.pagination &&
-                state.pagination.pageSize
-            }
+      // Use active view pagination
+      if (payload?.activeView && !payload?.keepPagination) {
+        payload.activeView.pagination = {
+          currentPage: 1,
+          pageSize:
+            payload.activeView.pagination &&
+            payload.activeView.pagination.pageSize
+        }
+      }
+
+      // Use root state pagination
+      if (
+        !payload?.activeView &&
+        !payload?.keepPagination
+      ) {
+        state.pagination = {
+          currentPage: 1,
+          pageSize:
+            state.pagination && state.pagination.pageSize
+        }
+      }
     },
 
     FETCH_SUCCESS(state, payload) {

--- a/frontend/src/shared/store/mutations.js
+++ b/frontend/src/shared/store/mutations.js
@@ -35,24 +35,25 @@ export default () => {
       }
 
       // Use active view pagination
-      if (payload?.activeView && !payload?.keepPagination) {
+      if (
+        payload?.activeView?.pagination &&
+        !payload?.keepPagination
+      ) {
         payload.activeView.pagination = {
           currentPage: 1,
-          pageSize:
-            payload.activeView.pagination &&
-            payload.activeView.pagination.pageSize
+          pageSize: payload.activeView.pagination.pageSize
         }
       }
 
       // Use root state pagination
       if (
         !payload?.activeView &&
+        state.pagination &&
         !payload?.keepPagination
       ) {
         state.pagination = {
           currentPage: 1,
-          pageSize:
-            state.pagination && state.pagination.pageSize
+          pageSize: state.pagination.pageSize
         }
       }
     },


### PR DESCRIPTION
# Changes proposed ✍️
- When fetching for new results and `keepPagination` is false, the pagination object should be reset. This should take into account if the module handles the pagination within active views or on the state root. Fix actions and mutations so that each. module use the correct pagination object according to the state structure

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.