### PR TITLE
Mark as team organization

### DIFF
--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -65,6 +65,27 @@ async function createMembers(options) {
   ]
 }
 
+async function createOrganization(organization: any, options, members = []) {
+  const memberIds = []
+  for (const member of members) {
+    const memberCreated = await MemberRepository.create(
+      SequelizeTestUtils.objectWithoutKey(member, 'activities'),
+      options,
+    )
+
+    if (member.activities) {
+      for (const activity of member.activities) {
+        await ActivityRepository.create({ ...activity, member: memberCreated.id }, options)
+      }
+    }
+
+    memberIds.push(memberCreated.id)
+  }
+  organization.members = memberIds
+  const organizationCreated = await OrganizationRepository.create(organization, options)
+  return { ...organizationCreated, members: memberIds }
+}
+
 describe('OrganizationRepository tests', () => {
   beforeEach(async () => {
     await SequelizeTestUtils.wipeDatabase(db)
@@ -576,26 +597,6 @@ describe('OrganizationRepository tests', () => {
       },
     }
 
-    async function createOrganization(organization: any, options, members = []) {
-      const memberIds = []
-      for (const member of members) {
-        const memberCreated = await MemberRepository.create(
-          SequelizeTestUtils.objectWithoutKey(member, 'activities'),
-          options,
-        )
-
-        if (member.activities) {
-          for (const activity of member.activities) {
-            await ActivityRepository.create({ ...activity, member: memberCreated.id }, options)
-          }
-        }
-
-        memberIds.push(memberCreated.id)
-      }
-      organization.members = memberIds
-      return OrganizationRepository.create(organization, options)
-    }
-
     it('Should filter by name', async () => {
       const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
       await createOrganization(crowddev, mockIRepositoryOptions)
@@ -894,6 +895,8 @@ describe('OrganizationRepository tests', () => {
         mockIRepositoryOptions,
       )
 
+      delete org1.members
+
       expect(found.count).toBe(1)
       expect(found.rows).toStrictEqual([org1])
     })
@@ -941,6 +944,9 @@ describe('OrganizationRepository tests', () => {
         },
         mockIRepositoryOptions,
       )
+
+      delete org1.members
+      delete org2.members
 
       expect(found.count).toBe(2)
       expect(found.rows.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))).toStrictEqual([
@@ -1032,6 +1038,8 @@ describe('OrganizationRepository tests', () => {
         },
         mockIRepositoryOptions,
       )
+
+      delete org2.members
 
       expect(found.count).toBe(1)
       expect(found.rows.sort((a, b) => (a.createdAt > b.createdAt ? 1 : -1))).toStrictEqual([org2])
@@ -1213,6 +1221,157 @@ describe('OrganizationRepository tests', () => {
           mockIRepositoryOptions,
         ),
       ).rejects.toThrowError(new Error404())
+    })
+  })
+
+  describe('setOrganizationIsTeam method', () => {
+    const member1 = {
+      username: {
+        devto: 'iambarker',
+        github: 'barker',
+      },
+      displayName: 'Jack Barker',
+      attributes: {
+        bio: {
+          github: 'Head of development at Hooli',
+          twitter: 'Head of development at Hooli | ex CEO at Pied Piper',
+        },
+        sample: { crowd: true, default: true },
+        jobTitle: { custom: 'Head of development', default: 'Head of development' },
+        location: { github: 'Silicon Valley', default: 'Silicon Valley' },
+        avatarUrl: {
+          custom:
+            'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/jack-barker-best.jpg',
+          default:
+            'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/jack-barker-best.jpg',
+        },
+      },
+      joinedAt: moment().toDate(),
+      activities: [
+        {
+          type: 'star',
+          timestamp: '2020-05-27T15:13:30Z',
+          platform: PlatformType.GITHUB,
+          sourceId: '#sourceId1',
+        },
+      ],
+    }
+
+    const member2 = {
+      username: {
+        devto: 'thebelson',
+        github: 'gavinbelson',
+        discord: 'gavinbelson',
+        twitter: 'gavin',
+        linkedin: 'gavinbelson',
+      },
+      displayName: 'Gavin Belson',
+      attributes: {
+        bio: {
+          custom: 'CEO at Hooli',
+          github: 'CEO at Hooli',
+          default: 'CEO at Hooli',
+          twitter: 'CEO at Hooli',
+        },
+        sample: { crowd: true, default: true },
+        jobTitle: { custom: 'CEO', default: 'CEO' },
+        location: { github: 'Silicon Valley', default: 'Silicon Valley' },
+        avatarUrl: {
+          custom: 'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/gavin.jpg',
+          default: 'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/gavin.jpg',
+        },
+      },
+      joinedAt: moment().toDate(),
+      activities: [
+        {
+          type: 'star',
+          timestamp: '2020-05-28T15:13:30Z',
+          platform: PlatformType.GITHUB,
+          sourceId: '#sourceId2',
+        },
+      ],
+    }
+
+    const member3 = {
+      username: {
+        devto: 'bigheader',
+        github: 'bighead',
+      },
+      displayName: 'Big Head',
+      attributes: {
+        bio: {
+          custom: 'Executive at the Hooli XYZ project',
+          github: 'Co-head Dreamer of the Hooli XYZ project',
+          default: 'Executive at the Hooli XYZ project',
+          twitter: 'Co-head Dreamer of the Hooli XYZ project',
+        },
+        sample: { crowd: true, default: true },
+        jobTitle: { custom: 'Co-head Dreamer', default: 'Co-head Dreamer' },
+        location: { github: 'Silicon Valley', default: 'Silicon Valley' },
+        avatarUrl: {
+          custom: 'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/big-head-small.jpg',
+          default: 'https://s3.eu-central-1.amazonaws.com/crowd.dev-sample-data/big-head-small.jpg',
+        },
+      },
+      joinedAt: moment().toDate(),
+      activities: [
+        {
+          type: 'star',
+          timestamp: '2020-05-29T15:13:30Z',
+          platform: PlatformType.GITHUB,
+          sourceId: '#sourceId3',
+        },
+      ],
+    }
+    it('Should succesfully set/unset organization members as team members', async () => {
+      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+      const org = await createOrganization(toCreate, mockIRepositoryOptions, [
+        member1,
+        member2,
+        member3,
+      ])
+
+      // mark organization members as team members
+      await OrganizationRepository.setOrganizationIsTeam(org.id, true, mockIRepositoryOptions)
+
+      let m1 = await MemberRepository.findById(org.members[0], mockIRepositoryOptions)
+      let m2 = await MemberRepository.findById(org.members[1], mockIRepositoryOptions)
+      let m3 = await MemberRepository.findById(org.members[2], mockIRepositoryOptions)
+
+      expect(m1.attributes.isTeamMember.default).toEqual(true)
+      expect(m2.attributes.isTeamMember.default).toEqual(true)
+      expect(m3.attributes.isTeamMember.default).toEqual(true)
+
+      // expect other attributes intact
+      delete m1.attributes.isTeamMember
+      expect(m1.attributes).toStrictEqual(member1.attributes)
+
+      delete m2.attributes.isTeamMember
+      expect(m2.attributes).toStrictEqual(member2.attributes)
+
+      delete m3.attributes.isTeamMember
+      expect(m3.attributes).toStrictEqual(member3.attributes)
+
+      // now unmark
+      await OrganizationRepository.setOrganizationIsTeam(org.id, false, mockIRepositoryOptions)
+
+      m1 = await MemberRepository.findById(org.members[0], mockIRepositoryOptions)
+      m2 = await MemberRepository.findById(org.members[1], mockIRepositoryOptions)
+      m3 = await MemberRepository.findById(org.members[2], mockIRepositoryOptions)
+
+      expect(m1.attributes.isTeamMember.default).toEqual(false)
+      expect(m2.attributes.isTeamMember.default).toEqual(false)
+      expect(m3.attributes.isTeamMember.default).toEqual(false)
+
+      // expect other attributes intact
+      delete m1.attributes.isTeamMember
+      expect(m1.attributes).toStrictEqual(member1.attributes)
+
+      delete m2.attributes.isTeamMember
+      expect(m2.attributes).toStrictEqual(member2.attributes)
+
+      delete m3.attributes.isTeamMember
+      expect(m3.attributes).toStrictEqual(member3.attributes)
     })
   })
 

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -140,12 +140,14 @@ class OrganizationRepository {
       set attributes = jsonb_set("attributes", '{isTeamMember}', '{"default": ${isTeam}}'::jsonb)
       from "memberOrganizations" as mo
       where mo."memberId" = m.id
-      and mo."organizationId" = :organizationId;
+      and mo."organizationId" = :organizationId
+      and m."tenantId" = : tenantId;
    `,
       {
         replacements: {
           isTeam,
           organizationId,
+          tenantId: options.currentTenant.id,
         },
         type: QueryTypes.UPDATE,
       },

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -141,7 +141,7 @@ class OrganizationRepository {
       from "memberOrganizations" as mo
       where mo."memberId" = m.id
       and mo."organizationId" = :organizationId
-      and m."tenantId" = : tenantId;
+      and m."tenantId" = :tenantId;
    `,
       {
         replacements: {

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1,5 +1,5 @@
 import lodash from 'lodash'
-import Sequelize from 'sequelize'
+import Sequelize, { QueryTypes } from 'sequelize'
 import SequelizeRepository from './sequelizeRepository'
 import AuditLogRepository from './auditLogRepository'
 import SequelizeFilterUtils from '../utils/sequelizeFilterUtils'
@@ -110,9 +110,46 @@ class OrganizationRepository {
       })
     }
 
+    if (
+      data.isTeamOrganization === true ||
+      data.isTeamOrganization === 'true' ||
+      data.isTeamOrganization === false ||
+      data.isTeamOrganization === 'false'
+    ) {
+      await this.setOrganizationIsTeam(record.id, data.isTeamOrganization, options)
+    }
+
     await this._createAuditLog(AuditLogRepository.UPDATE, record, data, options)
 
     return this.findById(record.id, options)
+  }
+
+  /**
+   * Marks/unmarks an organization's members as team members
+   * @param organizationId
+   * @param isTeam
+   * @param options
+   */
+  static async setOrganizationIsTeam(
+    organizationId: string,
+    isTeam: boolean,
+    options: IRepositoryOptions,
+  ): Promise<void> {
+    await options.database.sequelize.query(
+      `update members as m
+      set attributes = jsonb_set("attributes", '{isTeamMember}', '{"default": ${isTeam}}'::jsonb)
+      from "memberOrganizations" as mo
+      where mo."memberId" = m.id
+      and mo."organizationId" = :organizationId;
+   `,
+      {
+        replacements: {
+          isTeam,
+          organizationId,
+        },
+        type: QueryTypes.UPDATE,
+      },
+    )
   }
 
   static async destroy(id, options: IRepositoryOptions, force = false) {


### PR DESCRIPTION
# Changes proposed ✍️
While updating organizations, we can now set it as team organization, which in result marks all organization's members as team member.

Example payload:
```
POST api/tenant/:tenantId/organization/:organizationId
{
   "isTeamOrganization": true
}
```

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.