### PR TITLE
Getting installed repositories with pagination

### DIFF
--- a/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
@@ -4,32 +4,55 @@ import { Repos } from '../../../types/regularTypes'
 
 const log = createServiceChildLogger('getInstalledRepositories')
 
+const getRepositoriesFromGH = async (page: number, installToken: string): Promise<any> => {
+  const REPOS_PER_PAGE = 100
+
+  const requestConfig = {
+    method: 'get',
+    url: `https://api.github.com/installation/repositories?page=${page}&per_page=${REPOS_PER_PAGE}`,
+    headers: {
+      Authorization: `Bearer ${installToken}`,
+    },
+  } as AxiosRequestConfig
+
+  const response = await axios(requestConfig)
+  return response.data
+}
+
+const parseRepos = (repositories: any): Repos => {
+  const repos: Repos = []
+
+  for (const repo of repositories) {
+    repos.push({
+      url: repo.html_url,
+      owner: repo.owner.login,
+      createdAt: repo.created_at,
+      name: repo.name,
+    })
+  }
+
+  return repos
+}
+
 export const getInstalledRepositories = async (installToken: string): Promise<Repos> => {
   try {
-    const requestConfig = {
-      method: 'get',
-      url: `https://api.github.com/installation/repositories`,
-      headers: {
-        Authorization: `Bearer ${installToken}`,
-      },
-    } as AxiosRequestConfig
-    const response = await axios(requestConfig)
-    const data = response.data
+    let page = 1
+    let hasMorePages = true
+
     const repos: Repos = []
 
-    if (data.repositories) {
-      for (const repo of data.repositories) {
-        repos.push({
-          url: repo.html_url,
-          owner: repo.owner.login,
-          createdAt: repo.created_at,
-          name: repo.name,
-        })
+    while (hasMorePages) {
+      const data = await getRepositoriesFromGH(page, installToken)
+
+      if (data.repositories) {
+        repos.push(...parseRepos(data.repositories))
       }
-      return repos
+
+      hasMorePages = data.total_count && data.total_count > 0 && data.total_count > repos.length
+      page += 1
     }
 
-    return []
+    return repos
   } catch (err: any) {
     log.error(err, 'Error fetching installed repositories!')
     throw err


### PR DESCRIPTION
# Changes proposed ✍️
- Default repos per page for this endpoint was 30, when user had more that 30 repos we were ignoring the rest. Now we try to find all pages.
- Also changed repos per page to 100 from default 30.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.