### PR TITLE
Sort eagle eye feed

### DIFF
--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-list.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-list.vue
@@ -9,7 +9,7 @@
     >
       <div
         v-for="(item, index) in getItemsInColumn(i)"
-        :key="item.post.title"
+        :key="item.url"
       >
         <app-eagle-eye-result-card
           :result="item"

--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-tabs.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-tabs.vue
@@ -53,18 +53,39 @@ const views = computed(() => {
   return Object.values(store.state.eagleEye.views)
 })
 
-const sorter = computed(() => activeView.value?.sorter)
-const sorterOptions = [
-  {
-    value: 'individualBookmarks',
-    label: 'My bookmarks'
+const sorter = computed({
+  get() {
+    return activeView.value?.sorter
   },
-  {
-    value: 'teamBookmarks',
-    label: 'Team bookmarks',
-    description: 'All posts bookmarked by your team'
+  set() {}
+})
+
+const sorterOptions = computed(() => {
+  if (activeView.value.id === 'bookmarked') {
+    return [
+      {
+        value: 'individualBookmarks',
+        label: 'My bookmarks'
+      },
+      {
+        value: 'teamBookmarks',
+        label: 'Team bookmarks',
+        description: 'All posts bookmarked by your team'
+      }
+    ]
   }
-]
+
+  return [
+    {
+      value: 'relevant',
+      label: 'Most relevant'
+    },
+    {
+      value: 'recent',
+      label: 'Most recent'
+    }
+  ]
+})
 </script>
 
 <style lang="scss" scope>

--- a/frontend/src/premium/eagle-eye/store/mutations.js
+++ b/frontend/src/premium/eagle-eye/store/mutations.js
@@ -24,9 +24,19 @@ export default {
     { list, count, appendToList, activeView }
   ) {
     state.views[activeView].list.loading = false
+
     if (appendToList) {
       state.views[activeView].list.posts.push(...list)
     } else {
+      const { sorter } = state.views[activeView]
+
+      if (activeView === 'feed' && sorter === 'recent') {
+        list.sort(
+          (a, b) =>
+            new Date(b.postedAt) - new Date(a.postedAt)
+        )
+      }
+
       state.views[activeView].list.posts = list
     }
     state.views[activeView].count = count

--- a/frontend/src/premium/eagle-eye/store/state.js
+++ b/frontend/src/premium/eagle-eye/store/state.js
@@ -12,7 +12,8 @@ export default () => {
           loading: false
         },
         count: 0,
-        active: true
+        active: true,
+        sorter: 'relevant'
       },
       bookmarked: {
         id: 'bookmarked',

--- a/frontend/src/shared/form/inline-select-input.vue
+++ b/frontend/src/shared/form/inline-select-input.vue
@@ -14,7 +14,7 @@
           modelLabel
         }}</span>
         <i
-          class="ri-arrow-down-s-line"
+          class="ri-arrow-down-s-line ml-1"
           :style="
             dropdownExpanded
               ? 'transform: rotate(180deg)'


### PR DESCRIPTION
# Changes proposed ✍️
- Update eagle eye card key to be `url`, titles didn't exist for twitter posts
- Add sorter options for Feed tab
- Sort list in mutations each time it is in the feed tab and the sorter is recent. Local storage will always remain the same with the list sorter by relevance (retrieved from the backend)
  
### Screenshots (front-end changes only)
![Screenshot 2023-03-07 at 17 05 28](https://user-images.githubusercontent.com/20134207/223499612-aa84ea39-ff0b-4ce9-837a-7b394c2aa45c.png)


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.