### PR TITLE
Organization members page is still using the old members query

### DIFF
--- a/frontend/src/modules/organization/components/view/organization-view-members.vue
+++ b/frontend/src/modules/organization/components/view/organization-view-members.vue
@@ -170,6 +170,11 @@ const fetchMembers = async () => {
       orderBy: 'joinedAt_DESC',
       limit: limit.value,
       offset: offset.value
+    },
+    {
+      headers: {
+        'x-crowd-api-version': '1'
+      }
     }
   )
 


### PR DESCRIPTION
# Changes proposed ✍️
- Move it to the new and optimized members query
  

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.