### PR TITLE
Fix filters using OR operators

### DIFF
--- a/frontend/src/modules/activity/activity-service.js
+++ b/frontend/src/modules/activity/activity-service.js
@@ -1,6 +1,7 @@
 import authAxios from '@/shared/axios/auth-axios'
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant'
 import buildApiPayload from '@/shared/filter/helpers/build-api-payload'
+import { DEFAULT_ACTIVITY_FILTERS } from '@/modules/activity/store/constants'
 
 export class ActivityService {
   static async update(id, data) {
@@ -94,19 +95,12 @@ export class ActivityService {
     offset,
     buildFilter = true
   ) {
-    let builtFilter = buildFilter
-      ? buildApiPayload(filter)
-      : filter
-    builtFilter = {
-      ...builtFilter,
-      member: {
-        isTeamMember: { not: true },
-        isBot: { not: true }
-      }
-    }
-
     const body = {
-      filter: builtFilter,
+      filter: buildApiPayload({
+        customFilters: filter,
+        defaultRootFilters: DEFAULT_ACTIVITY_FILTERS,
+        buildFilter
+      }),
       orderBy,
       limit,
       offset

--- a/frontend/src/modules/activity/store/actions.js
+++ b/frontend/src/modules/activity/store/actions.js
@@ -26,7 +26,10 @@ export default {
 
       if (getters.activeView.type === 'conversations') {
         response = await ConversationService.query(
-          buildApiPayload(getters.activeView.filter),
+          buildApiPayload({
+            customFilters: getters.activeView.filter,
+            buildFilter: true
+          }),
           getters.orderBy,
           getters.limit,
           getters.offset

--- a/frontend/src/modules/activity/store/constants.js
+++ b/frontend/src/modules/activity/store/constants.js
@@ -2,6 +2,19 @@ import { formatDate } from '@/utils/date'
 
 export const INITIAL_PAGE_SIZE = 20
 
+export const DEFAULT_ACTIVITY_FILTERS = [
+  {
+    member: {
+      isTeamMember: {
+        not: true
+      },
+      isBot: {
+        not: true
+      }
+    }
+  }
+]
+
 export const TRENDING_CONVERSATIONS_FILTER = {
   operator: 'and',
   attributes: {

--- a/frontend/src/modules/conversation/conversation-service.js
+++ b/frontend/src/modules/conversation/conversation-service.js
@@ -88,7 +88,10 @@ export class ConversationService {
 
   static async list(filter, orderBy, limit, offset) {
     const body = {
-      filter: buildApiPayload(filter),
+      filter: buildApiPayload({
+        customFilters: filter,
+        buildFilter: true
+      }),
       orderBy,
       limit,
       offset

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -284,11 +284,6 @@ export default {
                 .toISOString()
             }
           },
-          {
-            isTeamOrganization: {
-              not: true
-            }
-          },
           ...(platform !== 'all'
             ? [
                 {
@@ -334,11 +329,6 @@ export default {
                 .toISOString()
             }
           },
-          {
-            isTeamOrganization: {
-              not: true
-            }
-          },
           ...(platform !== 'all'
             ? [
                 {
@@ -366,17 +356,7 @@ export default {
 
   // Fetch  organizations count
   async getOrganizationsCount({ state }) {
-    return OrganizationService.list(
-      {
-        isTeamOrganization: {
-          not: true
-        }
-      },
-      '',
-      1,
-      0,
-      false
-    )
+    return OrganizationService.list(null, '', 1, 0, false)
       .then(({ count }) => {
         state.organizations.total = count
         return Promise.resolve(count)

--- a/frontend/src/modules/member/member-service.js
+++ b/frontend/src/modules/member/member-service.js
@@ -1,6 +1,7 @@
 import authAxios from '@/shared/axios/auth-axios'
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant'
-import buildApiFilter from '@/shared/filter/helpers/build-api-payload'
+import buildApiPayload from '@/shared/filter/helpers/build-api-payload'
+import { DEFAULT_MEMBER_FILTERS } from '@/modules/member/store/constants'
 
 export class MemberService {
   static async update(id, data) {
@@ -77,7 +78,10 @@ export class MemberService {
     buildFilter = true
   ) {
     const body = {
-      filter: buildFilter ? buildApiFilter(filter) : filter,
+      filter: buildApiPayload({
+        customFilters: filter,
+        buildFilter
+      }),
       orderBy,
       limit,
       offset
@@ -112,7 +116,7 @@ export class MemberService {
   }
 
   static async list(
-    filter,
+    customFilters,
     orderBy,
     limit,
     offset,
@@ -120,22 +124,16 @@ export class MemberService {
     countOnly = false
   ) {
     const body = {
-      filter:
-        (buildFilter ? buildApiFilter(filter) : filter) ||
-        {},
+      filter: buildApiPayload({
+        customFilters,
+        defaultFilters: DEFAULT_MEMBER_FILTERS,
+        buildFilter
+      }),
       orderBy,
       limit,
       offset,
       countOnly
     }
-
-    // Remove members marked as organizations from all responses
-    body.filter.and = [
-      {
-        isOrganization: { not: true }
-      },
-      { ...body.filter }
-    ]
 
     const sampleTenant =
       AuthCurrentTenant.getSampleTenantData()

--- a/frontend/src/modules/member/store/constants.js
+++ b/frontend/src/modules/member/store/constants.js
@@ -2,6 +2,27 @@ import { formatDate } from '@/utils/date'
 
 export const INITIAL_PAGE_SIZE = 20
 
+export const DEFAULT_MEMBER_FILTERS = [
+  {
+    isTeamMember: {
+      not: true
+    }
+  },
+  {
+    isOrganization: {
+      not: true
+    }
+  }
+]
+
+export const DEFAULT_INITIAL_VIEW_ALL_FILTER = [
+  {
+    activityCount: {
+      gt: 0
+    }
+  }
+]
+
 export const ACTIVITY_COUNT_BIGGER_THAN_0_FILTER = {
   activityCount: {
     name: 'activityCount',
@@ -18,26 +39,9 @@ export const ACTIVITY_COUNT_BIGGER_THAN_0_FILTER = {
   }
 }
 
-export const NOT_TEAM_MEMBER_FILTER = {
-  isTeamMember: {
-    name: 'isTeamMember',
-    label: 'Team member',
-    custom: false,
-    props: {},
-    defaultValue: true,
-    value: true,
-    defaultOperator: 'not',
-    operator: 'not',
-    type: 'boolean',
-    expanded: false,
-    show: false
-  }
-}
-
 export const INITIAL_VIEW_ALL_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_MEMBER_FILTER,
     ...ACTIVITY_COUNT_BIGGER_THAN_0_FILTER
   }
 }
@@ -45,7 +49,6 @@ export const INITIAL_VIEW_ALL_FILTER = {
 export const INITIAL_VIEW_ACTIVE_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_MEMBER_FILTER,
     score: {
       name: 'score',
       label: 'Engagement Level',
@@ -110,7 +113,6 @@ export const INITIAL_VIEW_ACTIVE_FILTER = {
 export const INITIAL_VIEW_SLIPPING_AWAY_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_MEMBER_FILTER,
     score: {
       name: 'score',
       label: 'Engagement Level',
@@ -190,7 +192,6 @@ export const INITIAL_VIEW_SLIPPING_AWAY_FILTER = {
 export const INITIAL_VIEW_RECENT_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_MEMBER_FILTER,
     joinedAt: {
       name: 'joinedAt',
       label: 'Joined date',
@@ -247,7 +248,6 @@ export const INITIAL_VIEW_TEAM_MEMBERS_FILTER = {
 export const INITIAL_VIEW_INFLUENTIAL_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_MEMBER_FILTER,
     isTeamMember: {
       name: 'reach',
       label: 'Reach',

--- a/frontend/src/modules/member/store/constants.js
+++ b/frontend/src/modules/member/store/constants.js
@@ -15,14 +15,6 @@ export const DEFAULT_MEMBER_FILTERS = [
   }
 ]
 
-export const DEFAULT_INITIAL_VIEW_ALL_FILTER = [
-  {
-    activityCount: {
-      gt: 0
-    }
-  }
-]
-
 export const ACTIVITY_COUNT_BIGGER_THAN_0_FILTER = {
   activityCount: {
     name: 'activityCount',

--- a/frontend/src/modules/organization/organization-service.js
+++ b/frontend/src/modules/organization/organization-service.js
@@ -1,6 +1,7 @@
 import authAxios from '@/shared/axios/auth-axios'
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant'
-import buildApiFilter from '@/shared/filter/helpers/build-api-payload'
+import buildApiPayload from '@/shared/filter/helpers/build-api-payload'
+import { DEFAULT_ORGANIZATION_FILTERS } from '@/modules/organization/store/constants'
 
 export class OrganizationService {
   static async update(id, data) {
@@ -68,7 +69,11 @@ export class OrganizationService {
     buildFilter = true
   ) {
     const body = {
-      filter: buildFilter ? buildApiFilter(filter) : filter,
+      filter: buildApiPayload({
+        customFilters: filter,
+        defaultFilters: DEFAULT_ORGANIZATION_FILTERS,
+        buildFilter
+      }),
       orderBy,
       limit,
       offset

--- a/frontend/src/modules/organization/store/constants.js
+++ b/frontend/src/modules/organization/store/constants.js
@@ -3,33 +3,17 @@ import OrganizationEmployeesField from '@/modules/organization/organization-empl
 
 export const INITIAL_PAGE_SIZE = 20
 
-const NOT_TEAM_ORGANIZATION_FILTER = {
-  isTeamOrganization: {
-    name: 'isTeamOrganization',
-    label: 'Team organization',
-    custom: false,
-    props: {},
-    defaultValue: true,
-    value: true,
-    defaultOperator: 'not',
-    operator: 'not',
-    type: 'boolean',
-    expanded: false,
-    show: false
+export const DEFAULT_ORGANIZATION_FILTERS = [
+  {
+    isTeamOrganization: {
+      not: true
+    }
   }
-}
-
-export const INITIAL_VIEW_ALL_FILTER = {
-  operator: 'and',
-  attributes: {
-    ...NOT_TEAM_ORGANIZATION_FILTER
-  }
-}
+]
 
 export const INITIAL_VIEW_NEW_AND_ACTIVE_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_ORGANIZATION_FILTER,
     joinedAt: {
       name: 'joinedAt',
       label: 'Joined date',
@@ -52,7 +36,6 @@ export const INITIAL_VIEW_NEW_AND_ACTIVE_FILTER = {
 export const INITIAL_VIEW_ENTERPRISE_SIZE_FILTER = {
   operator: 'and',
   attributes: {
-    ...NOT_TEAM_ORGANIZATION_FILTER,
     employees: {
       name: 'employees',
       label: '# of employees',

--- a/frontend/src/modules/organization/store/state.js
+++ b/frontend/src/modules/organization/store/state.js
@@ -1,6 +1,5 @@
 import { INITIAL_PAGE_SIZE } from './constants'
 import {
-  INITIAL_VIEW_ALL_FILTER,
   INITIAL_VIEW_NEW_AND_ACTIVE_FILTER,
   INITIAL_VIEW_TEAM_ORGANIZATIONS_FILTER
 } from './constants'
@@ -13,10 +12,14 @@ export default () => {
         id: 'all',
         label: 'All organizations',
         columns: [],
-        initialFilter: INITIAL_VIEW_ALL_FILTER,
-        filter: JSON.parse(
-          JSON.stringify(INITIAL_VIEW_ALL_FILTER)
-        ),
+        filter: {
+          operator: 'and',
+          attributes: {}
+        },
+        initialFilter: {
+          operator: 'and',
+          attributes: {}
+        },
         pagination: {
           currentPage: 1,
           pageSize: INITIAL_PAGE_SIZE
@@ -55,10 +58,14 @@ export default () => {
       'most-members': {
         id: 'most-members',
         label: 'Most members',
-        initialFilter: INITIAL_VIEW_ALL_FILTER,
-        filter: JSON.parse(
-          JSON.stringify(INITIAL_VIEW_ALL_FILTER)
-        ),
+        filter: {
+          operator: 'and',
+          attributes: {}
+        },
+        initialFilter: {
+          operator: 'and',
+          attributes: {}
+        },
         pagination: {
           currentPage: 1,
           pageSize: INITIAL_PAGE_SIZE

--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -35,12 +35,26 @@ const setApiFilters = ({
   isBot,
   filters
 }) => {
-  // Only add filter if team members are excluded
   if (selectedHasTeamMembers === false) {
     filters.push({
       isTeamMember: {
         not: true
       }
+    })
+  } else {
+    filters.push({
+      or: [
+        {
+          isTeamMember: {
+            not: true
+          }
+        },
+        {
+          isTeamMember: {
+            eq: true
+          }
+        }
+      ]
     })
   }
 
@@ -56,7 +70,7 @@ const setApiFilters = ({
   if (selectedPlatforms.length) {
     filters.push({
       or: selectedPlatforms.map((platform) => ({
-        platform: { jsonContains: platform.value }
+        identities: { contains: [platform.value] }
       }))
     })
   }

--- a/frontend/src/shared/fields/search-field.js
+++ b/frontend/src/shared/fields/search-field.js
@@ -20,7 +20,8 @@ export default class SearchField extends GenericField {
       defaultOperator: 'textContains',
       operator: 'textContains',
       type: 'search',
-      fields: this.fields
+      fields: this.fields,
+      show: false
     }
   }
 }

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -96,14 +96,12 @@ const buildDefaultAttributeBlock = ({
   customFilters,
   defaultFilters
 }) => {
-  const keys = customFilters?.attributes
-    ? Object.keys(customFilters.attributes)
-    : []
+  const filters = JSON.stringify(customFilters || {})
 
   return defaultFilters.filter((filter) => {
     const defaultName = Object.keys(filter)[0]
 
-    return !keys.includes(defaultName)
+    return !filters.includes(defaultName)
   })
 }
 

--- a/frontend/src/shared/filter/helpers/build-api-payload.js
+++ b/frontend/src/shared/filter/helpers/build-api-payload.js
@@ -1,29 +1,110 @@
-export default (filter) => {
-  if (Object.keys(filter).length === 0) {
-    return {}
-  } else {
-    const hasAttributes =
-      Object.keys(filter.attributes).length > 0
-    return !hasAttributes
-      ? {}
-      : {
-          [filter.operator]: Object.values(
-            filter.attributes
-          ).reduce((acc, item) => {
-            if (
-              Array.isArray(item.value)
-                ? item.value.length > 0
-                : item.value !== '' &&
-                  item.value !== null &&
-                  item.value !== {}
-            ) {
-              acc.push(_buildAttributeBlock(item))
-            }
+export default ({
+  customFilters = {},
+  defaultFilters = [],
+  defaultRootFilters = [],
+  buildFilter = false
+}) => {
+  let customAttributes = !buildFilter
+    ? customFilters || {}
+    : {}
 
-            return acc
-          }, [])
+  // Parse filters into API format
+  if (buildFilter && Object.keys(customFilters).length) {
+    const hasAttributes = Object.keys(
+      customFilters.attributes
+    ).length
+
+    if (!hasAttributes) {
+      customAttributes = {}
+    } else {
+      // Separate hidden from visible attributes
+      // Distinguished by show property
+      let hiddenAttributes = []
+      let visibleAttributes = Object.values(
+        customFilters.attributes
+      ).reduce((acc, item) => {
+        const attribute = _buildAttributeBlock(item)
+
+        if (
+          Array.isArray(item.value)
+            ? item.value.length > 0
+            : item.value !== '' &&
+              item.value !== null &&
+              item.value !== {}
+        ) {
+          if (item.show === false) {
+            hiddenAttributes.push(attribute)
+          } else {
+            acc.push(attribute)
+          }
         }
+
+        return acc
+      }, [])
+
+      // Hidden properties should always be inside an AND operator
+      // so that are always taken into account
+      // Visible attributes should be inside the operator defined in the UI
+      if (hiddenAttributes.length) {
+        customAttributes = {
+          and: [
+            ...hiddenAttributes,
+            {
+              ...(visibleAttributes.length && {
+                [customFilters.operator]: visibleAttributes
+              })
+            }
+          ]
+        }
+      } else if (visibleAttributes.length) {
+        customAttributes = {
+          [customFilters.operator]: visibleAttributes
+        }
+      }
+    }
   }
+
+  let payload = customAttributes
+
+  // Default filters should always be inside an AND operator
+  // so that they are always taken into account
+  // All other filters should handle their operators on their own
+  if (defaultFilters.length) {
+    payload = {
+      and: [
+        ...buildDefaultAttributeBlock({
+          customFilters,
+          defaultFilters
+        }),
+        customAttributes
+      ]
+    }
+  }
+
+  // Default root filters can be added diretly in the filter payload
+  // without being inside an operator
+  if (defaultRootFilters.length) {
+    Object.assign(payload, ...defaultRootFilters)
+  }
+
+  return payload
+}
+
+// Only add as default filter if custom filters do not have the same attribute as well
+// Scenarios where default filters are overriden by the same filter in the UI
+const buildDefaultAttributeBlock = ({
+  customFilters,
+  defaultFilters
+}) => {
+  const keys = customFilters?.attributes
+    ? Object.keys(customFilters.attributes)
+    : []
+
+  return defaultFilters.filter((filter) => {
+    const defaultName = Object.keys(filter)[0]
+
+    return !keys.includes(defaultName)
+  })
 }
 
 function _buildAttributeBlock(attribute) {


### PR DESCRIPTION
# Changes proposed ✍️
- Refactor method to `buildApiPayload` so that it handles all logic to add filters
   - This method now accepts, `customFilters`, `defaultFilters`, and `defaultRootFilters`. Default filters are added to the root of the object inside an AND operator. Default root filters are added to the root of the object without being inside any operator. Custom filters are parsed to match the API format.
   - By having default filters directly passed to the `buildApiPayload` method, we will no longer have default filters scattered throughout the code, being added for each call to the API
   - Extra logic was added to the method to handle the structure of the filters object depending on default filters, custom filters and if the attributes within the filters are visible or hidden. Hidden attributes can be added to specific views but not be visible to the user


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.