### PR TITLE
Public reports viewedBy exception

### DIFF
--- a/backend/src/api/report/reportFind.ts
+++ b/backend/src/api/report/reportFind.ts
@@ -9,6 +9,9 @@ export default async (req, res) => {
 
   if (!payload.public) {
     new PermissionChecker(req).validateHas(Permissions.values.reportRead)
+  }
+
+  if (req.currentUser && req.currentUser.id){
     const viewedBy = new Set<string>(payload.viewedBy).add(req.currentUser.id)
     await reportService.update(payload.id, { viewedBy: Array.from(viewedBy) })
   }

--- a/backend/src/api/report/reportFind.ts
+++ b/backend/src/api/report/reportFind.ts
@@ -11,7 +11,7 @@ export default async (req, res) => {
     new PermissionChecker(req).validateHas(Permissions.values.reportRead)
   }
 
-  if (req.currentUser && req.currentUser.id){
+  if (req.currentUser && req.currentUser.id) {
     const viewedBy = new Set<string>(payload.viewedBy).add(req.currentUser.id)
     await reportService.update(payload.id, { viewedBy: Array.from(viewedBy) })
   }

--- a/backend/src/api/report/reportFind.ts
+++ b/backend/src/api/report/reportFind.ts
@@ -9,10 +9,9 @@ export default async (req, res) => {
 
   if (!payload.public) {
     new PermissionChecker(req).validateHas(Permissions.values.reportRead)
+    const viewedBy = new Set<string>(payload.viewedBy).add(req.currentUser.id)
+    await reportService.update(payload.id, { viewedBy: Array.from(viewedBy) })
   }
-
-  const viewedBy = new Set<string>(payload.viewedBy).add(req.currentUser.id)
-  await reportService.update(payload.id, { viewedBy: Array.from(viewedBy) })
 
   track('Report Viewed', { id: payload.id, name: payload.name, public: payload.public }, { ...req })
 


### PR DESCRIPTION
# Changes proposed ✍️
- Now we don't try to update `report.viewedBy` when user isn't present (public access) on calling `report.findById`.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.