### PR TITLE
Set report widgets only if sent in the payload

### DIFF
--- a/backend/src/database/repositories/reportRepository.ts
+++ b/backend/src/database/repositories/reportRepository.ts
@@ -70,7 +70,7 @@ class ReportRepository {
       },
     )
 
-    if (data.widgets){
+    if (data.widgets) {
       await record.setWidgets(data.widgets || [], {
         transaction,
       })

--- a/backend/src/database/repositories/reportRepository.ts
+++ b/backend/src/database/repositories/reportRepository.ts
@@ -70,9 +70,11 @@ class ReportRepository {
       },
     )
 
-    await record.setWidgets(data.widgets || [], {
-      transaction,
-    })
+    if (data.widgets){
+      await record.setWidgets(data.widgets || [], {
+        transaction,
+      })
+    }
 
     await this._createAuditLog(AuditLogRepository.UPDATE, record, data, options)
 


### PR DESCRIPTION
# Changes proposed ✍️
- When updating a report, if we don't send widgets in the payload, currently it's emptying the widgets of a report. Now we only set widgets when it's actually sent

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.