### PR TITLE
changed log level for some logs from info to debug

### DIFF
--- a/backend/src/bin/discord-ws.ts
+++ b/backend/src/bin/discord-ws.ts
@@ -110,7 +110,7 @@ async function spawnClient(
   })
 
   client.on(Events.Debug, (message) => {
-    logger.info({ debugMsg: message }, 'Discord WS client debug message!')
+    logger.debug({ debugMsg: message }, 'Discord WS client debug message!')
   })
 
   client.on(Events.Warn, (message) => {
@@ -124,7 +124,7 @@ async function spawnClient(
       `member-${member.userId}`,
       cache,
       async () => {
-        logger.info(
+        logger.debug(
           {
             member: member.displayName,
             guildId: member.guildId ?? member.guild.id,
@@ -148,7 +148,7 @@ async function spawnClient(
         `msg-${message.id}`,
         cache,
         async () => {
-          logger.info(
+          logger.debug(
             {
               guildId: message.guildId,
               channelId: message.channelId,
@@ -170,7 +170,7 @@ async function spawnClient(
         `msg-modified-${newMessage.id}-${newMessage.editedTimestamp}`,
         cache,
         async () => {
-          logger.info(
+          logger.debug(
             {
               guildId: newMessage.guildId,
               channelId: newMessage.channelId,


### PR DESCRIPTION
# Changes proposed ✍️
- Discord websocket service is pumping out a lot of logs which we don't really need since we are already saving that data to database for processing

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.