### PR TITLE
Fix granularity formatting

### DIFF
--- a/frontend/src/modules/widget/components/cube/widget-cube.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube.vue
@@ -324,6 +324,9 @@ export default {
           seriesItem.title
         )
 
+        const granularity =
+          this.query.timeDimensions[0].granularity
+
         if (
           this.query.timeDimensions.length &&
           !this.query.timeDimensions[0].granularity
@@ -340,11 +343,12 @@ export default {
                 'widget.cubejs.cubes.' +
                   this.query.measures[0].split('.')[0]
               )
+
         return {
           name: seriesName,
           data: seriesItem.series.map((item) => {
             const formattedDate = moment(item.x).format(
-              'MMM DD'
+              this.getDateFormatForGranularity(granularity)
             )
             item.x = item.x === '∅' ? 'unknown' : item.x
             return [
@@ -361,6 +365,18 @@ export default {
           })
         }
       })
+    },
+    getDateFormatForGranularity(granularity) {
+      const granularityFormat = {
+        day: 'MMM DD',
+        week: 'MMM DD',
+        month: 'MMM YY',
+        year: 'YYYY'
+      }
+
+      return granularity && granularity in granularityFormat
+        ? granularityFormat[granularity]
+        : 'MMM DD'
     },
     tableData(resultSet) {
       // For tables


### PR DESCRIPTION
# Changes proposed ✍️
- bar charts for granularity month and year were wrongly displaying

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [ ] All changes are working locally running crowd.dev's Docker local environment.