### PR TITLE
Enable onboarding integration processing to last multiple days because of rate limits

### DIFF
--- a/backend/src/types/mq/nodeWorkerIntegrationProcessMessage.ts
+++ b/backend/src/types/mq/nodeWorkerIntegrationProcessMessage.ts
@@ -19,6 +19,7 @@ export class NodeWorkerIntegrationProcessMessage extends NodeWorkerMessageBase {
     public readonly metadata?: any,
     public readonly retryStreams?: IIntegrationStreamRetry[],
     public readonly remainingStreams?: IIntegrationStream[],
+    public readonly totalDuration?: number,
   ) {
     super(NodeWorkerMessageType.INTEGRATION_PROCESS)
   }


### PR DESCRIPTION
# Changes proposed ✍️
- If we hit rate limit exception we should pause and delay and only set integration to done/error when we are really done
- max 7 days per integration onboarding limit
  

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.