### PR TITLE
Appending appHost to all dynamic template variables

### DIFF
--- a/backend/src/services/emailSender.ts
+++ b/backend/src/services/emailSender.ts
@@ -62,7 +62,7 @@ export default class EmailSender extends LoggingBase {
       templateId: this.templateId,
       dynamicTemplateData: {
         ...this.variables,
-        appHost: API_CONFIG.frontendUrl
+        appHost: API_CONFIG.frontendUrl,
       },
     } as any
 

--- a/backend/src/services/emailSender.ts
+++ b/backend/src/services/emailSender.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import sendgridMail from '@sendgrid/mail'
-import { SENDGRID_CONFIG } from '../config'
+import { API_CONFIG, SENDGRID_CONFIG } from '../config'
 import { AdvancedSuppressionManager } from './helpers/sendgridAsmType'
 import { LoggingBase } from './loggingBase'
 
@@ -60,7 +60,10 @@ export default class EmailSender extends LoggingBase {
         email: SENDGRID_CONFIG.emailFrom,
       },
       templateId: this.templateId,
-      dynamicTemplateData: this.variables,
+      dynamicTemplateData: {
+        ...this.variables,
+        appHost: API_CONFIG.frontendUrl
+      },
     } as any
 
     if (this.tenantId) {


### PR DESCRIPTION
# Changes proposed ✍️
- We now append `appHost` variable to all email templates before sending it to SendGrid. This value will be used for links in the emails.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.