### PR TITLE
Null values for raw query parser

### DIFF
--- a/backend/src/database/repositories/filters/rawQueryParser.ts
+++ b/backend/src/database/repositories/filters/rawQueryParser.ts
@@ -207,13 +207,19 @@ export default class RawQueryParser {
 
     const paramName = this.getParamName(key, params)
 
-    if (operator === Operator.EQUAL && (value === null || value.toLowerCase() === 'null')) {
-      params[paramName] = value
+    if (
+      operator === Operator.EQUAL &&
+      (value === null || (typeof value === 'string' && value.toLowerCase() === 'null'))
+    ) {
+      params[paramName] = null
       return `(${column} is :${paramName})`
     }
 
-    if (operator === Operator.NOT_EQUAL && (value === null || value.toLowerCase() === 'null')) {
-      params[paramName] = value
+    if (
+      operator === Operator.NOT_EQUAL &&
+      (value === null || (typeof value === 'string' && value.toLowerCase() === 'null'))
+    ) {
+      params[paramName] = null
       return `(${column} is not :${paramName})`
     }
 

--- a/backend/src/database/repositories/filters/rawQueryParser.ts
+++ b/backend/src/database/repositories/filters/rawQueryParser.ts
@@ -204,7 +204,19 @@ export default class RawQueryParser {
       const paramNamesString = paramNames.join(', ')
       return `(${column} ${actualOperator} (${paramNamesString}))`
     }
+
     const paramName = this.getParamName(key, params)
+
+    if (operator === Operator.EQUAL && (value === null || value.toLowerCase() === "null") ){
+      params[paramName] = value
+      return `(${column} is :${paramName})`
+    }
+
+    if (operator === Operator.NOT_EQUAL && (value === null || value.toLowerCase() === "null") ){
+      params[paramName] = value
+      return `(${column} is not :${paramName})`
+    }
+
     if (
       operator === Operator.LIKE ||
       operator === Operator.NOT_LIKE ||

--- a/backend/src/database/repositories/filters/rawQueryParser.ts
+++ b/backend/src/database/repositories/filters/rawQueryParser.ts
@@ -207,12 +207,12 @@ export default class RawQueryParser {
 
     const paramName = this.getParamName(key, params)
 
-    if (operator === Operator.EQUAL && (value === null || value.toLowerCase() === "null") ){
+    if (operator === Operator.EQUAL && (value === null || value.toLowerCase() === 'null')) {
       params[paramName] = value
       return `(${column} is :${paramName})`
     }
 
-    if (operator === Operator.NOT_EQUAL && (value === null || value.toLowerCase() === "null") ){
+    if (operator === Operator.NOT_EQUAL && (value === null || value.toLowerCase() === 'null')) {
       params[paramName] = value
       return `(${column} is not :${paramName})`
     }


### PR DESCRIPTION
# Changes proposed ✍️
- Null values for raw query parser when sending with `eq` and `ne` operators

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [ ] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.