### PR TITLE
Only use posts that have publishedAt property set.

### DIFF
--- a/backend/src/serverless/integrations/usecases/linkedin/getOrganizationPosts.ts
+++ b/backend/src/serverless/integrations/usecases/linkedin/getOrganizationPosts.ts
@@ -33,21 +33,23 @@ export const getOrganizationPosts = async (
 
     let stop = false
 
-    const elements = response.elements.map((e) => {
-      if (lookBackUntilTs && e.createdAt <= lookBackUntilTs) {
-        stop = true
-      }
+    const elements = response.elements
+      .filter((e) => e.publishedAt !== undefined)
+      .map((e) => {
+        if (lookBackUntilTs && e.createdAt <= lookBackUntilTs) {
+          stop = true
+        }
 
-      return {
-        urnId: e.id,
-        lifecycleState: e.lifecycleState,
-        visibility: e.visibility,
-        authorUrn: e.author,
-        body: e.commentary,
-        originalUrnId: e.reshareContext?.parent,
-        timestamp: e.createdAt,
-      }
-    })
+        return {
+          urnId: e.id,
+          lifecycleState: e.lifecycleState,
+          visibility: e.visibility,
+          authorUrn: e.author,
+          body: e.commentary,
+          originalUrnId: e.reshareContext?.parent,
+          timestamp: e.createdAt,
+        }
+      })
 
     if (stop) {
       return {


### PR DESCRIPTION
# Changes proposed ✍️
- For some posts we were getting 404 when fetching their comments/reactions - the only difference was that those posts didn't have `publishedAt` property returned from LinkedIn API so we are filtering those out for now

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.