### PR TITLE
Keep track of activity's channels

### DIFF
--- a/backend/src/database/migrations/U1680601431__addActivityToSettings.sql
+++ b/backend/src/database/migrations/U1680601431__addActivityToSettings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."settings" DROP COLUMN "activityChannels"

--- a/backend/src/database/migrations/U1680601431__addActivityToSettings.sql
+++ b/backend/src/database/migrations/U1680601431__addActivityToSettings.sql
@@ -1,1 +1,1 @@
-ALTER TABLE public."settings" DROP COLUMN "activityChannels"
+ALTER TABLE public."settings" DROP COLUMN "activityChannels";

--- a/backend/src/database/migrations/V1680601431__addActivityToSettings.sql
+++ b/backend/src/database/migrations/V1680601431__addActivityToSettings.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."settings" ADD COLUMN "activityChannels" jsonb DEFAULT null;

--- a/backend/src/database/migrations/V1680601431__addActivityToSettings.sql
+++ b/backend/src/database/migrations/V1680601431__addActivityToSettings.sql
@@ -1,1 +1,1 @@
-ALTER TABLE public."settings" ADD COLUMN "activityChannels" jsonb DEFAULT null;
+ALTER TABLE public."settings" ADD COLUMN "activityChannels" jsonb DEFAULT '{}';

--- a/backend/src/database/models/settings.ts
+++ b/backend/src/database/models/settings.ts
@@ -42,10 +42,10 @@ export default (sequelize, DataTypes) => {
           ],
         },
       },
-      activityChannels : {
-            type: DataTypes.JSONB,
-            defaultValue: {}
-      }
+      activityChannels: {
+        type: DataTypes.JSONB,
+        defaultValue: {},
+      },
     },
     {
       timestamps: true,

--- a/backend/src/database/models/settings.ts
+++ b/backend/src/database/models/settings.ts
@@ -42,6 +42,10 @@ export default (sequelize, DataTypes) => {
           ],
         },
       },
+      activityChannels : {
+            type: DataTypes.JSONB,
+            defaultValue: {}
+      }
     },
     {
       timestamps: true,

--- a/backend/src/database/repositories/settingsRepository.ts
+++ b/backend/src/database/repositories/settingsRepository.ts
@@ -75,6 +75,10 @@ export default class SettingsRepository {
     return activityTypes
   }
 
+  static getActivityChannels(options: IRepositoryOptions) {
+    return options.currentTenant?.settings[0]?.activityChannels
+  }
+
   static getActivityTypes(options: IRepositoryOptions): ActivityTypeSettings {
     return options.currentTenant?.settings[0]?.dataValues.activityTypes
   }

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -27,6 +27,12 @@ const en = {
         notFound: `Activity type with key {0} is not found.`,
       },
     },
+    activityChannels: {
+      errors: {
+        typeRequiredWhenCreating: `Type field is required when creating a custom activity channel.`,
+        notFound: `Activity type with key {0} is not found.`,
+      },
+    },
   },
 
   auth: {

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -740,7 +740,7 @@ describe('ActivityService tests', () => {
           label: 'positive',
           sentiment: 0.98,
         },
-        channel: "TestChannel",
+        channel: 'TestChannel',
         attributes: {
           replies: 12,
         },
@@ -751,7 +751,7 @@ describe('ActivityService tests', () => {
       }
 
       await new ActivityService(mockIRepositoryOptions).upsert(activity)
-      const settings = await SettingsRepository.findOrCreateDefault({},mockIRepositoryOptions)
+      const settings = await SettingsRepository.findOrCreateDefault({}, mockIRepositoryOptions)
 
       expect(settings.activityChannels[activity.platform].includes(activity.channel)).toBe(true)
     })
@@ -780,7 +780,7 @@ describe('ActivityService tests', () => {
           label: 'positive',
           sentiment: 0.98,
         },
-        channel: "TestChannel",
+        channel: 'TestChannel',
         attributes: {
           replies: 12,
         },
@@ -791,7 +791,7 @@ describe('ActivityService tests', () => {
       }
 
       await new ActivityService(mockIRepositoryOptions).upsert(activity)
-      let settings = await SettingsRepository.findOrCreateDefault({},mockIRepositoryOptions)
+      let settings = await SettingsRepository.findOrCreateDefault({}, mockIRepositoryOptions)
       const activity1 = {
         type: 'activity1',
         timestamp: '2020-05-27T15:13:30Z',
@@ -807,7 +807,7 @@ describe('ActivityService tests', () => {
           label: 'positive',
           sentiment: 0.98,
         },
-        channel: "TestChannel",
+        channel: 'TestChannel',
         attributes: {
           replies: 12,
         },
@@ -817,8 +817,8 @@ describe('ActivityService tests', () => {
         score: 1,
       }
       await new ActivityService(mockIRepositoryOptions).upsert(activity)
-      settings = await SettingsRepository.findOrCreateDefault({},mockIRepositoryOptions)
-      console.log("Hhoho", settings)
+      settings = await SettingsRepository.findOrCreateDefault({}, mockIRepositoryOptions)
+      console.log('Hhoho', settings)
       expect(settings.activityChannels[activity1.platform].length).toBe(1)
     })
   })

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -818,7 +818,6 @@ describe('ActivityService tests', () => {
       }
       await new ActivityService(mockIRepositoryOptions).upsert(activity)
       settings = await SettingsRepository.findOrCreateDefault({}, mockIRepositoryOptions)
-      console.log('Hhoho', settings)
       expect(settings.activityChannels[activity1.platform].length).toBe(1)
     })
   })

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -63,12 +63,9 @@ export default class ActivityService extends LoggingBase {
       }
 
       // check if channel exists in settings for respective platform. If not, update by adding channel to settings
-      if (
-          data.platform &&
-          data.channel
-        ) {
-          await SettingsService.updateActivityChannels(data, this.options)
-        }
+      if (data.platform && data.channel) {
+        await SettingsService.updateActivityChannels(data, this.options)
+      }
 
       // If a sourceParentId is sent, try to find it in our db
       if ('sourceParentId' in data && data.sourceParentId) {

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -62,6 +62,14 @@ export default class ActivityService extends LoggingBase {
         await SettingsService.createActivityType({ type: data.type }, this.options, data.platform)
       }
 
+      // check if channel exists in settings for respective platform. If not, update by adding channel to settings
+      if (
+          data.platform &&
+          data.channel
+        ) {
+          await SettingsService.updateActivityChannels(data, this.options)
+        }
+
       // If a sourceParentId is sent, try to find it in our db
       if ('sourceParentId' in data && data.sourceParentId) {
         const parent = await ActivityRepository.findOne(

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -54,6 +54,7 @@ class SettingsService {
 
     return updated.activityTypes
   }
+
   /**
    * update activity channels after checking for duplicates with platform key
    */
@@ -63,8 +64,8 @@ class SettingsService {
     }
 
     const settings  = await this.findOrCreateDefault(options)
-    let activityChannels = settings.activityChannels
-    //const channelKey = getCleanString(data.channel) Maybe this is required?
+    const activityChannels = settings.activityChannels
+    // const channelKey = getCleanString(data.channel) Maybe this is required?
 
 
     if(activityChannels[data.platform]) {
@@ -78,7 +79,7 @@ class SettingsService {
     }
     const updated = await SettingsRepository.save(
       {
-        activityChannels: activityChannels,
+        activityChannels,
       },
       options,
     )

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -63,8 +63,8 @@ class SettingsService {
       throw new Error400(options.language, 'settings.activityTypes.errors.typeRequiredWhenCreating')
     }
 
-    const settings = await this.findOrCreateDefault(options)
-    const activityChannels = settings.activityChannels
+
+    const activityChannels = await SettingsRepository.getActivityChannels(options)
     // const channelKey = getCleanString(data.channel) Maybe this is required?
 
     if (activityChannels[data.platform]) {

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -63,14 +63,13 @@ class SettingsService {
       throw new Error400(options.language, 'settings.activityTypes.errors.typeRequiredWhenCreating')
     }
 
-    const settings  = await this.findOrCreateDefault(options)
+    const settings = await this.findOrCreateDefault(options)
     const activityChannels = settings.activityChannels
     // const channelKey = getCleanString(data.channel) Maybe this is required?
 
-
-    if(activityChannels[data.platform]) {
+    if (activityChannels[data.platform]) {
       const channelList = activityChannels[data.platform]
-      if(!channelList.includes(data.channel)) {
+      if (!channelList.includes(data.channel)) {
         const updatedChannelList = [...channelList, data.channel]
         activityChannels[data.platform] = updatedChannelList
       }
@@ -84,10 +83,7 @@ class SettingsService {
       options,
     )
     return updated.activityChannels
-
-
   }
-
 
   /**
    * unnest activity types with platform for easy access/manipulation

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -54,6 +54,39 @@ class SettingsService {
 
     return updated.activityTypes
   }
+  /**
+   * update activity channels after checking for duplicates with platform key
+   */
+  static async updateActivityChannels(data, options) {
+    if (!data.channel) {
+      throw new Error400(options.language, 'settings.activityTypes.errors.typeRequiredWhenCreating')
+    }
+
+    const settings  = await this.findOrCreateDefault(options)
+    let activityChannels = settings.activityChannels
+    //const channelKey = getCleanString(data.channel) Maybe this is required?
+
+
+    if(activityChannels[data.platform]) {
+      const channelList = activityChannels[data.platform]
+      if(!channelList.includes(data.channel)) {
+        const updatedChannelList = [...channelList, data.channel]
+        activityChannels[data.platform] = updatedChannelList
+      }
+    } else {
+      activityChannels[data.platform] = [data.channel]
+    }
+    const updated = await SettingsRepository.save(
+      {
+        activityChannels: activityChannels,
+      },
+      options,
+    )
+    return updated.activityChannels
+
+
+  }
+
 
   /**
    * unnest activity types with platform for easy access/manipulation

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -60,9 +60,11 @@ class SettingsService {
    */
   static async updateActivityChannels(data, options) {
     if (!data.channel) {
-      throw new Error400(options.language, 'settings.activityTypes.errors.typeRequiredWhenCreating')
+      throw new Error400(
+        options.language,
+        'settings.activityChannels.errors.typeRequiredWhenCreating',
+      )
     }
-
 
     const activityChannels = await SettingsRepository.getActivityChannels(options)
     // const channelKey = getCleanString(data.channel) Maybe this is required?

--- a/backend/src/services/settingsService.ts
+++ b/backend/src/services/settingsService.ts
@@ -66,8 +66,7 @@ class SettingsService {
       )
     }
 
-    const activityChannels = await SettingsRepository.getActivityChannels(options)
-    // const channelKey = getCleanString(data.channel) Maybe this is required?
+    const activityChannels = SettingsRepository.getActivityChannels(options)
 
     if (activityChannels[data.platform]) {
       const channelList = activityChannels[data.platform]


### PR DESCRIPTION
# Changes proposed ✍️
 This PR contains code for the following.
- Creating a migration for adding a column called activityChannels in Settings table.
- This Column is kept up to date using the add activity API, when new channels are encountered, they are then updated in the settings table in the respective platform.
  

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.