### PR TITLE
Fix discord channels semantics

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -525,9 +525,9 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
             ? DiscordIntegrationService.replaceMentions(record.content, record.mentions)
             : '',
           url: `https://discordapp.com/channels/${channel.guild_id}/${channel.id}/${record.id}`,
-          channel: channel.name,
+          channel: parentChannel,
           attributes: {
-            parentChannel,
+            childChannel: channel.name,
             thread: isThread,
             reactions: record.reactions ? record.reactions : [],
             attachments: record.attachments ? record.attachments : [],

--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -525,9 +525,9 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
             ? DiscordIntegrationService.replaceMentions(record.content, record.mentions)
             : '',
           url: `https://discordapp.com/channels/${channel.guild_id}/${channel.id}/${record.id}`,
-          channel: parentChannel,
+          channel: parentChannel || channel.name,
           attributes: {
-            childChannel: channel.name,
+            childChannel: parentChannel ? channel.name : undefined,
             thread: isThread,
             reactions: record.reactions ? record.reactions : [],
             attachments: record.attachments ? record.attachments : [],

--- a/backend/src/types/activityTypes.ts
+++ b/backend/src/types/activityTypes.ts
@@ -293,10 +293,10 @@ export const DEFAULT_ACTIVITY_TYPE_SETTINGS: DefaultActivityTypes = {
     [DiscordtoActivityType.THREAD_MESSAGE]: {
       display: {
         default:
-          'replied to a message in thread <span class="text-brand-500 truncate max-w-2xs">#{channel}</span> -> <span class="text-brand-500">{attributes.parentChannel}</span>',
+          'replied to a message in thread <span class="text-brand-500 truncate max-w-2xs">#{channel}</span> -> <span class="text-brand-500">{attributes.childChannel}</span>',
         short: 'replied to a message',
         channel:
-          '<span class="text-brand-500 truncate max-w-2xs">thread #{channel}</span> -> <span class="text-brand-500">#{attributes.parentChannel}</span>',
+          '<span class="text-brand-500 truncate max-w-2xs">thread #{channel}</span> -> <span class="text-brand-500">#{attributes.childChannel}</span>',
       },
       isContribution: DiscordGrid.message.isContribution,
     },


### PR DESCRIPTION
# Changes proposed ✍️
- For some Discord messages, we were setting the channel as the thread name and keeping the actual channel name in the attributes.

This is now the other way around