### PR TITLE
Fixed member joinedAt being overwritten for the Slack and Twitter integrations

### DIFF
--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -1591,14 +1591,10 @@ describe('ActivityService tests', () => {
         await memberAttributeSettingsService.createPredefined(GithubMemberAttributes)
         await memberAttributeSettingsService.createPredefined(TwitterMemberAttributes)
 
-        const member = {
-          username: {
-            [PlatformType.TWITTER]: 'anil',
-          },
-        }
-
         const data = {
-          member,
+          member: {
+            username: 'anil,',
+          },
           timestamp: '1970-01-01T00:00:00.000Z',
           type: 'follow',
           platform: PlatformType.TWITTER,
@@ -1609,10 +1605,18 @@ describe('ActivityService tests', () => {
           mockIRepositoryOptions,
         ).createWithMember(data)
 
-        data.timestamp = '2021-09-30T14:20:27.000Z'
-
-        // Upsert the same activity with a different timestamp
-        await new ActivityService(mockIRepositoryOptions).createWithMember(data)
+        const data2 = {
+          member: {
+            username: 'anil,',
+          },
+          timestamp: '2021-09-30T14:20:27.000Z',
+          type: 'follow',
+          platform: PlatformType.TWITTER,
+          sourceId: '#sourceId1',
+        }
+        data.timestamp =
+          // Upsert the same activity with a different timestamp
+          await new ActivityService(mockIRepositoryOptions).createWithMember(data2)
 
         const memberFound = await MemberRepository.findById(
           activityWithMember.memberId,

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -1595,7 +1595,6 @@ describe('ActivityService tests', () => {
           username: {
             [PlatformType.TWITTER]: 'anil',
           },
-          displayName: 'Anil',
         }
 
         const data = {
@@ -1610,11 +1609,10 @@ describe('ActivityService tests', () => {
           mockIRepositoryOptions,
         ).createWithMember(data)
 
-        const data2 = data
-        data2.timestamp = '2021-09-30T14:20:27.000Z'
+        data.timestamp = '2021-09-30T14:20:27.000Z'
 
         // Upsert the same activity with a different timestamp
-        await new ActivityService(mockIRepositoryOptions).createWithMember(data2)
+        await new ActivityService(mockIRepositoryOptions).createWithMember(data)
 
         const memberFound = await MemberRepository.findById(
           activityWithMember.memberId,

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -1464,7 +1464,7 @@ describe('ActivityService tests', () => {
         })
       })
 
-      it('It should replace joinedAt if the orginal was in year 1000', async () => {
+      it('It should replace joinedAt if the orginal was in year 1970', async () => {
         const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
         const memberAttributeSettingsService = new MemberAttributeSettingsService(
           mockIRepositoryOptions,
@@ -1499,7 +1499,7 @@ describe('ActivityService tests', () => {
             },
           },
           organisation: 'Crowd',
-          joinedAt: new Date('1000-01-01T00:00:00Z'),
+          joinedAt: new Date('1970-01-01T00:00:00Z'),
         }
 
         await MemberRepository.create(member, mockIRepositoryOptions)
@@ -1575,6 +1575,55 @@ describe('ActivityService tests', () => {
         expect(memberFound.username).toStrictEqual({
           [PlatformType.GITHUB]: 'anil_github',
         })
+      })
+
+      it('Should respect joinedAt when an existing activity comes in with a different timestamp', async () => {
+        // This can happen in cases like the Twitter integration.
+        // For follow activities, if we are onboarding we set the timestamp to 1970,
+        // but if we are not onboarding, we set the timestamp to the current time.
+        // This can cause having 2 activities with different timestamps, but the same sourceId.
+        // The joinedAt should stay untouched in this case.
+        const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
+        const memberAttributeSettingsService = new MemberAttributeSettingsService(
+          mockIRepositoryOptions,
+        )
+
+        await memberAttributeSettingsService.createPredefined(GithubMemberAttributes)
+        await memberAttributeSettingsService.createPredefined(TwitterMemberAttributes)
+
+        const member = {
+          username: {
+            [PlatformType.TWITTER]: 'anil',
+          },
+          displayName: 'Anil',
+        }
+
+        await MemberRepository.create(member, mockIRepositoryOptions)
+
+        const data = {
+          member,
+          timestamp: '1970-01-01T00:00:00.000Z',
+          type: 'follow',
+          platform: PlatformType.TWITTER,
+          sourceId: '#sourceId1',
+        }
+
+        const activityWithMember = await new ActivityService(
+          mockIRepositoryOptions,
+        ).createWithMember(data)
+
+        const data2 = data
+        data2.timestamp = '2021-09-30T14:20:27.000Z'
+
+        // Upsert the same activity with a different timestamp
+        await new ActivityService(mockIRepositoryOptions).createWithMember(data2)
+
+        const memberFound = await MemberRepository.findById(
+          activityWithMember.memberId,
+          mockIRepositoryOptions,
+        )
+        // The joinedAt should stay untouched
+        expect(memberFound.joinedAt).toStrictEqual(new Date('1970-01-01T00:00:00.000Z'))
       })
     })
   })

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -1598,8 +1598,6 @@ describe('ActivityService tests', () => {
           displayName: 'Anil',
         }
 
-        await MemberRepository.create(member, mockIRepositoryOptions)
-
         const data = {
           member,
           timestamp: '1970-01-01T00:00:00.000Z',

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -400,7 +400,7 @@ export default class ActivityService extends LoggingBase {
         {
           ...data.member,
           platform: data.platform,
-          joinedAt: data.timestamp,
+          joinedAt: activityExists ? activityExists.timestamp : data.timestamp,
         },
         existingMember,
       )

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -188,7 +188,7 @@ export default class MemberService extends LoggingBase {
     if (!('platform' in data)) {
       throw new Error400(this.options.language, 'activity.platformRequiredWhileUpsert')
     }
-
+    console.log(data)
     if (!data.displayName) {
       if (typeof data.username === 'string') {
         data.displayName = data.username


### PR DESCRIPTION
# Changes proposed ✍️

When we onboarded we set the follow timestamp to 1970, and the member’s joinedAt as well. So far so good.
But when we onboard, we upsert that same activity with timestamp now(). The upsert for activities was working fine. However, when it was calling the upsert for members, it was sending the timestamp now() as joinedAt , when it should have been sending the timestamp of the existing activity.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [x] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.