### PR TITLE
Issue when deleting sample data on onboarding integration

### DIFF
--- a/backend/src/api/eagleEyeContent/eagleEyeContentTrack.ts
+++ b/backend/src/api/eagleEyeContent/eagleEyeContentTrack.ts
@@ -12,20 +12,9 @@ export default async (req, res) => {
 
   switch (event) {
     case 'postClicked':
-      console.log('Eagle Eye post clicked', {
-        url: params.url,
-        platform: params.platform,
-      })
       EagleEyeContentService.trackPostClicked(req.body.url, req.body.platform, req)
       break
     case 'generatedReply':
-      console.log('Eagle Eye AI reply generated', {
-        title: params.title,
-        description: params.description,
-        platform: params.platform,
-        reply: params.reply,
-        url: params.url,
-      })
       track(
         'Eagle Eye AI reply generated',
         {
@@ -39,14 +28,6 @@ export default async (req, res) => {
       )
       break
     case 'generatedReplyFeedback':
-      console.log('Eagle Eye AI reply feedback', {
-        type: params.type,
-        title: params.title,
-        description: params.description,
-        platform: params.platform,
-        reply: params.reply,
-        url: params.url,
-      })
       track(
         'Eagle Eye AI reply feedback',
         {
@@ -61,13 +42,6 @@ export default async (req, res) => {
       )
       break
     case 'generatedReplyCopied':
-      console.log('Eagle Eye AI reply copied', {
-        title: params.title,
-        description: params.description,
-        platform: params.platform,
-        url: params.url,
-        reply: params.reply,
-      })
       track(
         'Eagle Eye AI reply copied',
         {

--- a/backend/src/api/integration/helpers/redditValidator.ts
+++ b/backend/src/api/integration/helpers/redditValidator.ts
@@ -20,7 +20,6 @@ export default async (req, res) => {
         result.data.data.children &&
         result.data.data.children.length > 0
       ) {
-        console.log('here')
         track(
           'Reddit: subreddit input',
           {

--- a/backend/src/api/integration/helpers/stackOverflowValidator.ts
+++ b/backend/src/api/integration/helpers/stackOverflowValidator.ts
@@ -24,7 +24,6 @@ export default async (req, res) => {
         },
       )
       const data = result.data as StackOverflowTagsResponse
-      console.log(data)
       if (
         result.status === 200 &&
         data.items &&
@@ -32,7 +31,6 @@ export default async (req, res) => {
         data.items[0].is_moderator_only === false &&
         data.items[0].count > 0
       ) {
-        console.log('here')
         track(
           'Stack Overflow: tag input',
           {

--- a/backend/src/api/integration/helpers/stackOverflowVolume.ts
+++ b/backend/src/api/integration/helpers/stackOverflowVolume.ts
@@ -24,7 +24,6 @@ export default async (req, res) => {
       )
       const responses = await Promise.all(promises)
       if (responses.every((response) => response.status === 200)) {
-        console.log('here')
         return req.responseHandler.success(req, res, {
           total: responses.reduce((acc, response) => acc + response.data.total, 0),
         })

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -85,6 +85,7 @@ class MemberRepository {
   }
 
   static async findSampleDataMemberIds(options: IRepositoryOptions) {
+    const transaction = SequelizeRepository.getTransaction(options)
     const currentTenant = SequelizeRepository.getCurrentTenant(options)
     const sampleMemberIds = await options.database.sequelize.query(
       `select m.id from members m
@@ -96,6 +97,7 @@ class MemberRepository {
           tenantId: currentTenant.id,
         },
         type: QueryTypes.SELECT,
+        transaction,
       },
     )
 

--- a/backend/src/serverless/integrations/services/integrationProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationProcessor.ts
@@ -425,7 +425,18 @@ export class IntegrationProcessor extends LoggingBase {
 
     // delete sample data on onboarding
     if (run.onboarding) {
-      await new SampleDataService(userContext).deleteSampleData()
+      try {
+        await new SampleDataService(userContext).deleteSampleData()
+      } catch (err) {
+        logger.error(err, { tenantId: integration.tenantId }, 'Error deleting sample data!')
+        await this.integrationRunRepository.markError(req.runId, {
+          errorPoint: 'delete_sample_data',
+          message: err.message,
+          stack: err.stack,
+          errorString: JSON.stringify(err),
+        })
+        return
+      }
     }
 
     // keep track of failed streams

--- a/backend/src/services/eventTrackingService.ts
+++ b/backend/src/services/eventTrackingService.ts
@@ -13,6 +13,5 @@ export default class EventTrackingService extends LoggingBase {
 
   async trackEvent(event: Event) {
     await track(event.name, event.properties, this.options)
-    console.log('trackEvent', event)
   }
 }

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -188,7 +188,6 @@ export default class MemberService extends LoggingBase {
     if (!('platform' in data)) {
       throw new Error400(this.options.language, 'activity.platformRequiredWhileUpsert')
     }
-    console.log(data)
     if (!data.displayName) {
       if (typeof data.username === 'string') {
         data.displayName = data.username

--- a/backend/src/services/sampleDataService.ts
+++ b/backend/src/services/sampleDataService.ts
@@ -162,7 +162,6 @@ export default class SampleDataService extends LoggingBase {
         for (const member of members) {
           const tagList = []
           const noteList = []
-          console.log(member.displayName, member.tags)
           for (const tag of member.tags || []) {
             const found = (await tagService.findAndCountAll({ advancedFilter: { name: tag } }))
               .rows[0]

--- a/backend/src/services/sampleDataService.ts
+++ b/backend/src/services/sampleDataService.ts
@@ -27,6 +27,7 @@ import NoteService from './noteService'
 import TagService from './tagService'
 import { AttributeType } from '../database/attributes/types'
 import { API_CONFIG } from '../config'
+import SequelizeRepository from '../database/repositories/sequelizeRepository'
 
 export default class SampleDataService extends LoggingBase {
   options: IServiceOptions
@@ -248,58 +249,76 @@ export default class SampleDataService extends LoggingBase {
    * Also removes settings for attributes.sample.crowd
    */
   async deleteSampleData(): Promise<void> {
-    const tenantService = new TenantService(this.options)
+    const tx = await SequelizeRepository.createTransaction(this.options)
 
-    const tenant = await tenantService.findById(this.options.currentTenant.id)
+    const txOptions = { ...this.options, transaction: tx }
 
-    if (tenant.hasSampleData) {
-      if (API_CONFIG.edition !== 'crowd-hosted') {
-        const memberService = new MemberService(this.options)
-        const memberAttributeSettingsService = new MemberAttributeSettingsService(this.options)
+    try {
+      const tenantService = new TenantService(txOptions)
 
-        const memberIds = await MemberRepository.findSampleDataMemberIds(this.options)
+      const tenant = await tenantService.findById(this.options.currentTenant.id)
 
-        const organizationService = new OrganizationService(this.options)
+      if (tenant.hasSampleData) {
+        if (API_CONFIG.edition !== 'crowd-hosted') {
+          const memberService = new MemberService(txOptions)
+          const memberAttributeSettingsService = new MemberAttributeSettingsService(txOptions)
 
-        const organizationIds = (
-          await organizationService.findAndCountAll({
-            advancedFilter: {
-              members: memberIds,
-            },
-          })
-        ).rows.map((org) => org.id)
+          const memberIds = await MemberRepository.findSampleDataMemberIds(txOptions)
 
-        await organizationService.destroyBulk(organizationIds)
+          const organizationService = new OrganizationService(txOptions)
 
-        // deleting sample members should cascade to their activities as well
-        await memberService.destroyBulk(memberIds)
+          const organizationIds = (
+            await organizationService.findAndCountAll({
+              advancedFilter: {
+                members: memberIds,
+              },
+            })
+          ).rows.map((org) => org.id)
 
-        const conversationService = new ConversationService(this.options)
-        const conversationIds = (
-          await conversationService.findAndCountAll({
-            advancedFilter: {
-              activityCount: 0,
-            },
-            limit: 200,
-          })
-        ).rows.map((conv) => conv.id)
+          await organizationService.destroyBulk(organizationIds)
 
-        await conversationService.destroyBulk(conversationIds)
+          // deleting sample members should cascade to their activities as well
+          await memberService.destroyBulk(memberIds)
 
-        // delete attribute settings for attributes.sample.crowd as well
-        const sampleAttributeSettings = (
-          await memberAttributeSettingsService.findAndCountAll({
-            filter: { name: MemberAttributeName.SAMPLE },
-          })
-        ).rows[0]
-        await memberAttributeSettingsService.destroyAll([sampleAttributeSettings.id])
+          const conversationService = new ConversationService(txOptions)
+          const conversationIds = (
+            await conversationService.findAndCountAll({
+              advancedFilter: {
+                activityCount: 0,
+              },
+              limit: 200,
+            })
+          ).rows.map((conv) => conv.id)
+
+          await conversationService.destroyBulk(conversationIds)
+
+          // delete attribute settings for attributes.sample.crowd as well
+          const sampleAttributeSettings = (
+            await memberAttributeSettingsService.findAndCountAll({
+              filter: { name: MemberAttributeName.SAMPLE },
+            })
+          ).rows[0]
+          await memberAttributeSettingsService.destroyAll([sampleAttributeSettings.id])
+        }
+
+        await tenantService.update(
+          this.options.currentTenant.id,
+          {
+            hasSampleData: false,
+          },
+          true,
+        )
       }
 
-      await tenantService.update(this.options.currentTenant.id, {
-        hasSampleData: false,
-      })
-    }
+      await SequelizeRepository.commitTransaction(tx)
+      this.log.info(`Sample data for tenant ${this.options.currentTenant.id} deleted succesfully.`)
+    } catch (err) {
+      this.log.error(err, 'Error deleting sample data!')
+      if (tx) {
+        await SequelizeRepository.rollbackTransaction(tx)
+      }
 
-    this.log.info(`Sample data for tenant ${this.options.currentTenant.id} deleted succesfully.`)
+      throw err
+    }
   }
 }

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -276,7 +276,7 @@ export default class TenantService {
     }
   }
 
-  async update(id, data) {
+  async update(id, data, force = false) {
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
     try {
@@ -290,10 +290,12 @@ export default class TenantService {
         data.hasSampleData = record.hasSampleData
       }
 
-      new PermissionChecker({
-        ...this.options,
-        currentTenant: { id },
-      }).validateHas(Permissions.values.tenantEdit)
+      if (!force) {
+        new PermissionChecker({
+          ...this.options,
+          currentTenant: { id },
+        }).validateHas(Permissions.values.tenantEdit)
+      }
 
       // if tenant already has some published conversations, updating url is not allowed
       if (data.url && data.url !== record.url) {


### PR DESCRIPTION
# Changes proposed ✍️
- When trying to delete sample data permission checker error gets thrown - no permission to edit tenant so I added a force flag to bypass that permission check if we are doing updates from our internal services
- Sample data deletion was not in transaction so I fixed that as well because in this case the last function call failed but then it failed earlier since some other data was already gone. It should be rolled back.
- Removed a bunch of console.log statements since they are blowing up our log usage

## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [x] Tests are passing.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~Environment variables have been updated:~
  - [ ] ~Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.~
  - [ ] ~Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.~
  - [ ] ~[Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.~
  - [ ] ~Team members only: update environment variables in override, staging and production env. files and trigger update config script.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.