### PR TITLE
New UI for Pull Request Conversations

### DIFF
--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -484,6 +484,8 @@ class ConversationRepository {
                   allActivities[allActivities.length - 2],
                   allActivities[allActivities.length - 1],
                 ]
+              } else if(allActivities.length === 1) {
+                neededActivities = [allActivities[0]]
               } else {
                 neededActivities = [allActivities[0], allActivities[allActivities.length - 1]]
               }

--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -484,8 +484,6 @@ class ConversationRepository {
                   allActivities[allActivities.length - 2],
                   allActivities[allActivities.length - 1],
                 ]
-              } else if(allActivities.length === 1) {
-                neededActivities = [allActivities[0]]
               } else {
                 neededActivities = [allActivities[0], allActivities[allActivities.length - 1]]
               }

--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -477,15 +477,20 @@ class ConversationRepository {
 
             if (allActivities.length > 0) {
               let neededActivities = []
+              const parentActivity = allActivities.find((a) => a.parent === null)
+
+              if (parentActivity) {
+                neededActivities = [parentActivity]
+              }
 
               if (allActivities.length > 2) {
                 neededActivities = [
-                  allActivities[0],
+                  ...neededActivities,
                   allActivities[allActivities.length - 2],
                   allActivities[allActivities.length - 1],
                 ]
               } else {
-                neededActivities = [allActivities[0], allActivities[allActivities.length - 1]]
+                neededActivities = [...neededActivities, allActivities[allActivities.length - 1]]
               }
 
               const promises = neededActivities.map(async (act) => {

--- a/backend/src/database/repositories/conversationRepository.ts
+++ b/backend/src/database/repositories/conversationRepository.ts
@@ -492,6 +492,11 @@ class ConversationRepository {
                 const member = (await act.getMember()).get({ plain: true })
                 act = act.get({ plain: true })
                 act.member = member
+                act.display = ActivityDisplayService.getDisplayOptions(
+                  act,
+                  SettingsRepository.getActivityTypes(options),
+                )
+
                 return act
               })
               const returnedNeededActivities = await Promise.all(promises)
@@ -551,6 +556,10 @@ class ConversationRepository {
       const member = (await act.getMember()).get({ plain: true })
       act = act.get({ plain: true })
       act.member = member
+      act.display = ActivityDisplayService.getDisplayOptions(
+        act,
+        SettingsRepository.getActivityTypes(options),
+      )
       return act
     })
 

--- a/backend/src/types/activityTypes.ts
+++ b/backend/src/types/activityTypes.ts
@@ -251,6 +251,66 @@ export const DEFAULT_ACTIVITY_TYPE_SETTINGS: DefaultActivityTypes = {
       },
       isContribution: GitHubGrid.unStar.isContribution,
     },
+    [GithubActivityType.PULL_REQUEST_MERGED]: {
+      display: {
+        default: 'merged pull request {self}',
+        short: 'merged a pull request',
+        channel: '{channel}',
+        formatter: {
+          channel: defaultGithubChannelFormatter,
+          self: (activity) => {
+            const prNumberAndTitle = `#${activity.url.split('/')[6]} ${activity.parent.title}`
+            return `<a href="${activity.url}" target="_blank">${prNumberAndTitle}</a>`
+          },
+        },
+      },
+      isContribution: GitHubGrid.pullRequestMerged.isContribution,
+    },
+    [GithubActivityType.PULL_REQUEST_ASSIGNED]: {
+      display: {
+        default: 'assigned pull request {self}',
+        short: 'assigned a pull request',
+        channel: '{channel}',
+        formatter: {
+          channel: defaultGithubChannelFormatter,
+          self: (activity) => {
+            const prNumberAndTitle = `#${activity.url.split('/')[6]} ${activity.parent.title}`
+            return `<a href="${activity.url}" style="max-width:150px" target="_blank">${prNumberAndTitle}</a> to <a href="/members/${activity.objectMemberId}" target="_blank">${activity.objectMember.displayName}</a>`
+          },
+        },
+      },
+      isContribution: GitHubGrid.pullRequestAssigned.isContribution,
+    },
+    [GithubActivityType.PULL_REQUEST_REVIEWED]: {
+      display: {
+        default: 'reviewed pull request {self}',
+        short: 'reviewed a pull request',
+        channel: '{channel}',
+        formatter: {
+          channel: defaultGithubChannelFormatter,
+          self: (activity) => {
+            const prNumberAndTitle = `#${activity.url.split('/')[6]} ${activity.parent.title}`
+            return `<a href="${activity.url}" target="_blank">${prNumberAndTitle}</a>`
+          },
+        },
+      },
+      isContribution: GitHubGrid.pullRequestReviewed.isContribution,
+    },
+    [GithubActivityType.PULL_REQUEST_REVIEW_REQUESTED]: {
+      display: {
+        default: 'requested a review for pull request {self}',
+        short: 'requested a pull request review',
+        channel: '{channel}',
+        formatter: {
+          channel: defaultGithubChannelFormatter,
+          self: (activity) => {
+            const prNumberAndTitle = `#${activity.url.split('/')[6]} ${activity.parent.title}`
+            return `<a href="${activity.url}" style="max-width:150px" target="_blank">${prNumberAndTitle}</a> from <a href="/members/${activity.objectMemberId}" target="_blank">${activity.objectMember.displayName}</a>`
+          },
+        },
+      },
+      isContribution: GitHubGrid.pullRequestReviewRequested.isContribution,
+    },
   },
   [PlatformType.DEVTO]: {
     [DevtoActivityType.COMMENT]: {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -43,12 +43,12 @@
     <link
       rel="preload"
       as="style"
-      href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css"
+      href="https://cdn.jsdelivr.net/npm/remixicon@3.1.1/fonts/remixicon.css"
     />
 
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css"
+      href="https://cdn.jsdelivr.net/npm/remixicon@3.1.1/fonts/remixicon.css"
       media="print"
       onload="this.media='all'"
     />
@@ -60,7 +60,7 @@
       />
       <link
         as="style"
-        href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css"
+        href="https://cdn.jsdelivr.net/npm/remixicon@3.1.1/fonts/remixicon.css"
       />
     </noscript>
     <script type="text/javascript">

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -333,6 +333,10 @@ const en = {
           'commented on a pull request',
         'discussion-started': 'started a discussion',
         'discussion-comment': 'commented on a discussion',
+        'pull_request-review-requested': 'requested a pull request review',
+        'pull_request-reviewed': 'reviewed a pull request',
+        'pull_request-assigned': 'assigned a pull request',
+        'pull_request-merged': 'merged a pull request',
         contributed_to_community:
           'contributed to community',
         joined_community: 'joined community',

--- a/frontend/src/jsons/activity-types.json
+++ b/frontend/src/jsons/activity-types.json
@@ -10,7 +10,11 @@
     "unstar",
     "pull_request-comment",
     "issue-comment",
-    "discussion-comment"
+    "discussion-comment",
+    "pull_request-review-requested",
+    "pull_request-reviewed",
+    "pull_request-assigned",
+    "pull_request-merged"
   ],
   "discord": [
     "message",

--- a/frontend/src/modules/activity/components/activity-content.vue
+++ b/frontend/src/modules/activity/components/activity-content.vue
@@ -9,9 +9,16 @@
           && displayTitle
       "
     >
-      <span class="block title" :class="titleClasses">{{
-        activity.title
-      }}</span>
+      <span
+        class="block"
+        :class="{
+          title: !titleClasses,
+          [titleClasses]: titleClasses,
+        }"
+      >
+        {{
+          activity.title
+        }}</span>
     </div>
 
     <div

--- a/frontend/src/modules/activity/components/activity-content.vue
+++ b/frontend/src/modules/activity/components/activity-content.vue
@@ -77,6 +77,16 @@
       </div>
     </div>
   </div>
+  <div v-else-if="activity.display?.default">
+    <div
+      class="first-letter:uppercase font-medium text-gray-900 text-sm"
+      v-html="
+        contentRenderEmojis(
+          $sanitize($marked(activity.display.default)),
+        )
+      "
+    />
+  </div>
 </template>
 
 <script>

--- a/frontend/src/modules/activity/components/activity-icon.vue
+++ b/frontend/src/modules/activity/components/activity-icon.vue
@@ -1,0 +1,74 @@
+<template>
+  <div
+    v-if="icons[platform]?.[type]"
+    class="absolute z-10 -top-1.5 -right-1.5 outline outline-2 outline-offset-0
+  outline-white rounded-full h-5 w-5 flex items-center justify-center"
+    :class="icons[platform][type].bgColor"
+  >
+    <i :class="`${icons[platform][type].iconClass} ${icons[platform][type].color} text-2xs leading-3`" />
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  type: {
+    type: String,
+    required: true,
+  },
+  platform: {
+    type: String,
+    required: true,
+  },
+});
+
+const icons = {
+  github: {
+    'pull_request-opened': {
+      iconClass: 'ri-git-pull-request-line',
+      color: 'text-white',
+      bgColor: 'bg-green-600',
+    },
+    'pull_request-closed': {
+      iconClass: 'ri-git-close-pull-request-line',
+      color: 'text-white',
+      bgColor: 'bg-red-600',
+    },
+    'pull_request-comment': {
+      iconClass: 'ri-chat-4-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
+    'discussion-comment': {
+      iconClass: 'ri-chat-4-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
+    'pull_request-review-requested': {
+      iconClass: 'ri-eye-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
+    'pull_request-reviewed': {
+      iconClass: 'ri-eye-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
+    'pull_request-assigned': {
+      iconClass: 'ri-user-shared-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
+    'pull_request-merged': {
+      iconClass: 'ri-git-merge-line',
+      color: 'text-white',
+      bgColor: 'bg-purple-600',
+    },
+  },
+};
+</script>
+
+<script>
+export default {
+  name: 'AppActivityIcon',
+};
+</script>

--- a/frontend/src/modules/activity/components/activity-icon.vue
+++ b/frontend/src/modules/activity/components/activity-icon.vue
@@ -23,6 +23,11 @@ defineProps({
 
 const icons = {
   github: {
+    'issue-comment': {
+      iconClass: 'ri-chat-4-line',
+      color: 'text-black',
+      bgColor: 'bg-gray-200',
+    },
     'pull_request-opened': {
       iconClass: 'ri-git-pull-request-line',
       color: 'text-white',

--- a/frontend/src/modules/conversation/components/conversation-details-footer.vue
+++ b/frontend/src/modules/conversation/components/conversation-details-footer.vue
@@ -1,0 +1,94 @@
+<template>
+  <app-conversation-footer-wrapper :conversation="conversation">
+    <template
+      #footer="{
+        attributes,
+        isGithubConversation,
+        replyContent,
+      }"
+    >
+      <div
+        class="flex items-center gap-3"
+      >
+        <div
+          class="flex items-center tag h-8 !rounded-md"
+        >
+          <i
+            class="ri-group-line text-base mr-2 text-gray-400"
+          />
+          <p
+            class="text-xs text-gray-900"
+          >
+            {{ pluralize('participant', conversation.memberCount, true) }}
+          </p>
+        </div>
+        <div
+          class="flex items-center tag h-8 !rounded-md"
+        >
+          <i
+            :class="`${replyContent.icon} text-base mr-2 text-gray-400`"
+          />
+          <p
+            class="text-xs text-gray-900"
+          >
+            {{ pluralize(replyContent.copy, replyContent.number, true) }}
+          </p>
+        </div>
+        <div v-if="isGithubConversation && attributes" class="flex items-center">
+          <div
+            class="flex items-center tag h-8 !rounded-l-md !rounded-r-none"
+          >
+            <i
+              class="ri-file-edit-line text-base mr-2 text-gray-400"
+            />
+            <p
+              class="text-xs text-gray-900"
+            >
+              {{ pluralize('file change', attributes.changedFiles || 0, true) }}
+            </p>
+          </div>
+          <div class="bg-gray-50 h-8 rounded-r-md flex items-center gap-2 text-xs px-3 border-y border-r border-gray-200">
+            <div class="text-green-600">
+              +{{ attributes.additions || 0 }}
+            </div>
+            <div class="text-red-600">
+              -{{ attributes.deletions || 0 }}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-if="isGithubConversation && attributes.labels?.length" class="mt-5">
+        <div class="uppercase font-semibold text-2xs tracking-1 text-gray-400 mb-2">
+          Labels
+        </div>
+        <div class="flex items-center flex-wrap gap-3">
+          <div
+            v-for="label in attributes.labels"
+            :key="label"
+            class="h-8 rounded-lg text-gray-900 border border-gray-200 bg-white text-xs flex items-center px-3"
+          >
+            {{ label }}
+          </div>
+        </div>
+      </div>
+    </template>
+  </app-conversation-footer-wrapper>
+</template>
+
+<script setup>
+import pluralize from 'pluralize';
+import AppConversationFooterWrapper from '@/modules/conversation/components/conversation-footer-wrapper.vue';
+
+defineProps({
+  conversation: {
+    type: Object,
+    required: true,
+  },
+});
+</script>
+
+<script>
+export default {
+  name: 'AppConversationParentFooter',
+};
+</script>

--- a/frontend/src/modules/conversation/components/conversation-details-footer.vue
+++ b/frontend/src/modules/conversation/components/conversation-details-footer.vue
@@ -34,7 +34,11 @@
             {{ pluralize(replyContent.copy, replyContent.number, true) }}
           </p>
         </div>
-        <div v-if="isGithubConversation && attributes" class="flex items-center">
+        <div
+          v-if="isGithubConversation
+            && (attributes?.changedFiles || attributes?.additions || attributes?.deletions)"
+          class="flex items-center"
+        >
           <div
             class="flex items-center tag h-8 !rounded-l-md !rounded-r-none"
           >

--- a/frontend/src/modules/conversation/components/conversation-details.vue
+++ b/frontend/src/modules/conversation/components/conversation-details.vue
@@ -121,7 +121,7 @@
         Activities
       </h6>
 
-      <div v-if="conversationTypes.length > 1" class="flex gap-1 items-center text-sm">
+      <div v-if="conversationTypes.length > 2" class="flex gap-1 items-center text-sm">
         <span class="text-gray-500">Activity type:</span>
 
         <app-inline-select-input

--- a/frontend/src/modules/conversation/components/conversation-details.vue
+++ b/frontend/src/modules/conversation/components/conversation-details.vue
@@ -88,7 +88,7 @@
             ? 'text-sm'
             : 'text-base'
         "
-        title-classes="text-base font-medium"
+        title-classes="text-[18px] font-semibold"
         :activity="conversation.conversationStarter"
         :show-more="true"
       />
@@ -121,7 +121,7 @@
         Activities
       </h6>
 
-      <div v-if="conversationTypes.length > 2" class="flex gap-1 items-center text-sm">
+      <div v-if="sorterOptions.length > 2" class="flex gap-1 items-center text-sm">
         <span class="text-gray-500">Activity type:</span>
 
         <app-inline-select-input

--- a/frontend/src/modules/conversation/components/conversation-drawer.vue
+++ b/frontend/src/modules/conversation/components/conversation-drawer.vue
@@ -19,7 +19,7 @@
         v-if="loading"
         :loading="true"
       />
-      <div v-else>
+      <div v-else class="h-full">
         <app-conversation-details
           v-if="conversation"
           :conversation="conversation"

--- a/frontend/src/modules/conversation/components/conversation-footer-wrapper.vue
+++ b/frontend/src/modules/conversation/components/conversation-footer-wrapper.vue
@@ -1,0 +1,52 @@
+<template>
+  <slot
+    name="footer"
+    v-bind="{
+      attributes,
+      isGithubConversation,
+      replyContent,
+    }"
+  />
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+  conversation: {
+    type: Object,
+    required: true,
+  },
+});
+
+const attributes = computed(() => props.conversation.conversationStarter.attributes);
+const isGithubConversation = computed(() => props.conversation.platform === 'github');
+const replyContent = computed(() => {
+  if (isGithubConversation.value) {
+    const activities = props.conversation.lastReplies || props.conversation.activities;
+    return {
+      icon: 'ri-chat-4-line',
+      copy: 'comment',
+      number: activities.reduce((acc, activity) => {
+        if (activity.type.includes('comment')) {
+          return acc + 1;
+        }
+
+        return acc;
+      }, 0),
+    };
+  }
+
+  return {
+    icon: 'ri-reply-line',
+    copy: 'reply',
+    number: props.conversation.activityCount - 1,
+  };
+});
+</script>
+
+<script>
+export default {
+  name: 'AppConversationParentFooter',
+};
+</script>

--- a/frontend/src/modules/conversation/components/conversation-footer.vue
+++ b/frontend/src/modules/conversation/components/conversation-footer.vue
@@ -1,0 +1,105 @@
+<template>
+  <app-conversation-footer-wrapper :conversation="conversation">
+    <template
+      #footer="{
+        attributes,
+        isGithubConversation,
+        replyContent,
+      }"
+    >
+      <div
+        class="flex items-center gap-6"
+      >
+        <div
+          class="flex items-center"
+        >
+          <i
+            class="ri-group-line text-base mr-2 text-gray-500"
+          />
+          <p
+            class="text-xs text-gray-600"
+          >
+            {{ pluralize('participant', conversation.memberCount, true) }}
+          </p>
+        </div>
+        <div
+          class="flex items-center"
+        >
+          <i
+            :class="`${replyContent.icon} text-base mr-2 text-gray-500`"
+          />
+          <p
+            class="text-xs text-gray-600"
+          >
+            {{ pluralize(replyContent.copy, replyContent.number, true) }}
+          </p>
+        </div>
+        <div v-if="isGithubConversation && attributes" class="flex items-center">
+          <div
+            class="flex items-center"
+          >
+            <i
+              class="ri-file-edit-line text-base mr-2 text-gray-500"
+            />
+            <p
+              class="text-xs text-gray-600"
+            >
+              {{ pluralize('file change', attributes.changedFiles || 0, true) }}
+            </p>
+          </div>
+          <div class="rounded-r-md flex items-center gap-1 text-xs ml-2">
+            <div class="text-green-600">
+              +{{ attributes.additions || 0 }}
+            </div>
+            <div class="text-red-600">
+              -{{ attributes.deletions || 0 }}
+            </div>
+          </div>
+        </div>
+
+        <div v-if="isGithubConversation && attributes.labels?.length">
+          <el-tooltip
+            :content="attributes.labels.join(' ・ ')"
+            placement="top"
+            :disabled="attributes.labels.length === 1"
+          >
+            <div class="flex items-center">
+              <i
+                class="ri-price-tag-3-line text-base mr-2 text-gray-500"
+              />
+              <p
+                class="text-xs text-gray-600"
+              >
+                {{ attributes.labels.length === 1 ? attributes.labels[0] : pluralize('label', attributes.labels.length, true) }}
+              </p>
+            </div>
+          </el-tooltip>
+        </div>
+      </div>
+      <div>
+        <app-activity-link
+          :activity="conversation.conversationStarter"
+        />
+      </div>
+    </template>
+  </app-conversation-footer-wrapper>
+</template>
+
+<script setup>
+import pluralize from 'pluralize';
+import AppActivityLink from '@/modules/activity/components/activity-link.vue';
+import AppConversationFooterWrapper from '@/modules/conversation/components/conversation-footer-wrapper.vue';
+
+defineProps({
+  conversation: {
+    type: Object,
+    required: true,
+  },
+});
+</script>
+
+<script>
+export default {
+  name: 'AppConversationParentFooter',
+};
+</script>

--- a/frontend/src/modules/conversation/components/conversation-footer.vue
+++ b/frontend/src/modules/conversation/components/conversation-footer.vue
@@ -34,7 +34,11 @@
             {{ pluralize(replyContent.copy, replyContent.number, true) }}
           </p>
         </div>
-        <div v-if="isGithubConversation && attributes" class="flex items-center">
+        <div
+          v-if="isGithubConversation
+            && (attributes?.changedFiles || attributes?.additions || attributes?.deletions)"
+          class="flex items-center"
+        >
           <div
             class="flex items-center"
           >

--- a/frontend/src/modules/conversation/components/conversation-item.vue
+++ b/frontend/src/modules/conversation/components/conversation-item.vue
@@ -70,16 +70,10 @@
     <div class="flex items-center py-6">
       <div class="flex-grow border-b border-gray-200" />
       <div
-        v-if="conversation.activityCount.length > 3"
+        v-if="conversation.activityCount > 3"
         class="text-xs h-6 flex items-center px-3 rounded-3xl border border-gray-200 text-gray-500"
       >
-        {{ conversation.activityCount.length - 3 }}
-        more
-        {{
-          conversation.activityCount.length > 4
-            ? 'replies'
-            : 'reply'
-        }}
+        {{ separatorContent }}
       </div>
       <div class="flex-grow border-b border-gray-200" />
     </div>
@@ -100,36 +94,7 @@
     <div
       class="-mx-6 -mb-6 px-6 py-4 flex items-center justify-between bg-gray-50"
     >
-      <div class="flex items-center">
-        <div class="flex items-center mr-6">
-          <i
-            class="ri-group-line text-base mr-2 text-gray-400"
-          />
-          <p class="text-xs text-gray-600">
-            {{ conversation.memberCount }} participant{{
-              conversation.memberCount > 1 ? 's' : ''
-            }}
-          </p>
-        </div>
-        <div class="flex items-center">
-          <i
-            class="ri-reply-line text-base mr-2 text-gray-400"
-          />
-          <p class="text-xs text-gray-600">
-            {{ conversation.activityCount - 1 }}
-            {{
-              conversation.activityCount > 2
-                ? 'replies'
-                : 'reply'
-            }}
-          </p>
-        </div>
-      </div>
-      <div>
-        <app-activity-link
-          :activity="conversation.conversationStarter"
-        />
-      </div>
+      <app-conversation-footer :conversation="conversation" />
     </div>
   </article>
 </template>
@@ -143,20 +108,21 @@ import AppMemberDisplayName from '@/modules/member/components/member-display-nam
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import AppConversationReply from '@/modules/conversation/components/conversation-reply.vue';
 import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
-import AppActivityLink from '@/modules/activity/components/activity-link.vue';
 import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
+import AppConversationFooter from '@/modules/conversation/components/conversation-footer.vue';
+import pluralize from 'pluralize';
 
 export default {
   name: 'AppConversationItem',
   components: {
     AppMemberDisplayName,
-    AppActivityLink,
     AppActivityMessage,
     AppConversationReply,
     AppActivityContent,
     AppActivitySentiment,
     AppLoading,
     AppAvatar,
+    AppConversationFooter,
   },
   props: {
     conversation: {
@@ -186,6 +152,12 @@ export default {
     },
     url() {
       return this.conversation.url;
+    },
+    separatorContent() {
+      const remainingActivitiesCount = this.conversation.activityCount - 3;
+      const copy = this.conversation.platform === 'github' ? 'activity' : 'reply';
+
+      return pluralize(`more ${copy}`, remainingActivitiesCount, true);
     },
   },
   methods: {

--- a/frontend/src/modules/conversation/components/conversation-reply.vue
+++ b/frontend/src/modules/conversation/components/conversation-reply.vue
@@ -14,7 +14,14 @@
   <article v-else>
     <div class="flex">
       <div class="flex flex-col items-center">
-        <app-avatar :entity="member" size="xs" />
+        <app-avatar :entity="member" size="xs">
+          <template v-if="isGithubConversation" #icon>
+            <app-activity-icon
+              :type="activity.type"
+              :platform="activity.platform"
+            />
+          </template>
+        </app-avatar>
         <slot name="underAvatar" />
       </div>
       <div class="flex-grow pl-3" :class="bodyClasses">
@@ -30,7 +37,7 @@
             />
             <span class="mx-1">·</span>
             <span>{{ timeAgo(activity.timestamp) }}</span>
-            <span class="mx-1">·</span>
+            <span v-if="sentiment" class="mx-1">·</span>
           </p>
           <app-activity-sentiment
             v-if="sentiment"
@@ -62,6 +69,7 @@ import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
+import AppActivityIcon from '@/modules/activity/components/activity-icon.vue';
 
 export default {
   name: 'AppConversationReply',
@@ -71,6 +79,7 @@ export default {
     AppActivitySentiment,
     AppLoading,
     AppAvatar,
+    AppActivityIcon,
   },
   props: {
     activity: {
@@ -117,6 +126,9 @@ export default {
         return this.activity.sentiment.sentiment;
       }
       return 0;
+    },
+    isGithubConversation() {
+      return this.activity.platform === 'github';
     },
   },
   methods: {

--- a/frontend/src/shared/avatar/avatar.vue
+++ b/frontend/src/shared/avatar/avatar.vue
@@ -1,11 +1,14 @@
 <template>
-  <div
-    v-if="entity"
-    class="avatar"
-    :style="computedStyle"
-    :aria-label="computedInitials"
-  >
-    <img :src="url" alt="">
+  <div class="relative">
+    <div
+      v-if="entity"
+      class="avatar"
+      :style="computedStyle"
+      :aria-label="computedInitials"
+    >
+      <img :src="url" alt="">
+    </div>
+    <slot name="icon" />
   </div>
 </template>
 


### PR DESCRIPTION
# Changes proposed ✍️
**Backend:**
- Add display object to activities inside conversations (both in lastReplies and activities array)
- Fix copy for new activity types in github
**Frontend:**
- Upgrade remixicons version
- Add new activity types to filter
- Update activity content to also be able to read from display object
- Render activity type icon next to avatar for github activities inside conversations
- Create conversation footer components to handle the display of conversation information
- Fix/refactor separator in conversation items, to display the number of hidden replies/activities
  
### Screenshots (front-end changes only)


## Checklist ✅
- [x] Label appropriately with `Feature`, `Enhancement`, or `Bug`.
- [ ] Tests are passing.
- [ ] New backend functionality has been unit-tested.
- [ ] Environment variables have been updated:
  - [ ] Local frontend configuration: `frontend/.env.dist.local`, `frontend/.env.dist.composed`.
  - [ ] Local backend: `backend/.env.dist.local`, `backend/.env.dist.composed`.
  - [ ] [Configuration docs](https://docs.crowd.dev/docs/configuration) have been updated.
  - [ ] Team members only: update environment variables in override, staging and production env. files and trigger update config script.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
- [x] All changes have been tested in a staging site.
- [x] All changes are working locally running crowd.dev's Docker local environment.