### PR TITLE
Members report drawers timeframe

### DIFF
--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -48,22 +48,23 @@ cube(`Members`, {
       },
     },
 
-    MembersActivities: {
-      measures: [Members.count],
-      dimensions: [
-        Members.tenantId,
-        Activities.platform,
-        Activities.type,
-        Members.isTeamMember,
-        Members.isBot,
-        Members.isOrganization,
-      ],
-      timeDimension: Activities.date,
-      granularity: `day`,
-      refreshKey: {
-        every: `10 minute`,
-      },
-    },
+    // Pre aggregation is causing for duplicated member's count for same ids
+    // MembersActivities: {
+    //   measures: [Members.count],
+    //   dimensions: [
+    //     Members.tenantId,
+    //     Activities.platform,
+    //     Activities.type,
+    //     Members.isTeamMember,
+    //     Members.isBot,
+    //     Members.isOrganization,
+    //   ],
+    //   timeDimension: Activities.date,
+    //   granularity: `day`,
+    //   refreshKey: {
+    //     every: `10 minute`,
+    //   },
+    // },
 
     MembersTags: {
       measures: [Members.count],

--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -48,23 +48,22 @@ cube(`Members`, {
       },
     },
 
-    // Pre aggregation is causing for duplicated member's count for same ids
-    // MembersActivities: {
-    //   measures: [Members.count],
-    //   dimensions: [
-    //     Members.tenantId,
-    //     Activities.platform,
-    //     Activities.type,
-    //     Members.isTeamMember,
-    //     Members.isBot,
-    //     Members.isOrganization,
-    //   ],
-    //   timeDimension: Activities.date,
-    //   granularity: `day`,
-    //   refreshKey: {
-    //     every: `10 minute`,
-    //   },
-    // },
+    MembersActivities: {
+      measures: [Members.count],
+      dimensions: [
+        Members.tenantId,
+        Activities.platform,
+        Activities.type,
+        Members.isTeamMember,
+        Members.isBot,
+        Members.isOrganization,
+      ],
+      timeDimension: Activities.date,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
+    },
 
     MembersTags: {
       measures: [Members.count],

--- a/frontend/src/modules/widget/components/v2/member/widget-active-members-area.vue
+++ b/frontend/src/modules/widget/components/v2/member/widget-active-members-area.vue
@@ -164,8 +164,8 @@ const query = computed(() => [
 
 // Fetch function to pass to detail drawer
 const getActiveMembers = async ({ pagination }) => {
-  const startDate = moment(drawerDate.value).startOf('day');
-  const endDate = moment(drawerDate.value);
+  const startDate = moment.utc(drawerDate.value).startOf('day');
+  const endDate = moment.utc(drawerDate.value);
 
   if (granularity.value.value === 'day') {
     endDate.endOf('day');

--- a/frontend/src/modules/widget/components/v2/product-community-fit/widget-monthly-active-contributors.vue
+++ b/frontend/src/modules/widget/components/v2/product-community-fit/widget-monthly-active-contributors.vue
@@ -230,8 +230,8 @@ const onUpdatePeriod = (updatedPeriod) => {
 
 // Fetch function to pass to detail drawer
 const getActiveMembers = async ({ pagination }) => {
-  const startDate = moment(drawerDate.value).startOf('day');
-  const endDate = moment(drawerDate.value);
+  const startDate = moment.utc(drawerDate.value).startOf('day');
+  const endDate = moment.utc(drawerDate.value);
 
   if (granularity.value.value === 'month') {
     endDate.startOf('day').add(1, 'month');


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aeb3c84</samp>

Used `moment.utc` to ensure consistent query results across time zones in the frontend for the `widget-active-members-area` and `widget-monthly-active-contributors` widgets.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aeb3c84</samp>

> _`MembersActivities`_
> _Duplicated counts no more_
> _Bug fixed in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aeb3c84</samp>

  - `widget-active-members-area.vue` in `frontend/src/modules/widget/components/v2/member` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/776/files?diff=unified&w=0#diff-43e2338953c203562e44a17d96f58dbe7ee5ea7308027b7c8f81fabfe713d4b0L167-R168))
  - `widget-monthly-active-contributors.vue` in `frontend/src/modules/widget/components/v2/product-community-fit` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/776/files?diff=unified&w=0#diff-4ae6f116b66564315c25bdacc4760cf97d1f55a2ae2b1ddf25f25a63a9577170L233-R234))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
