### PR TITLE
Fix count values on platform selection on the home page

### DIFF
--- a/frontend/src/modules/dashboard/components/dashboard-widget-header.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-widget-header.vue
@@ -7,7 +7,7 @@
         {{ props.title }}
       </h5>
       <app-loading
-        v-if="props.loading"
+        v-if="props.totalLoading"
         height="20px"
         width="60px"
       />

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -77,7 +77,6 @@ export default {
   },
   // fetch conversations total
   async getConversationCount({ state }) {
-    const { platform } = state.filters;
     return ConversationService.list({}, '', 1, 0)
       .then(({ count }) => {
         state.conversations.total = count;

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -30,7 +30,7 @@ export default {
   // fetch conversations data
   async getConversations({ dispatch }) {
     dispatch('getTrendingConversations');
-    dispatch('getConversationCount');
+    // dispatch('getConversationCount');
   },
   // Fetch trending conversations
   async getTrendingConversations({ commit, state }) {
@@ -78,23 +78,7 @@ export default {
   // fetch conversations total
   async getConversationCount({ state }) {
     const { platform } = state.filters;
-    return ConversationService.query(
-      (platform === 'all' ? {}
-        : {
-          and: [
-            ...(platform !== 'all'
-              ? [
-                {
-                  platform,
-                },
-              ]
-              : []),
-          ],
-        }),
-      '',
-      1,
-      0,
-    )
+    return ConversationService.list({}, '', 1, 0)
       .then(({ count }) => {
         state.conversations.total = count;
         return Promise.resolve(count);

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -30,7 +30,7 @@ export default {
   // fetch conversations data
   async getConversations({ dispatch }) {
     dispatch('getTrendingConversations');
-    // dispatch('getConversationCount')
+    dispatch('getConversationCount')
   },
   // Fetch trending conversations
   async getTrendingConversations({ commit, state }) {
@@ -77,7 +77,24 @@ export default {
   },
   // fetch conversations total
   async getConversationCount({ state }) {
-    return ConversationService.list({}, '', 1, 0)
+    const { platform } = state.filters;
+    return ConversationService.query(
+      (platform === 'all' ? {}
+        : {
+          and: [
+            ...(platform !== 'all'
+              ? [
+                {
+                  platform,
+                },
+              ]
+              : []),
+          ],
+        }),
+      '',
+      1,
+      0,
+    )
       .then(({ count }) => {
         state.conversations.total = count;
         return Promise.resolve(count);
@@ -145,7 +162,7 @@ export default {
             ...(platform !== 'all'
               ? [
                 {
-                  platform
+                  platform,
                 },
               ]
               : []),
@@ -154,7 +171,7 @@ export default {
       '',
       1,
       0,
-      false
+      false,
     )
       .then(({ count }) => {
         state.activities.total = count;
@@ -287,7 +304,7 @@ export default {
       1,
       0,
       false,
-      true
+      true,
     )
       .then(({ count }) => {
         state.members.total = count;
@@ -397,7 +414,27 @@ export default {
 
   // Fetch  organizations count
   async getOrganizationsCount({ state }) {
-    return OrganizationService.list(null, '', 1, 0, false)
+    const { platform } = state.filters;
+    return OrganizationService.list(
+      (platform === 'all' ? null
+        : {
+          and: [
+            ...(platform !== 'all'
+              ? [
+                {
+                  identities: {
+                    contains: [platform],
+                  },
+                },
+              ]
+              : []),
+          ],
+        }),
+      '',
+      1,
+      0,
+      false,
+    )
       .then(({ count }) => {
         state.organizations.total = count;
         return Promise.resolve(count);

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -134,9 +134,28 @@ export default {
         state.activities.loading = false;
       });
   },
+
   // Fetch activities count
   async getActivitiesCount({ state }) {
-    return ActivityService.list({}, '', 1, 0)
+    const { platform } = state.filters;
+    return ActivityService.list(
+      (platform === 'all' ? {}
+        : {
+          and: [
+            ...(platform !== 'all'
+              ? [
+                {
+                  platform
+                },
+              ]
+              : []),
+          ],
+        }),
+      '',
+      1,
+      0,
+      false
+    )
       .then(({ count }) => {
         state.activities.total = count;
         return Promise.resolve(count);
@@ -245,9 +264,31 @@ export default {
         state.members.loadingRecent = false;
       });
   },
+
   // Fetch members count
   async getMembersCount({ state }) {
-    return MemberService.list(null, '', 1, 0, false, true)
+    const { platform } = state.filters;
+    return MemberService.list(
+      (platform === 'all' ? null
+        : {
+          and: [
+            ...(platform !== 'all'
+              ? [
+                {
+                  identities: {
+                    contains: [platform],
+                  },
+                },
+              ]
+              : []),
+          ],
+        }),
+      '',
+      1,
+      0,
+      false,
+      true
+    )
       .then(({ count }) => {
         state.members.total = count;
         return Promise.resolve(count);

--- a/frontend/src/modules/dashboard/store/actions.js
+++ b/frontend/src/modules/dashboard/store/actions.js
@@ -30,7 +30,7 @@ export default {
   // fetch conversations data
   async getConversations({ dispatch }) {
     dispatch('getTrendingConversations');
-    dispatch('getConversationCount')
+    dispatch('getConversationCount');
   },
   // Fetch trending conversations
   async getTrendingConversations({ commit, state }) {


### PR DESCRIPTION
# Changes proposed ✍️
Fix count values on platform selection on the home page

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b43a433</samp>

/claim #752

Added platform filter and improved loading indicator for dashboard widget header. The filter allows users to see platform-specific data, and the indicator shows the correct loading state for the total counts.
​Fixes #752 
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b43a433</samp>

> _To show counts of members and acts_
> _We added a platform filter fact_
> _But the `app-loading` prop_
> _Needed a little swap_
> _To match the total data impact_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b43a433</samp>

*  Use `totalLoading` prop instead of `loading` prop for `app-loading` component in dashboard widget header to match total counts of activities and members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/781/files?diff=unified&w=0#diff-c73dcfef3257e628345e2d77c634d5a440999368b2ddc1955008d8b911d77d1fL10-R10))
*  Pass `platform` filter from state to `ActivityService.list` and `MemberService.list` methods in dashboard store actions to get platform-specific counts of activities and members for dashboard widget header ([link](https://github.com/CrowdDotDev/crowd.dev/pull/781/files?diff=unified&w=0#diff-3229e811e36fcc52729fe2443f9ca14ae324f62b35ac2d6aaf15daf705b6bd1dL137-R158), [link](https://github.com/CrowdDotDev/crowd.dev/pull/781/files?diff=unified&w=0#diff-3229e811e36fcc52729fe2443f9ca14ae324f62b35ac2d6aaf15daf705b6bd1dL248-R291))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
