### PR TITLE
Enhancement/merge duplicated members with extra identities c 1216

### DIFF
--- a/backend/src/bin/scripts/merge-duplicated-members.ts
+++ b/backend/src/bin/scripts/merge-duplicated-members.ts
@@ -1,5 +1,6 @@
 import { QueryTypes } from 'sequelize'
 import { v4 as uuid } from 'uuid'
+import MemberRepository from '../../database/repositories/memberRepository'
 import SequelizeRepository from '../../database/repositories/sequelizeRepository'
 import MemberService from '../../services/memberService'
 import { Logger, createChildLogger, createServiceLogger } from '../../utils/logging'
@@ -66,29 +67,27 @@ async function check(): Promise<number> {
   log.info('Querying database for duplicated members...')
 
   const results = await seq.query(
-    `with activity_counts as (select count(id) as count, "memberId"
-                              from activities
-                              group by "memberId")
+    `  with activity_counts as (select count(id) as count, "memberId"
+                             from activities
+                            group by "memberId")
       select keys.platform,
             m.username ->> keys.platform as username,
             m."tenantId",
             count(*)                     as duplicate_count,
             coalesce(sum(ac.count), 0)   as total_activitites,
             json_agg(m.id)               as all_ids,
-            --jsonb_agg(m."crowdInfo")     as all_crowd_infos,
             jsonb_agg(m.emails)          as all_emails,
-            --jsonb_agg(m.attributes)      as all_attributes,
-            jsonb_agg(m.username)        as all_usernames            
-      from members m
-              left join activity_counts ac on ac."memberId" = m.id,
-          lateral jsonb_object_keys(m.username) as keys(platform)
+            jsonb_agg(m.username)        as all_usernames
+        from members m
+                left join activity_counts ac on ac."memberId" = m.id,
+            lateral jsonb_object_keys(m.username) as keys(platform)
       group by keys.platform,
-              m.username ->> keys.platform,
-              m."tenantId"
+                m.username ->> keys.platform,
+                m."tenantId"
       having count(*) > 1
       order by duplicate_count desc,
-              keys.platform,
-              m."tenantId";`,
+                keys.platform,
+                m."tenantId";`,
     {
       type: QueryTypes.SELECT,
     },
@@ -103,9 +102,17 @@ async function check(): Promise<number> {
   for (const [i, data] of results.entries() as any) {
     log.info(`Processing ${i + 1}/${results.length}...`)
 
+    if (data.username.toLowerCase().includes('deleted')) {
+      log.warn('Skipping deleted member...')
+      continue
+    }
+
     if (checkUsernames(data.all_usernames) && checkEmails(data.all_emails)) {
       const logger = createChildLogger('merger', log, {
         requestId: uuid(),
+        platform: data.platform,
+        tenantId: data.tenantId,
+        username: data.username,
       })
       logger.info(`Found ${data.all_ids.length} duplicated members with same usernames and emails.`)
 
@@ -129,6 +136,67 @@ async function check(): Promise<number> {
           }),
       )
       count++
+    } else {
+      const logger = createChildLogger('fixer', log, {
+        requestId: uuid(),
+        platform: data.platform,
+        tenantId: data.tenantId,
+        username: data.username,
+      })
+      logger.info(
+        'Can not automatically merge - first member in the group by joinedAt will get the identity and the rest will get them as weakIdentities.',
+      )
+
+      const options = { ...dbOptions, log: logger, tenant: { id: data.tenantId } }
+
+      let transaction
+      try {
+        transaction = await SequelizeRepository.createTransaction(options)
+        const txOptions = { ...options, transaction }
+
+        const allMembers = []
+        for (const id of data.all_ids) {
+          const member = await MemberRepository.findById(id, txOptions)
+          allMembers.push(member)
+        }
+
+        // sort so the oldest members by joinedAt are first
+        allMembers.sort((a, b) => new Date(a.joinedAt).getTime() - new Date(b.joinedAt).getTime())
+
+        // first member stays the same - it will keep the identity
+        // these ones will get the duplicated identity as weakIdentities
+        const otherMembers = allMembers.slice(1)
+
+        for (const member of otherMembers) {
+          logger.info({ memberId: member.id }, 'Removing identity from member.username column!')
+          // let's remove this identity from the member.username column
+          delete member.username[data.platform]
+          await MemberRepository.update(
+            member.id,
+            {
+              username: member.username,
+            },
+            txOptions,
+          )
+        }
+
+        logger.info('Adding duplicated identity to other members as weakIdentity...')
+        // finally let's add the duplicated identity as weakIdentity
+        await MemberRepository.addToWeakIdentities(
+          otherMembers.map((m) => m.id),
+          data.username,
+          data.platform,
+          txOptions,
+        )
+
+        await SequelizeRepository.commitTransaction(transaction)
+        count++
+      } catch (err) {
+        logger.error(err, 'Error while merging members that can not be automatically merged!')
+        if (transaction) {
+          await SequelizeRepository.rollbackTransaction(transaction)
+        }
+      }
     }
   }
 

--- a/backend/src/database/migrations/U1681893786__member-extra-identities.sql
+++ b/backend/src/database/migrations/U1681893786__member-extra-identities.sql
@@ -1,0 +1,2 @@
+alter table members
+  drop column "weakIdentities";

--- a/backend/src/database/migrations/V1681893786__member-extra-identities.sql
+++ b/backend/src/database/migrations/V1681893786__member-extra-identities.sql
@@ -1,0 +1,2 @@
+alter table members
+  add column "weakIdentities" jsonb not null default '[]'::jsonb;

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1,23 +1,23 @@
 import lodash from 'lodash'
 import Sequelize, { QueryTypes } from 'sequelize'
-import SequelizeRepository from './sequelizeRepository'
-import AuditLogRepository from './auditLogRepository'
-import Error404 from '../../errors/Error404'
-import { IRepositoryOptions } from './IRepositoryOptions'
-import QueryParser from './filters/queryParser'
-import { JsonColumnInfo, QueryOutput } from './filters/queryTypes'
-import { AttributeData } from '../attributes/attribute'
-import SequelizeFilterUtils from '../utils/sequelizeFilterUtils'
 import { KUBE_MODE, SERVICE } from '../../config'
 import { ServiceType } from '../../config/configTypes'
-import { AttributeType } from '../attributes/types'
-import TenantRepository from './tenantRepository'
-import { PageData } from '../../types/common'
-import { IActiveMemberData, IActiveMemberFilter } from './types/memberTypes'
-import { ALL_PLATFORM_TYPES } from '../../types/integrationEnums'
-import RawQueryParser from './filters/rawQueryParser'
+import Error404 from '../../errors/Error404'
 import ActivityDisplayService from '../../services/activityDisplayService'
+import { PageData } from '../../types/common'
+import { ALL_PLATFORM_TYPES } from '../../types/integrationEnums'
+import { AttributeData } from '../attributes/attribute'
+import { AttributeType } from '../attributes/types'
+import SequelizeFilterUtils from '../utils/sequelizeFilterUtils'
+import { IRepositoryOptions } from './IRepositoryOptions'
+import AuditLogRepository from './auditLogRepository'
+import QueryParser from './filters/queryParser'
+import { JsonColumnInfo, QueryOutput } from './filters/queryTypes'
+import RawQueryParser from './filters/rawQueryParser'
+import SequelizeRepository from './sequelizeRepository'
 import SettingsRepository from './settingsRepository'
+import TenantRepository from './tenantRepository'
+import { IActiveMemberData, IActiveMemberFilter } from './types/memberTypes'
 
 const { Op } = Sequelize
 
@@ -1561,7 +1561,11 @@ where m."deletedAt" is null
     const query = `
     update members
     set "weakIdentities" = "weakIdentities" || jsonb_build_object('username', :username, 'platform', :platform)::jsonb
-    where id in (:memberIds) and "tenantId" = :tenantId;
+    where id in (:memberIds)
+      and not exists (select 1
+                      from jsonb_array_elements("weakIdentities") as wi
+                      where wi ->> 'username' = :username
+                        and wi ->> 'platform' = :platform);
     `
 
     await seq.query(query, {

--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -1,6 +1,7 @@
 import moment from 'moment/moment'
 import lodash from 'lodash'
 import { ChannelType, MessageType } from 'discord.js'
+import { v4 as uuid } from 'uuid'
 import {
   DiscordApiChannel,
   DiscordApiMember,
@@ -403,6 +404,12 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
         const joinedAt = moment(record.joined_at).utc().toDate()
         const sourceId = `gen-${record.user.id}-${joinedAt.toISOString()}`
 
+        let username = record.user.username
+
+        if (username === 'Deleted User') {
+          username = `${username}:${uuid()}`
+        }
+
         acc.push({
           tenant: context.integration.tenantId,
           platform: PlatformType.DISCORD,
@@ -410,7 +417,7 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
           sourceId,
           timestamp: joinedAt,
           member: {
-            username: record.user.username,
+            username,
             attributes: {
               [MemberAttributeName.SOURCE_ID]: {
                 [PlatformType.DISCORD]: record.user.id,
@@ -513,6 +520,12 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
       }
 
       if (!record.author.bot && [MessageType.Default, MessageType.Reply].includes(record.type)) {
+        let username = record.author.username
+
+        if (username === 'Deleted User') {
+          username = `${username}:${uuid()}`
+        }
+
         const activityObject = {
           tenant: context.integration.tenantId,
           platform: PlatformType.DISCORD,
@@ -534,7 +547,7 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
             forum: isForum,
           },
           member: {
-            username: record.author.username,
+            username,
             attributes: {
               [MemberAttributeName.SOURCE_ID]: {
                 [PlatformType.DISCORD]: record.author.id,


### PR DESCRIPTION
# Changes proposed ✍️

### What
- fixed `Deleted User` usernames in discord integration service
- a migration to add `weakIdentities` column to `members` database table (empty JSON array by default)
- updated a script for member de-duplication to handle members that can't be automatically merged by fixing them via `weakIdentities` column
​
### Why
To prepare the database for member identities changes where each tenant will only be allowed to have one member with a specific platform:username combination (to prevent duplicate members and easier querying).

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
