### PR TITLE
Add number of activities column to all member views

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -141,12 +141,10 @@
                 </template>
               </el-table-column>
               <el-table-column
-                v-for="column of extraColumns"
-                :key="column.name"
-                :prop="column.name"
-                :label="column.label"
-                :width="column.width || 200"
-                :sortable="column.sortable ? 'custom' : ''"
+                label="# of Activities"
+                prop="activityCount"
+                width="200"
+                sortable="custom"
               >
                 <template #default="scope">
                   <router-link
@@ -156,11 +154,7 @@
                     }"
                     class="block !text-gray-500"
                   >
-                    {{
-                      column.formatter
-                        ? column.formatter(scope.row[column.name])
-                        : scope.row[column.name]
-                    }}
+                    {{ formatNumber(scope.row.activityCount) }}
                   </router-link>
                 </template>
               </el-table-column>
@@ -328,7 +322,7 @@
                             <i
                               v-if="email"
                               class="ri-external-link-line text-gray-400"
-                            /></span>
+                          /></span>
                         </template>
                         <div @click.prevent>
                           <a
@@ -337,7 +331,7 @@
                             class="badge--interactive"
                             :href="`mailto:${email}`"
                             @click.stop="trackEmailClick"
-                          >{{ email }}</a>
+                            >{{ email }}</a>
                         </div>
                       </el-tooltip>
                     </div>
@@ -408,7 +402,7 @@ import AppMemberListToolbar from '@/modules/member/components/list/member-list-t
 import AppMemberOrganizations from '@/modules/member/components/member-organizations.vue';
 import AppTagList from '@/modules/tag/components/tag-list.vue';
 import { formatDateToTimeAgo } from '@/utils/date';
-import { formatNumberToCompact } from '@/utils/number';
+import { formatNumberToCompact, formatNumber } from '@/utils/number';
 import AppMemberBadge from '../member-badge.vue';
 import AppMemberDropdown from '../member-dropdown.vue';
 import AppMemberChannels from '../member-channels.vue';
@@ -441,10 +435,6 @@ const props = defineProps({
     default: () => true,
   },
 });
-
-const extraColumns = computed(
-  () => store.getters['member/activeView']?.columns || [],
-);
 
 const activeView = computed(() => store.getters['member/activeView']);
 

--- a/frontend/src/modules/member/store/state.js
+++ b/frontend/src/modules/member/store/state.js
@@ -14,13 +14,7 @@ export default () => ({
     all: {
       id: 'all',
       label: 'All members',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true,
-        },
-      ],
+      columns: [],
       initialFilter: INITIAL_VIEW_ALL_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_ALL_FILTER),
@@ -42,13 +36,7 @@ export default () => ({
     'new-and-active': {
       id: 'new-and-active',
       label: 'New and active',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true,
-        },
-      ],
+      columns: [],
       initialFilter: INITIAL_VIEW_RECENT_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_RECENT_FILTER),
@@ -70,13 +58,7 @@ export default () => ({
     'slipping-away': {
       id: 'slipping-away',
       label: 'Slipping away',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true,
-        },
-      ],
+      columns: [],
       initialFilter: INITIAL_VIEW_SLIPPING_AWAY_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_SLIPPING_AWAY_FILTER),
@@ -98,13 +80,7 @@ export default () => ({
     'most-engaged': {
       id: 'most-engaged',
       label: 'Most engaged',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true,
-        },
-      ],
+      columns: [],
       initialFilter: INITIAL_VIEW_ACTIVE_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_ACTIVE_FILTER),
@@ -148,13 +124,7 @@ export default () => ({
     team: {
       id: 'team',
       label: 'Team members',
-      columns: [
-        {
-          name: 'activityCount',
-          label: '# of Activities',
-          sortable: true,
-        },
-      ],
+      columns: [],
       initialFilter: INITIAL_VIEW_TEAM_MEMBERS_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_TEAM_MEMBERS_FILTER),

--- a/frontend/src/modules/member/store/state.js
+++ b/frontend/src/modules/member/store/state.js
@@ -14,7 +14,13 @@ export default () => ({
     all: {
       id: 'all',
       label: 'All members',
-      columns: [],
+      columns: [
+        {
+          name: 'activityCount',
+          label: '# of Activities',
+          sortable: true,
+        },
+      ],
       initialFilter: INITIAL_VIEW_ALL_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_ALL_FILTER),
@@ -36,7 +42,13 @@ export default () => ({
     'new-and-active': {
       id: 'new-and-active',
       label: 'New and active',
-      columns: [],
+      columns: [
+        {
+          name: 'activityCount',
+          label: '# of Activities',
+          sortable: true,
+        },
+      ],
       initialFilter: INITIAL_VIEW_RECENT_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_RECENT_FILTER),
@@ -58,7 +70,13 @@ export default () => ({
     'slipping-away': {
       id: 'slipping-away',
       label: 'Slipping away',
-      columns: [],
+      columns: [
+        {
+          name: 'activityCount',
+          label: '# of Activities',
+          sortable: true,
+        },
+      ],
       initialFilter: INITIAL_VIEW_SLIPPING_AWAY_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_SLIPPING_AWAY_FILTER),
@@ -130,6 +148,13 @@ export default () => ({
     team: {
       id: 'team',
       label: 'Team members',
+      columns: [
+        {
+          name: 'activityCount',
+          label: '# of Activities',
+          sortable: true,
+        },
+      ],
       initialFilter: INITIAL_VIEW_TEAM_MEMBERS_FILTER,
       filter: JSON.parse(
         JSON.stringify(INITIAL_VIEW_TEAM_MEMBERS_FILTER),


### PR DESCRIPTION
# Changes proposed ✍️
 Add number of activities column to all member views
 
Fixes #779 
### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33cdb12</samp>

Added a new frontend feature to show member activities in the crowd. The feature involves a new `activities` column in the `member` table and some changes in the `frontend/src/modules/member/store/state.js` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33cdb12</samp>

> _`Activities` of the crowd, a new column of power_
> _Revealing the secrets of the members, their deeds and their hours_
> _Who is the most active, who is the most slack?_
> _Who will rise to the challenge, who will fall to the back?_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 33cdb12</samp>

*  Add a new column for activity count to the member table views ([link](https://github.com/CrowdDotDev/crowd.dev/pull/789/files?diff=unified&w=0#diff-1953e5af73761581e41be13ac142f58683f500db936c6f8a84a0031f38bc5eafL17-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/789/files?diff=unified&w=0#diff-1953e5af73761581e41be13ac142f58683f500db936c6f8a84a0031f38bc5eafL39-R51), [link](https://github.com/CrowdDotDev/crowd.dev/pull/789/files?diff=unified&w=0#diff-1953e5af73761581e41be13ac142f58683f500db936c6f8a84a0031f38bc5eafL61-R79), [link](https://github.com/CrowdDotDev/crowd.dev/pull/789/files?diff=unified&w=0#diff-1953e5af73761581e41be13ac142f58683f500db936c6f8a84a0031f38bc5eafR151-R157))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
