### PR TITLE
Github forks stream re-enabled

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -129,7 +129,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     return context.pipelineData.repos.reduce((acc, repo) => {
       for (const endpoint of [
         GithubStreamType.STARGAZERS,
-        // GithubStreamType.FORKS,
+        GithubStreamType.FORKS,
         GithubStreamType.PULLS,
         GithubStreamType.ISSUES,
         GithubStreamType.DISCUSSIONS,


### PR DESCRIPTION
# Changes proposed ✍️
Enables forks stream in github integration. onboarding will be fired for all gh after merge. This will also get missed discussion activities.

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e26bf81</samp>

Uncommented the `GithubStreamType.FORKS` endpoint in the `GithubIntegrationService` class to enable fetching and streaming fork data from the GitHub API. This change supports a new feature for analyzing forks of a GitHub repository.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e26bf81</samp>

> _`FORKS` endpoint on_
> _Streaming data from GitHub_
> _Winter of coding_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e26bf81</samp>

* Enable fetching and streaming of fork data from GitHub API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/796/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L132-R132))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screehshots to the PR description for relevant FE changes
- [x] New backend functionality has been unit-tested.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
