### PR TITLE
Remove hash function for star and follow activity sourceId generation

### DIFF
--- a/backend/src/database/initializers/twitterSourceIdsFixedTimestamps.ts
+++ b/backend/src/database/initializers/twitterSourceIdsFixedTimestamps.ts
@@ -11,7 +11,6 @@ import IntegrationService from '../../services/integrationService'
 import TenantService from '../../services/tenantService'
 import { PlatformType } from '../../types/integrationEnums'
 import getUserContext from '../utils/getUserContext'
-import { IntegrationServiceBase } from '../../serverless/integrations/services/integrationServiceBase'
 
 const path = require('path')
 

--- a/backend/src/database/initializers/twitterSourceIdsFixedTimestamps.ts
+++ b/backend/src/database/initializers/twitterSourceIdsFixedTimestamps.ts
@@ -48,12 +48,7 @@ async function twitterFollowsFixSourceIdsWithTimestamp() {
       for (const activity of activities.rows) {
         log.info({ activity }, 'Activity')
         // calculate sourceId with fixed timestamps
-        const sourceIdRegenerated = IntegrationServiceBase.generateSourceIdHash(
-          activity.communityMember.username.twitter,
-          'follow',
-          '1970-01-01T00:00:00+00:00',
-          'twitter',
-        )
+        const sourceIdRegenerated = `gen-${activity.communityMember.username.twitter}_follow_1970-01-01T00:00:00+00:00_twitter`
         await actService.update(activity.id, { sourceId: sourceIdRegenerated })
       }
     }

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -465,12 +465,9 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         timestamp: starredAt.toDate(),
         platform: PlatformType.GITHUB,
         tenant: context.integration.tenantId,
-        sourceId: IntegrationServiceBase.generateSourceIdHash(
-          payload.sender.login,
-          type,
-          starredAt.unix().toString(),
-          PlatformType.GITHUB,
-        ),
+        sourceId: `gen-${payload.sender.login}_${type}_${starredAt.toISOString()}_${
+          PlatformType.GITHUB
+        }`,
         sourceParentId: null,
         channel: payload.repository.html_url,
         score: type === 'star' ? GitHubGrid.star.score : GitHubGrid.unStar.score,
@@ -494,12 +491,9 @@ export class GithubIntegrationService extends IntegrationServiceBase {
         username: member.username[PlatformType.GITHUB].username,
         platform: PlatformType.GITHUB,
         type: GithubActivityType.STAR,
-        sourceId: IntegrationServiceBase.generateSourceIdHash(
-          record.node.login,
-          GithubActivityType.STAR,
-          moment(record.starredAt).utc().unix().toString(),
-          PlatformType.GITHUB,
-        ),
+        sourceId: `gen-${record.node.login}_${GithubActivityType.STAR}_${moment(record.starredAt)
+          .utc()
+          .toISOString()}_${PlatformType.GITHUB}`,
         sourceParentId: '',
         timestamp: moment(record.starredAt).utc().toDate(),
         channel: repo.url,

--- a/backend/src/serverless/integrations/services/integrations/twitterIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/twitterIntegrationService.ts
@@ -220,12 +220,9 @@ export class TwitterIntegrationService extends IntegrationServiceBase {
       tenant: context.integration.tenantId,
       platform: PlatformType.TWITTER,
       type: 'follow',
-      sourceId: IntegrationServiceBase.generateSourceIdHash(
-        record.username,
-        'follow',
-        moment('1970-01-01T00:00:00+00:00').utc().unix().toString(),
-        PlatformType.TWITTER,
-      ),
+      sourceId: `gen-${record.username}_follow_${timestampObj.toISOString()}_${
+        PlatformType.TWITTER
+      }`,
       // When onboarding we need an old date. Otherwise, we can place it in a 2h window
       timestamp: timestampObj.toDate(),
       url: `https://twitter.com/${record.username}`,

--- a/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
+++ b/backend/src/serverless/integrations/webhooks/__tests__/github.test.ts
@@ -720,12 +720,9 @@ describe('Github webhooks tests', () => {
         platform: PlatformType.GITHUB,
         tenant: tenantId,
         timestamp: moment(TestEvents.star.created.starred_at).toDate(),
-        sourceId: IntegrationServiceBase.generateSourceIdHash(
-          'joanreyero',
-          GithubActivityType.STAR,
-          moment(TestEvents.star.created.starred_at).unix().toString(),
-          PlatformType.GITHUB,
-        ),
+        sourceId: `gen-joanreyero_${GithubActivityType.STAR}_${moment(
+          TestEvents.star.created.starred_at,
+        ).toISOString()}_${PlatformType.GITHUB}`,
         sourceParentId: null,
         channel: TestEvents.star.created.repository.html_url,
         score: 2,
@@ -754,12 +751,9 @@ describe('Github webhooks tests', () => {
         type: GithubActivityType.UNSTAR,
         platform: PlatformType.GITHUB,
         tenant: tenantId,
-        sourceId: IntegrationServiceBase.generateSourceIdHash(
-          'joanreyero',
-          GithubActivityType.UNSTAR,
-          moment(starTimestamp).unix().toString(),
-          PlatformType.GITHUB,
-        ),
+        sourceId: `gen-joanreyero_${GithubActivityType.UNSTAR}_${moment(
+          starTimestamp,
+        ).toISOString()}_${PlatformType.GITHUB}`,
         sourceParentId: null,
         channel: TestEvents.star.deleted.repository.html_url,
         score: -2,

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -152,7 +152,11 @@ export default class ActivityService extends LoggingBase {
 
       await SequelizeRepository.commitTransaction(transaction)
 
-      if (!existing && record.type !== GithubActivityType.STAR && record.type !== TwitterActivityType.FOLLOW) {
+      if (
+        !existing &&
+        !(record.platform === PlatformType.GITHUB && record.type === GithubActivityType.STAR) &&
+        !(record.platform === PlatformType.TWITTER && record.type === TwitterActivityType.FOLLOW)
+      ) {
         try {
           await sendNewActivityNodeSQSMessage(this.options.currentTenant.id, record)
         } catch (err) {

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -20,6 +20,7 @@ import MemberAttributeSettingsRepository from '../database/repositories/memberAt
 import SettingsRepository from '../database/repositories/settingsRepository'
 import SettingsService from './settingsService'
 import { mapUsernameToIdentities } from '../database/repositories/types/memberTypes'
+import { GithubActivityType, TwitterActivityType } from '../types/activityTypes'
 
 export default class ActivityService extends LoggingBase {
   options: IServiceOptions
@@ -151,7 +152,7 @@ export default class ActivityService extends LoggingBase {
 
       await SequelizeRepository.commitTransaction(transaction)
 
-      if (!existing) {
+      if (!existing && record.type !== GithubActivityType.STAR && record.type !== TwitterActivityType.FOLLOW) {
         try {
           await sendNewActivityNodeSQSMessage(this.options.currentTenant.id, record)
         } catch (err) {


### PR DESCRIPTION
# Changes proposed ✍️
Removes usage of md5 hash function from star and follow activities because of possible hash collision between different activities.

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1ec2b0</samp>

This pull request simplifies the generation of the `sourceId` for GitHub star and Twitter follow activities by using template literals instead of a hash function. This avoids collisions and inconsistencies in the `sourceId` values that were affecting the integration service and the database. The changes affect the files `githubIntegrationService.ts`, `twitterIntegrationService.ts`, `github.test.ts`, and `twitterSourceIdsFixedTimestamps.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f1ec2b0</samp>

> _`sourceId` simpler_
> _No more hash function woes_
> _Spring cleaning the code_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1ec2b0</samp>

*  Simplify the generation of sourceId for Twitter and GitHub activities by using template literals instead of hash function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-15fb26b6b19d95891d26cc7677f33721b04b8c885a925c203cbd9192847dec33L51-R51), [link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L468-R470), [link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L497-R496), [link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-21784d824d466c87632d75eebe945929dfc041e9fe11246fefa2451a8705849dL223-R225))
*  Update the unit tests for the GitHub integration service to reflect the new sourceId format ([link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-0afd6e642043d9965516a715c4eee0fe55b0f55c0e460f1473544b6d94ccab65L723-R725), [link](https://github.com/CrowdDotDev/crowd.dev/pull/805/files?diff=unified&w=0#diff-0afd6e642043d9965516a715c4eee0fe55b0f55c0e460f1473544b6d94ccab65L757-R756))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
