### PR TITLE
Better integration resilience 

### DIFF
--- a/backend/src/bin/jobs/checkStuckIntegrationRuns.ts
+++ b/backend/src/bin/jobs/checkStuckIntegrationRuns.ts
@@ -8,10 +8,12 @@ import SequelizeRepository from '../../database/repositories/sequelizeRepository
 import { CrowdJob } from '../../types/jobTypes'
 import { IntegrationRunState } from '../../types/integrationRunTypes'
 import { INTEGRATION_PROCESSING_CONFIG } from '../../config'
+import IntegrationRepository from '../../database/repositories/integrationRepository'
 
 const log = createServiceChildLogger('checkStuckIntegrationRuns')
 
-const THRESHOLD_HOURS = 3
+// we are checking "integrationRuns"."updatedAt" column
+const THRESHOLD_HOURS = 1
 
 let running = false
 
@@ -30,6 +32,161 @@ function sortStreamsFromNewestToOldest(streams: IntegrationStream[]) {
   })
 }
 
+async function checkStuckIntegrations(): Promise<void> {
+  // find integrations that are in-progress but their last integration run is:
+  // in final state (processed or error) and it has no streams
+  // this happens when integration run is triggered but for some reason fails before streams are generated
+
+  const dbOptions = await SequelizeRepository.getDefaultIRepositoryOptions()
+  const runsRepo = new IntegrationRunRepository(dbOptions)
+  const streamsRepo = new IntegrationStreamRepository(dbOptions)
+
+  const inProgressIntegrations = await IntegrationRepository.findByStatus('in-progress', dbOptions)
+
+  if (inProgressIntegrations.length > 0) {
+    log.info(`Found ${inProgressIntegrations.length} integrations in progress!`)
+    for (const integration of inProgressIntegrations) {
+      const lastRun = await runsRepo.findLastRun(integration.id)
+
+      if (
+        lastRun.state === IntegrationRunState.PROCESSED ||
+        lastRun.state === IntegrationRunState.ERROR
+      ) {
+        const streams = await streamsRepo.findByRunId(lastRun.id)
+        if (streams.length === 0) {
+          log.info(
+            `Found integration ${integration.id} in progress but last run ${lastRun.id} is in final state and has no streams! Restarting the run!`,
+          )
+
+          await runsRepo.restart(lastRun.id)
+          const delayUntil = moment().add(1, 'second').toDate()
+          await runsRepo.delay(lastRun.id, delayUntil)
+        }
+      }
+    }
+  }
+}
+
+async function checkRuns(): Promise<void> {
+  const dbOptions = await SequelizeRepository.getDefaultIRepositoryOptions()
+  const runsRepo = new IntegrationRunRepository(dbOptions)
+  const streamsRepo = new IntegrationStreamRepository(dbOptions)
+
+  const runsToCheck = await runsRepo.findIntegrationsByState([
+    IntegrationRunState.PENDING,
+    IntegrationRunState.PROCESSING,
+  ])
+
+  const now = moment()
+  for (const run of runsToCheck) {
+    // let's first check if the integration run itself is older than 3 hours
+    // we are updating updatedAt at the end of the integration run when we process all streams or if it's stopped by rate limit/delays
+    // so it should be a good indicator if the integration run is stuck
+    // but because some integrations are really long running it must not be the only one
+
+    const integrationLastUpdatedAt = moment(run.updatedAt)
+    const diff = now.diff(integrationLastUpdatedAt, 'hours')
+
+    if (diff >= THRESHOLD_HOURS) {
+      const logger = createChildLogger('fixer', log, { runId: run.id })
+      log.warn({ runId: run.id }, 'Investigating possible stuck integration run!')
+
+      // first lets check if the we have any integration streams that are in state processing
+      // and if we have let's see when were they moved to that state based on updatedAt column
+      // if they are older than 3 hours we will reset them to pending state and start integration back up
+      const processingStreams = await streamsRepo.findByRunId(run.id, [
+        IntegrationStreamState.PROCESSING,
+      ])
+
+      let stuck = false
+
+      if (processingStreams.length > 0) {
+        sortStreamsFromNewestToOldest(processingStreams)
+        const newestStream = processingStreams[0]
+        const streamLastUpdatedAt = moment(newestStream.updatedAt)
+        const diff = now.diff(streamLastUpdatedAt, 'hours')
+        if (diff >= THRESHOLD_HOURS) {
+          logger.warn(
+            { streamId: newestStream.id },
+            'Found stuck processing stream! Reseting all processing streams!',
+          )
+          stuck = true
+
+          for (const stream of processingStreams) {
+            await streamsRepo.reset(stream.id)
+          }
+        }
+      }
+
+      // if there were no processing streams lets check if we have pending streams that are older than 3 hours
+      if (!stuck) {
+        const pendingStreams = await streamsRepo.findByRunId(run.id, [
+          IntegrationStreamState.PENDING,
+        ])
+        if (pendingStreams.length > 0) {
+          sortStreamsFromNewestToOldest(pendingStreams)
+          const newestStream = pendingStreams[0]
+          const streamLastUpdatedAt = moment(newestStream.updatedAt)
+          const diff = now.diff(streamLastUpdatedAt, 'hours')
+          if (diff >= THRESHOLD_HOURS) {
+            logger.warn({ streamId: newestStream.id }, 'Found stuck pending stream!')
+            stuck = true
+          }
+        }
+      }
+
+      // and the last check is to see whether we have any errored streams that are older than 3 hours and haven't been retried enough times
+      if (!stuck) {
+        const errorStreams = await streamsRepo.findByRunId(run.id, [IntegrationStreamState.ERROR])
+
+        const notEnoughRetries = errorStreams.filter(
+          (stream) => stream.retries < INTEGRATION_PROCESSING_CONFIG.maxRetries,
+        )
+
+        if (notEnoughRetries.length > 0) {
+          logger.warn(`Found ${notEnoughRetries.length} errored streams with not enough retries!`)
+
+          sortStreamsFromNewestToOldest(notEnoughRetries)
+          const newestStream = notEnoughRetries[0]
+          const streamLastUpdatedAt = moment(newestStream.updatedAt)
+          const diff = now.diff(streamLastUpdatedAt, 'hours')
+          if (diff >= THRESHOLD_HOURS) {
+            logger.warn({ streamId: newestStream.id }, 'Found stuck errored stream!')
+            stuck = true
+          }
+        }
+      }
+
+      // this check tries to see whether the integration run is actually finished but it's in a wrong state
+      // by checking all streams and determining whether they are in a final state
+      if (!stuck) {
+        // check if there are any streams that are not in a final state
+        const notFinalStreams = await streamsRepo.findByRunId(run.id, [
+          IntegrationStreamState.PENDING,
+          IntegrationStreamState.PROCESSING,
+        ])
+
+        if (notFinalStreams.length === 0) {
+          logger.warn(
+            'Found no streams in a final state! Setting integration to either error or processed!',
+          )
+
+          const state = await runsRepo.touchState(run.id)
+          if (state !== IntegrationRunState.ERROR && state !== IntegrationRunState.PROCESSED) {
+            logger.error('Integration is not in a final state! Requires manual intervention!')
+          }
+        }
+      }
+
+      if (stuck) {
+        logger.warn('Delaying integration for 1 second to restart it!')
+        const delayUntil = moment().add(1, 'second').toDate()
+        await runsRepo.delay(run.id, delayUntil)
+      }
+    }
+  }
+}
+
 const job: CrowdJob = {
   name: 'Detect & Fix Stuck Integration Runs',
   cronTime: cronGenerator.every(30).minutes(),
@@ -37,136 +194,7 @@ const job: CrowdJob = {
     if (!running) {
       running = true
       try {
-        const dbOptions = await SequelizeRepository.getDefaultIRepositoryOptions()
-        const runsRepo = new IntegrationRunRepository(dbOptions)
-        const streamsRepo = new IntegrationStreamRepository(dbOptions)
-
-        const runsToCheck = await runsRepo.findIntegrationsByState([
-          IntegrationRunState.PENDING,
-          IntegrationRunState.PROCESSING,
-        ])
-
-        const now = moment()
-        for (const run of runsToCheck) {
-          // let's first check if the integration run itself is older than 3 hours
-          // we are updating updatedAt at the end of the integration run when we process all streams or if it's stopped by rate limit/delays
-          // so it should be a good indicator if the integration run is stuck
-          // but because some integrations are really long running it must not be the only one
-
-          const integrationLastUpdatedAt = moment(run.updatedAt)
-          const diff = now.diff(integrationLastUpdatedAt, 'hours')
-
-          if (diff >= THRESHOLD_HOURS) {
-            const logger = createChildLogger('fixer', log, { runId: run.id })
-            log.warn({ runId: run.id }, 'Investigating possible stuck integration run!')
-
-            // first lets check if the we have any integration streams that are in state processing
-            // and if we have let's see when were they moved to that state based on updatedAt column
-            // if they are older than 3 hours we will reset them to pending state and start integration back up
-            const processingStreams = await streamsRepo.findByRunId(
-              run.id,
-              IntegrationStreamState.PROCESSING,
-            )
-
-            let stuck = false
-
-            if (processingStreams.length > 0) {
-              sortStreamsFromNewestToOldest(processingStreams)
-              const newestStream = processingStreams[0]
-              const streamLastUpdatedAt = moment(newestStream.updatedAt)
-              const diff = now.diff(streamLastUpdatedAt, 'hours')
-              if (diff >= THRESHOLD_HOURS) {
-                logger.warn(
-                  { streamId: newestStream.id },
-                  'Found stuck processing stream! Reseting all processing streams!',
-                )
-                stuck = true
-
-                for (const stream of processingStreams) {
-                  await streamsRepo.reset(stream.id)
-                }
-              }
-            }
-
-            // if there were no processing streams lets check if we have pending streams that are older than 3 hours
-            if (!stuck) {
-              const pendingStreams = await streamsRepo.findByRunId(
-                run.id,
-                IntegrationStreamState.PENDING,
-              )
-              if (pendingStreams.length > 0) {
-                sortStreamsFromNewestToOldest(pendingStreams)
-                const newestStream = pendingStreams[0]
-                const streamLastUpdatedAt = moment(newestStream.updatedAt)
-                const diff = now.diff(streamLastUpdatedAt, 'hours')
-                if (diff >= THRESHOLD_HOURS) {
-                  logger.warn({ streamId: newestStream.id }, 'Found stuck pending stream!')
-                  stuck = true
-                }
-              }
-            }
-
-            // and the last check is to see whether we have any errored streams that are older than 3 hours and haven't been retried enough times
-            if (!stuck) {
-              const errorStreams = await streamsRepo.findByRunId(
-                run.id,
-                IntegrationStreamState.ERROR,
-              )
-
-              const notEnoughRetries = errorStreams.filter(
-                (stream) => stream.retries < INTEGRATION_PROCESSING_CONFIG.maxRetries,
-              )
-
-              if (notEnoughRetries.length > 0) {
-                logger.warn(
-                  `Found ${notEnoughRetries.length} errored streams with not enough retries!`,
-                )
-
-                sortStreamsFromNewestToOldest(notEnoughRetries)
-                const newestStream = notEnoughRetries[0]
-                const streamLastUpdatedAt = moment(newestStream.updatedAt)
-                const diff = now.diff(streamLastUpdatedAt, 'hours')
-                if (diff >= THRESHOLD_HOURS) {
-                  logger.warn({ streamId: newestStream.id }, 'Found stuck errored stream!')
-                  stuck = true
-                }
-              }
-            }
-
-            // this check tries to see whether the integration run is actually finished but it's in a wrong state
-            // by checking all streams and determining whether they are in a final state
-            if (!stuck) {
-              // check if there are any streams that are not in a final state
-              const allStreams = await streamsRepo.findByRunId(run.id)
-
-              const notFinalStreams = allStreams.filter(
-                (stream) =>
-                  stream.state !== IntegrationStreamState.ERROR &&
-                  stream.state !== IntegrationStreamState.PROCESSED,
-              )
-
-              if (notFinalStreams.length === 0) {
-                logger.warn(
-                  'Found no streams in a final state! Setting integration to either error or processed!',
-                )
-
-                const state = await runsRepo.touchState(run.id)
-                if (
-                  state !== IntegrationRunState.ERROR &&
-                  state !== IntegrationRunState.PROCESSED
-                ) {
-                  logger.error('Integration is not in a final state! Requires manual intervention!')
-                }
-              }
-            }
-
-            if (stuck) {
-              logger.warn('Delaying integration for 1 second to restart it!')
-              const delayUntil = moment().add(1, 'second').toDate()
-              await runsRepo.delay(run.id, delayUntil)
-            }
-          }
-        }
+        await Promise.all([checkRuns(), checkStuckIntegrations()])
       } finally {
         running = false
       }

--- a/backend/src/bin/nodejs-worker.ts
+++ b/backend/src/bin/nodejs-worker.ts
@@ -96,7 +96,7 @@ async function handleDelayedMessages() {
 }
 
 let processingMessages = 0
-const isWorkerAvailable = (): boolean => processingMessages <= 5
+const isWorkerAvailable = (): boolean => processingMessages <= 2
 const addWorkerJob = (): void => {
   processingMessages++
 }

--- a/backend/src/database/repositories/integrationRepository.ts
+++ b/backend/src/database/repositories/integrationRepository.ts
@@ -1,5 +1,5 @@
 import lodash from 'lodash'
-import Sequelize from 'sequelize'
+import Sequelize, { QueryTypes } from 'sequelize'
 import SequelizeRepository from './sequelizeRepository'
 import AuditLogRepository from './auditLogRepository'
 import SequelizeFilterUtils from '../utils/sequelizeFilterUtils'
@@ -162,6 +162,26 @@ class IntegrationRepository {
     }
 
     return Promise.all(records.map((record) => this._populateRelations(record)))
+  }
+
+  static async findByStatus(status: string, options: IRepositoryOptions): Promise<any[]> {
+    const query = `
+      select * from integrations where status = :status
+    `
+
+    const seq = SequelizeRepository.getSequelize(options)
+
+    const transaction = SequelizeRepository.getTransaction(options)
+
+    const integrations = await seq.query(query, {
+      replacements: {
+        status,
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    })
+
+    return integrations as any[]
   }
 
   /**

--- a/backend/src/database/repositories/integrationRunRepository.ts
+++ b/backend/src/database/repositories/integrationRunRepository.ts
@@ -89,6 +89,44 @@ export default class IntegrationRunRepository extends RepositoryBase<
     return results as IntegrationRun[]
   }
 
+  async findLastRun(integrationId: string): Promise<IntegrationRun | undefined> {
+    const transaction = this.transaction
+
+    const seq = this.seq
+
+    const query = `
+    select  id,
+            "tenantId",
+            "integrationId",
+            "microserviceId",
+            onboarding,
+            state,
+            "delayedUntil",
+            "processedAt",
+            error,
+            "createdAt",
+            "updatedAt"
+    from "integrationRuns"
+    where "integrationId" = :integrationId
+    order by "createdAt" desc
+    limit 1
+    `
+
+    const results = await seq.query(query, {
+      replacements: {
+        integrationId,
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    })
+
+    if (results.length === 0) {
+      return undefined
+    }
+
+    return results[0] as IntegrationRun
+  }
+
   async findLastProcessingRun(
     integrationId?: string,
     microserviceId?: string,

--- a/backend/src/database/repositories/integrationStreamRepository.ts
+++ b/backend/src/database/repositories/integrationStreamRepository.ts
@@ -57,7 +57,10 @@ export default class IntegrationStreamRepository extends RepositoryBase<
     return result[0] as IntegrationStream
   }
 
-  async findByRunId(runId: string, state?: IntegrationStreamState): Promise<IntegrationStream[]> {
+  async findByRunId(
+    runId: string,
+    states?: IntegrationStreamState[],
+  ): Promise<IntegrationStream[]> {
     const transaction = this.transaction
 
     const seq = this.seq
@@ -67,9 +70,9 @@ export default class IntegrationStreamRepository extends RepositoryBase<
     }
 
     let condition = `1=1`
-    if (state) {
-      condition = `"state" = :state`
-      replacements.state = state
+    if (states && states.length > 0) {
+      condition = `"state" in (:states)`
+      replacements.states = states
     }
 
     const query = `


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b49fca</samp>

The pull request adds new methods and enhances existing ones in the `IntegrationRepository`, `IntegrationStreamRepository`, and `IntegrationRunRepository` classes. These changes improve the flexibility and performance of querying integrations, integration streams, and integration runs from the database using raw SQL and sequelize. The changes are part of the backend logic for the integration service.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b49fca</samp>

> _To query integrations with ease_
> _The code uses raw SQL queries_
> _It adds `findLastRun`_
> _And `findByRunId` is fun_
> _With multiple states for the streams_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b49fca</samp>

*  Add and modify methods for querying integrations, integration runs, and integration streams by various criteria ([link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-5b1c50661ca3f395a4ec888993b46eadd35b277a777e88e0e81e1f88461124a3R167-R186), [link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4R92-R129), [link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-245c125d8740d71e5bfcd3fc4fc0328fac7b9d75b7d9897d6baca5d30f21c9caL60-R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-245c125d8740d71e5bfcd3fc4fc0328fac7b9d75b7d9897d6baca5d30f21c9caL70-R75))
  * In `integrationRepository.ts`, add `findByStatus` method to return integrations with a given status using a raw SQL query with `QueryTypes.SELECT` and a parameterized status value ([link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-5b1c50661ca3f395a4ec888993b46eadd35b277a777e88e0e81e1f88461124a3R167-R186))
  * In `integrationRunRepository.ts`, add `findLastRun` method to return the last integration run for an integration id using a raw SQL query with `QueryTypes.SELECT`, a parameterized integration id, and an order by clause ([link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4R92-R129))
  * In `integrationStreamRepository.ts`, modify `findByRunId` method to accept an optional array of states instead of a single state and use the `in` operator and a parameterized array of states in the SQL query condition ([link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-245c125d8740d71e5bfcd3fc4fc0328fac7b9d75b7d9897d6baca5d30f21c9caL60-R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-245c125d8740d71e5bfcd3fc4fc0328fac7b9d75b7d9897d6baca5d30f21c9caL70-R75))
* Import `QueryTypes` enum from `sequelize` in `integrationRepository.ts` to use it for specifying the type of SQL queries ([link](https://github.com/CrowdDotDev/crowd.dev/pull/809/files?diff=unified&w=0#diff-5b1c50661ca3f395a4ec888993b46eadd35b277a777e88e0e81e1f88461124a3L2-R2))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
