### PR TITLE
Activities cumulative count with cubejs

### DIFF
--- a/backend/src/cubejs/schema/Activities.js
+++ b/backend/src/cubejs/schema/Activities.js
@@ -20,12 +20,23 @@ cube(`Activities`, {
         every: `10 minute`,
       },
     },
-  },
-
-  joins: {
-    Members: {
-      sql: `${CUBE}."memberId" = ${Members}."id"`,
-      relationship: `belongsTo`,
+    ActivitiesCumulative: {
+      measures: [Activities.cumulativeCount],
+      dimensions: [
+        Activities.platform,
+        Activities.type,
+        Members.score,
+        Members.location,
+        Members.tenantId,
+        Members.isTeamMember,
+        Members.isBot,
+        Activities.tenantId,
+      ],
+      timeDimension: Activities.date,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
     },
   },
 
@@ -44,6 +55,12 @@ cube(`Activities`, {
         updatedat,
         date,
       ],
+    },
+    cumulativeCount: {
+      type: `count`,
+      rollingWindow: {
+        trailing: `unbounded`,
+      },
     },
   },
 

--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -55,6 +55,16 @@ cube(`Members`, {
 
     MembersActivities: {
       measures: [Members.count],
+      dimensions: [Members.tenantId, Members.isTeamMember, Members.isBot, Members.isOrganization],
+      timeDimension: Activities.date,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
+    },
+
+    MActivitiesDupDimensions: {
+      measures: [Members.count],
       dimensions: [
         Members.tenantId,
         Activities.platform,


### PR DESCRIPTION
- Cubejs now also supports cumulative activity count metric.
- Also fixed a bug in cubejs preaggregations that was causing the wrong active member count when hit by the cache table.

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf21d28</samp>

This pull request adds new subcubes and measures to the `Activities` and `Members` cubes, to support the analysis and visualization of the cumulative activities and the number of members over time, by different dimensions. It also updates the refresh intervals and the time granularities of the subcubes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf21d28</samp>

> _We count the members in the dark_
> _With `MActivitiesDupDimensions`_
> _We track their actions day by day_
> _With `ActivitiesCumulative`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf21d28</samp>

*  Add subcubes to calculate cumulative activities and member counts by day and various dimensions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/810/files?diff=unified&w=0#diff-18be38929d9b055bee85cbfcb1615f06add8a86fd76742759651951612d075c2L23-R39), [link](https://github.com/CrowdDotDev/crowd.dev/pull/810/files?diff=unified&w=0#diff-25a3b498daa1b4590f9bc69dfa3b2a15b502df38e12e9350d85d7ccacd9f6a53R58-R67))
* Add measure to count cumulative activities in `Activities` cube ([link](https://github.com/CrowdDotDev/crowd.dev/pull/810/files?diff=unified&w=0#diff-18be38929d9b055bee85cbfcb1615f06add8a86fd76742759651951612d075c2R59-R64))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
