### PR TITLE
Removed filtering by is_latest when getting existing member

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -403,7 +403,6 @@ class MemberRepository {
                                        row_number() over (partition by "memberId", platform order by "createdAt" desc) =
                                        1 as is_latest
                                 from "memberIdentities" where "tenantId" = :tenantId) sub
-                          where is_latest
                           group by "memberId", platform) mi
                     group by mi."memberId")
       select m."id",


### PR DESCRIPTION
# Changes proposed ✍️
When checking member existence, instead of returning the latest username of a platform, now we return all of them - This fixes an issue in integrations where member.username comes with an already-existing identity and when member has multiple identities per platform. Before, the newest identity was picked and rest were ignored and when upserting the member we tried to add the is_latest=0 identity again into the database that was resulting in a unique error.

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcdbdd2</samp>

Fixed a bug in `memberRepository.ts` that caused incorrect filtering of members by skills. Removed the `is_latest` condition from the SQL query to return all matching member versions.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bcdbdd2</samp>

> _`is_latest` gone_
> _query returns all versions_
> _bug fixed in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcdbdd2</samp>

* Fix a bug that caused the query to fetch members by skills to return only the latest version of each member, instead of all the versions that match the skills. Remove the condition `where is_latest` from the SQL query in `memberRepository.ts`.

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
