### PR TITLE
Fix new badge in dashboard for active members

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -894,6 +894,7 @@ class MemberRepository {
              m.attributes,
              ad."activityCount",
              ad."activeDaysCount",
+             m."joinedAt",
              coalesce(o.organizations, json_build_array()) as organizations,
              count(*) over ()                  as "totalCount"
       from members m
@@ -936,6 +937,7 @@ class MemberRepository {
         organizations: row.organizations,
         activityCount: parseInt(row.activityCount, 10),
         activeDaysCount: parseInt(row.activeDaysCount, 10),
+        joinedAt: row.joinedAt,
       }
     })
 


### PR DESCRIPTION
# Changes proposed ✍️
Return `joinedAt` in members payload of `api/tenant/{id}/member/active` endpoint

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12e1cee</samp>

This pull request adds a new `joinedAt` attribute to the member entities in the `memberRepository.ts` file. This allows the backend to store and retrieve the join date of each member for the frontend.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 12e1cee</samp>

> _`joinedAt` reveals_
> _when members came to platform_
> _a spring of new friends_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12e1cee</samp>

*  Add `joinedAt` column and property to members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/815/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR897), [link](https://github.com/CrowdDotDev/crowd.dev/pull/815/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR940))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
