### PR TITLE
Fix members list display for null emails

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -307,7 +307,7 @@
                     class="block"
                   >
                     <div
-                      v-if="scope.row.emails.length"
+                      v-if="scope.row.emails?.length && scope.row.emails?.some((e) => !!e)"
                       class="text-sm cursor-auto flex flex-wrap gap-1"
                     >
                       <el-tooltip
@@ -488,7 +488,7 @@ const emailsColumnWidth = computed(() => {
 
   rows.value.forEach((row) => {
     const tabWidth = row.emails
-      .map((email) => email.length * 12)
+      .map((email) => (email ? email.length * 12 : 0))
       .reduce((a, b) => a + b, 0);
 
     if (tabWidth > maxTabWidth) {

--- a/frontend/src/modules/organization/components/list/organization-list-table.vue
+++ b/frontend/src/modules/organization/components/list/organization-list-table.vue
@@ -294,7 +294,7 @@
                     class="block"
                   >
                     <div
-                      v-if="scope.row.emails?.length"
+                      v-if="scope.row.emails?.length && scope.row.emails?.some((e) => !!e)"
                       class="text-sm cursor-auto flex flex-wrap gap-1"
                     >
                       <el-tooltip
@@ -505,7 +505,7 @@ const emailsColumnWidth = computed(() => {
   let maxTabWidth = 0;
   rows.value.forEach((row) => {
     const tabWidth = row.emails
-      ?.map((email) => email.length * 12)
+      ?.map((email) => (email ? email.length * 12 : 0))
       .reduce((a, b) => a + b, 0);
 
     if (tabWidth > maxTabWidth) {


### PR DESCRIPTION
# Changes proposed ✍️
- Protect members list from null emails

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at efb17f1</samp>

This pull request improves the email badge rendering in the member and organization list tables. It fixes some bugs in `member-list-table.vue` and applies some fixes from other components to `organization-list-table.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at efb17f1</samp>

> _Some bugs in the `member-list-table` were found_
> _That made email badges look weird or not sound_
> _So they added some checks_
> _To avoid rendering wrecks_
> _And copied some fixes from elsewhere around_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at efb17f1</samp>

*  Prevent rendering empty email badges in member and organization list tables ([link](https://github.com/CrowdDotDev/crowd.dev/pull/817/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L310-R310), [link](https://github.com/CrowdDotDev/crowd.dev/pull/817/files?diff=unified&w=0#diff-99194084f4efcde26d486e359545dd27d3144d0fa43834a7afe08d928753cec0L297-R297))
*  Avoid calculating NaN tab width for email badges in member and organization list tables ([link](https://github.com/CrowdDotDev/crowd.dev/pull/817/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L491-R491), [link](https://github.com/CrowdDotDev/crowd.dev/pull/817/files?diff=unified&w=0#diff-99194084f4efcde26d486e359545dd27d3144d0fa43834a7afe08d928753cec0L508-R508))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
