### PR TITLE
Getting enrichment from GitHub, fixed the handle

### DIFF
--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -228,7 +228,9 @@ export default class MemberEnrichmentService extends LoggingBase {
     // If the member has a GitHub handle, use it to make a request to the Enrichment API
     if (member.username[PlatformType.GITHUB]) {
       enrichedFrom = 'github'
-      enrichmentData = await this.getEnrichmentByGithubHandle(member.username[PlatformType.GITHUB])
+      enrichmentData = await this.getEnrichmentByGithubHandle(
+        member.username[PlatformType.GITHUB][0],
+      )
     } else if (member.emails.length > 0) {
       enrichedFrom = 'email'
       // If the member has an email address, use it to make a request to the Enrichment API


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d18177</samp>

Fixed a type mismatch bug in the `getEnrichmentByGithubHandle` function of the `memberEnrichmentService`. This function now correctly passes a string instead of an array to the GitHub API.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d18177</samp>

> _`getEnrichmentBy`_
> _takes a string, not an array_
> _bug fix for winter_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d18177</samp>

* Fix bug in member enrichment service by passing primary GitHub handle to `getEnrichmentByGithubHandle` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/820/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L231-R233))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
