### PR TITLE
Mark/Unmark as bot & exclude bot members from search

### DIFF
--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -124,6 +124,19 @@
             class="text-xs"
           >Mark as bot</span>
         </el-dropdown-item>
+        <el-dropdown-item
+          v-if="member.attributes.isBot?.default"
+          class="h-10"
+          :command="{
+            action: 'memberUnmarkAsBot',
+            member: member,
+          }"
+          :disabled="isEditLockedForSampleData"
+        >
+          <i class="ri-robot-line text-base mr-2" /><span
+            class="text-xs"
+          >Unmark as bot</span>
+        </el-dropdown-item>
         <el-divider class="border-gray-200" />
         <el-dropdown-item
           class="h-10"
@@ -263,12 +276,12 @@ export default {
         } else {
           this.doFind(command.member.id);
         }
-      } else if (command.action === 'memberMarkAsBot') {
+      } else if (command.action === 'memberMarkAsBot' || command.action === 'memberUnmarkAsBot') {
         await MemberService.update(command.member.id, {
           attributes: {
             ...command.member.attributes,
             isBot: {
-              default: true,
+              default: command.action === 'memberMarkAsBot',
             },
           },
         });

--- a/frontend/src/modules/member/store/constants.js
+++ b/frontend/src/modules/member/store/constants.js
@@ -13,6 +13,11 @@ export const DEFAULT_MEMBER_FILTERS = [
       not: true,
     },
   },
+  {
+    isBot: {
+      not: true,
+    },
+  },
 ];
 
 const ACTIVITY_COUNT_BIGGER_THAN_0_FILTER = {

--- a/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
@@ -77,11 +77,17 @@ export default {
         operator: 'equals',
         values: ['0'],
       };
+      const isBot = {
+        member: 'Members.isBot',
+        operator: 'equals',
+        values: ['0'],
+      };
 
       if (!widgetQuery.filters) {
-        widgetQuery.filters = [isTeamMemberFilter];
+        widgetQuery.filters = [isTeamMemberFilter, isBot];
       } else {
         widgetQuery.filters.push(isTeamMemberFilter);
+        widgetQuery.filters.push(isBot);
       }
 
       return widgetQuery;

--- a/frontend/src/shared/cube/cube-render.vue
+++ b/frontend/src/shared/cube/cube-render.vue
@@ -45,11 +45,17 @@ export default {
         operator: 'equals',
         values: ['0'],
       };
+      const isBot = {
+        member: 'Members.isBot',
+        operator: 'equals',
+        values: ['0'],
+      };
 
       if (!widgetQuery.filters) {
-        widgetQuery.filters = [isTeamMemberFilter];
+        widgetQuery.filters = [isTeamMemberFilter, isBot];
       } else {
         widgetQuery.filters.push(isTeamMemberFilter);
+        widgetQuery.filters.push(isBot);
       }
 
       return widgetQuery;


### PR DESCRIPTION
# Changes proposed ✍️
- Ability to unmark member as bot

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8c2976</samp>

This pull request adds a feature to unmark a member as a bot and a filter to exclude bots from the members list by default. It also refactors the code for bot-related actions in `member-dropdown.vue` and `MemberService`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d8c2976</samp>

> _No more bots in the members list_
> _We filter them out with a twist_
> _But if you want to unmark one_
> _You can do it from the dropdown_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8c2976</samp>

*  Add option to unmark a member as a bot in the member dropdown menu ([link](https://github.com/CrowdDotDev/crowd.dev/pull/837/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4R127-R139))
*  Simplify logic of handling member dropdown actions and update member `isBot` attribute accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/837/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4L266-R284))
*  Exclude bots from the default member filters in `frontend/src/modules/member/store/constants.js` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/837/files?diff=unified&w=0#diff-a8c816899503edd7933bd17181714398f41d74af81f3e1fac8a1096accd9431eR16-R20))

<img width="229" alt="image" src="https://user-images.githubusercontent.com/15195228/237012903-48e2d9fb-9991-43fd-83d7-6386fe473ed1.png">

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
