### PR TITLE
Conditional webhook firing

### DIFF
--- a/backend/src/bin/scripts/process-webhook.ts
+++ b/backend/src/bin/scripts/process-webhook.ts
@@ -117,7 +117,7 @@ if (parameters.help || (!parameters.webhook && !parameters.processPlatformErrors
           log.info(
             `Queue size(${queueSize}) is bigger than threshold(${PROCESS_QUEUE_THRESHOLD}), waiting 30 seconds before retrying.`,
           )
-          await timeout(5000)
+          await timeout(30000)
           queueSize = await getCurrentQueueSize(sqs, SQS_CONFIG.nodejsWorkerQueue)
         }
 

--- a/backend/src/bin/scripts/process-webhook.ts
+++ b/backend/src/bin/scripts/process-webhook.ts
@@ -92,6 +92,7 @@ if (parameters.help || (!parameters.webhook && !parameters.processPlatformErrors
 
       log.debug('Processing error state webhooks!')
       let webhooks = await repo.findError(webhookType, currentPage, PAGE_SIZE)
+
       log.info(webhooks.map((w) => w.id))
 
       while (webhooks.length > 0) {
@@ -99,7 +100,7 @@ if (parameters.help || (!parameters.webhook && !parameters.processPlatformErrors
           log.info({ webhook }, 'Webhook found - triggering SQS message!')
           await sendNodeWorkerMessage(
             webhook.tenantId,
-            new NodeWorkerProcessWebhookMessage(webhook.tenantId, webhook.id, true),
+            new NodeWorkerProcessWebhookMessage(webhook.tenantId, webhook.id, true, false),
           )
         }
 
@@ -116,7 +117,7 @@ if (parameters.help || (!parameters.webhook && !parameters.processPlatformErrors
           log.info(
             `Queue size(${queueSize}) is bigger than threshold(${PROCESS_QUEUE_THRESHOLD}), waiting 30 seconds before retrying.`,
           )
-          await timeout(30000)
+          await timeout(5000)
           queueSize = await getCurrentQueueSize(sqs, SQS_CONFIG.nodejsWorkerQueue)
         }
 

--- a/backend/src/bin/worker/integrations.ts
+++ b/backend/src/bin/worker/integrations.ts
@@ -45,5 +45,5 @@ export const processWebhook = async (
   messageLogger: Logger,
 ): Promise<void> => {
   const processor = await getIntegrationProcessor(messageLogger)
-  await processor.processWebhook(msg.webhookId, msg.force)
+  await processor.processWebhook(msg.webhookId, msg.force, msg.fireCrowdWebhooks)
 }

--- a/backend/src/serverless/dbOperations/operationsWorker.ts
+++ b/backend/src/serverless/dbOperations/operationsWorker.ts
@@ -41,12 +41,13 @@ async function upsertMembers(records: Array<any>, options: IServiceOptions): Pro
 async function upsertActivityWithMembers(
   records: Array<any>,
   options: IServiceOptions,
+  fireCrowdWebhooks: boolean = true,
 ): Promise<any> {
   const activityService = new ActivityService(options)
 
   while (records.length > 0) {
     const record = records.shift()
-    await activityService.createWithMember(record)
+    await activityService.createWithMember(record, fireCrowdWebhooks)
   }
 }
 
@@ -87,6 +88,7 @@ async function bulkOperations(
   operation: string,
   records: Array<any>,
   options: IServiceOptions,
+  fireCrowdWebhooks?: boolean,
 ): Promise<any> {
   switch (operation) {
     case Operations.UPDATE_MEMBERS:
@@ -96,7 +98,7 @@ async function bulkOperations(
       return upsertMembers(records, options)
 
     case Operations.UPSERT_ACTIVITIES_WITH_MEMBERS:
-      return upsertActivityWithMembers(records, options)
+      return upsertActivityWithMembers(records, options, fireCrowdWebhooks)
 
     case Operations.UPDATE_INTEGRATIONS:
       return updateIntegrations(records, options)

--- a/backend/src/serverless/integrations/services/integrationProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationProcessor.ts
@@ -111,8 +111,8 @@ export class IntegrationProcessor extends LoggingBase {
     await this.checkProcessor.processCheck(type)
   }
 
-  async processWebhook(webhookId: string, force?: boolean) {
-    await this.webhookProcessor.processWebhook(webhookId, force)
+  async processWebhook(webhookId: string, force?: boolean, fireCrowdWebhooks?: boolean) {
+    await this.webhookProcessor.processWebhook(webhookId, force, fireCrowdWebhooks)
   }
 
   async process(req: NodeWorkerIntegrationProcessMessage) {

--- a/backend/src/serverless/integrations/services/webhookProcessor.ts
+++ b/backend/src/serverless/integrations/services/webhookProcessor.ts
@@ -23,7 +23,7 @@ export class WebhookProcessor extends LoggingBase {
     super(options)
   }
 
-  async processWebhook(webhookId: string, force?: boolean) {
+  async processWebhook(webhookId: string, force?: boolean, fireCrowdWebhooks?: boolean) {
     const options = (await SequelizeRepository.getDefaultIRepositoryOptions()) as IRepositoryOptions
     const repo = new IncomingWebhookRepository(options)
     const webhook = await repo.findById(webhookId)
@@ -98,7 +98,7 @@ export class WebhookProcessor extends LoggingBase {
             { operationType: operation.type },
             `Processing bulk operation with ${operation.records.length} records!`,
           )
-          await bulkOperations(operation.type, operation.records, userContext)
+          await bulkOperations(operation.type, operation.records, userContext, fireCrowdWebhooks)
         }
       }
       await repo.markCompleted(webhook.id)

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -43,7 +43,7 @@ export default class ActivityService extends LoggingBase {
    * @param existing If the activity already exists, the activity. If it doesn't or we don't know, false
    * @returns The upserted activity
    */
-  async upsert(data, existing: boolean | any = false) {
+  async upsert(data, existing: boolean | any = false, fireCrowdWebhooks: boolean = false) {
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
     try {
@@ -160,7 +160,7 @@ export default class ActivityService extends LoggingBase {
 
       await SequelizeRepository.commitTransaction(transaction)
 
-      if (!existing) {
+      if (!existing && fireCrowdWebhooks) {
         try {
           await sendNewActivityNodeSQSMessage(this.options.currentTenant.id, record)
         } catch (err) {
@@ -414,7 +414,7 @@ export default class ActivityService extends LoggingBase {
     return exists || false
   }
 
-  async createWithMember(data) {
+  async createWithMember(data, fireCrowdWebhooks: boolean = true) {
     const logger = this.options.log
 
     const errorDetails: any = {}
@@ -493,6 +493,7 @@ export default class ActivityService extends LoggingBase {
           joinedAt: activityExists ? activityExists.timestamp : data.timestamp,
         },
         existingMember,
+        fireCrowdWebhooks,
       )
 
       if (data.objectMember) {
@@ -518,11 +519,15 @@ export default class ActivityService extends LoggingBase {
           }
         }
 
-        const objectMember = await memberService.upsert({
-          ...data.objectMember,
-          platform: data.platform,
-          joinedAt: data.timestamp,
-        })
+        const objectMember = await memberService.upsert(
+          {
+            ...data.objectMember,
+            platform: data.platform,
+            joinedAt: data.timestamp,
+          },
+          false,
+          fireCrowdWebhooks,
+        )
 
         if (!data.objectMemberUsername) {
           data.objectMemberUsername = data.objectMember.username[data.platform].username
@@ -533,7 +538,7 @@ export default class ActivityService extends LoggingBase {
 
       data.member = member.id
 
-      const record = await this.upsert(data, activityExists)
+      const record = await this.upsert(data, activityExists, fireCrowdWebhooks)
 
       await SequelizeRepository.commitTransaction(transaction)
 

--- a/backend/src/types/mq/nodeWorkerProcessWebhookMessage.ts
+++ b/backend/src/types/mq/nodeWorkerProcessWebhookMessage.ts
@@ -6,6 +6,7 @@ export class NodeWorkerProcessWebhookMessage extends NodeWorkerMessageBase {
     public readonly tenantId: string,
     public readonly webhookId: string,
     public readonly force?: boolean,
+    public readonly fireCrowdWebhooks?: boolean,
   ) {
     super(NodeWorkerMessageType.PROCESS_WEBHOOK)
   }


### PR DESCRIPTION
# Changes proposed ✍️
- conditional outgoing webhook firing via queue message field
- organization merge was failing due to a bug that caused objects and string arrays to be concatenated before sending it to upsert
- also saving `originalError` to webhook error jsonb to see more of the errors

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f06101</samp>

No summary available (Limit exceeded: required to process 65479 tokens, but only 50000 are allowed per call)
​
copilot:poem

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f06101</samp>

No walkthrough available (Limit exceeded: required to process 65479 tokens, but only 50000 are allowed per call)

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
