### PR TITLE
isTeamMember check fix for new activity automation

### DIFF
--- a/backend/src/serverless/microservices/nodejs/automation/workers/__tests__/newActivityWorker.test.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/__tests__/newActivityWorker.test.ts
@@ -62,6 +62,7 @@ describe('New Activity Automation Worker tests', () => {
       member: {
         attributes: {
           isTeamMember: {
+            default: true,
             custom: true,
           },
         },
@@ -143,6 +144,7 @@ describe('New Activity Automation Worker tests', () => {
       member: {
         attributes: {
           isTeamMember: {
+            default: true,
             custom: true,
           },
         },

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -71,7 +71,7 @@ export const shouldProcessActivity = async (
     process &&
     !settings.teamMemberActivities &&
     activity.member.attributes.isTeamMember &&
-    activity.member.attributes.isTeamMember.custom
+    activity.member.attributes.isTeamMember.default
   ) {
     log.warn(
       `Ignoring automation ${automation.id} - Activity ${activity.id} belongs to a team member!`,


### PR DESCRIPTION
# Changes proposed ✍️
- We were checking `attributes.isTeamMember.custom`, instead we should check `attributes.isTeamMember.default`

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06b5a6c</samp>

Fixed a bug in `newActivityWorker.ts` that caused team member activities to be skipped. Changed the logic to use the `default` property of the `isTeamMember` attribute instead of the `custom` property.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 06b5a6c</samp>

> _`shouldProcessActivity`_
> _uses `default` now, not `custom`_
> _bug fixed in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06b5a6c</samp>

*  Fix bug where team member activities were not processed correctly by using the `default` property of the `isTeamMember` attribute ([link](https://github.com/CrowdDotDev/crowd.dev/pull/845/files?diff=unified&w=0#diff-38ef99903ebbf342c27ff354fbc7dfaa8727b41b09bbdef36f31f7d2a9dab7bbL74-R74))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [x] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
