### PR TITLE
Fix activity types display in dashboard

### DIFF
--- a/frontend/src/modules/dashboard/components/activity/dashboard-activity-types.vue
+++ b/frontend/src/modules/dashboard/components/activity/dashboard-activity-types.vue
@@ -63,10 +63,9 @@
               <p v-if="typeNames?.[plat]?.[type]?.display" class="text-xs leading-5 activity-type">
                 {{ typeNames?.[plat]?.[type]?.display?.short }}
               </p>
-              <app-i18n
-                v-else-if="getPlatformDetails(plat)"
-                :code="`entities.activity.${plat}.${type}`"
-              />
+              <div v-else class="text-xs leading-5 activity-type">
+                Conducted an activity
+              </div>
             </div>
             <p class="text-2xs text-gray-400">
               {{ pluralize('activity', total, true) }} ・
@@ -112,6 +111,7 @@ import { useActivityTypeStore } from '@/modules/activity/store/type';
 import { storeToRefs } from 'pinia';
 import { computed, watch } from 'vue';
 import pluralize from 'pluralize';
+import merge from 'lodash/merge';
 
 const { period, platform } = mapGetters('dashboard');
 const { currentTenant } = mapGetters('auth');
@@ -120,10 +120,7 @@ const activityTypeStore = useActivityTypeStore();
 const { types } = storeToRefs(activityTypeStore);
 const { setTypes } = activityTypeStore;
 
-const typeNames = computed(() => ({
-  ...types.value.default,
-  ...types.value.custom,
-}));
+const typeNames = computed(() => (merge(types.value.default, types.value.custom)));
 
 watch(
   () => currentTenant,

--- a/frontend/src/modules/dashboard/pages/dashboard-page.vue
+++ b/frontend/src/modules/dashboard/pages/dashboard-page.vue
@@ -18,7 +18,7 @@
               class="leading-8 font-semibold transition-all duration-100"
               :class="scrolled ? 'text-base' : 'text-xl'"
             >
-              {{ currentTenant.name }} team overview
+              {{ currentTenant?.name }} team overview
             </h4>
           </div>
 


### PR DESCRIPTION
# Changes proposed ✍️
- Remove translation to render activity types, add a fallback instead
- Use merge method from lodash to merge custom and default activities, so if the same platforms exist on both, the activity types are merged instead of replaced by custom ones as it was before

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8301a72</samp>

The pull request improves the dashboard UI by enhancing the display of activity types from different sources and avoiding errors when the tenant name is missing. It uses `lodash.merge` and optional chaining in `dashboard-activity-types.vue` and `dashboard-page.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8301a72</samp>

> _To avoid errors from `currentTenant`_
> _The code added a chaining element_
> _It also merged types_
> _From different pipes_
> _And handled unknowns with a comment_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8301a72</samp>

*  Handle unknown or unsupported activity types in dashboard by displaying a default text ([link](https://github.com/CrowdDotDev/crowd.dev/pull/847/files?diff=unified&w=0#diff-ad12f37742fcb2e2260856fe4cbf692742aceccd22972118ab0f9e30dc00c405L66-R68))
*  Import and use `merge` function from `lodash` library to combine default and custom activity types without overwriting or losing nested properties ([link](https://github.com/CrowdDotDev/crowd.dev/pull/847/files?diff=unified&w=0#diff-ad12f37742fcb2e2260856fe4cbf692742aceccd22972118ab0f9e30dc00c405R114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/847/files?diff=unified&w=0#diff-ad12f37742fcb2e2260856fe4cbf692742aceccd22972118ab0f9e30dc00c405L123-R123))
*  Add optional chaining operator to `currentTenant.name` expression in `dashboard-page.vue` to prevent errors if `currentTenant` is null or undefined ([link](https://github.com/CrowdDotDev/crowd.dev/pull/847/files?diff=unified&w=0#diff-1a28b05f485413666bd99bab81639ee6e16d343a1c83a9240d7306f6a1f697f3L21-R21))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
