### PR TITLE
Replaced nango cli with curl call

### DIFF
--- a/scripts/nango-integrations.sh
+++ b/scripts/nango-integrations.sh
@@ -24,9 +24,11 @@ function create_nango_integration() {
         printf "The variables needed are: \n- CROWD_${KEY}_CLIENT_ID \n- CROWD_${KEY}_CLIENT_SECRET \n- CROWD_${KEY}_SCOPES"
         return
     else
-        export NANGO_SECRET_KEY=$CROWD_NANGO_SECRET_KEY
-        printf "\nCreating $1 Integration with client ID: $clientId"    
-        npx nango config:create $1 $1 $clientId $clientSecret "$scopes"
+        printf "\nCreating $1 Integration with client ID: $clientId\n"
+        curl    -u "$CROWD_NANGO_SECRET_KEY:" \
+                --location 'http://localhost:3003/config' \
+                --header 'Content-Type: application/json' \
+                --data "{\"provider_config_key\": \"$1\",\"provider\": \"$1\",\"oauth_client_id\": \"$clientId\",\"oauth_client_secret\": \"$clientSecret\",\"oauth_scopes\": \"$scopes\"}"
     fi
 
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4251932</samp>

Replaced `npx nango` with `curl` in `scripts/nango-integrations.sh` to create provider configs for the new crowd.dev API. Improved script readability with newlines.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4251932</samp>

> _`npx nango` gone_
> _curl creates provider config_
> _autumn of old tools_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4251932</samp>

* Replace npx nango with curl to create provider config for integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/850/files?diff=unified&w=0#diff-0dfc8e205ac75dcd157cd1b67c48323f0c5cde761562c7124b51412aad7382a2L27-R31))
* Add newlines for readability around curl command ([link](https://github.com/CrowdDotDev/crowd.dev/pull/850/files?diff=unified&w=0#diff-0dfc8e205ac75dcd157cd1b67c48323f0c5cde761562c7124b51412aad7382a2L27-R31))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
