### PR TITLE
Fix activity type filter display

### DIFF
--- a/frontend/src/modules/activity/activity-type-field.js
+++ b/frontend/src/modules/activity/activity-type-field.js
@@ -18,17 +18,25 @@ export default class ActivityTypeField extends JSONField {
   }
 
   getActivityTypes(activityTypes) {
-    return Object.entries(activityTypes).map(([key, value]) => ({
-      label: {
-        type: 'platform',
-        key,
-        value: CrowdIntegrations.getConfig(key)?.name || 'Custom',
-      },
-      nestedOptions: Object.entries(value).map(([activityKey, activityValue]) => ({
-        value: activityKey,
-        label: toSentenceCase(activityValue.display.short),
-      })),
-    }));
+    return Object.entries(activityTypes).map(([key, value]) => {
+      let platformName = CrowdIntegrations.getConfig(key)?.name;
+
+      if (!platformName) {
+        platformName = key === 'other' ? 'Custom' : key;
+      }
+
+      return {
+        label: {
+          type: 'platform',
+          key,
+          value: platformName,
+        },
+        nestedOptions: Object.entries(value).map(([activityKey, activityValue]) => ({
+          value: activityKey,
+          label: toSentenceCase(activityValue.display.short),
+        })),
+      };
+    });
   }
 
   dropdownOptions() {


### PR DESCRIPTION
# Changes proposed ✍️
Currently we are receiving custom activity types outside of "other" object in settings. This PR fixes the platform display that groups the activity types in the activity type filter:
- Show "Custom" if activity types are inside "other"
- Show default platform name if platform exists in our configuration (e.g. github)
- Show platform key coming from settings if platform doesn't exist in our settings and is not inside other

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f317c34</samp>

Improved activity type labels for undefined platforms. Modified `getActivityTypes` in `activity-type-field.js` to use the activity type key as the label, unless it is 'other'.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f317c34</samp>

> _`getActivityTypes`_
> _More precise labels now_
> _Fall leaves no confusion_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f317c34</samp>

*  Handle undefined platform name in activity type labels ([link](https://github.com/CrowdDotDev/crowd.dev/pull/851/files?diff=unified&w=0#diff-c66d8bf25ee879d4a9fa88fcb2652b766faf57b9daedde3f9dbc89885a22059fL21-R39))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
