### PR TITLE
Update organizations default sorter

### DIFF
--- a/frontend/src/modules/organization/store/state.js
+++ b/frontend/src/modules/organization/store/state.js
@@ -24,11 +24,11 @@ export default () => ({
         pageSize: INITIAL_PAGE_SIZE,
       },
       initialSorter: {
-        prop: 'joinedAt',
+        prop: 'activityCount',
         order: 'descending',
       },
       sorter: {
-        prop: 'joinedAt',
+        prop: 'activityCount',
         order: 'descending',
       },
       active: true,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cd1dc8</samp>

Changed the default sorting criteria of the organization members table from `joinedAt` to `activityCount` in `frontend/src/modules/organization/store/state.js`. This makes the table more informative and relevant to the issue #123.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1cd1dc8</samp>

> _`activityCount`_
> _now sorts organization_
> _falling leaves of work_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cd1dc8</samp>

* Sort organization members by activity count instead of join date ([link](https://github.com/CrowdDotDev/crowd.dev/pull/871/files?diff=unified&w=0#diff-07c492eaf4337465f9211c39bf6f4007eccc72dfc76f444f3a3f3169970d2172L27-R31))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
