### PR TITLE
Bugfix: Google signup issues

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -16,6 +16,7 @@ import formbricks from '@/plugins/formbricks';
 
 import { init as i18nInit } from '@/i18n';
 
+import { AuthService } from '@/modules/auth/auth-service';
 import { AuthToken } from '@/modules/auth/auth-token';
 import { TenantService } from '@/modules/tenant/tenant-service';
 import 'v-network-graph/lib/style.css';
@@ -40,8 +41,13 @@ i18nInit();
   const router = await createRouter();
   const store = await createStore(LogRocket);
 
+  const isSocialOnboardRequested = AuthService.isSocialOnboardRequested();
+
   AuthToken.applyFromLocationUrlIfExists();
   await TenantService.fetchAndApply();
+  if (isSocialOnboardRequested) {
+    await AuthService.socialOnboard();
+  }
 
   app.use(VueGridLayout);
   app.use(Vue3Sanitize, vueSanitizeOptions);

--- a/frontend/src/modules/dashboard/pages/dashboard-page.vue
+++ b/frontend/src/modules/dashboard/pages/dashboard-page.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex -m-5">
+  <div v-if="currentTenant" class="flex -m-5">
     <div
       class="flex-grow overflow-auto"
       :style="{
@@ -79,7 +79,10 @@ const handleScroll = (event) => {
 
 onMounted(() => {
   window.analytics.page('Dashboard');
-  doFetch({});
+
+  if (currentTenant.value) {
+    doFetch({});
+  }
 
   storeUnsubscribe.value = store.subscribeAction(
     (action) => {


### PR DESCRIPTION
# Changes proposed ✍️

### What
Fixes two issues with signing up with a google account:
1. If a user tries to accept an invitation to a workspace using a google signup, they see a 403 page. This happens because when a user is created by a callback from google, we don't accept the original invitation, and the invited `tenantUser` remains in a `invited` state, cause all `/api/tenant/:tenantId/...` requests end up with 403.
2. If a user signs up with google without any invitation, they get redirected to `/onboard` page, but with lots of error toasts in the bottom right corner. This happens because when a google signup redirects the user back to the app, they're redirected to the root page `/`, which tries to render the dashboard. And since the user doesn't have a connected workspace yet, all the requests made by the dashboard trying to render itself (such as `/api/tenant/:tenantId/activity/query` or `/api/tenant/:tenantId/conversation/query`) fail because with empty `tenantId` they look like `/api/tenant/null/activity/query`. Eventually the frontend figures out that there is no `tenantId` and redirects the user to `/onboard` page, but the dashboard already tried to render and made all those XHR requests.

#### Copilot summary
copilot:summary
​
#### Copilot poem
copilot:poem

### Why
Because these are bugs

### How
1. When getting redirected after the google signup, we now also make a call to [`/api/auth/social/onboard` endpoint](https://github.com/CrowdDotDev/crowd.dev/blob/5cdcc9977160ae151da873e9d08b88faaff7d121/backend/src/api/auth/authSocial.ts#L19-L25), which takes `{ invitationToken, tenantId }` and accepts the invitation changing status of `tenantUser` to `active`. This call used to be done by the frontend at some point, but [was removed](https://github.com/CrowdDotDev/crowd.dev/commit/32dd67c2ca855e227cbd8ce9f8d7f315996ac7e3#diff-2f46f8a9c2b03069ecfe187fdaec0f865901d86ba8426dda8b437788b10e8ca7L40-L46) as part of [Vue 3 migration PR](https://github.com/CrowdDotDev/crowd.dev/pull/15).
2. We don't render the dashboard page if we don't have a tenant id

#### Copilot walkthrough
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
