### PR TITLE
Automations paywall

### DIFF
--- a/frontend/src/modules/automation/store/actions.js
+++ b/frontend/src/modules/automation/store/actions.js
@@ -1,4 +1,5 @@
 import { AutomationService } from '@/modules/automation/automation-service';
+import { store } from '@/store';
 
 export default {
   getAutomations() {
@@ -32,6 +33,9 @@ export default {
   createAutomation(data) {
     return AutomationService.create(data)
       .then((res) => {
+        // Make sure that feature flags are updated for automationsCount
+        store.dispatch('auth/doRefreshCurrentUser');
+
         this.getAutomations();
         return Promise.resolve(res);
       });
@@ -46,6 +50,9 @@ export default {
   deleteAutomation(id) {
     return AutomationService.destroy(id)
       .then((res) => {
+        // Make sure that feature flags are updated for automationsCount
+        store.dispatch('auth/doRefreshCurrentUser');
+
         this.getAutomations();
         return Promise.resolve(res);
       });


### PR DESCRIPTION
# Changes proposed ✍️
- Show paywall for automations:
   - For Essential users: Show paywall after limit of 2 automations 
   - For Growth users: Show paywall after limit of 10 automations

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f46bc5c</samp>

The code adds feature flag and workflow limit checks for the automation list page, and refreshes the user's feature flags after creating or deleting an automations. This improves the user experience and security of the automation features.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f46bc5c</samp>

> _We're sailing on the automation sea_
> _With `feature-flag` and `workflow-limit` we_
> _Check if we can add or edit with `canAddAutomation`_
> _And refresh our flags with `doRefreshCurrentUser` action_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f46bc5c</samp>

*  Add feature flag and limit logic for automations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR134-R135), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bL162-R188), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR217-R220), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR36-R38), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR53-R55))
  * Import `featureFlag` and `workflowLimit` modules in `automation-list-page.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR134-R135))
  * Define `canAddAutomation` function to check feature flag and limit before creating or editing automations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bL162-R188), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR217-R220))
  * Show dialog if limit is reached or feature flag is disabled ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bL162-R188), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR217-R220))
  * Import `store` module in `actions.js` to access auth actions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR2))
  * Dispatch `doRefreshCurrentUser` action after creating or deleting automations to update feature flags ([link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR36-R38), [link](https://github.com/CrowdDotDev/crowd.dev/pull/892/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fR53-R55))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
