### PR TITLE
Fix slackWebhook Typos

### DIFF
--- a/backend/src/database/repositories/settingsRepository.ts
+++ b/backend/src/database/repositories/settingsRepository.ts
@@ -34,8 +34,8 @@ export default class SettingsRepository {
     data.backgroundImageUrl = _get(data, 'backgroundImages[0].downloadUrl', null)
     data.logoUrl = _get(data, 'logos[0].downloadUrl', null)
     if (
-      typeof data.slackWebhook !== 'string' ||
-      (typeof data.slackWebhook === 'string' && !data.slackWebHook?.startsWith('https://'))
+      typeof data.slackWebHook !== 'string' ||
+      (typeof data.slackWebHook === 'string' && !data.slackWebHook?.startsWith('https://'))
     ) {
       data.slackWebHook = undefined
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc14501</samp>

Fixed a typo in the `slackWebHook` property name in the `settingsRepository.ts` file. This ensures that the Slack webhook URL is stored and retrieved correctly for notifications.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cc14501</samp>

> _`slackWebHook` fixed_
> _A typo caused confusion_
> _Autumn of errors_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc14501</samp>

* Fix casing of `slackWebHook` property in settings repository ([link](https://github.com/CrowdDotDev/crowd.dev/pull/894/files?diff=unified&w=0#diff-d5aa6e974cb09ab05d06e41f99a6a2b16adc64e1a70b7098762b8df8251bf708L37-R38))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
