### PR TITLE
Member enrichment upsert by existing platform instead of GitHub

### DIFF
--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -263,7 +263,7 @@ export default class MemberEnrichmentService extends LoggingBase {
         this.options,
       )
 
-      return memberService.upsert({ ...normalized, platform: PlatformType.GITHUB })
+      return memberService.upsert({ ...normalized, platform: Object.keys(member.username)[0] })
     }
     return null
   }
@@ -485,7 +485,7 @@ export default class MemberEnrichmentService extends LoggingBase {
       // Make the GET request and extract the profile data from the response
       const response: EnrichmentAPIResponse = (await axios(config)).data
 
-      if (response.error) {
+      if (response.error || response.profile === undefined) {
         this.log.error(githubHandle, `Member not found using github handle.`)
         throw new Error400(this.options.language, 'enrichment.errors.memberNotFound')
       }


### PR DESCRIPTION
- Enrichment service was trying to upsert the member with GitHub platform always - This was causing a problem when the member was enriched by e-mail and didn't have any GitHub identities before. We were trying to upsert the member using the GitHub platform, and `memberExists` function was failing to return the existing member.
Now we try to upsert the existing member with the first identity of the member instead of GitHub.

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfd812e</samp>

Improved the member service to handle different platforms and avoid errors. Refactored the `memberService.upsert` method and added a check for `response.profile` in `memberEnrichmentService.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfd812e</samp>

> _We are the members of the service_
> _We rise from different platforms_
> _We don't need no profile data_
> _We upsert with our usernames_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfd812e</samp>

*  Enable upserting members from different platforms ([link](https://github.com/CrowdDotDev/crowd.dev/pull/906/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L266-R266))
*  Fix possible error when accessing profile data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/906/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L488-R488))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [x] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
