### PR TITLE
Added a filter for the deleted users

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discordIntegrationService.ts
@@ -566,6 +566,12 @@ export class DiscordIntegrationService extends IntegrationServiceBase {
                   [PlatformType.DISCORD]: avatarUrl,
                 },
               }),
+              // Add isBot attribute for deleted users to exclude from search. Add if username contains Deleted User
+              ...(username.includes('Deleted User') && {
+                [MemberAttributeName.IS_BOT]: {
+                  [PlatformType.DISCORD]: true,
+                },
+              }),
             },
           },
           score: DiscordGrid.message.score,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a906fd3</samp>

Added a `isBot` attribute to the member object in the Discord integration service to exclude bot users from the frontend search results. This improves the user experience of finding and filtering members by platform and role.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a906fd3</samp>

> _`isBot` attribute_
> _filters out the noisy ones_
> _autumn of silence_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a906fd3</samp>

*  Add bot attribute to member object based on username ([link](https://github.com/CrowdDotDev/crowd.dev/pull/911/files?diff=unified&w=0#diff-ac7575a17bc8ee86d23325bb4aa8cd9cb439879bee08cf7e9855a031be09be93R569-R574)) in `discordIntegrationService.ts`

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
