### PR TITLE
Control integration error banner display

### DIFF
--- a/frontend/src/modules/dashboard/components/dashboard-active-integrations.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-active-integrations.vue
@@ -48,11 +48,7 @@
           </div>
           <div>
             <div
-              v-if="
-                integration.status === 'done'
-                  || (integration.status === 'error'
-                    && !isCurrentDateAfterGivenWorkingDays(integration.updatedAt, 3))
-              "
+              v-if="showIsConnectedIntegration(integration)"
             >
               <el-tooltip
                 effect="dark"
@@ -65,10 +61,7 @@
               </el-tooltip>
             </div>
             <div
-              v-else-if="
-                integration.status === 'error'
-                  && isCurrentDateAfterGivenWorkingDays(integration.updatedAt, 3)
-              "
+              v-else-if="showIsFailedIntegration(integration)"
             >
               <el-tooltip
                 effect="dark"
@@ -174,6 +167,7 @@ import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
 import {
   computed, onBeforeUnmount, onMounted, ref,
 } from 'vue';
+import { ERROR_BANNER_WORKING_DAYS_DISPLAY } from '@/modules/integration/integration-store';
 
 const store = useStore();
 const storeUnsubscribe = ref(() => {});
@@ -205,6 +199,19 @@ const platformDetails = (platform) => CrowdIntegrations.getMappedConfig(
   platform,
   store,
 );
+
+const showIsConnectedIntegration = (integration) => integration.status === 'done'
+  || (integration.status === 'error'
+    && !isCurrentDateAfterGivenWorkingDays(
+      integration.updatedAt,
+      ERROR_BANNER_WORKING_DAYS_DISPLAY,
+    ));
+
+const showIsFailedIntegration = (integration) => integration.status === 'error'
+  && isCurrentDateAfterGivenWorkingDays(
+    integration.updatedAt,
+    ERROR_BANNER_WORKING_DAYS_DISPLAY,
+  );
 </script>
 
 <script>

--- a/frontend/src/modules/integration/components/integration-list-item.vue
+++ b/frontend/src/modules/integration/components/integration-list-item.vue
@@ -95,6 +95,7 @@ import { useStore } from 'vuex';
 import { defineProps, computed, ref } from 'vue';
 import { FeatureFlag } from '@/featureFlag';
 import AppIntegrationConnect from '@/modules/integration/components/integration-connect.vue';
+import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
 
 const store = useStore();
 const props = defineProps({
@@ -110,9 +111,16 @@ const computedClass = computed(() => ({
 
 const isConnected = computed(() => props.integration.status !== undefined);
 
-const isDone = computed(() => props.integration.status === 'done');
+const isDone = computed(
+  () => props.integration.status === 'done'
+    || (props.integration.status === 'error'
+      && !isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, 3)),
+);
 
-const isError = computed(() => props.integration.status === 'error');
+const isError = computed(
+  () => props.integration.status === 'error'
+    && isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, 3),
+);
 
 const isNoData = computed(() => props.integration.status === 'no-data');
 

--- a/frontend/src/modules/integration/components/integration-list-item.vue
+++ b/frontend/src/modules/integration/components/integration-list-item.vue
@@ -96,6 +96,7 @@ import { defineProps, computed, ref } from 'vue';
 import { FeatureFlag } from '@/featureFlag';
 import AppIntegrationConnect from '@/modules/integration/components/integration-connect.vue';
 import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
+import { ERROR_BANNER_WORKING_DAYS_DISPLAY } from '@/modules/integration/integration-store';
 
 const store = useStore();
 const props = defineProps({
@@ -114,12 +115,12 @@ const isConnected = computed(() => props.integration.status !== undefined);
 const isDone = computed(
   () => props.integration.status === 'done'
     || (props.integration.status === 'error'
-      && !isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, 3)),
+      && !isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, ERROR_BANNER_WORKING_DAYS_DISPLAY)),
 );
 
 const isError = computed(
   () => props.integration.status === 'error'
-    && isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, 3),
+    && isCurrentDateAfterGivenWorkingDays(props.integration.updatedAt, ERROR_BANNER_WORKING_DAYS_DISPLAY),
 );
 
 const isNoData = computed(() => props.integration.status === 'no-data');

--- a/frontend/src/modules/integration/integration-store.js
+++ b/frontend/src/modules/integration/integration-store.js
@@ -2,6 +2,7 @@ import { IntegrationService } from '@/modules/integration/integration-service';
 import Errors from '@/shared/error/errors';
 import { router } from '@/router';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
+import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
 import Message from '../../shared/message/message';
 
 export default {
@@ -66,7 +67,7 @@ export default {
     ),
 
     withErrors: (state, getters) => getters.array.filter(
-      (i) => i.status === 'error',
+      (i) => i.status === 'error' && isCurrentDateAfterGivenWorkingDays(i.updatedAt, 3),
     ),
 
     withNoData: (state, getters) => getters.array.filter(

--- a/frontend/src/modules/integration/integration-store.js
+++ b/frontend/src/modules/integration/integration-store.js
@@ -5,6 +5,8 @@ import { CrowdIntegrations } from '@/integrations/integrations-config';
 import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
 import Message from '../../shared/message/message';
 
+export const ERROR_BANNER_WORKING_DAYS_DISPLAY = 3;
+
 export default {
   namespaced: true,
 
@@ -67,7 +69,7 @@ export default {
     ),
 
     withErrors: (state, getters) => getters.array.filter(
-      (i) => i.status === 'error' && isCurrentDateAfterGivenWorkingDays(i.updatedAt, 3),
+      (i) => i.status === 'error' && isCurrentDateAfterGivenWorkingDays(i.updatedAt, ERROR_BANNER_WORKING_DAYS_DISPLAY),
     ),
 
     withNoData: (state, getters) => getters.array.filter(

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -58,3 +58,21 @@ export const getTrialDate = (tenant) => {
 
   return `Trial (${daysLeft < 0 ? 0 : daysLeft} days left)`;
 };
+
+export const isCurrentDateAfterGivenWorkingDays = (date, workingDays = 3) => {
+  const givenDate = new Date(date);
+  let workingDaysAdded = 0;
+
+  while (workingDaysAdded < workingDays) {
+    givenDate.setDate(givenDate.getDate() + 1);
+
+    // Check if the current day is a weekend day (Saturday or Sunday)
+    const isWeekendDay = givenDate.getDay() === 0 || givenDate.getDay() === 6;
+
+    if (!isWeekendDay) {
+      workingDaysAdded += 1;
+    }
+  }
+
+  return new Date() > givenDate;
+};


### PR DESCRIPTION
# Changes proposed ✍️
- Moved `dashboard-active-integrations.vue` component to Composition API
- Prevent banner/labels to show error if integration `updatedAt` date is not after 3 working days of the current date
   - Validation on pages banner, integrations banner, integration card and dashboard integration item

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f06c75c</samp>

This pull request improves the user interface and the code quality of the integrations feature. It adds icons to show the status and recency of integrations on the dashboard, and refactors the logic for checking the integration status to use a common utility function. It also introduces the `script setup` syntax for Vue 3 in one of the components. The utility function `isCurrentDateAfterGivenWorkingDays` is added to the `date.js` module and used by the integration store and components.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f06c75c</samp>

> _`date.js` adds function_
> _To check integration status_
> _Icons change with time_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f06c75c</samp>

*  Refactor dashboard-active-integrations.vue component to use script setup syntax and align integration status icon logic with other components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-9ce5d8ffbe0ca96d5de0fa2ccc7ff6ba8b65477bc876509fd0fd154497aa6d95L50-R56), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-9ce5d8ffbe0ca96d5de0fa2ccc7ff6ba8b65477bc876509fd0fd154497aa6d95L61-R72), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-9ce5d8ffbe0ca96d5de0fa2ccc7ff6ba8b65477bc876509fd0fd154497aa6d95L67-R78), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-9ce5d8ffbe0ca96d5de0fa2ccc7ff6ba8b65477bc876509fd0fd154497aa6d95L160-R212))
*  Import and use isCurrentDateAfterGivenWorkingDays function from date.js utility module in integration-list-item.vue component and integration-store.js module to align integration status icon logic with dashboard-active-integrations.vue component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6L113-R123), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-8b83462272f6fab878c7d2d63afa1207f20990660debf46dfd0f9971d5f3f9ddR5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-8b83462272f6fab878c7d2d63afa1207f20990660debf46dfd0f9971d5f3f9ddL69-R70))
*  Add isCurrentDateAfterGivenWorkingDays function to date.js utility module to determine the validity and recency of an integration status based on the updatedAt date and a number of working days ([link](https://github.com/CrowdDotDev/crowd.dev/pull/914/files?diff=unified&w=0#diff-0d756bdd9b909ebc5b40e8ba22ab46ab0909ad34e02a25962d6af7d4b806c598R61-R78))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
