### PR TITLE
fix github webhook early return

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -531,7 +531,6 @@ export class GithubIntegrationService extends IntegrationServiceBase {
   }
 
   private static verifyWebhookSignature(signature: string, data: any): void {
-    return
     if (IS_TEST_ENV) {
       return
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 334afe5</samp>

Fixed a bug in `GithubIntegrationService` that prevented webhook creation. Removed an unnecessary return statement from `createGithubWebhook` method in `backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 334afe5</samp>

> _`createGithubWebhook`_
> _No more early return - bug fixed_
> _Webhooks blossom in spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 334afe5</samp>

* Fix bug that prevented webhook creation for Github integrations by removing unnecessary return statement ([link](https://github.com/CrowdDotDev/crowd.dev/pull/917/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L534))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
