### PR TITLE
fixed docker entrypoints

### DIFF
--- a/services/apps/data_sink_worker/package.json
+++ b/services/apps/data_sink_worker/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node -r tsconfig-paths/register -r ts-node/register src/main.ts --transpile-only",
-    "start:debug": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=data-sink-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9233 -r tsconfig-paths/register -r ts-node/register src/main.ts --transpile-only",
+    "start:debug:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=data-sink-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9233 -r tsconfig-paths/register -r ts-node/register src/main.ts --transpile-only",
+    "start:debug": "SERVICE=data-sink-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9233 -r tsconfig-paths/register -r ts-node/register src/main.ts --transpile-only",
+    "start:watch:local": "nodemon --watch src --ext ts --exec npm run start:debug:local",
     "start:watch": "nodemon --watch src --ext ts --exec npm run start:debug",
+    "dev:local": "concurrently \"npm run start:watch:local\" \"../../scripts/watch_libs.sh --service data_sink_worker\"",
     "dev": "concurrently \"npm run start:watch\" \"../../scripts/watch_libs.sh --service data_sink_worker\"",
     "lint": "eslint --ext .ts src --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/services/apps/integration_data_worker/package.json
+++ b/services/apps/integration_data_worker/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node -r ts-node/register src/main.ts --transpile-only",
-    "start:debug": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-data-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9232 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-data-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9232 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug": "SERVICE=integration-data-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9232 -r ts-node/register src/main.ts --transpile-only",
+    "start:watch:local": "nodemon --watch src --ext ts --exec npm run start:debug:local",
     "start:watch": "nodemon --watch src --ext ts --exec npm run start:debug",
+    "dev:local": "concurrently \"npm run start:watch:local\" \"../../scripts/watch_libs.sh --service integration_data_worker\"",
     "dev": "concurrently \"npm run start:watch\" \"../../scripts/watch_libs.sh --service integration_data_worker\"",
     "lint": "eslint --ext .ts src --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/services/apps/integration_run_worker/package.json
+++ b/services/apps/integration_run_worker/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node -r ts-node/register src/main.ts --transpile-only",
-    "start:debug": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-run-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9230 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-run-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9230 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug": "SERVICE=integration-run-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9230 -r ts-node/register src/main.ts --transpile-only",
+    "start:watc:local": "nodemon --watch src --ext ts --exec npm run start:debug:local",
     "start:watch": "nodemon --watch src --ext ts --exec npm run start:debug",
+    "dev:local": "concurrently \"npm run start:watch:local\" \"../../scripts/watch_libs.sh --service integration_run_worker\"",
     "dev": "concurrently \"npm run start:watch\" \"../../scripts/watch_libs.sh --service integration_run_worker\"",
     "lint": "eslint --ext .ts src --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\"",

--- a/services/apps/integration_stream_worker/package.json
+++ b/services/apps/integration_stream_worker/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node -r ts-node/register src/main.ts --transpile-only",
-    "start:debug": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-stream-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9231 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=integration-stream-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9231 -r ts-node/register src/main.ts --transpile-only",
+    "start:debug": "SERVICE=integration-stream-worker LOG_LEVEL=trace node --inspect=0.0.0.0:9231 -r ts-node/register src/main.ts --transpile-only",
+    "start:watch:local": "nodemon --watch src --ext ts --exec npm run start:debug:local",
     "start:watch": "nodemon --watch src --ext ts --exec npm run start:debug",
+    "dev:local": "concurrently \"npm run start:watch:local\" \"../../scripts/watch_libs.sh --service integration_stream_worker\"",
     "dev": "concurrently \"npm run start:watch\" \"../../scripts/watch_libs.sh --service integration_stream_worker\"",
     "lint": "eslint --ext .ts src --max-warnings=0",
     "format": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 496b16e</samp>

This pull request updates the `package.json` scripts of four worker services (`data_sink_worker`, `integration_data_worker`, `integration_run_worker`, and `integration_stream_worker`) to support local and remote debugging modes. This allows developers to easily switch between different environments without modifying the `.env` files or the scripts.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 496b16e</samp>

> _`start:watch` scripts_
> _split for local and remote_
> _debugging in fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 496b16e</samp>

* Split `start:debug` and `start:watch` scripts into local and remote variants for four worker services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5L7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-356df5ace11b7af626f46f92d3c7528003c8671a0a55bb3f4d9e175877a9900dL7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-d1ce9411b1493ff8abbf60c134dd2fe51eb93f05bdc6b6303ad7a2c2a21b64a0L7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-3831ba00f8d2658b222de90c364557d3fe41a692351de3b8fca48e7831d57e5fL7-R11))
* Add `dev:local` and `dev` scripts that run `start:watch` and `watch_libs.sh` concurrently for four worker services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5L7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-356df5ace11b7af626f46f92d3c7528003c8671a0a55bb3f4d9e175877a9900dL7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-d1ce9411b1493ff8abbf60c134dd2fe51eb93f05bdc6b6303ad7a2c2a21b64a0L7-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/929/files?diff=unified&w=0#diff-3831ba00f8d2658b222de90c364557d3fe41a692351de3b8fca48e7831d57e5fL7-R11))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
