### PR TITLE
Changed frontend to be able to enrich only 1 member

### DIFF
--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -13,7 +13,11 @@ import {
   showEnrichmentLoadingMessage,
   checkEnrichmentPlan,
 } from '@/modules/member/member-enrichment';
-import { getExportMax, showExportLimitDialog, showExportDialog } from '@/modules/member/member-export-limit';
+import {
+  getExportMax,
+  showExportLimitDialog,
+  showExportDialog,
+} from '@/modules/member/member-export-limit';
 import { MemberModel } from '../member-model';
 
 export default {
@@ -55,16 +59,15 @@ export default {
       const currentTenant = rootGetters['auth/currentTenant'];
 
       const tenantCsvExportCount = currentTenant.csvExportCount;
-      const planExportCountMax = getExportMax(
-        currentTenant.plan,
-      );
+      const planExportCountMax = getExportMax(currentTenant.plan);
 
       await showExportDialog({
         tenantCsvExportCount,
         planExportCountMax,
-        badgeContent: selected || count
-          ? pluralize('member', count || getters.selectedRows.length, true)
-          : `View: ${getters.activeView.label}`,
+        badgeContent:
+          selected || count
+            ? pluralize('member', count || getters.selectedRows.length, true)
+            : `View: ${getters.activeView.label}`,
       });
 
       await MemberService.export(
@@ -79,18 +82,14 @@ export default {
         root: true,
       });
 
-      Message.success(
-        'CSV download link will be sent to your e-mail',
-      );
+      Message.success('CSV download link will be sent to your e-mail');
     } catch (error) {
       commit('EXPORT_ERROR');
       console.error(error);
 
       if (error.response?.status === 403) {
         const currentTenant = rootGetters['auth/currentTenant'];
-        const planExportCountMax = getExportMax(
-          currentTenant.plan,
-        );
+        const planExportCountMax = getExportMax(currentTenant.plan);
 
         showExportLimitDialog({ planExportCountMax });
       } else if (error !== 'cancel') {
@@ -124,19 +123,14 @@ export default {
       });
 
       Message.success(
-        `Member${
-          selectedRows.length > 1 ? 's' : ''
-        } updated successfully`,
+        `Member${selectedRows.length > 1 ? 's' : ''} updated successfully`,
       );
     } catch (error) {
       Errors.handle(error);
     }
   },
 
-  async doDestroyCustomAttributes(
-    { commit, dispatch },
-    id,
-  ) {
+  async doDestroyCustomAttributes({ commit, dispatch }, id) {
     try {
       commit('DESTROY_CUSTOM_ATTRIBUTES_STARTED');
       const response = await MemberService.destroyCustomAttribute(id);
@@ -149,10 +143,7 @@ export default {
     }
   },
 
-  async doUpdateCustomAttributes(
-    { commit, dispatch },
-    { id, data },
-  ) {
+  async doUpdateCustomAttributes({ commit, dispatch }, { id, data }) {
     try {
       commit('UPDATE_CUSTOM_ATTRIBUTES_STARTED');
       const response = await MemberService.updateCustomAttribute(id, data);
@@ -176,10 +167,7 @@ export default {
     }
   },
 
-  async doCreateCustomAttributes(
-    { commit, dispatch },
-    values,
-  ) {
+  async doCreateCustomAttributes({ commit, dispatch }, values) {
     try {
       commit('CREATE_ATTRIBUTES_STARTED');
       const response = await MemberService.createCustomAttributes(values);
@@ -194,17 +182,12 @@ export default {
       }
       commit('CREATE_ATTRIBUTES_ERROR');
 
-      Message.error(
-        i18n('entities.member.attributes.error'),
-      );
+      Message.error(i18n('entities.member.attributes.error'));
     }
     return null;
   },
 
-  async doMerge(
-    { commit },
-    { memberToKeep, memberToMerge },
-  ) {
+  async doMerge({ commit }, { memberToKeep, memberToMerge }) {
     try {
       commit('MERGE_STARTED', {
         memberToKeep,
@@ -245,12 +228,10 @@ export default {
       });
       const payload = members.reduce((acc, item) => {
         const memberToUpdate = { ...item };
-        const tagsToKeep = item.tags.filter((tag) => (
-          tagsInCommon.filter((t) => t.id === tag.id)
-            .length === 0
-            && tagsToSave.filter((t) => t.id === tag.id)
-              .length === 0
-        ));
+        const tagsToKeep = item.tags.filter(
+          (tag) => tagsInCommon.filter((t) => t.id === tag.id).length === 0
+            && tagsToSave.filter((t) => t.id === tag.id).length === 0,
+        );
 
         memberToUpdate.tags = [...tagsToKeep, ...tagsToSave];
         acc.push(
@@ -261,13 +242,8 @@ export default {
         );
         return acc;
       }, []);
-      const updatedMembers = await MemberService.updateBulk(
-        payload,
-      );
-      commit(
-        'BULK_UPDATE_MEMBERS_TAGS_SUCCESS',
-        updatedMembers,
-      );
+      const updatedMembers = await MemberService.updateBulk(payload);
+      commit('BULK_UPDATE_MEMBERS_TAGS_SUCCESS', updatedMembers);
     } catch (error) {
       Errors.handle(error);
       commit('BULK_UPDATE_MEMBERS_TAGS_ERROR');
@@ -278,9 +254,7 @@ export default {
     try {
       const currentTenant = rootGetters['auth/currentTenant'];
 
-      const planEnrichmentCountMax = getEnrichmentMax(
-        currentTenant.plan,
-      );
+      const planEnrichmentCountMax = getEnrichmentMax(currentTenant.plan);
 
       // Check if it has reached enrichment maximum
       // If so, show dialog to upgrade plan
@@ -306,8 +280,7 @@ export default {
 
       // Show enrichment success message
       showEnrichmentSuccessMessage({
-        memberEnrichmentCount:
-          updatedTenant.memberEnrichmentCount,
+        memberEnrichmentCount: updatedTenant.memberEnrichmentCount,
         planEnrichmentCountMax,
         plan: currentTenant.plan,
         isBulk: false,
@@ -336,16 +309,13 @@ export default {
       const currentTenant = rootGetters['auth/currentTenant'];
 
       const { memberEnrichmentCount } = currentTenant;
-      const planEnrichmentCountMax = getEnrichmentMax(
-        currentTenant.plan,
-      );
+      const planEnrichmentCountMax = getEnrichmentMax(currentTenant.plan);
 
       // Check if it is trying to enrich more members than
       // the number available for the current tenant plan
       if (
         checkEnrichmentPlan({
-          enrichmentCount:
-            memberEnrichmentCount + ids.length,
+          enrichmentCount: memberEnrichmentCount + ids.length,
           planEnrichmentCountMax,
         })
       ) {
@@ -358,10 +328,15 @@ export default {
         return;
       }
 
-      // Show enrichment loading message
-      showEnrichmentLoadingMessage({ isBulk: true });
-
-      await MemberService.enrichMemberBulk(ids);
+      if (ids.length === 1) {
+        // showEnrichmentLoadingMessage({ isBulk: false });
+        console.log('here');
+        await MemberService.enrichMember(ids[0]);
+      } else {
+        // Show enrichment loading message
+        showEnrichmentLoadingMessage({ isBulk: true });
+        await MemberService.enrichMemberBulk(ids);
+      }
 
       await dispatch('doFetchCustomAttributes');
     } catch (error) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bef1d58</samp>

This pull request improves the code style and adds a new feature to the member store module. It formats the code in `actions.js` to follow consistent conventions and handle edge cases. It also enables the `doEnrichMemberBulk` action to enrich a single member if the input array has only one element.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bef1d58</samp>

> _Sing, O Muse, of the code that was polished and refined_
> _By the skillful developer, who sought to align_
> _The style and the syntax of `actions.js`_
> _And make it more pleasing to human and god._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bef1d58</samp>

*  Add conditional logic to handle single member enrichment ([link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L361-R340))
*  Format import statement and object properties for readability and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L16-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L58-R70), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L82-R85), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L91-R92), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L127-R126), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L309-R283), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L347-R318))
*  Remove extra line breaks after function calls for readability and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L136-R133), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L152-R146), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L179-R170), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L197-R190), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L264-R246), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L281-R257), [link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L339-R312))
*  Break long filter condition into multiple lines for readability and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/937/files?diff=unified&w=0#diff-11e9ed0fba3fba017067eab22849c3df888bee08581e04ad53adbe1c75f72a16L248-R234))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
