### PR TITLE
fix member display name issue

### DIFF
--- a/frontend/src/modules/member/components/member-display-name.vue
+++ b/frontend/src/modules/member/components/member-display-name.vue
@@ -1,14 +1,14 @@
 <template>
-  <div>
+  <div style="display: flex">
     <component
       :is="customComponent"
       :class="`member-display-name ${customClass}`"
       :to="
         withLink
           ? {
-            name: 'memberView',
-            params: { id: member.id },
-          }
+              name: 'memberView',
+              params: { id: member.id },
+            }
           : null
       "
     >
@@ -19,8 +19,8 @@
 </template>
 
 <script setup>
-import { defineProps } from 'vue';
-import AppMemberBadge from '@/modules/member/components/member-badge.vue';
+import { defineProps } from "vue";
+import AppMemberBadge from "@/modules/member/components/member-badge.vue";
 
 const props = defineProps({
   member: {
@@ -42,13 +42,11 @@ const props = defineProps({
   },
 });
 
-const customComponent = props.withLink
-  ? 'router-link'
-  : 'span';
+const customComponent = props.withLink ? "router-link" : "span";
 </script>
 
 <script>
 export default {
-  name: 'AppMemberDisplayName',
+  name: "AppMemberDisplayName",
 };
 </script>


### PR DESCRIPTION
- add display flex on the wrapper for badge and name

# Changes proposed ✍️

### What
This solves the issue #920 

<img width="709" alt="Screenshot 2023-06-02 at 7 54 12 PM" src="https://github.com/CrowdDotDev/crowd.dev/assets/97662335/030a2b1d-a101-4b15-8183-0baec71f81d8">

​
### Why


### How
Add style="display: flex" to the div wrapping the name and badge component

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
