### PR TITLE
Check null sentiments when calculating average sentiment

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -2333,12 +2333,12 @@ where m."deletedAt" is null
       output.activityCount > 0
         ? Math.round(
             (output.activities.reduce((acc, i) => {
-              if ('sentiment' in i.sentiment) {
+              if (i.sentiment && 'sentiment' in i.sentiment) {
                 acc += i.sentiment.sentiment
               }
               return acc
             }, 0) /
-              output.activities.filter((i) => 'sentiment' in i.sentiment).length) *
+              output.activities.filter((i) => i.sentiment && 'sentiment' in i.sentiment).length) *
               100,
           ) / 100
         : 0


### PR DESCRIPTION
# Changes proposed ✍️
- When sentiment is null (possibly can happen with the new integration framework, some LinkedIn integration had null sentiment) member findById was throwing an error - Now we ignore null sentiments from the calculation.

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09ec5c1</samp>

Fixed a potential bug in `memberRepository.ts` that could cause an error when calculating the sentiment score of a member. Added a null check for `i.sentiment` before accessing its `sentiment` property.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 09ec5c1</samp>

> _`i.sentiment` check_
> _avoids error in winter_
> _calm sentiment score_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 09ec5c1</samp>

*  Add a null check for `i.sentiment` before accessing its `sentiment` property to avoid errors when calculating the average sentiment score of a member's activities ([link](https://github.com/CrowdDotDev/crowd.dev/pull/943/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL2336-R2341)) in `memberRepository.ts`

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [x] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
