### PR TITLE
bugfix for pg promise named parameters

### DIFF
--- a/services/apps/data_sink_worker/package.json
+++ b/services/apps/data_sink_worker/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "format-check": "prettier --check .",
     "tsc-check": "tsc --noEmit",
-    "script:restart-failed-results": "node -r tsconfig-paths/register -r ts-node/register src/bin/restart-failed-results.ts --transpile-only"
+    "script:restart-failed-results": "node -r tsconfig-paths/register -r ts-node/register src/bin/restart-failed-results.ts --transpile-only",
+    "script:restart-result": "node -r tsconfig-paths/register -r ts-node/register src/bin/restart-result.ts --transpile-only"
   },
   "dependencies": {
     "@crowd/common": "file:../../libs/common",

--- a/services/apps/data_sink_worker/src/bin/restart-result.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-result.ts
@@ -1,0 +1,39 @@
+import { DB_CONFIG, SQS_CONFIG } from '@/conf'
+import DataSinkRepository from '@/repo/dataSink.repo'
+import { DbStore, getDbConnection } from '@crowd/database'
+import { getServiceLogger } from '@crowd/logging'
+import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(3)
+
+if (processArguments.length !== 1) {
+  log.error('Expected 1 argument: resultId')
+  process.exit(1)
+}
+
+const resultId = processArguments[0]
+
+setImmediate(async () => {
+  const sqsClient = getSqsClient(SQS_CONFIG())
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
+  await emitter.init()
+
+  const dbConnection = getDbConnection(DB_CONFIG())
+  const store = new DbStore(log, dbConnection)
+
+  const repo = new DataSinkRepository(store, log)
+
+  const result = await repo.getResultInfo(resultId)
+  if (!result) {
+    log.error(`Result ${resultId} not found!`)
+    process.exit(1)
+  } else {
+    await emitter.sendMessage(
+      `results-${result.tenantId}-${result.platform}`,
+      new ProcessIntegrationResultQueueMessage(result.id),
+    )
+  }
+})

--- a/services/libs/database/src/repoBase.ts
+++ b/services/libs/database/src/repoBase.ts
@@ -169,13 +169,14 @@ export abstract class RepositoryBase<TRepo extends RepositoryBase<TRepo>> extend
     }
   }
 
-  public static escapeString(str: string): string {
+  public escapeString(str: string): string {
     // need to escape $(), $<>, $[] and $// and prepend with another dollar sign
     // to avoid pg-promise named parameter parsing
     return str
       .replace(/(\$[{])/g, '$$$$1') // Replace ${ with $${ to escape it
       .replace(/(\$[[(])/g, '$$$$1') // Replace $[ with $$[ to escape it
       .replace(/(\$[<])/g, '$$$$1') // Replace $< with $$< to escape it
-      .replace(/(\$[\\/])/g, '$$$$1') // Replace $/ with $$/ to escape it;
+      .replace(/(\$[\\/])/g, '$$$$1') // Replace $/ with $$/ to escape it
+      .replace(/(\$[(])/g, '$$$$1') // Replace $( with $$(
   }
 }

--- a/services/libs/database/src/repoBase.ts
+++ b/services/libs/database/src/repoBase.ts
@@ -169,7 +169,7 @@ export abstract class RepositoryBase<TRepo extends RepositoryBase<TRepo>> extend
     }
   }
 
-  public escapeString(str: string): string {
+  public static escapeString(str: string): string {
     // need to escape $(), $<>, $[] and $// and prepend with another dollar sign
     // to avoid pg-promise named parameter parsing
     return str


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c03e3b9</samp>

Improved database security and added a script to restart results in `data_sink_worker` service. The changes enhance the reliability and usability of the data sink worker and the database layer.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c03e3b9</samp>

> _To restart a result by ID_
> _A new script was added, you see_
> _It helps with the workers_
> _Who process the lurkers_
> _From the crowd data sink service, gee_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c03e3b9</samp>

*  Add a script to restart a single result by its ID in the data sink worker service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/944/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5L17-R18))
*  Escape string values that contain special characters in the database repository base class to prevent SQL injection and syntax errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/944/files?diff=unified&w=0#diff-b2c2516b97d723612e391a1fcbb350a086f339b2327ae57b1427f31c1739387eL147-R155), [link](https://github.com/CrowdDotDev/crowd.dev/pull/944/files?diff=unified&w=0#diff-b2c2516b97d723612e391a1fcbb350a086f339b2327ae57b1427f31c1739387eR171-R180))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
