### PR TITLE
Member filters connect

### DIFF
--- a/backend/src/database/repositories/tagRepository.ts
+++ b/backend/src/database/repositories/tagRepository.ts
@@ -198,6 +198,13 @@ class TagRepository {
           id: filter.id,
         })
       }
+      if (filter.ids) {
+        advancedFilter.and.push({
+          or: filter.ids.map((id) => ({
+            id,
+          }))
+        })
+      }
 
       if (filter.name) {
         advancedFilter.and.push({

--- a/backend/src/database/repositories/tagRepository.ts
+++ b/backend/src/database/repositories/tagRepository.ts
@@ -202,7 +202,7 @@ class TagRepository {
         advancedFilter.and.push({
           or: filter.ids.map((id) => ({
             id,
-          }))
+          })),
         })
       }
 

--- a/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
@@ -148,7 +148,7 @@ export default class OrganizationEnrichmentService extends LoggingBase {
       ) {
         acc[platform] = {
           handle,
-          [platform === PlatformType.TWITTER? "site": "url"]: social,
+          [platform === PlatformType.TWITTER ? 'site' : 'url']: social,
         }
       }
       return acc

--- a/frontend/src/modules/auth/auth-socket.js
+++ b/frontend/src/modules/auth/auth-socket.js
@@ -112,7 +112,7 @@ export const connectSocket = (token) => {
       if (currentTenant.value.id === parsed.tenantId) {
         // Refresh list page
         const { fetchMembers } = useMemberStore();
-        await fetchMembers(null, true);
+        await fetchMembers({ reload: true });
       }
     }
   });

--- a/frontend/src/modules/auth/auth-socket.js
+++ b/frontend/src/modules/auth/auth-socket.js
@@ -8,6 +8,7 @@ import {
   showEnrichmentSuccessMessage,
   getEnrichmentMax,
 } from '@/modules/member/member-enrichment';
+import { useMemberStore } from '@/modules/member/store/pinia';
 
 let socketIoClient;
 
@@ -110,9 +111,8 @@ export const connectSocket = (token) => {
       // Update members list if tenant hasn't changed
       if (currentTenant.value.id === parsed.tenantId) {
         // Refresh list page
-        await store.dispatch('member/doFetch', {
-          keepPagination: true,
-        });
+        const { fetchMembers } = useMemberStore();
+        await fetchMembers(null, true);
       }
     }
   });

--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -41,6 +41,7 @@
             :total="totalMembers"
             :current-page="pagination.page"
             :has-page-counter="false"
+            :export="doExport"
             module="member"
             position="top"
             @change-sorter="doChangePaginationPageSize"
@@ -406,6 +407,7 @@ import { formatDateToTimeAgo } from '@/utils/date';
 import { formatNumberToCompact, formatNumber } from '@/utils/number';
 import { useMemberStore } from '@/modules/member/store/pinia';
 import { storeToRefs } from 'pinia';
+import { MemberService } from '@/modules/member/member-service';
 import AppMemberBadge from '../member-badge.vue';
 import AppMemberDropdown from '../member-dropdown.vue';
 import AppMemberIdentities from '../member-identities.vue';
@@ -441,7 +443,7 @@ const props = defineProps({
 
 const memberStore = useMemberStore();
 const {
-  members, totalMembers, filters, selectedMembers,
+  members, totalMembers, filters, selectedMembers, savedFilterBody,
 } = storeToRefs(memberStore);
 
 const defaultSort = computed(() => ({
@@ -605,6 +607,14 @@ watch(table, (newValue) => {
     tableHeaderRef.value.addEventListener('scroll', onTableHeaderScroll);
   }
 });
+
+const doExport = () => MemberService.export(
+  savedFilterBody.value.filter,
+  savedFilterBody.value.orderBy,
+  0,
+  null,
+  false,
+);
 
 onMounted(async () => {
   if (store.state.integration.count === 0) {

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -209,7 +209,7 @@ const handleMergeMembers = () => {
   return MemberService.merge(firstMember, secondMember)
     .then(() => {
       Message.success('Members merged successfuly');
-      fetchMembers({}, true);
+      fetchMembers({ reload: true });
     })
     .catch(() => {
       Message.error('Error merging members');
@@ -229,7 +229,7 @@ const doDestroyAllWithConfirm = () => ConfirmDialog({
     const ids = selectedMembers.value.map((m) => m.id);
     return MemberService.destroyAll(ids);
   })
-  .then(() => fetchMembers(null, true));
+  .then(() => fetchMembers({ reload: true }));
 
 const handleDoExport = async () => {
   const ids = selectedMembers.value.map((i) => i.id);
@@ -299,7 +299,7 @@ const doMarkAsTeamMember = (value) => {
     },
   })))
     .then(() => {
-      fetchMembers(null, true);
+      fetchMembers({ reload: true });
       Message.success(
         `Member${
           selectedMembers.value.length > 1 ? 's' : ''

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    v-if="selectedRows.length > 0"
+    v-if="selectedMembers.length > 0"
     class="app-list-table-bulk-actions"
   >
     <span class="block text-sm font-semibold mr-4">
-      {{ pluralize('member', selectedRows.length, true) }}
+      {{ pluralize('member', selectedMembers.length, true) }}
       selected</span>
     <el-dropdown trigger="click" @command="handleCommand">
       <button type="button" class="btn btn--bordered btn--sm">
@@ -17,7 +17,7 @@
           Export to CSV
         </el-dropdown-item>
         <el-dropdown-item
-          v-if="selectedRows.length === 2"
+          v-if="selectedMembers.length === 2"
           :command="{ action: 'mergeMembers' }"
           :disabled="isEditLockedForSampleData"
         >
@@ -97,261 +97,326 @@
 
     <app-member-list-bulk-update-tags
       v-model="bulkTagsUpdateVisible"
-      :loading="loading"
-      :selected-rows="selectedRows"
+      :selected-rows="selectedMembers"
     />
   </div>
 </template>
 
-<script>
-import { mapGetters, mapActions, mapState } from 'vuex';
-import pluralize from 'pluralize';
+<script setup>
+
+import { computed, ref } from 'vue';
 import { MemberPermissions } from '@/modules/member/member-permissions';
-import ConfirmDialog from '@/shared/dialog/confirm-dialog';
-import AppSvg from '@/shared/svg/svg.vue';
+import { useMemberStore } from '@/modules/member/store/pinia';
+import { storeToRefs } from 'pinia';
+import { mapActions, mapGetters } from '@/shared/vuex/vuex.helpers';
 import { MemberService } from '@/modules/member/member-service';
+import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import Message from '@/shared/message/message';
-import AppMemberListBulkUpdateTags from '@/modules/member/components/list/member-list-bulk-update-tags.vue';
+import pluralize from 'pluralize';
+import { getExportMax, showExportDialog, showExportLimitDialog } from '@/modules/member/member-export-limit';
+import {
+  checkEnrichmentLimit,
+  checkEnrichmentPlan,
+  getEnrichmentMax,
+  showEnrichmentLoadingMessage,
+} from '@/modules/member/member-enrichment';
 
-export default {
-  name: 'AppMemberListToolbar',
+const { currentUser, currentTenant } = mapGetters('auth');
+const { doRefreshCurrentUser } = mapActions('auth');
+const memberStore = useMemberStore();
+const { selectedMembers, filters } = storeToRefs(memberStore);
+const { fetchMembers, getMemberCustomAttributes } = memberStore;
 
-  components: {
-    AppMemberListBulkUpdateTags,
-    AppSvg,
-  },
+const bulkTagsUpdateVisible = ref(false);
 
-  data() {
+const isReadOnly = computed(() => (
+  new MemberPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).edit === false
+));
+
+const isEditLockedForSampleData = computed(() => (
+  new MemberPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).editLockedForSampleData
+));
+
+const isDeleteLockedForSampleData = computed(() => (
+  new MemberPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).destroyLockedForSampleData
+));
+
+const elegibleEnrichmentMembersIds = computed(() => selectedMembers.value
+  .filter(
+    (r) => r.username?.github?.length || r.emails?.length,
+  )
+  .map((item) => item.id));
+
+const enrichedMembers = computed(() => selectedMembers.value.filter((r) => r.lastEnriched)
+  .length);
+
+const enrichmentLabel = computed(() => {
+  if (
+    enrichedMembers.value
+    && enrichedMembers.value
+    === elegibleEnrichmentMembersIds.value.length
+  ) {
+    return `Re-enrich ${pluralize(
+      'member',
+      selectedIds.value.length,
+      false,
+    )}`;
+  }
+
+  return `Enrich ${pluralize(
+    'member',
+    selectedIds.value.length,
+    false,
+  )}`;
+});
+
+const selectedIds = computed(() => selectedMembers.value.map((item) => item.id));
+
+const markAsTeamMemberOptions = computed(() => {
+  const isTeamView = filters.value.settings.teamMember === 'filter';
+  const membersCopy = pluralize(
+    'member',
+    selectedMembers.value.length,
+    false,
+  );
+
+  if (isTeamView) {
     return {
-      bulkTagsUpdateVisible: false,
+      icon: 'ri-bookmark-2-line',
+      copy: `Unmark as team ${membersCopy}`,
+      value: false,
     };
-  },
+  }
 
-  computed: {
-    ...mapState({
-      loading: (state) => state.member.list.loading,
-    }),
-    ...mapGetters({
-      currentUser: 'auth/currentUser',
-      currentTenant: 'auth/currentTenant',
-      selectedRows: 'member/selectedRows',
-      activeView: 'member/activeView',
-    }),
-    isReadOnly() {
-      return (
-        new MemberPermissions(
-          this.currentTenant,
-          this.currentUser,
-        ).edit === false
+  return {
+    icon: 'ri-bookmark-line',
+    copy: `Mark as team ${membersCopy}`,
+    value: true,
+  };
+});
+
+const handleMergeMembers = () => {
+  const [firstMember, secondMember] = this.selectedRows;
+  return MemberService.merge(firstMember, secondMember)
+    .then(() => {
+      Message.success('Members merged successfuly');
+      fetchMembers({}, true);
+    })
+    .catch(() => {
+      Message.error('Error merging members');
+    });
+};
+
+const doDestroyAllWithConfirm = () => ConfirmDialog({
+  type: 'danger',
+  title: 'Delete members',
+  message:
+        "Are you sure you want to proceed? You can't undo this action",
+  confirmButtonText: 'Confirm',
+  cancelButtonText: 'Cancel',
+  icon: 'ri-delete-bin-line',
+})
+  .then(() => {
+    const ids = selectedMembers.value.map((m) => m.id);
+    return MemberService.destroyAll(ids);
+  })
+  .then(() => fetchMembers(null, true));
+
+const handleDoExport = async () => {
+  const ids = selectedMembers.value.map((i) => i.id);
+
+  const filter = {
+    id: {
+      in: ids,
+    },
+  };
+
+  try {
+    const tenantCsvExportCount = currentTenant.value.csvExportCount;
+    const planExportCountMax = getExportMax(
+      currentTenant.value.plan,
+    );
+
+    await showExportDialog({
+      tenantCsvExportCount,
+      planExportCountMax,
+      badgeContent: pluralize('member', selectedMembers.value.length, true),
+    });
+
+    await MemberService.export(
+      filter,
+      `${filters.value.order.prop}_${filters.value.order.order === 'descending' ? 'DESC' : 'ASC'}`,
+      0,
+      null,
+      false,
+    );
+
+    await doRefreshCurrentUser(null);
+
+    Message.success(
+      'CSV download link will be sent to your e-mail',
+    );
+  } catch (error) {
+    console.error(error);
+
+    if (error.response?.status === 403) {
+      const planExportCountMax = getExportMax(
+        currentTenant.value.plan,
       );
-    },
-    isEditLockedForSampleData() {
-      return new MemberPermissions(
-        this.currentTenant,
-        this.currentUser,
-      ).editLockedForSampleData;
-    },
-    isDeleteLockedForSampleData() {
-      return new MemberPermissions(
-        this.currentTenant,
-        this.currentUser,
-      ).destroyLockedForSampleData;
-    },
-    elegibleEnrichmentMembersIds() {
-      return this.selectedRows
-        .filter(
-          (r) => r.username?.github?.length || r.emails?.length,
-        )
-        .map((item) => item.id);
-    },
-    enrichedMembers() {
-      return this.selectedRows.filter((r) => r.lastEnriched)
-        .length;
-    },
-    enrichmentLabel() {
-      if (
-        this.enrichedMembers
-        && this.enrichedMembers
-          === this.elegibleEnrichmentMembersIds.length
-      ) {
-        return `Re-enrich ${pluralize(
-          'member',
-          this.selectedIds.length,
-          false,
-        )}`;
-      }
 
-      return `Enrich ${pluralize(
-        'member',
-        this.selectedIds.length,
-        false,
-      )}`;
-    },
-    selectedIds() {
-      return this.selectedRows.map((item) => item.id);
-    },
-    markAsTeamMemberOptions() {
-      const isTeamView = this.activeView.id === 'team';
-      const membersCopy = pluralize(
-        'member',
-        this.selectedRows.length,
-        false,
+      showExportLimitDialog({ planExportCountMax });
+    } else if (error !== 'cancel') {
+      Message.error(
+        'An error has occured while trying to export the CSV file. Please try again',
+        {
+          title: 'CSV Export failed',
+        },
       );
+    }
+  }
+};
 
-      if (isTeamView) {
-        return {
-          icon: 'ri-bookmark-2-line',
-          copy: `Unmark as team ${membersCopy}`,
-          value: false,
-        };
-      }
+const handleAddTags = async () => {
+  bulkTagsUpdateVisible.value = true;
+};
 
-      return {
-        icon: 'ri-bookmark-line',
-        copy: `Mark as team ${membersCopy}`,
-        value: true,
-      };
+const doMarkAsTeamMember = (value) => {
+  Promise.all(selectedMembers.value.map((member) => MemberService.update(member.id, {
+    attributes: {
+      ...member.attributes,
+      isTeamMember: {
+        default: value,
+      },
     },
-  },
+  })))
+    .then(() => {
+      fetchMembers(null, true);
+      Message.success(
+        `Member${
+          selectedMembers.value.length > 1 ? 's' : ''
+        } updated successfully`,
+      );
+    });
+};
 
-  methods: {
-    ...mapActions({
-      doExport: 'member/doExport',
-      doMarkAsTeamMember: 'member/doMarkAsTeamMember',
-      doDestroyAll: 'member/doDestroyAll',
-      doBulkEnrich: 'member/doBulkEnrich',
-      doFetch: 'member/doFetch',
-    }),
+const handleCommand = async (command) => {
+  if (command.action === 'markAsTeamMember') {
+    await doMarkAsTeamMember(command.value);
+  } else if (command.action === 'export') {
+    await handleDoExport();
+  } else if (command.action === 'mergeMembers') {
+    await handleMergeMembers();
+  } else if (command.action === 'editTags') {
+    await handleAddTags();
+  } else if (command.action === 'destroyAll') {
+    await doDestroyAllWithConfirm();
+  } else if (command.action === 'enrichMember') {
+    const enrichments = elegibleEnrichmentMembersIds.value.length;
+    let doEnrich = false;
+    let reEnrichmentMessage = null;
 
-    async handleCommand(command) {
-      if (command.action === 'markAsTeamMember') {
-        await this.doMarkAsTeamMember(command.value);
-      } else if (command.action === 'export') {
-        await this.handleDoExport();
-      } else if (command.action === 'mergeMembers') {
-        await this.handleMergeMembers();
-      } else if (command.action === 'editTags') {
-        await this.handleAddTags();
-      } else if (command.action === 'destroyAll') {
-        await this.doDestroyAllWithConfirm();
-      } else if (command.action === 'enrichMember') {
-        const enrichments = this.elegibleEnrichmentMembersIds.length;
-        let doEnrich = false;
-        let reEnrichmentMessage = null;
-
-        if (this.enrichedMembers) {
-          reEnrichmentMessage = this.enrichedMembers === 1
-            ? 'You selected 1 member that was already enriched. If you proceed, this member will be re-enriched and counted towards your quota.'
-            : `You selected ${this.enrichedMembers} members that were already enriched. If you proceed,
+    if (enrichedMembers.value) {
+      reEnrichmentMessage = enrichedMembers.value === 1
+        ? 'You selected 1 member that was already enriched. If you proceed, this member will be re-enriched and counted towards your quota.'
+        : `You selected ${enrichedMembers.value} members that were already enriched. If you proceed,
             these members will be re-enriched and counted towards your quota.`;
-        }
+    }
 
-        // All members are elegible for enrichment
-        if (enrichments === this.selectedIds.length) {
-          // If there are already enriched members, show a warning dialog
-          if (this.enrichedMembers) {
-            try {
-              await ConfirmDialog({
-                type: 'warning',
-                title: 'Some members were already enriched',
-                message: reEnrichmentMessage,
-                confirmButtonText: `Proceed with enrichment (${pluralize(
-                  'member',
-                  enrichments,
-                  true,
-                )})`,
-                cancelButtonText: 'Cancel',
-                icon: 'ri-alert-line',
-              });
+    // All members are elegible for enrichment
+    if (enrichments === selectedIds.value.length) {
+      if (!enrichedMembers.value) {
+        doEnrich = true;
+      } else {
+        try {
+          await ConfirmDialog({
+            type: 'warning',
+            title: 'Some members were already enriched',
+            message: reEnrichmentMessage,
+            confirmButtonText: `Proceed with enrichment (${pluralize(
+              'member',
+              enrichments,
+              true,
+            )})`,
+            cancelButtonText: 'Cancel',
+            icon: 'ri-alert-line',
+          });
 
-              doEnrich = true;
-            } catch (error) {
-              // no
-            }
-          } else {
-            doEnrich = true;
-          }
-          // Only a few members are elegible for enrichment
-        } else {
-          try {
-            await ConfirmDialog({
-              type: 'warning',
-              title:
-                'Some members lack an associated GitHub profile or Email',
-              message:
-                'Member enrichment requires an associated GitHub profile or Email. If you proceed, only the members who fulfill '
-                + 'this requirement will be enriched and counted towards your quota.',
-              confirmButtonText: `Proceed with enrichment (${pluralize(
-                'member',
-                enrichments,
-                true,
-              )})`,
-              highlightedInfo: reEnrichmentMessage,
-              cancelButtonText: 'Cancel',
-              icon: 'ri-alert-line',
-            });
-
-            doEnrich = true;
-          } catch (error) {
-            // no
-          }
-        }
-
-        if (doEnrich) {
-          await this.doBulkEnrich(
-            this.elegibleEnrichmentMembersIds,
-          );
+          doEnrich = true;
+        } catch (error) {
+          console.error(error);
         }
       }
-    },
-
-    handleMergeMembers() {
-      const [firstMember, secondMember] = this.selectedRows;
-      MemberService.merge(firstMember, secondMember)
-        .then(() => {
-          Message.success('Members merged successfuly');
-          this.doFetch({
-            keepPagination: true,
-          });
-        })
-        .catch(() => {
-          Message.error('Error merging members');
-        });
-    },
-
-    async doDestroyAllWithConfirm() {
+    } else {
       try {
         await ConfirmDialog({
-          type: 'danger',
-          title: 'Delete members',
+          type: 'warning',
+          title:
+            'Some members lack an associated GitHub profile or Email',
           message:
-            "Are you sure you want to proceed? You can't undo this action",
-          confirmButtonText: 'Confirm',
+            'Member enrichment requires an associated GitHub profile or Email. If you proceed, only the members who fulfill '
+            + 'this requirement will be enriched and counted towards your quota.',
+          confirmButtonText: `Proceed with enrichment (${pluralize(
+            'member',
+            enrichments,
+            true,
+          )})`,
+          highlightedInfo: reEnrichmentMessage,
           cancelButtonText: 'Cancel',
-          icon: 'ri-delete-bin-line',
+          icon: 'ri-alert-line',
         });
 
-        await this.doDestroyAll(
-          this.selectedRows.map((item) => item.id),
-        );
+        doEnrich = true;
       } catch (error) {
         console.error(error);
       }
-    },
+    }
 
-    async handleDoExport() {
-      try {
-        await this.doExport({ selected: true });
-      } catch (error) {
-        console.error(error);
+    if (doEnrich) {
+      const { memberEnrichmentCount } = currentTenant.value;
+      const planEnrichmentCountMax = getEnrichmentMax(
+        currentTenant.value.plan,
+      );
+
+      // Check if it is trying to enrich more members than
+      // the number available for the current tenant plan
+      if (
+        checkEnrichmentPlan({
+          enrichmentCount:
+            memberEnrichmentCount + elegibleEnrichmentMembersIds.value.length,
+          planEnrichmentCountMax,
+        })
+      ) {
+        return;
       }
-    },
 
-    async handleAddTags() {
-      this.bulkTagsUpdateVisible = true;
-    },
+      // Check if it has reached enrichment maximum
+      // If so, show dialog to upgrade plan
+      if (checkEnrichmentLimit(planEnrichmentCountMax)) {
+        return;
+      }
 
-    pluralize,
-  },
+      // Show enrichment loading message
+      showEnrichmentLoadingMessage({ isBulk: true });
+
+      await MemberService.enrichMemberBulk(elegibleEnrichmentMembersIds.value);
+
+      await getMemberCustomAttributes();
+    }
+  }
+};
+</script>
+
+<script>
+export default {
+  name: 'AppMemberListToolbar',
 };
 </script>

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -265,10 +265,10 @@ export default {
             },
           },
         });
-        await this.fetchMembers(null, true);
+        await this.fetchMembers({ reload: true });
         Message.success('Member updated successfully');
         if (this.$route.name === 'member') {
-          await this.fetchMembers(null, true);
+          await this.fetchMembers({ reload: true });
         } else {
           this.doFind(command.member.id);
         }
@@ -281,10 +281,10 @@ export default {
             },
           },
         });
-        await this.fetchMembers(null, true);
+        await this.fetchMembers({ reload: true });
         Message.success('Member updated successfully');
         if (this.$route.name === 'member') {
-          await this.fetchMembers(null, true);
+          await this.fetchMembers({ reload: true });
         } else {
           this.doFind(command.member.id);
         }

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -166,12 +166,14 @@
 
 <script>
 import { mapActions, mapGetters } from 'vuex';
+import { mapActions as piniaMapActions } from 'pinia';
 import { MemberService } from '@/modules/member/member-service';
 import Message from '@/shared/message/message';
 import { MemberPermissions } from '@/modules/member/member-permissions';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import AppSvg from '@/shared/svg/svg.vue';
 import AppMemberMergeDialog from '@/modules/member/components/member-merge-dialog.vue';
+import { useMemberStore } from '@/modules/member/store/pinia';
 
 export default {
   name: 'AppMemberDropdown',
@@ -226,11 +228,11 @@ export default {
   },
   methods: {
     ...mapActions({
-      doFetch: 'member/doFetch',
       doFind: 'member/doFind',
       doDestroy: 'member/doDestroy',
       doEnrich: 'member/doEnrich',
     }),
+    ...piniaMapActions(useMemberStore, ['fetchMembers']),
     async doDestroyWithConfirm(id) {
       try {
         await ConfirmDialog({
@@ -263,16 +265,10 @@ export default {
             },
           },
         });
-        await this.doFetch({
-          filter: {},
-          keepPagination: false,
-        });
+        await this.fetchMembers(null, true);
         Message.success('Member updated successfully');
         if (this.$route.name === 'member') {
-          this.doFetch({
-            filter: {},
-            keepPagination: true,
-          });
+          await this.fetchMembers(null, true);
         } else {
           this.doFind(command.member.id);
         }
@@ -285,16 +281,10 @@ export default {
             },
           },
         });
-        await this.doFetch({
-          filter: {},
-          keepPagination: false,
-        });
+        await this.fetchMembers(null, true);
         Message.success('Member updated successfully');
         if (this.$route.name === 'member') {
-          this.doFetch({
-            filter: {},
-            keepPagination: true,
-          });
+          await this.fetchMembers(null, true);
         } else {
           this.doFind(command.member.id);
         }

--- a/frontend/src/modules/member/config/filters/activityType/ActivityTypeFilter.vue
+++ b/frontend/src/modules/member/config/filters/activityType/ActivityTypeFilter.vue
@@ -1,23 +1,53 @@
 <template>
-  <cr-select-filter v-model="form" :options="options" />
+  <cr-select-filter v-model="form" :config="props.config as SelectFilterConfig" :options="data.options || []" />
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits, computed } from 'vue';
+import {
+  defineProps, defineEmits, computed, watch,
+} from 'vue';
 import CrSelectFilter from '@/shared/modules/filters/components/filterTypes/SelectFilter.vue';
-import { SelectFilterOptionGroup } from '@/shared/modules/filters/types/filterTypes/SelectFilterConfig';
+import {
+  SelectFilterConfig,
+} from '@/shared/modules/filters/types/filterTypes/SelectFilterConfig';
+import { CustomFilterConfig } from '@/shared/modules/filters/types/filterTypes/CustomFilterConfig';
+import { useActivityTypeStore } from '@/modules/activity/store/type';
+import { storeToRefs } from 'pinia';
 
 const props = defineProps<{
   modelValue: string
+  config: CustomFilterConfig,
+  data: any,
 }>();
 
-const emit = defineEmits<{(e: 'update:modelValue', value: string)}>();
+const emit = defineEmits<{(e: 'update:modelValue', value: string), (e: 'update:data', value: any),}>();
+
+const activityTypeStore = useActivityTypeStore();
+const { types } = storeToRefs(activityTypeStore);
 
 const form = computed({
   get: () => props.modelValue,
   set: (value: string) => emit('update:modelValue', value),
 });
 
-// TODO: fetch activity types
-const options: SelectFilterOptionGroup[] = [];
+const data = computed({
+  get: () => props.data,
+  set: (value: any) => emit('update:data', value),
+});
+
+watch(() => types, (typesValue: any) => {
+  const platforms = {
+    ...typesValue.value.default,
+    ...typesValue.value.custom,
+  };
+
+  data.value.options = Object.entries(platforms).map(([platform, activityTypes]: [string, any]) => ({
+    label: platform.replaceAll(/[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`),
+    options: Object.entries(activityTypes).map(([activityType, activityTypeData]) => ({
+      label: activityTypeData.display.short,
+      value: `${platform}:${activityType}`,
+    })),
+  }));
+}, { immediate: true });
+
 </script>

--- a/frontend/src/modules/member/config/filters/activityType/config.ts
+++ b/frontend/src/modules/member/config/filters/activityType/config.ts
@@ -4,6 +4,7 @@ import ActivityTypeFilter from '@/modules/member/config/filters/activityType/Act
 import { SelectFilterOptions, SelectFilterValue } from '@/shared/modules/filters/types/filterTypes/SelectFilterConfig';
 import { queryUrlParserByType } from '@/shared/modules/filters/config/queryUrlParserByType';
 import { itemLabelRendererByType } from '@/shared/modules/filters/config/itemLabelRendererByType';
+import { apiFilterRendererByType } from '@/shared/modules/filters/config/apiFilterRendererByType';
 
 const activityType: CustomFilterConfig = {
   id: 'activityType',
@@ -15,13 +16,10 @@ const activityType: CustomFilterConfig = {
   },
   queryUrlParser: queryUrlParserByType[FilterConfigType.SELECT],
   itemLabelRenderer(value: SelectFilterValue, options: SelectFilterOptions, data: any): string {
-    console.log(value, options, data);
     return itemLabelRendererByType[FilterConfigType.SELECT]('Activity type', value, data);
   },
   apiFilterRenderer(value: SelectFilterValue): any[] {
-    console.log(value);
-    return [];
-    // return apiFilterRendererByType[FilterConfigType.SELECT]('activityTypes', value);
+    return apiFilterRendererByType[FilterConfigType.SELECT]('activityTypes', value);
   },
 };
 

--- a/frontend/src/modules/member/config/filters/activityType/config.ts
+++ b/frontend/src/modules/member/config/filters/activityType/config.ts
@@ -1,10 +1,9 @@
 import { FilterConfigType } from '@/shared/modules/filters/types/FilterConfig';
 import { CustomFilterConfig } from '@/shared/modules/filters/types/filterTypes/CustomFilterConfig';
-import ActivityTypeFilter from '@/modules/activity/config/filters/activityType/ActivityTypeFilter.vue';
+import ActivityTypeFilter from '@/modules/member/config/filters/activityType/ActivityTypeFilter.vue';
 import { SelectFilterOptions, SelectFilterValue } from '@/shared/modules/filters/types/filterTypes/SelectFilterConfig';
 import { queryUrlParserByType } from '@/shared/modules/filters/config/queryUrlParserByType';
 import { itemLabelRendererByType } from '@/shared/modules/filters/config/itemLabelRendererByType';
-import { apiFilterRendererByType } from '@/shared/modules/filters/config/apiFilterRendererByType';
 
 const activityType: CustomFilterConfig = {
   id: 'activityType',
@@ -15,11 +14,14 @@ const activityType: CustomFilterConfig = {
   options: {
   },
   queryUrlParser: queryUrlParserByType[FilterConfigType.SELECT],
-  itemLabelRenderer(value: SelectFilterValue, options: SelectFilterOptions): string {
-    return itemLabelRendererByType[FilterConfigType.SELECT]('Activity type', value, options);
+  itemLabelRenderer(value: SelectFilterValue, options: SelectFilterOptions, data: any): string {
+    console.log(value, options, data);
+    return itemLabelRendererByType[FilterConfigType.SELECT]('Activity type', value, data);
   },
   apiFilterRenderer(value: SelectFilterValue): any[] {
-    return apiFilterRendererByType[FilterConfigType.SELECT]('activityTypes', value);
+    console.log(value);
+    return [];
+    // return apiFilterRendererByType[FilterConfigType.SELECT]('activityTypes', value);
   },
 };
 

--- a/frontend/src/modules/member/config/filters/avgSentiment/config.ts
+++ b/frontend/src/modules/member/config/filters/avgSentiment/config.ts
@@ -5,7 +5,6 @@ import {
   MultiSelectFilterValue,
 } from '@/shared/modules/filters/types/filterTypes/MultiSelectFilterConfig';
 import { itemLabelRendererByType } from '@/shared/modules/filters/config/itemLabelRendererByType';
-import { apiFilterRendererByType } from '@/shared/modules/filters/config/apiFilterRendererByType';
 import options from './options';
 
 const avgSentiment: MultiSelectFilterConfig = {
@@ -19,8 +18,17 @@ const avgSentiment: MultiSelectFilterConfig = {
   itemLabelRenderer(value: MultiSelectFilterValue, options: MultiSelectFilterOptions): string {
     return itemLabelRendererByType[FilterConfigType.MULTISELECT]('Avg. sentiment', value, options);
   },
-  apiFilterRenderer(value: MultiSelectFilterValue): any[] {
-    return apiFilterRendererByType[FilterConfigType.MULTISELECT]('averageSentiment', value);
+  apiFilterRenderer({ value, include }: MultiSelectFilterValue): any[] {
+    const filter = {
+      or: [
+        ...(value.includes('positive') ? [{ averageSentiment: { gte: 67 } }] : []),
+        ...(value.includes('negative') ? [{ averageSentiment: { lt: 33 } }] : []),
+        ...(value.includes('neutral') ? [{ averageSentiment: { between: [33, 67] } }] : []),
+      ],
+    };
+    return [
+      (include ? filter : { not: filter }),
+    ];
   },
 };
 

--- a/frontend/src/modules/member/config/filters/engagementLevel/config.ts
+++ b/frontend/src/modules/member/config/filters/engagementLevel/config.ts
@@ -5,7 +5,6 @@ import {
   MultiSelectFilterValue,
 } from '@/shared/modules/filters/types/filterTypes/MultiSelectFilterConfig';
 import { itemLabelRendererByType } from '@/shared/modules/filters/config/itemLabelRendererByType';
-import { apiFilterRendererByType } from '@/shared/modules/filters/config/apiFilterRendererByType';
 import options from './options';
 
 const engagementLevel: MultiSelectFilterConfig = {
@@ -19,8 +18,21 @@ const engagementLevel: MultiSelectFilterConfig = {
   itemLabelRenderer(value: MultiSelectFilterValue, options: MultiSelectFilterOptions): string {
     return itemLabelRendererByType[FilterConfigType.MULTISELECT]('Engagement level', value, options);
   },
-  apiFilterRenderer(value: MultiSelectFilterValue): any[] {
-    return apiFilterRendererByType[FilterConfigType.MULTISELECT]('score', value);
+  apiFilterRenderer({ value, include }: MultiSelectFilterValue): any[] {
+    const filter = {
+      score: {
+        in: [
+          ...(value.includes('silent') ? [0, 1] : []),
+          ...(value.includes('quiet') ? [2, 3] : []),
+          ...(value.includes('engaged') ? [4, 5, 6] : []),
+          ...(value.includes('fan') ? [7, 8] : []),
+          ...(value.includes('ultra') ? [9, 10] : []),
+        ],
+      },
+    };
+    return [
+      (include ? filter : { not: filter }),
+    ];
   },
 };
 

--- a/frontend/src/modules/member/config/filters/tags/config.ts
+++ b/frontend/src/modules/member/config/filters/tags/config.ts
@@ -1,26 +1,38 @@
 import { FilterConfigType } from '@/shared/modules/filters/types/FilterConfig';
-import {
-  MultiSelectFilterConfig,
-  MultiSelectFilterOptions,
-  MultiSelectFilterValue,
-} from '@/shared/modules/filters/types/filterTypes/MultiSelectFilterConfig';
 import { itemLabelRendererByType } from '@/shared/modules/filters/config/itemLabelRendererByType';
-import { apiFilterRendererByType } from '@/shared/modules/filters/config/apiFilterRendererByType';
+import {
+  MultiSelectAsyncFilterConfig, MultiSelectAsyncFilterOptions,
+  MultiSelectAsyncFilterValue,
+} from '@/shared/modules/filters/types/filterTypes/MultiSelectAsyncFilterConfig';
+import { TagService } from '@/modules/tag/tag-service';
 
-const tags: MultiSelectFilterConfig = {
+const tags: MultiSelectAsyncFilterConfig = {
   id: 'tags',
   label: 'Tags',
   iconClass: 'ri-bookmark-line',
-  type: FilterConfigType.MULTISELECT,
+  type: FilterConfigType.MULTISELECT_ASYNC,
   options: {
-    // TODO: load this options remote
-    options: [],
+    remoteMethod: (query) => TagService.listAutocomplete(query, 10)
+      .then((data: any[]) => data.map((tag) => ({
+        label: tag.label,
+        value: tag.id,
+      }))),
+    remotePopulateItems: (ids: string[]) => TagService.list({
+      ids,
+    }, null, ids.length, 0)
+      .then(({ rows }: any) => rows.map((tag: any) => ({
+        label: tag.name,
+        value: tag.id,
+      }))),
   },
-  itemLabelRenderer(value: MultiSelectFilterValue, options: MultiSelectFilterOptions): string {
-    return itemLabelRendererByType[FilterConfigType.MULTISELECT]('Active on', value, options);
+  itemLabelRenderer(value: MultiSelectAsyncFilterValue, options: MultiSelectAsyncFilterOptions, data: any): string {
+    return itemLabelRendererByType[FilterConfigType.MULTISELECT_ASYNC]('Tags', value, options, data);
   },
-  apiFilterRenderer(value: MultiSelectFilterValue): any[] {
-    return apiFilterRendererByType[FilterConfigType.MULTISELECT]('tags', value);
+  apiFilterRenderer({ value, include }: MultiSelectAsyncFilterValue): any[] {
+    const filter = { tags: value };
+    return [
+      (include ? filter : { not: filter }),
+    ];
   },
 };
 

--- a/frontend/src/modules/member/config/saved-views/views/all-members.ts
+++ b/frontend/src/modules/member/config/saved-views/views/all-members.ts
@@ -7,7 +7,7 @@ const allMembers: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'createdBy',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/config/saved-views/views/influential.ts
+++ b/frontend/src/modules/member/config/saved-views/views/influential.ts
@@ -7,7 +7,7 @@ const influential: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'lastActivity',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/config/saved-views/views/most-engaged.ts
+++ b/frontend/src/modules/member/config/saved-views/views/most-engaged.ts
@@ -7,7 +7,7 @@ const mostEngaged: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'lastActivity',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/config/saved-views/views/new-and-active.ts
+++ b/frontend/src/modules/member/config/saved-views/views/new-and-active.ts
@@ -8,7 +8,7 @@ const newAndActive: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'createdBy',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/config/saved-views/views/slipping-away.ts
+++ b/frontend/src/modules/member/config/saved-views/views/slipping-away.ts
@@ -8,7 +8,7 @@ const slippingAway: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'lastActivity',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/config/saved-views/views/team-members.ts
+++ b/frontend/src/modules/member/config/saved-views/views/team-members.ts
@@ -7,7 +7,7 @@ const teamMembers: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'lastActivity',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {

--- a/frontend/src/modules/member/member-service.js
+++ b/frontend/src/modules/member/member-service.js
@@ -150,6 +150,30 @@ export class MemberService {
     return response.data;
   }
 
+  static async listMembers(
+    body,
+    countOnly = false,
+  ) {
+    const sampleTenant = AuthCurrentTenant.getSampleTenantData();
+    const tenantId = sampleTenant?.id || AuthCurrentTenant.get();
+
+    const response = await authAxios.post(
+      `/tenant/${tenantId}/member/query`,
+      {
+        ...body,
+        countOnly,
+      },
+      {
+        headers: {
+          'x-crowd-api-version': '1',
+          Authorization: sampleTenant?.token,
+        },
+      },
+    );
+
+    return response.data;
+  }
+
   static async listActive({
     platform,
     isTeamMember,

--- a/frontend/src/modules/member/pages/member-form-page.vue
+++ b/frontend/src/modules/member/pages/member-form-page.vue
@@ -121,6 +121,7 @@ import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import getCustomAttributes from '@/shared/fields/get-custom-attributes';
 import getAttributesModel from '@/shared/attributes/get-attributes-model';
 import getParsedAttributes from '@/shared/attributes/get-parsed-attributes';
+import { useMemberStore } from '@/modules/member/store/pinia';
 
 const LoaderIcon = h(
   'i',
@@ -137,6 +138,7 @@ const ArrowPrevIcon = h(
   [],
 );
 
+const { getMemberCustomAttributes } = useMemberStore();
 const router = useRouter();
 const route = useRoute();
 const store = useStore();
@@ -249,7 +251,7 @@ onBeforeRouteLeave((to) => {
 
 onMounted(async () => {
   // Fetch custom attributes on mount
-  await store.dispatch('member/doFetchCustomAttributes');
+  await getMemberCustomAttributes();
 
   if (isEditPage.value) {
     const { id } = route.params;

--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -63,7 +63,7 @@
       />
       <app-member-list-table
         :has-integrations="hasIntegrations"
-        :has-members="true"
+        :has-members="membersCount > 0"
         :is-page-loading="loading"
       />
     </div>
@@ -122,14 +122,10 @@ const fetchMembersToMergeCount = () => {
 const loading = ref(true);
 
 const doGetMembersCount = () => {
-  (MemberService.list(
-    {},
-    '',
-    1,
-    0,
-    false,
-    true,
-  ) as Promise<any>)
+  (MemberService.listMembers({
+    limit: 1,
+    offset: 0,
+  }, true) as Promise<any>)
     .then(({ count }) => {
       membersCount.value = count;
     });
@@ -152,11 +148,13 @@ const fetch = ({
 }: FilterQuery) => {
   loading.value = showLoading(filter, body);
   fetchMembers({
-    ...body,
-    filter,
-    offset,
-    limit,
-    orderBy,
+    body: {
+      ...body,
+      filter,
+      offset,
+      limit,
+      orderBy,
+    },
   })
     .finally(() => {
       loading.value = false;

--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -61,11 +61,11 @@
         :custom-config="customAttributes"
         @fetch="fetch($event)"
       />
-      <!--      <app-member-list-table-->
-      <!--        :has-integrations="hasIntegrations"-->
-      <!--        :has-members="hasMembers"-->
-      <!--        :is-page-loading="isPageLoading"-->
-      <!--      />-->
+      <app-member-list-table
+        :has-integrations="hasIntegrations"
+        :has-members="true"
+        :is-page-loading="loading"
+      />
     </div>
   </app-page-wrapper>
 </template>
@@ -81,15 +81,13 @@ import { MemberPermissions } from '@/modules/member/member-permissions';
 import { mapGetters } from '@/shared/vuex/vuex.helpers';
 import { FilterQuery } from '@/shared/modules/filters/types/FilterQuery';
 import CrSavedViews from '@/shared/modules/saved-views/components/SavedViews.vue';
+import AppMemberListTable from '@/modules/member/components/list/member-list-table.vue';
 import { memberFilters, memberSearchFilter } from '../config/filters/main';
 import { memberSavedViews, memberViews } from '../config/saved-views/main';
-// import MemberListFilter from '@/modules/member/components/list/member-list-filter.vue';
-// import MemberListTable from '@/modules/member/components/list/member-list-table.vue';
-// import MemberListTabs from '@/modules/member/components/list/member-list-tabs.vue';
 
 const memberStore = useMemberStore();
-const { getMemberCustomAttributes } = memberStore;
-const { filters, customAttributes } = storeToRefs(memberStore);
+const { getMemberCustomAttributes, fetchMembers } = memberStore;
+const { filters, customAttributes, savedFilterBody } = storeToRefs(memberStore);
 
 const membersCount = ref(0);
 const membersToMergeCount = ref(0);
@@ -116,10 +114,12 @@ const isEditLockedForSampleData = computed(() => new MemberPermissions(
 
 const fetchMembersToMergeCount = () => {
   MemberService.fetchMergeSuggestions(1, 0)
-    .then(({ count }) => {
+    .then(({ count }: any) => {
       membersToMergeCount.value = count;
     });
 };
+
+const loading = ref(true);
 
 const doGetMembersCount = () => {
   (MemberService.list(
@@ -135,11 +135,32 @@ const doGetMembersCount = () => {
     });
 };
 
+const showLoading = (filter: any, body: any): boolean => {
+  const saved: any = { ...savedFilterBody.value };
+  delete saved.offset;
+  delete saved.limit;
+  delete saved.orderBy;
+  const compare = {
+    ...body,
+    filter,
+  };
+  return JSON.stringify(saved) !== JSON.stringify(compare);
+};
+
 const fetch = ({
   filter, offset, limit, orderBy, body,
 }: FilterQuery) => {
-  console.log(filter, offset, limit, orderBy, body);
-  // TODO: fetch members
+  loading.value = showLoading(filter, body);
+  fetchMembers({
+    ...body,
+    filter,
+    offset,
+    limit,
+    orderBy,
+  })
+    .finally(() => {
+      loading.value = false;
+    });
 };
 
 onMounted(() => {

--- a/frontend/src/modules/member/pages/member-view-page.vue
+++ b/frontend/src/modules/member/pages/member-view-page.vue
@@ -76,6 +76,7 @@ import AppMemberViewAside from '@/modules/member/components/view/member-view-asi
 import AppMemberViewNotes from '@/modules/member/components/view/member-view-notes.vue';
 import AppMemberViewContributions from '@/modules/member/components/view/member-view-contributions.vue';
 import AppMemberViewTasks from '@/modules/member/components/view/member-view-tasks.vue';
+import { useMemberStore } from '@/modules/member/store/pinia';
 
 const store = useStore();
 const props = defineProps({
@@ -86,6 +87,7 @@ const props = defineProps({
 });
 
 const { currentTenant, currentUser } = mapGetters('auth');
+const { getMemberCustomAttributes } = useMemberStore();
 
 const member = computed(() => store.getters['member/find'](props.id) || {});
 
@@ -113,7 +115,7 @@ onMounted(async () => {
     Object.keys(store.state.member.customAttributes)
       .length === 0
   ) {
-    await store.dispatch('member/doFetchCustomAttributes');
+    await getMemberCustomAttributes();
   }
   loading.value = false;
 });

--- a/frontend/src/modules/member/store/pinia/actions.ts
+++ b/frontend/src/modules/member/store/pinia/actions.ts
@@ -9,7 +9,7 @@ import { Member } from '@/modules/member/types/Member';
 const { buildFilterFromAttributes } = customAttributesService();
 
 export default {
-  fetchMembers(this: MemberState, body: any, reload = false): Promise<Pagination<Member>> {
+  fetchMembers(this: MemberState, { body = {}, reload = false } :{ body?: any, reload?: boolean }): Promise<Pagination<Member>> {
     const mappedBody = reload ? this.savedFilterBody : body;
     this.selectedMembers = [];
     this.members = [];

--- a/frontend/src/modules/member/store/pinia/actions.ts
+++ b/frontend/src/modules/member/store/pinia/actions.ts
@@ -3,10 +3,29 @@ import { customAttributesService } from '@/shared/modules/filters/services/custo
 import { FilterCustomAttribute } from '@/shared/modules/filters/types/FilterCustomAttribute';
 import { FilterConfig } from '@/shared/modules/filters/types/FilterConfig';
 import { MemberState } from '@/modules/member/store/pinia/state';
+import { Pagination } from '@/shared/types/Pagination';
+import { Member } from '@/modules/member/types/Member';
 
 const { buildFilterFromAttributes } = customAttributesService();
 
 export default {
+  fetchMembers(this: MemberState, body: any, reload = false): Promise<Pagination<Member>> {
+    const mappedBody = reload ? this.savedFilterBody : body;
+    this.selectedMembers = [];
+    this.members = [];
+    return MemberService.listMembers(mappedBody)
+      .then((data: Pagination<Member>) => {
+        this.members = data.rows;
+        this.totalMembers = data.count;
+        this.savedFilterBody = mappedBody;
+        return Promise.resolve(data);
+      })
+      .catch((err) => {
+        this.members = [];
+        this.totalMembers = 0;
+        return Promise.reject(err);
+      });
+  },
   getMemberCustomAttributes(this: MemberState): Promise<Record<string, FilterConfig>> {
     return MemberService.fetchCustomAttributes()
       .then(({ rows }: {rows: FilterCustomAttribute[]}) => {

--- a/frontend/src/modules/member/store/pinia/state.ts
+++ b/frontend/src/modules/member/store/pinia/state.ts
@@ -1,11 +1,16 @@
 import { Filter, FilterConfig } from '@/shared/modules/filters/types/FilterConfig';
+import { Member } from '@/modules/member/types/Member';
 
 export interface MemberState {
   filters: Filter,
-  customAttributes: Record<string, FilterConfig>
+  savedFilterBody: any,
+  customAttributes: Record<string, FilterConfig>,
+  members: Member[];
+  selectedMembers: Member[];
+  totalMembers: number;
 }
 
-export default () => ({
+const state: MemberState = {
   filters: {
     search: '',
     relation: 'and',
@@ -14,9 +19,15 @@ export default () => ({
       perPage: 20,
     },
     order: {
-      prop: 'createdBy',
+      prop: 'lastActive',
       order: 'descending',
     },
   } as Filter,
+  savedFilterBody: {},
   customAttributes: {},
-} as MemberState);
+  members: [],
+  totalMembers: 0,
+  selectedMembers: [],
+};
+
+export default () => state;

--- a/frontend/src/modules/member/types/Member.ts
+++ b/frontend/src/modules/member/types/Member.ts
@@ -1,0 +1,56 @@
+export interface MemberAttribute {
+  default: string;
+  custom: string;
+  github?: string;
+  twitter?: string;
+}
+
+export interface MemberContribution {
+  firstCommitDate: string;
+  id: number;
+  lastCommitDate: string;
+  numberCommits: number;
+  summary: string;
+  topics: string[];
+  url: string;
+}
+
+export interface MemberReach {
+  total: number;
+  github: number;
+  twitter: number;
+}
+
+export interface MemberTag {
+  id: string;
+  name: string;
+}
+
+export interface Member {
+  activeDaysCount: string;
+  activeOn: string[] | null;
+  activityCount: string;
+  activityTypes:string[] | null;
+  attributes: Record<string, MemberAttribute>
+  averageSentiment: string | null;
+  contributions: MemberContribution[]
+  createdAt: string;
+  displayName: string;
+  emails: string[]
+  id: string;
+  identities: string[] | null;
+  importHash: string | null;
+  joinedAt: string;
+  lastActive: string | null;
+  lastEnriched: string | null;
+  noMergeIds: string[] | null;
+  numberOfOpenSourceContributions: number | null;
+  organizations: any[];
+  reach:MemberReach;
+  score: number;
+  tags: MemberTag[];
+  tenantId: string;
+  toMergeIds: string[] | null;
+  updatedAt: string;
+  username: Record<string, string[]>
+}

--- a/frontend/src/shared/modules/filters/components/filterTypes/BooleanFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/BooleanFilter.vue
@@ -54,7 +54,7 @@ const rules: any = {
 useVuelidate(rules, form);
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 2) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/DateFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/DateFilter.vue
@@ -83,7 +83,7 @@ watch(() => form.value.operator, (operator, previousOperator) => {
 });
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 3) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
@@ -17,6 +17,7 @@
         class="filter-multiselect"
         popper-class="filter-multiselect-popper"
         :loading="loading"
+        no-data-text="No results"
       >
         <el-option
           v-for="option of data.selected"
@@ -132,7 +133,7 @@ const searchOptions = (query: string) => {
 
 onMounted(() => {
   searchOptions('');
-  if (!props.modelValue.value || Object.keys(props.modelValue.value).length === 0) {
+  if (!props.modelValue.value || Object.keys(props.modelValue.value).length < 2) {
     emit('update:modelValue', defaultForm);
   }
   if (!data.value.selected) {

--- a/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
@@ -100,10 +100,9 @@ const include = computed<boolean>({
   },
 });
 
-watch(() => props.modelValue.value, (value: string[]) => {
-  if (value.length !== data.value.selected?.length) {
-    console.log(value);
-    props.remotePopulateItems(value)
+watch(() => props.modelValue.value, (value?: string[]) => {
+  if (value?.length !== data.value.selected?.length) {
+    props.remotePopulateItems(value || [])
       .then((options) => {
         data.value.selected = options;
       });

--- a/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectAsyncFilter.vue
@@ -20,13 +20,6 @@
         no-data-text="No results"
       >
         <el-option
-          v-for="option of data.selected"
-          :key="option.value"
-          :label="option.label"
-          :value="option"
-          class="!hidden"
-        />
-        <el-option
           v-for="option of filteredOptions"
           :key="option.value"
           :label="option.label"
@@ -119,6 +112,8 @@ watch(() => data.value.selected, (value) => {
 
 const loading = ref<boolean>(false);
 const filteredOptions = ref<MultiSelectAsyncFilterOption[]>([]);
+
+const unselectedOptions = computed(() => filteredOptions.value.filter((o) => !props.modelValue.value.includes(o.value)));
 
 const searchOptions = (query: string) => {
   loading.value = true;

--- a/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/MultiSelectFilter.vue
@@ -61,7 +61,7 @@ const rules: any = {
 useVuelidate(rules, form);
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 2) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/NumberFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/NumberFilter.vue
@@ -128,7 +128,7 @@ watch(() => form.value.operator, (operator) => {
 });
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 3>) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/SelectFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/SelectFilter.vue
@@ -79,7 +79,7 @@ const rules: any = {
 useVuelidate(rules, form);
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 2) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/StringFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/StringFilter.vue
@@ -62,7 +62,7 @@ const rules: any = {
 useVuelidate(rules, form);
 
 onMounted(() => {
-  if (!form.value || Object.keys(form.value).length === 0) {
+  if (!form.value || Object.keys(form.value).length < 3) {
     form.value = defaultForm;
   }
 });

--- a/frontend/src/shared/modules/filters/components/filterTypes/multiselect/MultiSelectTagsFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/multiselect/MultiSelectTagsFilter.vue
@@ -1,40 +1,39 @@
 <template>
-  <div>
-    <div class="px-4 pt-3">
-      <el-select
-        v-model="form"
-        multiple
-        filterable
-        remote
-        :reserve-keyword="false"
-        placeholder="Select options"
-        :remote-method="searchOptions"
-        :teleported="false"
-        class="filter-multiselect"
-        popper-class="filter-multiselect-popper"
-      >
-        <template v-for="(group, gi) of filteredOptions" :key="gi">
-          <div
-            v-if="group.label && group.options.length > 0"
-            class="text-2xs text-gray-400 font-semibold tracking-wide leading-6 uppercase px-3 my-1"
-          >
-            {{ group.label }}
-          </div>
-          <el-option
-            v-for="option of group.options"
-            :key="option.value"
-            :label="option.label"
-            :value="option.value"
-          >
-            <el-checkbox
-              :model-value="form.includes(option.value)"
-              class="filter-checkbox h-4"
-            />
-            {{ option.label }}
-          </el-option>
-        </template>
-      </el-select>
-    </div>
+  <div v-if="form" class="px-4 pt-3">
+    <el-select
+      v-model="form"
+      multiple
+      filterable
+      remote
+      :reserve-keyword="false"
+      placeholder="Select options"
+      :remote-method="searchOptions"
+      :teleported="false"
+      class="filter-multiselect"
+      popper-class="filter-multiselect-popper"
+      no-data-text="No results"
+    >
+      <template v-for="(group, gi) of filteredOptions" :key="gi">
+        <div
+          v-if="group.label && group.options.length > 0"
+          class="text-2xs text-gray-400 font-semibold tracking-wide leading-6 uppercase px-3 my-1"
+        >
+          {{ group.label }}
+        </div>
+        <el-option
+          v-for="option of group.options"
+          :key="option.value"
+          :label="option.label"
+          :value="option.value"
+        >
+          <el-checkbox
+            :model-value="form.includes(option.value)"
+            class="filter-checkbox h-4"
+          />
+          {{ option.label }}
+        </el-option>
+      </template>
+    </el-select>
   </div>
 </template>
 

--- a/frontend/src/shared/modules/filters/components/partials/multiselect/FilterMultiSelectOption.vue
+++ b/frontend/src/shared/modules/filters/components/partials/multiselect/FilterMultiSelectOption.vue
@@ -34,7 +34,7 @@ const form = computed({
   },
 });
 
-const selected = computed(() => form.value.includes(props.value));
+const selected = computed(() => form.value?.includes(props.value));
 
 const selectOption = () => {
   if (selected.value) {

--- a/frontend/src/shared/modules/filters/config/apiFilterRenderer/multiselect.filter.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/apiFilterRenderer/multiselect.filter.renderer.ts
@@ -1,15 +1,15 @@
 import { MultiSelectFilterValue } from '@/shared/modules/filters/types/filterTypes/MultiSelectFilterConfig';
 
 export const multiSelectApiFilterRenderer = (property: string, { value, include }: MultiSelectFilterValue): any[] => {
-  const filter = { contains: value };
+  const filter = {
+    [property]: {
+      contains: value,
+    },
+  };
 
   return [
-    {
-      [property]: (include ? filter : {
-        not: {
-          filter,
-        },
-      }),
-    },
+    (include ? filter : {
+      not: filter,
+    }),
   ];
 };

--- a/frontend/src/shared/modules/filters/config/apiFilterRenderer/number.filter.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/apiFilterRenderer/number.filter.renderer.ts
@@ -12,9 +12,7 @@ export const numberApiFilterRenderer = (property: string, {
   return [
     {
       [property]: (include ? filter : {
-        not: {
-          filter,
-        },
+        not: filter,
       }),
     },
   ];

--- a/frontend/src/shared/modules/filters/config/apiFilterRenderer/string.filter.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/apiFilterRenderer/string.filter.renderer.ts
@@ -14,9 +14,7 @@ export const stringApiFilterRenderer = (property: string, { include, value, oper
   return [
     {
       [property]: (include ? filter : {
-        not: {
-          filter,
-        },
+        not: filter,
       }),
     },
   ];

--- a/frontend/src/shared/modules/filters/config/itemLabelRenderer/multiselectasync.label.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/itemLabelRenderer/multiselectasync.label.renderer.ts
@@ -14,7 +14,7 @@ export const multiSelectAsyncItemLabelRenderer = (
 
   const charLimit = 30;
 
-  const labelObject = (data.selected as MultiSelectAsyncFilterOption[])
+  const labelObject = ((data?.selected || []) as MultiSelectAsyncFilterOption[])
     .filter((option) => value.includes(option.value))
     .reduce((obj, option) => {
       // eslint-disable-next-line no-param-reassign

--- a/frontend/src/shared/types/Pagination.ts
+++ b/frontend/src/shared/types/Pagination.ts
@@ -1,0 +1,6 @@
+export interface Pagination<T>{
+  count: number;
+  limit: number;
+  offset: number;
+  rows: T[]
+}


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb7ee9c</samp>

This pull request migrates the member module from Vuex to pinia for state management, and improves the filtering and sorting features for the member views. It updates the frontend components, configs, and services to use the `useMemberStore` function and the pinia actions to fetch and manipulate members and their attributes. It also adds a custom select filter for activity types, and changes the default sorting of the saved views to use the `lastActive` prop. Additionally, it adds a condition to the `TagRepository` class in the backend to allow querying tags by ids.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bb7ee9c</samp>

> _We're breaking free from the old state_
> _We're using pinia to create_
> _A better way to query and filter_
> _The members of our fate_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bb7ee9c</samp>

*  Add `listMembers` method to `MemberService` class to query members with custom filters and pagination from the backend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-d594dfa297b5494ac2929e44d4272273ea117a81e07032d124f345aafbfc64dbR153-R176))
*  Add `TagRepository` class to filter tags by ids if the filter object has an ids property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-7387b5a28fca07f0f76d29f0d2396975b092f55cb9e74a37110b19821d775a9fR201-R207))
*  Replace `CrSelectFilter` component with `CrSelectFilterAsync` component for activity type filter and load options from the backend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-59768c401b689d0104e67273c59a560ab299fbcb88d3c52dc2b4cd3e42ed02ccL2-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-59768c401b689d0104e67273c59a560ab299fbcb88d3c52dc2b4cd3e42ed02ccL21-R52))
*  Replace `MultiSelectFilterConfig` import with `MultiSelectAsyncFilterConfig` import for tags filter and load options from the backend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-51f81af986540dab11b21d614e1ed345a221b5213e0c6483ce1fe67f455e4c2dL2-R35))
*  Replace `apiFilterRendererByType` calls with custom functions for average sentiment, engagement level, and tags filters to use custom logic for the backend query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-f95205f0059ef9af70f69e3d1e744b7255e6892e74e4938b214149a612524223L18-R24), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-f6a92526859e5edb064aa18470e2fb61648877ed9721c01726a9c5aee1b92921L22-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-fc1de8d4391ddc775ae953304ef1b816ec295fad96f864e7033955556f8427aeL22-R35))
*  Replace `createdBy` and `lastActivity` props with `lastActive` prop in the order objects of the saved views to update the default sorting ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-6b0a83abdf1dd3b8f4031ab4ea56bf93d9684a87b3837fa7d7cffec4e168c379L10-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-7d1d32b479a4d2cf31902bd7a4a1a2b08fc8ceedf15d224b230f326461165a7dL10-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-304e0860cd3815bf2a6111dc3e9defe9d46e82f1840bba0c2f6ecf8a1f837a0fL10-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-a5c9acb865a4601b8ef08373021c7eaa87bc0485fb37358ff41d2f83459947d9L11-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-c1aac5a82af9d3475f7946eb81fe8c8262724ce78a2304b6bd9198a3e1a44375L11-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4f4e5b447d19c90abec7c8ff7b875df7a1a29ccfa0fab7cac45ccc4180530f21L10-R10))
*  Import `useMemberStore` function from pinia module and access member store in various components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18R407-R408), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4R176), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768R124),  [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-8480f2cbc6672d653e5419b1a20824e1e2a8262d405084c5f14309e608fa7dcdR79))
*  Replace `store.dispatch` and `store.getters` calls with pinia actions and computed properties in various components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L113-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L40-R42), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L89-R88), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18R94), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L440-R451), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L462-R467), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L490-R485), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L503-R502), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L514-R522), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4L266-R271), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4L288-R287), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L252-R254), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-8480f2cbc6672d653e5419b1a20824e1e2a8262d405084c5f14309e608fa7dcdL116-R118))
*  Add `@selection-change` event handler to `el-table` component to assign selected members to the member store ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18R94))
*  Replace `count` prop with `totalMembers` prop in `app-empty-state-cta` and `app-pagination` components to use the total number of members from the last query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L30-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L378-R382))
*  Replace `pagination.pageSize` and `pagination.currentPage` props with `pagination.perPage` and `pagination.page` props in `app-pagination-sorter` component to use the current pagination settings from the filters object ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L40-R42))
*  Remove `width` prop from `app-member-list-filter` component to avoid a warning in the console ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L69))
*  Uncomment `app-member-list-table` component and register `AppMemberListTable` component in the member list page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-a16a3f5998f30c771f491f0b40da862d53738e6efe842aa604353f3c8f74be05L64-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-a16a3f5998f30c771f491f0b40da862d53738e6efe842aa604353f3c8f74be05L84-R90))
*  Add `loading` ref and `showLoading` function to the member list page to show a loading indicator while fetching data from the backend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-a16a3f5998f30c771f491f0b40da862d53738e6efe842aa604353f3c8f74be05L119-R123), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-a16a3f5998f30c771f491f0b40da862d53738e6efe842aa604353f3c8f74be05L138-R163))
*  Add `tableWidth` ref and assignment to the member list table component to store the width of the table element ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L503-R502), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18L585-R585))
*  Import `piniaMapActions` function from pinia module and map `fetchMembers` action to the member dropdown component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4R169), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-89fa78f92a02d51e13f5b1ce96100c87b46f06171254e7a9100fe82310a4c3c4L229-R235))
*  Remove unused `apiFilterRendererByType` imports from average sentiment and engagement level filter configs ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-f6a92526859e5edb064aa18470e2fb61648877ed9721c01726a9c5aee1b92921L8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-fc1de8d4391ddc775ae953304ef1b816ec295fad96f864e7033955556f8427aeL8))
*  Replace `itemLabelRendererByType` import with `apiFilterRendererByType` import in activity type filter config ([link](https://github.com/CrowdDotDev/crowd.dev/pull/948/files?diff=unified&w=0#diff-f95205f0059ef9af70f69e3d1e744b7255e6892e74e4938b214149a612524223L3-R6))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
