### PR TITLE
Getting only public repos that are not forks (LF)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,1 +1,5852 @@
-{"openapi":"3.0.3","info":{"title":"crowd.dev API","version":"1.0.5","description":"crowd.dev API\n","contact":{"email":"joan@crowd.dev"},"license":{"name":"Apache 2.0","url":"http://www.apache.org/licenses/LICENSE-2.0.html"},"x-github":"https://github.com/crowdHQ"},"servers":[{"url":"https://app.crowd.dev/api"}],"paths":{"/tenant/{tenantId}/activity/with-member":{"post":{"summary":"Create or update an activity with a member","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Create or update an activity with a member\nActivity existence is checked by sourceId and tenantId\nMember existence is checked by platform and username","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityUpsertWithMemberInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Activity"},"examples":{"Activity":{"$ref":"#/components/examples/ActivityUpsert"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/activity":{"post":{"summary":"Create or update an activity","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Create or update an activity. Existence is checked by sourceId and tenantId","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityUpsertInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Activity"},"examples":{"Activity":{"$ref":"#/components/examples/ActivityUpsert"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/activity/{id}":{"delete":{"summary":"Delete an activity","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Delete a activity given an ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the activity","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find an activity","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Find a single activity by ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the activity","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityResponse"},"examples":{"Activity":{"$ref":"#/components/examples/ActivityFind"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an activity","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Update an activity given an ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the activity","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityUpsertInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Activity"},"examples":{"Activity":{"$ref":"#/components/examples/ActivityFind"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/activity/query":{"post":{"summary":"Query activities","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Query activities. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityQuery"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityList"},"examples":{"Activity":{"$ref":"#/components/examples/ActivityList"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/automation":{"post":{"summary":"Create an automation","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Create a new automation for the tenant.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationCreateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Automation"},"examples":{"Automation":{"$ref":"#/components/examples/Automation"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}},"get":{"summary":"List automations","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Get all existing automation data for tenant.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"filter[type]","in":"query","description":"Filter by type of automation","required":false,"schema":{"type":"string"}},{"name":"filter[trigger]","in":"query","description":"Filter by trigger type of automation","required":false,"schema":{"type":"string"}},{"name":"filter[state]","in":"query","description":"Filter by state of automation","required":false,"schema":{"type":"string"}},{"name":"offset","in":"query","description":"Skip the first n results. Default 0.","required":false,"schema":{"type":"number"}},{"name":"limit","in":"query","description":"Limit the number of results. Default 50.","required":false,"schema":{"type":"number"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationPage"},"examples":{"AutomationPage":{"$ref":"#/components/examples/AutomationPage"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/automation/{automationId}":{"delete":{"summary":"Destroy an automation","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Destroys an existing automation in the tenant.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"automationId","in":"path","description":"Automation ID that you want to update","required":true,"schema":{"type":"string"}}],"responses":{"204":{"description":"Ok - No content"},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find an automation","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Get an existing automation data in the tenant.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"automationId","in":"path","description":"Automation ID that you want to find","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Automation"},"examples":{"Automation":{"$ref":"#/components/examples/Automation"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an automation","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Updates an existing automation in the tenant.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"automationId","in":"path","description":"Automation ID that you want to update","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationUpdateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Automation"},"examples":{"Automation":{"$ref":"#/components/examples/Automation"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/automation/{automationId}/executions":{"get":{"summary":"Get automation history","tags":["Automations"],"security":[{"Bearer":[]}],"description":"Get all automation execution history for tenant and automation","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"automationId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"offset","in":"query","description":"How many elements from the beginning would you like to skip","required":false,"schema":{"type":"integer","default":0}},{"name":"limit","in":"query","description":"How many elements would you like to fetch","required":false,"schema":{"type":"integer","default":10}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/AutomationExecutionPage"},"examples":{"AutomationExecutionPage":{"$ref":"#/components/examples/AutomationExecutionPage"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/conversation":{"post":{"summary":"Create a conversation","tags":["Conversations"],"security":[{"Bearer":[]}],"description":"Create a conversation.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConversationNoId"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Conversation"},"examples":{"Conversation":{"$ref":"#/components/examples/Conversation"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"List conversations","tags":["Conversations"],"security":[{"Bearer":[]}],"description":"Get a list of conversations with filtering, sorting and offsetting.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"filter[title]","in":"query","description":"Filter by the title of the conversation.","required":false,"schema":{"type":"string"}},{"name":"filter[slug]","in":"query","description":"Filter by the slug of the conversation.","required":false,"schema":{"type":"string"}},{"name":"filter[published]","in":"query","description":"Filter by whether it is published or not.","required":false,"schema":{"type":"string"}},{"name":"filter[platform]","in":"query","description":"Filter by the platform of the conversation.","required":false,"schema":{"type":"string"}},{"name":"filter[channel]","in":"query","description":"Filter by the channel of the conversation.","required":false,"schema":{"type":"string"}},{"name":"filter[activitiesCountRange]","in":"query","description":"activitiesCount lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.","required":false,"schema":{"type":"string"}},{"name":"filter[createdAtRange]","in":"query","description":"Created at lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.","required":false,"schema":{"type":"string"}},{"name":"orderBy","in":"query","description":"Sort the results. Default timestamp_DESC.","required":false,"schema":{"$ref":"#/components/schemas/ConversationSort"}},{"name":"offset","in":"query","description":"Skip the first n results. Default 0.","required":false,"schema":{"type":"number"}},{"name":"limit","in":"query","description":"Limit the number of results. Default 50.","required":false,"schema":{"type":"number"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConversationList"},"examples":{"Conversations":{"$ref":"#/components/examples/ConversationList"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/conversation/{id}":{"delete":{"summary":"Delete a conversation","tags":["Conversations"],"security":[{"Bearer":[]}],"description":"Delete a conversation.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the conversation","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find a conversation","tags":["Conversations"],"security":[{"Bearer":[]}],"description":"Find a conversation by ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID.","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the conversation.","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Conversation"},"examples":{"Conversation":{"$ref":"#/components/examples/Conversation"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an conversation","tags":["Conversations"],"security":[{"Bearer":[]}],"description":"Update a conversation given an ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the conversation","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ConversationNoId"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Conversation"},"examples":{"Conversation":{"$ref":"#/components/examples/Conversation"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/member/active":{"get":{"summary":"List active members","tags":["Members"],"security":[{"Bearer":[]}],"description":"List active members. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"filter[platforms]","in":"query","description":"Filter by activity platforms (comma separated list without spaces)","required":false,"schema":{"type":"string"}},{"name":"filter[isTeamMember]","in":"query","description":"If true we will return just team members, if false we will return just non-team members, if undefined we will return both.","required":false,"schema":{"type":"string"}},{"name":"filter[isBot]","in":"query","description":"If true we will return just members who are bots, if false we will return just non-bot members, if undefined we will return both.","required":false,"schema":{"type":"string"}},{"name":"filter[isOrganization]","in":"query","description":"If true we will return just members who are organizations (such as linkedin organizations that post), if false we will return just non-organization members, if undefined we will return both.","required":false,"schema":{"type":"string"}},{"name":"filter[activityTimestampFrom]","in":"query","description":"Filter by activity timestamp from (required)","required":false,"schema":{"type":"string"}},{"name":"filter[activityTimestampTo]","in":"query","description":"Filter by activity timestamp to (required)","required":false,"schema":{"type":"string"}},{"name":"filter[activityIsContribution]","in":"query","description":"Filter by activities that are contributions","required":false,"schema":{"type":"string"}},{"name":"orderBy","in":"query","description":"How to sort results. Available values: activityCount_DESC, activityCount_ASC, activeDaysCount_DESC, activeDaysCount_ASC (default activityCount_DESC)","required":false,"schema":{"type":"string"}},{"name":"offset","in":"query","description":"Skip the first n results. Default 0.","required":false,"schema":{"type":"number"}},{"name":"limit","in":"query","description":"Limit the number of results. Default 20.","required":false,"schema":{"type":"number"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/member":{"post":{"summary":"Create or update a member","tags":["Members"],"security":[{"Bearer":[]}],"description":"Create or update a member. Existence is checked by platform and username.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberUpsertInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Member"},"examples":{"Member":{"$ref":"#/components/examples/MemberUpsert"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/member/{id}":{"delete":{"summary":"Delete a member","tags":["Members"],"security":[{"Bearer":[]}],"description":"Delete a member given an ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find a member","tags":["Members"],"security":[{"Bearer":[]}],"description":"Find a single member by ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberResponse"},"examples":{"Member":{"$ref":"#/components/examples/MemberFind"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update a member","tags":["Members"],"security":[{"Bearer":[]}],"description":"Update a member","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberUpdateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Member"},"examples":{"Member":{"$ref":"#/components/examples/MemberUpsert"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/member/export":{"post":{"summary":"Export members as CSV","tags":["Members"],"security":[{"Bearer":[]}],"description":"Export members. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberQuery"}}}},"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/member/query":{"post":{"summary":"Query members","tags":["Members"],"security":[{"Bearer":[]}],"description":"Query members. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberQuery"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberList"},"examples":{"Member":{"$ref":"#/components/examples/MemberList"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/note":{"post":{"summary":"Create a note","tags":["Notes"],"security":[{"Bearer":[]}],"description":"Create a note","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/NoteNoId"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Note"},"examples":{"Note":{"$ref":"#/components/examples/Note"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/note/{id}":{"delete":{"summary":"Delete a note","tags":["Notes"],"security":[{"Bearer":[]}],"description":"Delete a note.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the note","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find a note","tags":["Notes"],"security":[{"Bearer":[]}],"description":"Find a note by ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID.","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the note.","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/NoteResponse"},"examples":{"Note":{"$ref":"#/components/examples/Note"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update a note","tags":["Notes"],"security":[{"Bearer":[]}],"description":"Update a note","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the note","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/NoteInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Note"},"examples":{"Note":{"$ref":"#/components/examples/Note"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/note/query":{"post":{"summary":"Query notes","tags":["Notes"],"security":[{"Bearer":[]}],"description":"Query notes. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/NoteQuery"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/NoteList"},"examples":{"Note":{"$ref":"#/components/examples/NoteList"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/organization":{"post":{"summary":"Create a organization","tags":["Organizations"],"security":[{"Bearer":[]}],"description":"Create a organization","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrganizationInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Organization"},"examples":{"Organization":{"$ref":"#/components/examples/OrganizationCreate"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/organization/{id}":{"delete":{"summary":"Delete a organization","tags":["Organizations"],"security":[{"Bearer":[]}],"description":"Delete a organization.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the organization","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find an organization","tags":["Organizations"],"security":[{"Bearer":[]}],"description":"Find an organization by ID.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the organization","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrganizationResponse"},"examples":{"Organization":{"$ref":"#/components/examples/Organization"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an organization","tags":["Organizations"],"security":[{"Bearer":[]}],"description":"Update a organization","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the organization","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrganizationInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Organization"},"examples":{"Organization":{"$ref":"#/components/examples/OrganizationCreate"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/organization/query":{"post":{"summary":"Query organizations","tags":["Organizations"],"security":[{"Bearer":[]}],"description":"Query organizations. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrganizationQuery"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/OrganizationList"},"examples":{"Organization":{"$ref":"#/components/examples/OrganizationList"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/settings/activity/types":{"post":{"summary":"Create an activity type","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Create a custom activity type","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityTypesCreateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityTypes"},"examples":{"ActivityTypes":{"$ref":"#/components/examples/ActivityTypes"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"List all activity types","tags":["Activities"],"security":[{"Bearer":[]}],"description":"List all activity types","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityTypes"},"examples":{"ActivityTypes":{"$ref":"#/components/examples/ActivityTypes"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/settings/activity/types/{key}":{"put":{"summary":"Update an activity type","tags":["Activities"],"security":[{"Bearer":[]}],"description":"Update a custom activity type","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"key","in":"path","description":"The key of the activity type","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityTypesUpdateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ActivityTypes"},"examples":{"ActivityTypes":{"$ref":"#/components/examples/ActivityTypes"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/settings/members/attributes":{"post":{"summary":"Attribute settings: create","tags":["Members"],"security":[{"Bearer":[]}],"description":"Create a members' attribute setting","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettingsCreateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettings"},"examples":{"MemberAttributeSettings":{"$ref":"#/components/examples/MemberAttributeSettings"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"delete":{"summary":"Attribute settings: delete","tags":["Members"],"security":[{"Bearer":[]}],"description":"Delete a members' attribute setting","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"query","description":"Id to destroy","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Attributes settings: list","tags":["Members"],"security":[{"Bearer":[]}],"description":"Get a list of members' attribute settings","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"filter[label]","in":"query","description":"Filter by label of member attribute settings","required":false,"schema":{"type":"string"}},{"name":"filter[name]","in":"query","description":"Filter by name of member attribute settings","required":false,"schema":{"type":"string"}},{"name":"filter[type]","in":"query","description":"Filter by type of member attribute settings","required":false,"schema":{"type":"string"}},{"name":"filter[canDelete]","in":"query","description":"Filter by canDelete: \"true\" or \"false\"","required":false,"schema":{"type":"string"}},{"name":"filter[show]","in":"query","description":"Filter by show: \"true\" or \"false\"","required":false,"schema":{"type":"string"}},{"name":"filter[createdAtRange]","in":"query","description":"CreatedAt lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.","required":false,"schema":{"type":"string"}},{"name":"orderBy","in":"query","description":"Sort the results. Default createdAt_DESC.","required":false,"schema":{"$ref":"#/components/schemas/MemberAttributeSettingsSort"}},{"name":"offset","in":"query","description":"Skip the first n results. Default 0.","required":false,"schema":{"type":"number"}},{"name":"limit","in":"query","description":"Limit the number of results. Default 50.","required":false,"schema":{"type":"number"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettingsList"},"examples":{"MemberAttributeSettings":{"$ref":"#/components/examples/MemberAttributeSettingsList"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/settings/members/attributes/{id}":{"get":{"summary":"Attributes settings: find","tags":["Members"],"security":[{"Bearer":[]}],"description":"Find a single members' attribute setting by ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member attribute's settings","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettings"},"examples":{"MemberAttributeSettings":{"$ref":"#/components/examples/MemberAttributeSettings"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Attribute settings: update","tags":["Members"],"security":[{"Bearer":[]}],"description":"Update a members' attribute setting","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member attribute settings","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettingsUpdateInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberAttributeSettings"},"examples":{"MemberAttributeSettings":{"$ref":"#/components/examples/MemberAttributeSettings"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/tag":{"post":{"summary":"Create a tag","tags":["Tags"],"security":[{"Bearer":[]}],"description":"Create a tag","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TagNoId"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Tag"},"examples":{"Tag":{"$ref":"#/components/examples/Tag"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"List tags","tags":["Tags"],"security":[{"Bearer":[]}],"description":"Get a list of tags with filtering, sorting and offsetting.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"filter[name]","in":"query","description":"Filter by the name of the tag.","required":false,"schema":{"type":"string"}},{"name":"filter[createdAtRange]","in":"query","description":"Created at lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.","required":false,"schema":{"type":"string"}},{"name":"orderBy","in":"query","description":"Sort the results. Default timestamp_DESC.","required":false,"schema":{"$ref":"#/components/schemas/TagSort"}},{"name":"offset","in":"query","description":"Skip the first n results. Default 0.","required":false,"schema":{"type":"number"}},{"name":"limit","in":"query","description":"Limit the number of results. Default 50.","required":false,"schema":{"type":"number"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TagList"},"examples":{"Tags":{"$ref":"#/components/examples/TagList"}}}}},"401":{"description":"Unauthorized"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/tag/{id}":{"delete":{"summary":"Delete a tag","tags":["Tags"],"security":[{"Bearer":[]}],"description":"Delete a tag.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the tag","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find a tag","tags":["Tags"],"security":[{"Bearer":[]}],"description":"Find a tag by ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the tag","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Tag"},"examples":{"Tag":{"$ref":"#/components/examples/Tag"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an tag","tags":["Tags"],"security":[{"Bearer":[]}],"description":"Update a tag","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the tag","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TagNoId"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Tag"},"examples":{"Tag":{"$ref":"#/components/examples/Tag"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/task/batch":{"post":{"summary":"Make batch operations on tasks","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Make batch operations on tasks","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskBatchInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskFindAndUpdateAll"},"examples":{"Task":{"$ref":"#/components/examples/TaskFindAndUpdateAll"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/task":{"post":{"summary":"Create a task","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Create a task","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Task"},"examples":{"Task":{"$ref":"#/components/examples/Task"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/task/{id}":{"delete":{"summary":"Delete a task","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Delete a task.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the task","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok"},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"get":{"summary":"Find a task","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Find a task by ID","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the task","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskResponse"},"examples":{"Task":{"$ref":"#/components/examples/Task"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}},"put":{"summary":"Update an task","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Update a task","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the task","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskInput"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/Task"},"examples":{"Task":{"$ref":"#/components/examples/Task"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/task/query":{"post":{"summary":"Query tasks","tags":["Tasks"],"security":[{"Bearer":[]}],"description":"Query tasks. It accepts filters, sorting options and pagination.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}}],"requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskQuery"}}}},"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/TaskList"},"examples":{"Task":{"$ref":"#/components/examples/TaskList"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}},"/tenant/{tenantId}/enrichment/member/{id}":{"put":{"summary":"Enrich a member","tags":["Members"],"security":[{"Bearer":[]}],"description":"Enrich a member.","parameters":[{"name":"tenantId","in":"path","description":"Your workspace/tenant ID","required":true,"schema":{"type":"string"}},{"name":"id","in":"path","description":"The ID of the member","required":true,"schema":{"type":"string"}}],"responses":{"200":{"description":"Ok","content":{"application/json":{"schema":{"$ref":"#/components/schemas/MemberResponse"},"examples":{"Member":{"$ref":"#/components/examples/MemberFind"}}}}},"401":{"description":"Unauthorized"},"404":{"description":"Not found"},"429":{"description":"Too many requests"}}}}},"components":{"securitySchemes":{"Bearer":{"type":"http","scheme":"bearer"}},"schemas":{"MemberType":{"type":"string","enum":["member"]},"MemberScore":{"type":"integer","minimum":-1,"maximum":10},"MemberSort":{"type":"string","enum":["activitiesCount_ASC","activitiesCount_DESC","score_ASC","score_ASC","joinedAt_ASC","joinedAt_DESC","createdAt_ASC","createdAt_DESC","organisation_ASC","organisation_DESC","location_ASC","location_DESC"]},"ActivitySort":{"type":"string","enum":["timestamp_DESC","timestamp_ASC","createdAt_DESC","createdAt_ASC","score_DESC","score_ASC","type_DESC","type_ASC","platform_DESC","platform_ASC","createdBy_DESC","createdBy_ASC"]},"ConversationSort":{"type":"string","enum":["createdAt_DESC","createdAt_ASC","activityCount_DESC","activityCount_ASC","platform_DESC","platform_ASC","channel_DESC","channel_ASC","createdBy_DESC","createdBy_ASC"]},"TagSort":{"type":"string","enum":["name_ASC","name_DESC","createdAt_DESC","createdAt_ASC"]},"MemberAttributeSettingsSort":{"type":"string","enum":["label_ASC","label_DESC","type_ASC","type_DESC","createdAt_DESC","createdAt_ASC"]},"ActivityRelationsInput":{"description":"Relations of an activity.","type":"object","properties":{"tasks":{"description":"Tasks associated with the activity","type":"array","items":{"$ref":"#/components/schemas/TaskNoId"}}}},"ActivityUpsertInput":{"required":["memberId"],"description":"An activity performed by a member of your community. The member is sent as an ID.","allOf":[{"$ref":"#/components/schemas/ActivityNoId"},{"$ref":"#/components/schemas/ActivityRelationsInput"}],"properties":{"memberId":{"description":"The ID of the member that performed the activity"}}},"ActivityUpsertWithMemberInput":{"type":"object","description":"An activity performed by a member of your community. The member is sent as a whole object.","allOf":[{"$ref":"#/components/schemas/ActivityNoId"},{"$ref":"#/components/schemas/ActivityRelationsInput"}],"properties":{"member":{"$ref":"#/components/schemas/MemberNoId"}}},"ActivityNoId":{"description":"An activity performed by a member of your community.","type":"object","required":["type","platform","timestamp","sourceId"],"properties":{"type":{"description":"Type of activity","type":"string"},"timestamp":{"description":"Date and time when the activity took place","type":"string","format":"date-time"},"platform":{"description":"Platform on which the activity took place","type":"string"},"title":{"description":"Title of the activity","type":"string"},"body":{"description":"Body of the activity","type":"string"},"channel":{"description":"Channel of the activity","type":"string"},"sentiment":{"description":"Sentiment of the activity","type":"object","properties":{"sentiment":{"description":"Default sentiment score. <br/>Computed by mapping (positive - negative) from 0 to 100","type":"number","minimum":0,"maximum":100},"label":{"description":"Sentiment label","type":"string","enum":["positive","negative","neutral","mixed"]},"positive":{"description":"Positive sentiment score","type":"number","minimum":0,"maximum":1},"negative":{"description":"Negative sentiment score","type":"number","minimum":0,"maximum":1},"neutral":{"description":"Neutral sentiment score","type":"number","minimum":0,"maximum":1},"mixed":{"description":"Mixed sentiment score. Mixed contains both positive and negative sentiments","type":"number","minimum":0,"maximum":1}}},"sourceId":{"description":"The id of the activity in the platform (e.g. the id of the message in Discord)","type":"string"},"sourceParentId":{"description":"The id of the parent activity in the platform (e.g. the id of the parent message in Discord)","type":"string"},"parentId":{"description":"Id of the parent activity, if the activity has a parent","type":"string","format":"uuid"},"score":{"description":"Score associated with the activity","type":"number"},"isContribution":{"description":"Whether the activity was a contribution","type":"boolean"},"attributes":{"description":"Extra attributes of the activity","type":"object","additionalProperties":true},"createdAt":{"description":"Date the activity was created","type":"string","format":"date-time"},"updatedAt":{"description":"Date the activity was last updated","type":"string","format":"date-time"}},"xml":{"name":"ActivityNoId"}},"FilterType":{"type":"object","additionalProperties":{"oneOf":[{"type":"string"},{"$ref":"#/components/schemas/FilterType"}]}},"ActivityQuery":{"description":"All the parameters you can use to query activitys.","properties":{"filter":{"description":"Filter. Please refer to filter docs.","type":"string","format":"blob"},"orderBy":{"type":"string","enum":["activitiesCount_DESC","score_ASC","score_ASC","joinedAt_ASC","joinedAt_DESC","createdAt_ASC","createdAt_DESC","organisation_ASC","organisation_DESC","location_ASC","location_DESC"]},"limit":{"description":"Limit the number of records returned. Default is 10.","type":"integer","minimum":1,"maximum":200,"default":10},"offset":{"description":"Offset the number of records returned. Default is 0.","type":"integer","minimum":0,"default":0}}},"Activity":{"type":"object","allOf":[{"$ref":"#/components/schemas/ActivityNoId"}],"properties":{"id":{"description":"The unique identifier for an activity."}}},"ActivityRelationsResponse":{"description":"Relations of an activity.","type":"object","properties":{"member":{"description":"Member that performed the activity","$ref":"#/components/schemas/Member"},"tasks":{"description":"Tasks associated with the activity.","type":"array","items":{"$ref":"#/components/schemas/Task"}}}},"ActivityResponse":{"description":"An activity performed by a member.","type":"object","allOf":[{"$ref":"#/components/schemas/Activity"},{"$ref":"#/components/schemas/ActivityRelationsResponse"}]},"ActivityList":{"description":"List and count of activities.","type":"object","properties":{"rows":{"description":"List of activities","type":"array","items":{"$ref":"#/components/schemas/ActivityResponse"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"ActivitiesList"}},"AutomationCreateInput":{"type":"object","description":"Data to create a new automation.","required":["type","trigger","settings"],"properties":{"type":{"$ref":"#/components/schemas/AutomationType"},"trigger":{"$ref":"#/components/schemas/AutomationTrigger"},"settings":{"$ref":"#/components/schemas/AutomationSettings"}}},"AutomationUpdateInput":{"type":"object","description":"Data to update an existing automation.","required":["trigger","settings","state"],"properties":{"trigger":{"$ref":"#/components/schemas/AutomationTrigger"},"settings":{"$ref":"#/components/schemas/AutomationSettings"},"state":{"$ref":"#/components/schemas/AutomationState"}}},"AutomationType":{"description":"Automation type","type":"string","enum":["webhook"]},"AutomationState":{"description":"Automation state","type":"string","enum":["active","disabled"]},"AutomationTrigger":{"description":"What will trigger an automation","type":"string","enum":["new_activity","new_member"]},"AutomationExecutionState":{"description":"What was the state of the automation execution","type":"string","enum":["success","error"]},"WebhookAutomationSettings":{"description":"Settings used by automation with type webhook","type":"object","required":["url"],"properties":{"url":{"description":"URL to POST webhook data to","type":"string","format":"uri"}}},"NewActivityAutomationSettings":{"description":"Settings used by automation that is triggered by new activities","type":"object","required":["types","platforms","keywords","teamMemberActivities"],"properties":{"types":{"description":"If activity type matches any of these we should trigger this automation","type":"array","items":{"type":"string"}},"platforms":{"description":"If activity came from any of these platforms we should trigger this automation","type":"array","items":{"type":"string"}},"keywords":{"description":"If activity content contains any of these keywords we should trigger this automation","type":"array","items":{"type":"string"}},"teamMemberActivities":{"description":"If activity came from any of our team members - should we trigger automation or not?","type":"boolean"}}},"AutomationSettings":{"description":"Settings based on automation type and trigger - you need to provide union object of both automation type based settings and trigger based settings","type":"object","anyOf":[{"$ref":"#/components/schemas/WebhookAutomationSettings"},{"$ref":"#/components/schemas/NewActivityAutomationSettings"}]},"Automation":{"type":"object","required":["id","type","tenantId","trigger","settings","state","createdAt"],"properties":{"id":{"description":"Automation unique ID","type":"string","format":"uuid"},"type":{"$ref":"#/components/schemas/AutomationType"},"tenantId":{"description":"Automation tenant unique ID","type":"string","format":"uuid"},"trigger":{"$ref":"#/components/schemas/AutomationTrigger"},"settings":{"$ref":"#/components/schemas/AutomationSettings"},"state":{"$ref":"#/components/schemas/AutomationState"},"createdAt":{"description":"When was automation created","type":"string","format":"date-time"},"lastExecutionAt":{"description":"When was automation last executed","type":"string","format":"date-time"},"lastExecutionState":{"description":"State of the last automation execution","$ref":"#/components/schemas/AutomationExecutionState"},"lastExecutionError":{"description":"Error information if last automation execution failed","type":"object"}}},"AutomationPage":{"type":"object","required":["rows","count","offset","limit"],"properties":{"rows":{"description":"Array of automations that were fetched","type":"array","items":{"$ref":"#/components/schemas/Automation"}},"count":{"description":"How many total automations there are","type":"integer"},"offset":{"description":"What offset was used when preparing this response","type":"integer"},"limit":{"description":"What limit was used when preparing this response","type":"integer"}}},"AutomationExecution":{"type":"object","required":["id","automationId","state","executedAt","eventId","payload"],"properties":{"id":{"description":"Automation execution unique ID","type":"string","format":"uuid"},"automationId":{"description":"Automation unique ID","type":"string","format":"uuid"},"state":{"description":"Automation execution state","$ref":"#/components/schemas/AutomationExecutionState"},"error":{"description":"If execution was not successful this object will contain error information","type":"object"},"executedAt":{"description":"Automation execution timestamp","type":"string","format":"date-time"},"eventId":{"description":"Unique ID of the event that triggered this automation execution.","type":"string"},"payload":{"description":"Payload that was sent when this execution was processed","type":"object"}}},"AutomationExecutionPage":{"type":"object","required":["rows","count","offset","limit"],"properties":{"rows":{"description":"Automation Execution List","type":"array","items":{"$ref":"#/components/schemas/AutomationExecution"}},"count":{"description":"How many items are there in total","type":"integer"},"offset":{"description":"What offset was used when preparing this response","type":"integer"},"limit":{"description":"What limit was used when preparing this response","type":"integer"}}},"ConversationNoId":{"type":"object","required":["platform","slug","tenantId"],"description":"A conversation is a group of activities. Some attributes, like slug, are mostly used in public pages.","properties":{"title":{"description":"Title of the conversation","type":"string"},"slug":{"description":"Unique slug of the conversation","type":"string"},"published":{"description":"Whether the conversation is publicaly visible from open pages.","type":"boolean","default":false},"conversationStarter":{"description":"The conversation starter activity","type":"object","additionalProperties":{"$ref":"#/components/schemas/Activity"}},"memberCount":{"description":"Number of participating members in the conversation.","type":"integer"},"lastActive":{"description":"Last activity time in the conversation","type":"string","format":"date-time"},"createdAt":{"description":"Date the conversation was created","type":"string","format":"date-time"},"updatedAt":{"description":"Date the conversation was last updated","type":"string","format":"date-time"},"tenantId":{"description":"Your workspace/tenant id","type":"string","format":"uuid"}},"xml":{"name":"Conversation"}},"Conversation":{"allOf":[{"$ref":"#/components/schemas/ConversationNoId"}],"properties":{"id":{"description":"Unique identifier of the conversation","type":"string"},"activities":{"description":"List of IDs of the activities in the conversation","type":"array","items":{"type":"string"}}}},"ConversationList":{"type":"object","properties":{"rows":{"type":"array","items":{"$ref":"#/components/schemas/Conversation"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}}},"MemberPlatformHelper":{"type":"object","required":["platform"],"properties":{"platform":{"type":"string","description":"Platform for which to check member existence."}}},"MemberOrganizations":{"type":"object","properties":{"organizations":{"description":"Organizations associated with the member. Each element in the array is the name of the organization, or an organization object. If the organization does not exist, it will be created.","type":"array","items":{"$ref":"#/components/schemas/OrganizationNoId"}}}},"MemberOrganizationsUpdate":{"type":"object","properties":{"organizations":{"description":"Organizations associated with the member. Each element in the array is the name of the organization, or an organization object. If the organization does not exist, it will be created.","type":"array","items":{"type":"string"}}}},"MemberInputRelations":{"type":"object","properties":{"tags":{"description":"Tags associated with the member. Each element in the array is the ID of the tag.","type":"array","items":{"type":"string"}},"tasks":{"description":"Tasks associated with the member. Each element in the array is the ID of the task.","type":"array","items":{"type":"string"}},"notes":{"description":"Notes associated with the member. Each element in the array is the ID of the note.","type":"array","items":{"type":"string"}},"activities":{"description":"Activities associated with the member. Each element in the array is the ID of the activity.","type":"array","items":{"type":"string"}}}},"MemberUpsertInput":{"allOf":[{"$ref":"#/components/schemas/MemberPlatformHelper"},{"$ref":"#/components/schemas/MemberNoId"},{"$ref":"#/components/schemas/MemberOrganizations"},{"$ref":"#/components/schemas/MemberInputRelations"}]},"MemberUpdateInput":{"allOf":[{"$ref":"#/components/schemas/MemberPlatformHelper"},{"$ref":"#/components/schemas/MemberNoId"},{"$ref":"#/components/schemas/MemberInputRelations"},{"$ref":"#/components/schemas/MemberOrganizationsUpdate"}]},"MemberNoId":{"description":"A member of your community.","type":"object","required":["username"],"properties":{"username":{"description":"Usernames of the member in each platform. Exactly one for each platform in which the member is active. <br/>Example: ```{ github: 'iamgilfoyle', discord: 'gilfoyle '}```","type":"object","additionalProperties":true},"displayName":{"description":"UI friendly name of the member","type":"string"},"emails":{"description":"Email addresses of the member","type":"array","items":{"type":"string"}},"joinedAt":{"description":"Date of joining the community","type":"string","format":"date-time"},"score":{"description":"Engagement score of the member. From 0 to 10. Set -1 for not yet calculated.","type":"number"},"reach":{"description":"Reach of the member in each platform. At most one for each platform in which the member is active. <br/>Example: ```{ github: 10, twitter: 250, total: 260 }```","type":"object","properties":{"total":{"description":"Sum of all the platform reaches.","type":"number"}},"additionalProperties":true},"attributes":{"description":"Attributes associated to the member. Each attribute must be an object with it's value for each platform, and a default.  <br/>For example: ```{\"location\": {\"github\": \"San Francisco\", \"twitter\": \"California\", \"default\": \"San Francisco\"}}```","type":"object","additionalProperties":{"$ref":"#/components/schemas/MemberAttribute"}},"createdAt":{"description":"Date the member was created","type":"string","format":"date-time"},"updatedAt":{"description":"Date the member was last updated","type":"string","format":"date-time"}},"xml":{"name":"Member"}},"MemberAttribute":{"description":"A key for each platform.  <br/>- ```default``` is the value that will be displayed by default in the app <br/>- ```custom``` is the value that will be displayed if the user has set a custom value for the attribute","type":"object","properties":{"default":{"description":"Default value for the attribute. This is set automatically according to <a target=\"_blank\" href=\"https://crowd.dev\">crowd.dev</a> rules.","type":"string"},"custom":{"description":"Custom value for the attribute. This is optionally set by the user. It will always be picked as the default when sent.","type":"string"}},"additionalProperties":true},"MemberQuery":{"description":"All the parameters you can use to query members.","properties":{"filter":{"description":"Filter. Please refer to filter docs.","type":"string","format":"blob"},"orderBy":{"type":"string","enum":["activityCount_ASC","activityCount_DESC","score_ASC","score_DESC","joinedAt_ASC","joinedAt_DESC","createdAt_ASC","createdAt_DESC","organisation_ASC","organisation_DESC","location_ASC","location_DESC"]},"limit":{"description":"Limit the number of records returned. Default is 10.","type":"integer","minimum":1,"maximum":200,"default":10},"offset":{"description":"Offset the number of records returned. Default is 0.","type":"integer","minimum":0,"default":0}}},"Member":{"type":"object","allOf":[{"$ref":"#/components/schemas/MemberNoId"}],"properties":{"id":{"description":"The unique identifier for a member of your community."},"activityCount":{"description":"Number of activities performed by the member.","type":"integer"},"lastActivity":{"description":"Timestamp, type and platform of the last activity performed by the member.","type":"object","properties":{"type":{"description":"Type of the last activity","type":"string"},"timestamp":{"description":"Date and time of the last activity","type":"string","format":"date-time"},"platform":{"description":"Platform of the last activity","type":"string"}}},"averageSentiment":{"description":"Average sentiment of the member. From 0 to 100.","type":"number"},"identities":{"description":"List of platforms the member has identities in.","type":"array","items":{"type":"string"}},"activeOn":{"description":"List of platforms the member is active on.","type":"array","items":{"type":"string"}}}},"MemberRelationsResponse":{"description":"Relations of a member.","type":"object","properties":{"tags":{"description":"Tags associated with the member.","type":"array","items":{"$ref":"#/components/schemas/Tag"}},"notes":{"description":"Notes associated with the member.","type":"array","items":{"$ref":"#/components/schemas/Note"}},"tasks":{"description":"Tasks associated with the member.","type":"array","items":{"$ref":"#/components/schemas/Task"}},"organizations":{"description":"Organizations associated with the member.","type":"array","items":{"$ref":"#/components/schemas/Organization"}}}},"MemberResponse":{"description":"A member of your community.","type":"object","allOf":[{"$ref":"#/components/schemas/Member"},{"$ref":"#/components/schemas/MemberRelationsResponse"}]},"MemberList":{"description":"List and count of members.","type":"object","properties":{"rows":{"description":"List of members","type":"array","items":{"$ref":"#/components/schemas/MemberResponse"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"MembersList"}},"NoteInputRelations":{"type":"object","properties":{"members":{"description":"Members associated with the note. Each element in the array is the ID of the member.","type":"array","items":{"type":"string"}}}},"NoteInput":{"allOf":[{"$ref":"#/components/schemas/NoteNoId"},{"$ref":"#/components/schemas/NoteInputRelations"}]},"NoteNoId":{"description":"A created note.","type":"object","properties":{"body":{"description":"The body of the note.","type":"string","format":"blob"},"createdAt":{"description":"Date the note was created.","type":"string","format":"date-time"},"updatedAt":{"description":"Date the note was last updated.","type":"string","format":"date-time"}},"xml":{"name":"Note"}},"NoteQuery":{"description":"All the parameters you can use to query notes.","properties":{"filter":{"description":"Filter. Please refer to filter docs.","type":"string","format":"blob"},"orderBy":{"type":"string","enum":["createdAt_ASC","createdAt_DESC"]},"limit":{"description":"Limit the number of records returned. Default is 10.","type":"integer","minimum":1,"maximum":200,"default":10},"offset":{"description":"Offset the number of records returned. Default is 0.","type":"integer","minimum":0,"default":0}}},"Note":{"type":"object","allOf":[{"$ref":"#/components/schemas/NoteNoId"}],"properties":{"id":{"description":"The ID of the note."},"body":{"description":"The body of the note.","type":"string","format":"blob"}}},"NoteRelationsResponse":{"description":"Relations of a note.","type":"object","properties":{"members":{"description":"Members associated with the note.","type":"array","items":{"$ref":"#/components/schemas/Member"}}}},"NoteResponse":{"description":"A note of your community.","type":"object","allOf":[{"$ref":"#/components/schemas/Note"},{"$ref":"#/components/schemas/NoteRelationsResponse"}]},"NoteList":{"description":"List and count of notes.","type":"object","properties":{"rows":{"description":"List of notes","type":"array","items":{"$ref":"#/components/schemas/NoteResponse"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"NotesList"}},"OrganizationInputRelations":{"type":"object","properties":{"members":{"description":"Members associated with the organization. Each element in the array is the ID of the member.","type":"array","items":{"type":"string","format":"uuid"}}}},"OrganizationInput":{"allOf":[{"$ref":"#/components/schemas/OrganizationNoId"},{"$ref":"#/components/schemas/OrganizationInputRelations"}]},"OrganizationNoId":{"description":"A created organization.","type":"object","required":["name"],"properties":{"name":{"description":"The name of the organization.","type":"string"},"url":{"description":"The URL of the organization.","type":"string"},"description":{"description":"A short description of the organization.","type":"string","format":"blob"},"logo":{"description":"A URL for logo of the organization.","type":"string"},"emails":{"description":"The emails for contacting the organization.","type":"array","items":{"type":"string"}},"phoneNumbers":{"description":"The phone numbers for contacting for the organization.","type":"array","items":{"type":"string"}},"parentUrl":{"description":"The URL of the parent organization if it has one (for example if it has been acquired).","type":"string"},"tags":{"description":"Tags associated with the organization.","type":"array","items":{"type":"string"}},"twitter":{"description":"Twitter information for the organization.","type":"object","properties":{"handle":{"description":"The Twitter handle for the organization.","type":"string"},"id":{"description":"The Twitter ID for the organization.","type":"string"},"bio":{"description":"The Twitter bio for the organization.","type":"string"},"followers":{"description":"The number of followers on Twitter.","type":"integer"},"location":{"description":"The Twitter location for the organization.","type":"string"},"site":{"description":"The website linked to the organization's Twitter profile.","type":"string"},"avatar":{"description":"The URL for the organization's Twitter avatar.","type":"string"}}},"employees":{"description":"The number of employees of the organization.","type":"integer"},"revenueRange":{"description":"The estimated revenue range of the organization.","type":"object","properties":{"min":{"description":"The minimum estimated revenue of the organization.","type":"integer"},"max":{"description":"The maximum estimated revenue of the organization.","type":"integer"}}},"linkedin":{"description":"LinkedIn information for the organization.","type":"object","properties":{"handle":{"description":"The LinkedIn handle for the organization.","type":"string"}}},"crunchbase":{"description":"Crunchbase information for the organization.","type":"object","properties":{"handle":{"description":"The Crunchbase handle for the organization.","type":"string"}}},"activeOn":{"description":"List of platforms the organization members are active on.","type":"array","items":{"type":"string"}},"identities":{"description":"List of platforms the organization members have identities in.","type":"array","items":{"type":"string"}},"memberCount":{"description":"Number of members organization has.","type":"integer"},"createdAt":{"description":"Date the organization was created.","type":"string","format":"date-time"},"updatedAt":{"description":"Date the organization was last updated.","type":"string","format":"date-time"}},"xml":{"name":"Organization"}},"OrganizationQuery":{"description":"All the parameters you can use to query organizations.","properties":{"filter":{"description":"Filter. Please refer to filter docs.","type":"string","format":"blob"},"orderBy":{"type":"string","enum":["createdAt_ASC","createdAt_DESC","memberCount_ASC","memberCount_DESC","activityCount_ASC","activityCount_DESC","joinedAt_ASC","joinedAt_DESC","lastActive_ASC","lastActive_DESC"]},"limit":{"description":"Limit the number of records returned. Default is 10.","type":"integer","minimum":1,"maximum":200,"default":10},"offset":{"description":"Offset the number of records returned. Default is 0.","type":"integer","minimum":0,"default":0}}},"Organization":{"type":"object","allOf":[{"$ref":"#/components/schemas/OrganizationNoId"}],"properties":{"id":{"description":"The ID of the organization."},"body":{"description":"The body of the organization.","type":"string","format":"blob"}}},"OrganizationRelationsResponse":{"description":"Relations of a organization.","type":"object","properties":{"members":{"description":"Members associated with the organization.","type":"array","items":{"$ref":"#/components/schemas/Member"}},"activeOn":{"description":"The platforms where the organization is active.","type":"array","items":{"type":"string"}},"identities":{"description":"The list of identities of the members in the organization.","type":"array","items":{"type":"string"}},"lastActive":{"description":"The last time the organization was active.","type":"string","format":"date-time"},"joinedAt":{"description":"The date the first member from the organization joined the community.","type":"string","format":"date-time"}}},"OrganizationResponse":{"description":"A organization of your community.","type":"object","allOf":[{"$ref":"#/components/schemas/Organization"},{"$ref":"#/components/schemas/OrganizationRelationsResponse"}]},"OrganizationList":{"description":"List and count of organizations.","type":"object","properties":{"rows":{"description":"List of organizations","type":"array","items":{"$ref":"#/components/schemas/OrganizationResponse"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"OrganizationsList"}},"TagNoId":{"description":"A tag associated with a member.","type":"object","required":["name","tenantId"],"properties":{"name":{"description":"The name of the tag","type":"string"},"createdAt":{"description":"Date the tag was created","type":"string","format":"date-time"},"updatedAt":{"description":"Date the tag was last updated","type":"string","format":"date-time"},"tenantId":{"description":"Your workspace/tenant id","type":"string","format":"uuid"}},"xml":{"name":"Tag"}},"Tag":{"type":"object","allOf":[{"$ref":"#/components/schemas/TagNoId"}],"properties":{"id":{"description":"The unique identifier for a tag."}}},"TagList":{"description":"List and count of tags.","type":"object","properties":{"rows":{"description":"List of tags","type":"array","items":{"$ref":"#/components/schemas/Tag"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"TagsList"}},"TaskInputRelations":{"type":"object","properties":{"members":{"description":"Members associated with the task. Each element in the array is the ID of the member.","type":"array","items":{"type":"string","format":"uuid"}},"activities":{"description":"Activities associated with the task. Each element in the array is the ID of the activity.","type":"array","items":{"type":"string","format":"uuid"}},"assignees":{"description":"Users assigned with the task. Each element in the array is the ID of the user.","type":"string","format":"uuid","default":null}}},"TaskInput":{"allOf":[{"$ref":"#/components/schemas/TaskNoId"},{"$ref":"#/components/schemas/TaskInputRelations"}]},"TaskBatchInput":{"type":"object","properties":{"operation":{"description":"Batch operation name.","type":"string","enum":["findAndUpdateAll"]},"payload":{"type":"object","description":"Payload to send to the batch operation","properties":{"filter":{"description":"Filter to select the task entities. Please refer to filter docs.","type":"string","format":"blob"},"update":{"description":"key value object with desired updated fields.","type":"object"}}}}},"TaskNoId":{"description":"A created task.","type":"object","properties":{"name":{"description":"The name of the task.","type":"string"},"body":{"description":"The body of the task.","type":"string","format":"blob"},"status":{"description":"The status of the task.","type":"string","enum":["in-progress","done"],"default":null},"createdAt":{"description":"Date the task was created.","type":"string","format":"date-time"},"updatedAt":{"description":"Date the task was last updated.","type":"string","format":"date-time"}},"xml":{"name":"Task"}},"TaskQuery":{"description":"All the parameters you can use to query tasks.","properties":{"filter":{"description":"Filter. Please refer to filter docs.","type":"string","format":"blob"},"orderBy":{"type":"string","enum":["createdAt_ASC","createdAt_DESC"]},"limit":{"description":"Limit the number of records returned. Default is 10.","type":"integer","minimum":1,"maximum":200,"default":10},"offset":{"description":"Offset the number of records returned. Default is 0.","type":"integer","minimum":0,"default":0}}},"Task":{"type":"object","allOf":[{"$ref":"#/components/schemas/TaskNoId"}],"properties":{"id":{"description":"The ID of the task."},"body":{"description":"The body of the task.","type":"string","format":"blob"}}},"TaskRelationsResponse":{"description":"Relations of a task.","type":"object","properties":{"members":{"description":"Members associated with the task.","type":"array","items":{"$ref":"#/components/schemas/Member"}},"activities":{"description":"Activities associated with the task.","type":"array","items":{"$ref":"#/components/schemas/Activity"}},"assignedTo":{"description":"The workspace member assigned to the task.","$ref":"#/components/schemas/Member"}}},"TaskResponse":{"description":"A task of your community.","type":"object","allOf":[{"$ref":"#/components/schemas/Task"},{"$ref":"#/components/schemas/TaskRelationsResponse"}]},"TaskList":{"description":"List and count of tasks.","type":"object","properties":{"rows":{"description":"List of tasks","type":"array","items":{"$ref":"#/components/schemas/TaskResponse"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"TasksList"}},"TaskFindAndUpdateAll":{"description":"Returns number of tasks updated","type":"object","properties":{"rowsUpdated":{"description":"Number of tasks updated","type":"integer"}}},"ActivityTypesCreateInput":{"description":"An activity type.","properties":{"type":{"description":"Human-friendly type of the activity. Default and short displays will set to this and key will be generated using this value."}}},"ActivityTypesUpdateInput":{"description":"An activity type.","properties":{"type":{"description":"Human-friendly type of the activity. Default and short displays will set to this and key will be generated using this value."}}},"ActivityTypeDisplayOptions":{"type":"object","required":["default","short","channel"],"description":"Activity type display options.","properties":{"default":{"description":"Default display of an activity type. Used in the activity module in the app.","type":"string"},"short":{"description":"Short display version of an activity type. Used in the member list -> last activity.","type":"string"},"channel":{"description":"Channel display of an activity type. Used in Dashboard -> trending conversations.","type":"string"}},"xml":{"name":"ActivityTypeDisplayOptions"}},"ActivityTypes":{"type":"object","properties":{"custom":{"type":"object","description":"Custom activity types defined by the user.","additionalProperties":{"$ref":"#/components/schemas/ActivityTypeDisplayOptions"}},"default":{"type":"object","description":"Default activity types used by the integrations.","additionalProperties":{"$ref":"#/components/schemas/ActivityTypeDisplayOptions"}}}},"MemberAttributeSettingsCreateInput":{"description":"A member attribute.","allOf":[{"$ref":"#/components/schemas/MemberAttributeSettingsNoId"}]},"MemberAttributeSettingsUpdateInput":{"description":"A member attribute.","properties":{"label":{"description":"Human-friendly name of the attribute. Label is unique in workspaces.","type":"string"},"show":{"description":"Whether to show the member attribute in the web app or not.","type":"boolean","default":true}}},"MemberAttributeSettingsNoId":{"type":"object","required":["label","type"],"description":"A member attribute that can be created dynamically.","properties":{"label":{"description":"Human-friendly name of the attribute. Label is unique in workspaces.","type":"string"},"name":{"description":"Camel-case code friendly name of the attribute. If ommited, name will be generated from the label. Name is unique in workspaces.","type":"string"},"type":{"description":"Type of the attribute's value","type":"string","enum":["boolean","number","email","string","url","date"]},"canDelete":{"description":"If set to false, member attribute can not be deleted in future requests.","type":"boolean","default":false},"show":{"description":"Whether to show the member attribute in the web app or not.","type":"boolean","default":true},"createdAt":{"description":"Date the member attribute was created.","type":"string","format":"date-time"},"updatedAt":{"description":"Date the member attribute was last updated.","type":"string","format":"date-time"}},"xml":{"name":"MemberAttributeSettings"}},"MemberAttributeSettings":{"type":"object","allOf":[{"$ref":"#/components/schemas/MemberAttributeSettingsNoId"}],"properties":{"id":{"description":"The attribute settings ID."}}},"MemberAttributeSettingsList":{"description":"List and count member attribute settings.","type":"object","properties":{"rows":{"description":"List of member attribute settings","type":"array","items":{"$ref":"#/components/schemas/MemberAttributeSettings"}},"count":{"description":"Count","type":"integer"},"limit":{"description":"Limit of records returned","type":"integer"},"offset":{"description":"Offset, for pagination","type":"integer"}},"xml":{"name":"MemberAttributeSettingsList"}}},"examples":{"ActivityUpsert":{"value":{"id":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","type":"message","timestamp":"2020-05-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"1234","sourceParentId":null,"attributes":{"reactions":43},"channel":"dev","body":"It's not magic. It's talend and sweat.","title":null,"url":"discord.gg/1234","sentiment":{"label":"negative","mixed":1.1410574428737164,"neutral":11.00325882434845,"negative":85.99738478660583,"positive":1.8582981079816818,"sentiment":2},"importHash":null,"createdAt":"2022-10-03T15:18:11.294Z","updatedAt":"2022-10-03T15:21:49.402Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":null,"parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-03T15:17:27.073Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"parent":null,"tasks":[]}},"ActivityFind":{"value":{"id":"462ddc6b-5672-43b2-9018-4e3fd7332228","type":"pull_request-closed","timestamp":"2021-07-27T20:20:30.000Z","platform":"github","isContribution":true,"score":10,"sourceId":"gh_1","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Last one to finish the code sprint! But I will have fewer bugs than Gilfoyle.","title":"Code sprint over!","url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":0.7594161201268435,"neutral":39.13898766040802,"negative":12.336093187332153,"positive":47.76550233364105,"sentiment":79},"createdAt":"2022-10-03T15:36:43.775Z","updatedAt":"2022-10-03T15:39:38.199Z","deletedAt":null,"memberId":"2effc566-1932-44f3-a821-2d692933a953","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"2effc566-1932-44f3-a821-2d692933a953","username":{"github":"dinesh","twitter":"dinesh.chugtai"},"attributes":{"bio":{"github":"Lead developer at Pied Piper","default":"Pakistani Denzel. Tesla and gold chain owner.","twitter":"Pakistani Denzel. Tesla and gold chain owner."},"url":{"github":"https://github.com/dinesh","default":"https://t.co/d","twitter":"https://t.co/d"},"location":{"custom":"Silicon Valley","github":"Palo alto","default":"Silicon Valley"}},"displayName":"Dinesh","email":"dinesh@piedpiper.io","score":9,"joinedAt":"2022-10-03T15:30:55.672Z","importHash":null,"reach":{"total":100,"github":60,"twitter":40},"createdAt":"2022-10-03T15:30:55.679Z","updatedAt":"2022-10-03T15:30:55.679Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"parent":null,"tasks":[]}},"ActivityFind2":{"value":{"id":"73aa13b7-1ef9-4987-a273-e560edff94ca","type":"pull_request-comment","timestamp":"2021-07-27T20:22:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_2","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"I will never underestimate my talents again.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":14.308956265449524,"neutral":14.437079429626465,"negative":9.826807677745819,"positive":61.42715811729431,"sentiment":86},"importHash":null,"createdAt":"2022-10-03T15:38:05.847Z","updatedAt":"2022-10-03T15:46:34.610Z","deletedAt":null,"memberId":"2effc566-1932-44f3-a821-2d692933a953","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"2effc566-1932-44f3-a821-2d692933a953","username":{"github":"dinesh","twitter":"dinesh.chugtai"},"attributes":{"bio":{"github":"Lead developer at Pied Piper","default":"Pakistani Denzel. Tesla and gold chain owner.","twitter":"Pakistani Denzel. Tesla and gold chain owner."},"url":{"github":"https://github.com/dinesh","default":"https://t.co/d","twitter":"https://t.co/d"},"location":{"custom":"Silicon Valley","github":"Palo alto","default":"Silicon Valley"}},"displayName":"Dinesh","email":"dinesh@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:30:55.672Z","importHash":null,"reach":{"total":100,"github":60,"twitter":40},"createdAt":"2022-10-03T15:30:55.679Z","updatedAt":"2022-10-03T15:30:55.679Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"parent":{"id":"462ddc6b-5672-43b2-9018-4e3fd7332228","type":"pull_request-closed","timestamp":"2021-07-27T20:22:30.000Z","platform":"github","isContribution":true,"score":10,"sourceId":"gh_1","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Last one to finish the code sprint! But I will have less bugs than Gilfoyle.","title":"Code sprint over!","url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":0.7594161201268435,"neutral":39.13898766040802,"negative":12.336093187332153,"positive":47.76550233364105,"sentiment":79},"importHash":null,"createdAt":"2022-10-03T15:36:43.775Z","updatedAt":"2022-10-03T15:39:38.199Z","deletedAt":null,"memberId":"2effc566-1932-44f3-a821-2d692933a953","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"tasks":[]}},"ActivityFind3":{"value":{"id":"2dcbe40e-36e0-4929-ab21-a30467fd9a65","type":"pull_request-comment","timestamp":"2021-07-27T20:23:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_3","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"Don't worry. I will continue to do it for you.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":2.9098065569996834,"neutral":25.578168034553528,"negative":2.241993509232998,"positive":69.27002668380737,"sentiment":97},"importHash":null,"createdAt":"2022-10-03T15:47:20.151Z","updatedAt":"2022-10-03T15:47:20.220Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-03T15:17:27.073Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"parent":{"id":"462ddc6b-5672-43b2-9018-4e3fd7332228","type":"pull_request-closed","timestamp":"2021-07-27T20:22:30.000Z","platform":"github","isContribution":true,"score":10,"sourceId":"gh_1","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Last one to finish the code sprint! But I will have less bugs than Gilfoyle.","title":"Code sprint over!","url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":0.7594161201268435,"neutral":39.13898766040802,"negative":12.336093187332153,"positive":47.76550233364105,"sentiment":79},"importHash":null,"createdAt":"2022-10-03T15:36:43.775Z","updatedAt":"2022-10-03T15:39:38.199Z","deletedAt":null,"memberId":"2effc566-1932-44f3-a821-2d692933a953","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"tasks":[]}},"ActivityList":{"value":{"rows":[{"$ref":"#/components/examples/ActivityFind"},{"$ref":"#/components/examples/ActivityFind2"},{"$ref":"#/components/examples/ActivityFind3"}],"count":3,"limit":10,"offset":0}},"Automation":{"value":{"id":"b3297f3b-6924-4e92-80e7-ef2e0d87a120","type":"webhook","tenantId":"a3297f3b-6924-4e92-80e7-ef2e0d87a120","trigger":"new_activity","settings":{"url":"https://webhook.url/new_activities"},"createdAt":"2022-03-29T09:22:31.989Z"}},"AutomationPage":{"value":{"count":1,"offset":0,"limit":10,"rows":[{"id":"b3297f3b-6924-4e92-80e7-ef2e0d87a120","type":"webhook","tenantId":"a3297f3b-6924-4e92-80e7-ef2e0d87a120","trigger":"new_activity","settings":{"url":"https://webhook.url/new_activities"},"createdAt":"2022-03-29T09:22:31.989Z"}]}},"AutomationExecutionPage":{"value":{"count":1,"offset":0,"limit":10,"rows":[{"id":"b3297f3b-6924-4e92-80e7-ef2e0d87a120","automationId":"a3297f3b-6924-4e92-80e7-ef2e0d87a120","state":"success","executedAt":"2022-03-29T09:22:31.989Z","eventId":"a3297f3b-6924-4e92-80e7-ef2e0d87a121","payload":[{"id":"a3297f3b-6924-4e92-80e7-ef2e0d87a121","type":"comment","timestamp":"2022-03-29T09:22:31.989Z","platform":"twitter"}]}]}},"Conversation":{"value":{"id":"24bdea79-3125-4950-bb38-07fa4a555012","title":"Best of dinesh and Gilfoyle","slug":"best-of-dinesh-and-gilfoyle","published":true,"createdAt":"2022-10-05T12:21:53.271Z","updatedAt":"2022-10-05T12:21:53.271Z","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","activities":[{"id":"89a136ed-336d-4586-8842-790775465212","type":"message","timestamp":"2020-06-27T14:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"d42","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Sooner or later Gilfoyle's servers are going to fail and then it's all done","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"negative","mixed":3.6482997238636017,"neutral":19.5749893784523,"negative":75.36468505859375,"positive":1.4120269566774368,"sentiment":2},"importHash":null,"createdAt":"2022-10-05T12:09:44.414Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}},{"id":"c39dc046-da1d-4a25-8624-6b78aad00f30","type":"message","timestamp":"2020-06-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"2345","sourceParentId":"1234","attributes":{"reactions":68},"channel":"dev","body":"My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.","title":null,"url":"discord.gg/2345","sentiment":{"label":"negative","mixed":5.963129922747612,"neutral":20.673033595085144,"negative":69.99874711036682,"positive":3.365083411335945,"sentiment":5},"importHash":null,"createdAt":"2022-10-03T15:19:30.415Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}}],"conversationStarter":{"id":"89a136ed-336d-4586-8842-790775465212","type":"message","timestamp":"2020-06-27T14:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"d42","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Sooner or later Gilfoyle's servers are going to fail and then it's all done","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"negative","mixed":3.6482997238636017,"neutral":19.5749893784523,"negative":75.36468505859375,"positive":1.4120269566774368,"sentiment":2},"importHash":null,"createdAt":"2022-10-05T12:09:44.414Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}},"activityCount":2,"memberCount":2,"platform":"discord","channel":"piedpiper","lastActive":"2020-06-27T15:13:30.000Z"}},"ConversationList":{"value":{"rows":[{"id":"291af008-7717-457e-9242-f5c507c8987b","title":"Code sprint over!","slug":"code-sprint-over","published":false,"createdAt":"2022-10-03T15:38:05.900Z","updatedAt":"2022-10-03T15:38:05.900Z","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","platform":"github","activityCount":3,"lastActive":"2021-07-27T20:23:30.000Z","conversationStarter":{"id":"89a136ed-336d-4586-8842-790775465212","type":"message","timestamp":"2020-06-27T14:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"d42","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Sooner or later Gilfoyle's servers are going to fail and then it's all done","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"negative","mixed":3.6482997238636017,"neutral":19.5749893784523,"negative":75.36468505859375,"positive":1.4120269566774368,"sentiment":2},"importHash":null,"createdAt":"2022-10-05T12:09:44.414Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}},"lastReplies":[{"id":"c39dc046-da1d-4a25-8624-6b78aad00f30","type":"message","timestamp":"2020-06-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"2345","sourceParentId":"1234","attributes":{"reactions":68},"channel":"dev","body":"My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.","title":null,"url":"discord.gg/2345","sentiment":{"label":"negative","mixed":5.963129922747612,"neutral":20.673033595085144,"negative":69.99874711036682,"positive":3.365083411335945,"sentiment":5},"importHash":null,"createdAt":"2022-10-03T15:19:30.415Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}}],"memberCount":2,"channel":null},{"id":"24bdea79-3125-4950-bb38-07fa4a555012","title":"Best of dinesh and Gilfoyle","slug":"best-of-dinesh-and-gilfoyle","published":true,"createdAt":"2022-10-05T12:21:53.271Z","updatedAt":"2022-10-05T12:21:53.271Z","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","platform":"discord","activityCount":1,"lastActive":"2020-06-29T15:13:30.000Z","conversationStarter":{"id":"89a136ed-336d-4586-8842-790775465212","type":"message","timestamp":"2020-05-27T14:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"d42","sourceParentId":null,"attributes":{},"channel":"piedpiper","body":"Best of Dinesh and gilfoyle","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"negative","mixed":1.6482997238636017,"neutral":12.5749893784523,"negative":62.36468505859375,"positive":1.4120269566774368,"sentiment":2},"importHash":null,"createdAt":"2022-10-05T12:09:44.414Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}},"lastReplies":[{"id":"c39dc046-da1d-4a25-8624-6b78aad00f30","type":"message","timestamp":"2020-06-29T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"2345","sourceParentId":"1234","attributes":{"reactions":68},"channel":"dev","body":"A very last reply to the conversation.","title":null,"url":"discord.gg/2345","sentiment":{"label":"negative","mixed":5.963129922747612,"neutral":20.673033595085144,"negative":69.99874711036682,"positive":3.365083411335945,"sentiment":5},"importHash":null,"createdAt":"2022-10-03T15:19:30.415Z","updatedAt":"2022-10-05T12:21:53.279Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"24bdea79-3125-4950-bb38-07fa4a555012","parentId":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","member":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}}],"memberCount":2,"channel":"dev"}],"count":2,"limit":10,"offset":0}},"MemberUpsert":{"value":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-03T15:17:27.073Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}},"MemberFind":{"value":{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","activities":[{"id":"2dcbe40e-36e0-4929-ab21-a30467fd9a65","type":"pull_request-comment","timestamp":"2021-07-27T20:23:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_3","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"Don't worry. I will continue to do it for you.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":2.9098065569996834,"neutral":25.578168034553528,"negative":2.241993509232998,"positive":69.27002668380737,"sentiment":97},"importHash":null,"createdAt":"2022-10-03T15:47:20.151Z","updatedAt":"2022-10-03T15:47:20.220Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},{"id":"c39dc046-da1d-4a25-8624-6b78aad00f30","type":"message","timestamp":"2020-06-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"2345","sourceParentId":"1234","attributes":{"reactions":68},"channel":"dev","body":"My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.","title":null,"url":"discord.gg/2345","sentiment":{"label":"negative","mixed":5.963129922747612,"neutral":20.673033595085144,"negative":69.99874711036682,"positive":3.365083411335945,"sentiment":5},"importHash":null,"createdAt":"2022-10-03T15:19:30.415Z","updatedAt":"2022-10-03T15:26:02.599Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":null,"parentId":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},{"id":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","type":"message","timestamp":"2020-05-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"1234","sourceParentId":null,"attributes":{"reactions":43},"channel":"dev","body":"It's not magic. It's talend and sweat.","title":null,"url":"discord.gg/1234","sentiment":{"label":"negative","mixed":1.1410574428737164,"neutral":11.00325882434845,"negative":85.99738478660583,"positive":1.8582981079816818,"sentiment":2},"importHash":null,"createdAt":"2022-10-03T15:18:11.294Z","updatedAt":"2022-10-03T15:21:49.402Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":null,"parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"lastActivity":{"id":"2dcbe40e-36e0-4929-ab21-a30467fd9a65","type":"pull_request-comment","timestamp":"2021-07-27T20:23:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_3","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"Don't worry. I will continue to do it for you.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":2.9098065569996834,"neutral":25.578168034553528,"negative":2.241993509232998,"positive":69.27002668380737,"sentiment":97},"importHash":null,"createdAt":"2022-10-03T15:47:20.151Z","updatedAt":"2022-10-03T15:47:20.220Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"lastActive":"2021-07-27T20:23:30.000Z","activityCount":3,"averageSentiment":34.67,"tags":[{"id":"38807625-6302-47b5-9f35-58566ddec83b","name":"developer","importHash":null,"createdAt":"2022-10-05T11:41:20.162Z","updatedAt":"2022-10-05T11:41:20.162Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},{"id":"dca36c33-38cd-4e68-8ba8-515167e00971","name":"attended-hooli-con","importHash":null,"createdAt":"2022-10-05T11:42:17.414Z","updatedAt":"2022-10-05T11:42:17.414Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"organizations":[{"id":"31bff99a-2eac-49f5-b015-cba95aa6e530","name":"Pied Piper","url":"https://piedpiper.io","description":"The new internet","parentUrl":null,"emails":["richard@piedpiper.io","hello@piedpiper.io"],"phoneNumbers":null,"logo":null,"tags":["new-internet","making-the-world-a-better-place","not-like-hooli"],"twitter":{"bio":"The internet we deserve","handle":"PiedPiper","location":"The valley","followers":5000,"following":20},"linkedin":{"handle":"company/PiedPiper"},"crunchbase":{"handle":"company/PiedPiper"},"employees":50,"revenueRange":{"max":50,"min":10},"importHash":null,"createdAt":"2022-10-03T16:15:21.812Z","updatedAt":"2022-10-03T16:15:21.812Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"tasks":[],"notes":[],"noMerge":[],"toMerge":[]}},"MemberList":{"value":{"rows":[{"id":"2effc566-1932-44f3-a821-2d692933a953","username":{"github":"dinesh","twitter":"dinesh.chugtai"},"attributes":{"bio":{"github":"Lead developer at Pied Piper","default":"Pakistani Denzel. Tesla and gold chain owner.","twitter":"Pakistani Denzel. Tesla and gold chain owner."},"url":{"github":"https://github.com/dinesh","default":"https://t.co/d","twitter":"https://t.co/d"},"location":{"custom":"Silicon Valley","github":"Palo alto","default":"Silicon Valley"}},"displayName":"Dinesh","email":"dinesh@piedpiper.io","score":9,"joinedAt":"2022-10-03T15:30:55.672Z","importHash":null,"reach":{"total":100,"github":60,"twitter":40},"createdAt":"2022-10-03T15:30:55.679Z","updatedAt":"2022-10-05T11:39:58.095Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","identities":["github","twitter"],"activeOn":["github"],"activityCount":"2","lastActive":"2021-07-27T20:22:30.000Z","averageSentiment":"82.50","noMerge":[],"toMerge":[],"lastActivity":{"id":"73aa13b7-1ef9-4987-a273-e560edff94ca","type":"pull_request-comment","timestamp":"2021-07-27T20:22:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_2","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"I will never underestimate my talents again.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":14.308956265449524,"neutral":14.437079429626465,"negative":9.826807677745819,"positive":61.42715811729431,"sentiment":86},"importHash":null,"createdAt":"2022-10-03T15:38:05.847Z","updatedAt":"2022-10-03T15:46:34.610Z","deletedAt":null,"memberId":"2effc566-1932-44f3-a821-2d692933a953","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"organizations":[{"id":"31bff99a-2eac-49f5-b015-cba95aa6e530","name":"Pied Piper","url":"https://piedpiper.io","description":"The new internet","parentUrl":null,"emails":["richard@piedpiper.io","hello@piedpiper.io"],"phoneNumbers":null,"logo":null,"tags":["new-internet","making-the-world-a-better-place","not-like-hooli"],"twitter":{"bio":"The internet we deserve","handle":"PiedPiper","location":"The valley","followers":5000,"following":20},"linkedin":{"handle":"company/PiedPiper"},"crunchbase":{"handle":"company/PiedPiper"},"employees":50,"revenueRange":{"max":50,"min":10},"importHash":null,"createdAt":"2022-10-03T16:15:21.812Z","updatedAt":"2022-10-03T16:15:21.812Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"tags":[{"id":"38807625-6302-47b5-9f35-58566ddec83b","name":"developer","importHash":null,"createdAt":"2022-10-05T11:41:20.162Z","updatedAt":"2022-10-05T11:41:20.162Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]},{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","activityCount":"3","lastActive":"2021-07-27T20:23:30.000Z","averageSentiment":"34.67","noMerge":[],"toMerge":[],"lastActivity":{"id":"2dcbe40e-36e0-4929-ab21-a30467fd9a65","type":"pull_request-comment","timestamp":"2021-07-27T20:23:30.000Z","platform":"github","isContribution":true,"score":3,"sourceId":"gh_3","sourceParentId":"gh_1","attributes":{},"channel":"piedpiper","body":"Don't worry. I will continue to do it for you.","title":null,"url":"github.com/piedpiper/piedpier","sentiment":{"label":"positive","mixed":2.9098065569996834,"neutral":25.578168034553528,"negative":2.241993509232998,"positive":69.27002668380737,"sentiment":97},"importHash":null,"createdAt":"2022-10-03T15:47:20.151Z","updatedAt":"2022-10-03T15:47:20.220Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":"291af008-7717-457e-9242-f5c507c8987b","parentId":"462ddc6b-5672-43b2-9018-4e3fd7332228","tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},"organizations":[{"id":"31bff99a-2eac-49f5-b015-cba95aa6e530","name":"Pied Piper","url":"https://piedpiper.io","description":"The new internet","parentUrl":null,"emails":["richard@piedpiper.io","hello@piedpiper.io"],"phoneNumbers":null,"logo":null,"tags":["new-internet","making-the-world-a-better-place","not-like-hooli"],"twitter":{"bio":"The internet we deserve","handle":"PiedPiper","location":"The valley","followers":5000,"following":20},"linkedin":{"handle":"company/PiedPiper"},"crunchbase":{"handle":"company/PiedPiper"},"employees":50,"revenueRange":{"max":50,"min":10},"importHash":null,"createdAt":"2022-10-03T16:15:21.812Z","updatedAt":"2022-10-03T16:15:21.812Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"tags":[{"id":"38807625-6302-47b5-9f35-58566ddec83b","name":"developer","importHash":null,"createdAt":"2022-10-05T11:41:20.162Z","updatedAt":"2022-10-05T11:41:20.162Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},{"id":"dca36c33-38cd-4e68-8ba8-515167e00971","name":"attended-hooli-con","importHash":null,"createdAt":"2022-10-05T11:42:17.414Z","updatedAt":"2022-10-05T11:42:17.414Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}],"count":2,"offset":0,"limit":10}},"Note2":{"value":{"id":"39c850f6-fb96-4d16-8e8c-cd7072e33925","body":"Refused to have a user feedback call","importHash":null,"createdAt":"2022-10-03T16:00:57.867Z","updatedAt":"2022-10-03T16:00:57.867Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-03T15:17:27.073Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}},"Note":{"value":{"id":"196c07da-14e0-419e-bd9a-5f15c721a694","body":"Likes frunks","importHash":null,"createdAt":"2022-10-05T11:58:30.977Z","updatedAt":"2022-10-05T11:58:30.977Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[{"id":"2effc566-1932-44f3-a821-2d692933a953","username":{"github":"dinesh","twitter":"dinesh.chugtai"},"attributes":{"bio":{"github":"Lead developer at Pied Piper","default":"Pakistani Denzel. Tesla and gold chain owner.","twitter":"Pakistani Denzel. Tesla and gold chain owner."},"url":{"github":"https://github.com/dinesh","default":"https://t.co/d","twitter":"https://t.co/d"},"location":{"custom":"Silicon Valley","github":"Palo alto","default":"Silicon Valley"}},"displayName":"Dinesh","email":"dinesh@piedpiper.io","score":9,"joinedAt":"2022-10-03T15:30:55.672Z","importHash":null,"reach":{"total":100,"github":60,"twitter":40},"createdAt":"2022-10-03T15:30:55.679Z","updatedAt":"2022-10-05T11:39:58.095Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}},"NoteList":{"value":{"rows":[{"$ref":"#/components/examples/Note"},{"$ref":"#/components/examples/Note2"}],"count":2,"limit":10,"offset":0}},"OrganizationCreate":{"value":{"id":"31bff99a-2eac-49f5-b015-cba95aa6e530","name":"Pied Piper","url":"https://piedpiper.io","description":"The new internet","parentUrl":null,"emails":["richard@piedpiper.io","hello@piedpiper.io"],"phoneNumbers":null,"logo":null,"tags":["new-internet","making-the-world-a-better-place","not-like-hooli"],"twitter":{"bio":"The internet we deserve","handle":"PiedPiper","location":"The valley","followers":5000,"following":20},"linkedin":{"handle":"company/PiedPiper"},"crunchbase":{"handle":"company/PiedPiper"},"employees":50,"revenueRange":{"max":50,"min":10},"importHash":null,"createdAt":"2022-10-03T16:15:21.812Z","updatedAt":"2022-10-03T16:15:21.812Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","memberCount":2,"activityCount":4}},"Organization":{"value":{"id":"31bff99a-2eac-49f5-b015-cba95aa6e530","name":"Pied Piper","url":"https://piedpiper.io","description":"The new internet","parentUrl":null,"emails":["richard@piedpiper.io","hello@piedpiper.io"],"phoneNumbers":null,"logo":null,"tags":["new-internet","making-the-world-a-better-place","not-like-hooli"],"identities":["github","twitter"],"activeOn":["github"],"lastActive":"2022-10-03T16:15:21.812Z","joinedAt":"2022-05-03T11:16:32.812Z","twitter":{"bio":"The internet we deserve","handle":"PiedPiper","location":"The valley","followers":5000,"following":20},"linkedin":{"handle":"company/PiedPiper"},"crunchbase":{"handle":"company/PiedPiper"},"employees":50,"revenueRange":{"max":50,"min":10},"importHash":null,"createdAt":"2022-10-03T16:15:21.812Z","updatedAt":"2022-10-03T16:15:21.812Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","memberCount":2,"activityCount":4}},"Organization2":{"value":{"id":"65257687-0bfa-498e-8b2f-53559f41522b","name":"Hooli","url":"https://hooli.xyz","description":"Hooli is an international corporation founded by Gavin Belson and Peter Gregory","parentUrl":null,"emails":["gavin@hooli.xyz"],"phoneNumbers":null,"logo":null,"tags":["hooli","tethics","not-google"],"identities":["devto","github","twitter"],"activeOn":["devto"],"lastActive":"2022-10-04","joinedAt":"2020-01-30","twitter":{"bio":"Hooli is an international corporation founded by Gavin Belson and Peter Gregory","handle":"hooli","location":"Menlo Park","followers":500000,"following":0},"linkedin":{"handle":"company/Hooli"},"crunchbase":{"handle":"company/Hooli"},"employees":4000,"revenueRange":{"max":500,"min":100},"importHash":null,"createdAt":"2022-10-05T12:03:11.228Z","updatedAt":"2022-10-05T12:03:11.228Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","memberCount":0,"activityCount":0}},"OrganizationList":{"value":{"rows":[{"$ref":"#/components/examples/Organization"},{"$ref":"#/components/examples/Organization2"}],"count":2,"limit":10,"offset":0}},"Tag":{"value":{"id":"dca36c33-38cd-4e68-8ba8-515167e00971","name":"attended-hooli-con","importHash":null,"createdAt":"2022-10-05T11:42:17.414Z","updatedAt":"2022-10-05T11:42:17.414Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}},"Tag2":{"value":{"id":"38807625-6302-47b5-9f35-58566ddec83b","name":"developer","createdAt":"2022-10-05T11:41:20.162Z","updatedAt":"2022-10-05T11:41:20.162Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[{"id":"2effc566-1932-44f3-a821-2d692933a953","username":{"github":"dinesh","twitter":"dinesh.chugtai"},"attributes":{"bio":{"github":"Lead developer at Pied Piper","default":"Pakistani Denzel. Tesla and gold chain owner.","twitter":"Pakistani Denzel. Tesla and gold chain owner."},"url":{"github":"https://github.com/dinesh","default":"https://t.co/d","twitter":"https://t.co/d"},"location":{"custom":"Silicon Valley","github":"Palo alto","default":"Silicon Valley"}},"displayName":"Dinesh","email":"dinesh@piedpiper.io","score":9,"joinedAt":"2022-10-03T15:30:55.672Z","reach":{"total":100,"github":60,"twitter":40},"createdAt":"2022-10-03T15:30:55.679Z","updatedAt":"2022-10-05T11:39:58.095Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"},{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":8,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-05T11:40:32.560Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}},"TagList":{"value":{"rows":[{"$ref":"#/components/examples/Tag"},{"$ref":"#/components/examples/Tag2"}],"count":2,"limit":10,"offset":0}},"Task":{"value":{"id":"8a127785-f11d-4102-804d-5b79ccddd4cc","name":"Ask for tips on building a new Anton","body":null,"status":null,"dueDate":"2022-05-27T15:13:30.000Z","importHash":null,"createdAt":"2022-10-03T16:00:18.701Z","updatedAt":"2022-10-03T16:00:18.701Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","assignedToId":null,"createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[{"id":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","username":{"github":"gilfoyle","twitter":"gilfoyle"},"attributes":{"bio":{"github":"Systems engineer at Pied Piper","default":"It's not magic. It's talent and sweat","twitter":"It's not magic. It's talent and sweat"},"url":{"github":"https://github.com/gilfoyle","default":"https://t.co/g","twitter":"https://t.co/g"},"location":{"custom":"Erlich's house","github":"Palo alto","default":"Erlich's house"}},"displayName":"Gilfoyle","email":"gilfoyle@piedpiper.io","score":-1,"joinedAt":"2022-10-03T15:17:03.540Z","importHash":null,"reach":{"total":10000,"github":5000,"twitter":5000},"createdAt":"2022-10-03T15:17:03.547Z","updatedAt":"2022-10-03T15:17:27.073Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}],"activities":[]}},"Task2":{"value":{"id":"ef22fb05-a41b-472e-9917-a4d10d19fcc6","name":"Ask if we can use as quote","body":null,"status":null,"dueDate":"2022-08-27T00:00:00.000Z","importHash":null,"createdAt":"2022-10-05T11:55:55.606Z","updatedAt":"2022-10-05T11:55:55.606Z","deletedAt":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","assignedToId":null,"createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","members":[],"activities":[{"id":"782b426d-adc8-4fb4-a4ee-ab0bb07ffca0","type":"message","timestamp":"2020-05-27T15:13:30.000Z","platform":"discord","isContribution":true,"score":1,"sourceId":"1234","sourceParentId":null,"attributes":{"reactions":43},"channel":"dev","body":"It's not magic. It's talend and sweat.","title":null,"url":"discord.gg/1234","sentiment":{"label":"negative","mixed":1.1410574428737164,"neutral":11.00325882434845,"negative":85.99738478660583,"positive":1.8582981079816818,"sentiment":2},"importHash":null,"createdAt":"2022-10-03T15:18:11.294Z","updatedAt":"2022-10-03T15:21:49.402Z","deletedAt":null,"memberId":"ab7a9fe9-4576-46b1-a710-8b8eaeff87a5","conversationId":null,"parentId":null,"tenantId":"8642a2bd-965e-4acd-be8c-dfedc83ef0af","createdById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75","updatedById":"debc3c7f-4c5d-4bec-9130-17bb0aea8b75"}]}},"TaskList":{"value":{"rows":[{"$ref":"#/components/examples/Task"},{"$ref":"#/components/examples/Task2"}],"count":2,"limit":10,"offset":0}},"TaskFindAndUpdateAll":{"value":{"rowsUpdated":5}},"ActivityTypes":{"value":{"default":{"github":{"discussion-started":{"default":"started a discussion in {channel}","short":"started a discussion","channel":"{channel}"},"discussion-comment":{"default":"commented on a discussion in {channel}","short":"commented on a discussion","channel":"{channel}"},"fork":{"default":"forked {channel}","short":"forked","channel":"{channel}"},"issues-closed":{"default":"closed an issue in {channel}","short":"closed an issue","channel":"{channel}"},"issues-opened":{"default":"opened a new issue in {channel}","short":"opened an issue","channel":"{channel}"},"issue-comment":{"default":"commented on an issue in {channel}","short":"commented on an issue","channel":"{channel}"},"pull_request-closed":{"default":"closed a pull request in {channel}","short":"closed a pull request","channel":"{channel}"},"pull_request-opened":{"default":"opened a new pull request in {channel}","short":"opened a pull request","channel":"{channel}"},"pull_request-comment":{"default":"commented on a pull request in {channel}","short":"commented on a pull request","channel":"{channel}"},"star":{"default":"starred {channel}","short":"starred","channel":"{channel}"},"unstar":{"default":"unstarred {channel}","short":"unstarred","channel":"{channel}"}},"devto":{"comment":{"default":"commented on <a href=\"{attributes.articleUrl}\" class=\"truncate max-w-2xs\">{attributes.articleTitle}</a>","short":"commented","channel":"<a href=\"{attributes.articleUrl}\" class=\"truncate max-w-2xs\">{attributes.articleTitle}</a>"}},"discord":{"joined_guild":{"default":"joined server","short":"joined server","channel":""},"message":{"default":"sent a message in <span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span>","short":"sent a message","channel":"<span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span>"},"thread_started":{"default":"started a new thread","short":"started a new thread","channel":""},"thread_message":{"default":"replied to a message in thread <span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span> -> <span class=\"text-brand-500\">{attributes.parentChannel}</span>","short":"replied to a message","channel":"<span class=\"text-brand-500 truncate max-w-2xs\">thread #{channel}</span> -> <span class=\"text-brand-500\">#{attributes.parentChannel}</span>"}},"hackernews":{"comment":{"default":"commented on <a href=\"{attributes.parentUrl}\" target=\"_blank\">{attributes.parentTitle}</a>","short":"commented","channel":"{channel}"},"post":{"default":"posted mentioning {channel}","short":"posted","channel":"{channel}"}},"linkedin":{"comment":{"default":"commented on a post <a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>","short":"commented","channel":"<a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>"},"message":{"default":"sent a message","short":"sent a message","channel":""},"reaction":{"default":"reacted with <img src=\"/images/integrations/linkedin-reactions/{attributes.reactionType}.svg\"> on a post <a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>","short":"reacted","channel":"<a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>"}},"reddit":{"comment":{"default":"commented in subreddit <a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>","short":"commented on a post","channel":"<a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>"},"post":{"default":"posted in subreddit <a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>","short":"posted in subreddit","channel":"<a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>"}},"slack":{"channel_joined":{"default":"joined channel {channel}","short":"joined channel","channel":"{channel}"},"message":{"default":"sent a message in {channel}","short":"sent a message","channel":"{channel}"}},"twitter":{"hashtag":{"default":"posted a tweet","short":"posted a tweet","channel":""},"follow":{"default":"followed you","short":"followed you","channel":""},"mention":{"default":"mentioned you in a tweet","short":"mentioned you","channel":""}},"stackoverflow":{"question":{"default":"Asked a question {self}","short":"asked a question","channel":""},"answer":{"default":"Answered a question {self}","short":"answered a question","channel":""}}},"custom":{"other":{"attended-a-meeting":{"short":"Attended a meeting","channel":"","default":"Attended a meeting"},"asked-question-in-webinar":{"default":"Asked question in webinar","short":"Asked question in webinar","channel":""}}}}},"MemberAttributeSettings":{"value":{"id":"9eaedce9-1f3a-4a75-adc8-e475cbc47553'","type":"string","canDelete":false,"show":true,"label":"Url","name":"url","createdAt":"2022-09-07","updatedAt":"2022-09-07","tenantId":"fcd5b9cc-144b-4687-8fd9-34818f35e70d"}},"MemberAttributeSettings2":{"value":{"id":"13bb9e12-c371-44ad-8806-0678c2f53dd1","type":"boolean","canDelete":false,"show":true,"label":"is Hireable","name":"isHireable","createdAt":"2022-09-07","updatedAt":"2022-09-07","tenantId":"fcd5b9cc-144b-4687-8fd9-34818f35e70d"}},"MemberAttributeSettingsList":{"value":{"rows":[{"$ref":"#/components/examples/MemberAttributeSettings"},{"$ref":"#/components/examples/MemberAttributeSettings2"}],"count":2}}}},"tags":[{"name":"Members","description":"Everything about members"},{"name":"Member Attributes","description":"Settings for member's attributes"},{"name":"Activities","description":"Everything about activities"},{"name":"Organizations","description":"Everything about organizations"},{"name":"Conversations","description":"Everything about conversations"},{"name":"Tags","description":"Everything about tags"},{"name":"Automations","description":"Everything about automations"},{"name":"Notes","description":"Everything about notes"}]}
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "crowd.dev API",
+    "version": "1.0.5",
+    "description": "crowd.dev API\n",
+    "contact": { "email": "joan@crowd.dev" },
+    "license": { "name": "Apache 2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0.html" },
+    "x-github": "https://github.com/crowdHQ"
+  },
+  "servers": [{ "url": "https://app.crowd.dev/api" }],
+  "paths": {
+    "/tenant/{tenantId}/activity/with-member": {
+      "post": {
+        "summary": "Create or update an activity with a member",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create or update an activity with a member\nActivity existence is checked by sourceId and tenantId\nMember existence is checked by platform and username",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ActivityUpsertWithMemberInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Activity" },
+                "examples": { "Activity": { "$ref": "#/components/examples/ActivityUpsert" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/activity": {
+      "post": {
+        "summary": "Create or update an activity",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create or update an activity. Existence is checked by sourceId and tenantId",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ActivityUpsertInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Activity" },
+                "examples": { "Activity": { "$ref": "#/components/examples/ActivityUpsert" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/activity/{id}": {
+      "delete": {
+        "summary": "Delete an activity",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a activity given an ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the activity",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find an activity",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a single activity by ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the activity",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityResponse" },
+                "examples": { "Activity": { "$ref": "#/components/examples/ActivityFind" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an activity",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update an activity given an ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the activity",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ActivityUpsertInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Activity" },
+                "examples": { "Activity": { "$ref": "#/components/examples/ActivityFind" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/activity/query": {
+      "post": {
+        "summary": "Query activities",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Query activities. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ActivityQuery" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityList" },
+                "examples": { "Activity": { "$ref": "#/components/examples/ActivityList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/automation": {
+      "post": {
+        "summary": "Create an automation",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a new automation for the tenant.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AutomationCreateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Automation" },
+                "examples": { "Automation": { "$ref": "#/components/examples/Automation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "List automations",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get all existing automation data for tenant.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[type]",
+            "in": "query",
+            "description": "Filter by type of automation",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[trigger]",
+            "in": "query",
+            "description": "Filter by trigger type of automation",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[state]",
+            "in": "query",
+            "description": "Filter by state of automation",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Skip the first n results. Default 0.",
+            "required": false,
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limit the number of results. Default 50.",
+            "required": false,
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AutomationPage" },
+                "examples": { "AutomationPage": { "$ref": "#/components/examples/AutomationPage" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/automation/{automationId}": {
+      "delete": {
+        "summary": "Destroy an automation",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Destroys an existing automation in the tenant.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "automationId",
+            "in": "path",
+            "description": "Automation ID that you want to update",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "Ok - No content" },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find an automation",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get an existing automation data in the tenant.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "automationId",
+            "in": "path",
+            "description": "Automation ID that you want to find",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Automation" },
+                "examples": { "Automation": { "$ref": "#/components/examples/Automation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an automation",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Updates an existing automation in the tenant.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "automationId",
+            "in": "path",
+            "description": "Automation ID that you want to update",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AutomationUpdateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Automation" },
+                "examples": { "Automation": { "$ref": "#/components/examples/Automation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/automation/{automationId}/executions": {
+      "get": {
+        "summary": "Get automation history",
+        "tags": ["Automations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get all automation execution history for tenant and automation",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "automationId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "How many elements from the beginning would you like to skip",
+            "required": false,
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many elements would you like to fetch",
+            "required": false,
+            "schema": { "type": "integer", "default": 10 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AutomationExecutionPage" },
+                "examples": {
+                  "AutomationExecutionPage": {
+                    "$ref": "#/components/examples/AutomationExecutionPage"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/conversation": {
+      "post": {
+        "summary": "Create a conversation",
+        "tags": ["Conversations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a conversation.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ConversationNoId" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Conversation" },
+                "examples": { "Conversation": { "$ref": "#/components/examples/Conversation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "List conversations",
+        "tags": ["Conversations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get a list of conversations with filtering, sorting and offsetting.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[title]",
+            "in": "query",
+            "description": "Filter by the title of the conversation.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[slug]",
+            "in": "query",
+            "description": "Filter by the slug of the conversation.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[published]",
+            "in": "query",
+            "description": "Filter by whether it is published or not.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[platform]",
+            "in": "query",
+            "description": "Filter by the platform of the conversation.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[channel]",
+            "in": "query",
+            "description": "Filter by the channel of the conversation.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[activitiesCountRange]",
+            "in": "query",
+            "description": "activitiesCount lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[createdAtRange]",
+            "in": "query",
+            "description": "Created at lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Sort the results. Default timestamp_DESC.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/ConversationSort" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Skip the first n results. Default 0.",
+            "required": false,
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limit the number of results. Default 50.",
+            "required": false,
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ConversationList" },
+                "examples": {
+                  "Conversations": { "$ref": "#/components/examples/ConversationList" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/conversation/{id}": {
+      "delete": {
+        "summary": "Delete a conversation",
+        "tags": ["Conversations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a conversation.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the conversation",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find a conversation",
+        "tags": ["Conversations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a conversation by ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the conversation.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Conversation" },
+                "examples": { "Conversation": { "$ref": "#/components/examples/Conversation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an conversation",
+        "tags": ["Conversations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a conversation given an ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the conversation",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/ConversationNoId" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Conversation" },
+                "examples": { "Conversation": { "$ref": "#/components/examples/Conversation" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/member/active": {
+      "get": {
+        "summary": "List active members",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "List active members. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[platforms]",
+            "in": "query",
+            "description": "Filter by activity platforms (comma separated list without spaces)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[isTeamMember]",
+            "in": "query",
+            "description": "If true we will return just team members, if false we will return just non-team members, if undefined we will return both.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[isBot]",
+            "in": "query",
+            "description": "If true we will return just members who are bots, if false we will return just non-bot members, if undefined we will return both.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[isOrganization]",
+            "in": "query",
+            "description": "If true we will return just members who are organizations (such as linkedin organizations that post), if false we will return just non-organization members, if undefined we will return both.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[activityTimestampFrom]",
+            "in": "query",
+            "description": "Filter by activity timestamp from (required)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[activityTimestampTo]",
+            "in": "query",
+            "description": "Filter by activity timestamp to (required)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[activityIsContribution]",
+            "in": "query",
+            "description": "Filter by activities that are contributions",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "How to sort results. Available values: activityCount_DESC, activityCount_ASC, activeDaysCount_DESC, activeDaysCount_ASC (default activityCount_DESC)",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Skip the first n results. Default 0.",
+            "required": false,
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limit the number of results. Default 20.",
+            "required": false,
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/member": {
+      "post": {
+        "summary": "Create or update a member",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create or update a member. Existence is checked by platform and username.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/MemberUpsertInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" },
+                "examples": { "Member": { "$ref": "#/components/examples/MemberUpsert" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/member/{id}": {
+      "delete": {
+        "summary": "Delete a member",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a member given an ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find a member",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a single member by ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberResponse" },
+                "examples": { "Member": { "$ref": "#/components/examples/MemberFind" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update a member",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a member",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/MemberUpdateInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Member" },
+                "examples": { "Member": { "$ref": "#/components/examples/MemberUpsert" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/member/export": {
+      "post": {
+        "summary": "Export members as CSV",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Export members. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/MemberQuery" } }
+          }
+        },
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/member/query": {
+      "post": {
+        "summary": "Query members",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Query members. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/MemberQuery" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberList" },
+                "examples": { "Member": { "$ref": "#/components/examples/MemberList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/note": {
+      "post": {
+        "summary": "Create a note",
+        "tags": ["Notes"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a note",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NoteNoId" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Note" },
+                "examples": { "Note": { "$ref": "#/components/examples/Note" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/note/{id}": {
+      "delete": {
+        "summary": "Delete a note",
+        "tags": ["Notes"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a note.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the note",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find a note",
+        "tags": ["Notes"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a note by ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID.",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the note.",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/NoteResponse" },
+                "examples": { "Note": { "$ref": "#/components/examples/Note" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update a note",
+        "tags": ["Notes"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a note",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the note",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NoteInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Note" },
+                "examples": { "Note": { "$ref": "#/components/examples/Note" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/note/query": {
+      "post": {
+        "summary": "Query notes",
+        "tags": ["Notes"],
+        "security": [{ "Bearer": [] }],
+        "description": "Query notes. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NoteQuery" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/NoteList" },
+                "examples": { "Note": { "$ref": "#/components/examples/NoteList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/organization": {
+      "post": {
+        "summary": "Create a organization",
+        "tags": ["Organizations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a organization",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/OrganizationInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" },
+                "examples": {
+                  "Organization": { "$ref": "#/components/examples/OrganizationCreate" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/organization/{id}": {
+      "delete": {
+        "summary": "Delete a organization",
+        "tags": ["Organizations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a organization.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the organization",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find an organization",
+        "tags": ["Organizations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find an organization by ID.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the organization",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OrganizationResponse" },
+                "examples": { "Organization": { "$ref": "#/components/examples/Organization" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an organization",
+        "tags": ["Organizations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a organization",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the organization",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/OrganizationInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Organization" },
+                "examples": {
+                  "Organization": { "$ref": "#/components/examples/OrganizationCreate" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/organization/query": {
+      "post": {
+        "summary": "Query organizations",
+        "tags": ["Organizations"],
+        "security": [{ "Bearer": [] }],
+        "description": "Query organizations. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/OrganizationQuery" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OrganizationList" },
+                "examples": { "Organization": { "$ref": "#/components/examples/OrganizationList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/settings/activity/types": {
+      "post": {
+        "summary": "Create an activity type",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a custom activity type",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ActivityTypesCreateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityTypes" },
+                "examples": { "ActivityTypes": { "$ref": "#/components/examples/ActivityTypes" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "List all activity types",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "List all activity types",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityTypes" },
+                "examples": { "ActivityTypes": { "$ref": "#/components/examples/ActivityTypes" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/settings/activity/types/{key}": {
+      "put": {
+        "summary": "Update an activity type",
+        "tags": ["Activities"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a custom activity type",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "description": "The key of the activity type",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ActivityTypesUpdateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ActivityTypes" },
+                "examples": { "ActivityTypes": { "$ref": "#/components/examples/ActivityTypes" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/settings/members/attributes": {
+      "post": {
+        "summary": "Attribute settings: create",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a members' attribute setting",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MemberAttributeSettingsCreateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberAttributeSettings" },
+                "examples": {
+                  "MemberAttributeSettings": {
+                    "$ref": "#/components/examples/MemberAttributeSettings"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "delete": {
+        "summary": "Attribute settings: delete",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a members' attribute setting",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "description": "Id to destroy",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Attributes settings: list",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get a list of members' attribute settings",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[label]",
+            "in": "query",
+            "description": "Filter by label of member attribute settings",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter by name of member attribute settings",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[type]",
+            "in": "query",
+            "description": "Filter by type of member attribute settings",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[canDelete]",
+            "in": "query",
+            "description": "Filter by canDelete: \"true\" or \"false\"",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[show]",
+            "in": "query",
+            "description": "Filter by show: \"true\" or \"false\"",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[createdAtRange]",
+            "in": "query",
+            "description": "CreatedAt lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Sort the results. Default createdAt_DESC.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/MemberAttributeSettingsSort" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Skip the first n results. Default 0.",
+            "required": false,
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limit the number of results. Default 50.",
+            "required": false,
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberAttributeSettingsList" },
+                "examples": {
+                  "MemberAttributeSettings": {
+                    "$ref": "#/components/examples/MemberAttributeSettingsList"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/settings/members/attributes/{id}": {
+      "get": {
+        "summary": "Attributes settings: find",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a single members' attribute setting by ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member attribute's settings",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberAttributeSettings" },
+                "examples": {
+                  "MemberAttributeSettings": {
+                    "$ref": "#/components/examples/MemberAttributeSettings"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Attribute settings: update",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a members' attribute setting",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member attribute settings",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MemberAttributeSettingsUpdateInput" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberAttributeSettings" },
+                "examples": {
+                  "MemberAttributeSettings": {
+                    "$ref": "#/components/examples/MemberAttributeSettings"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/tag": {
+      "post": {
+        "summary": "Create a tag",
+        "tags": ["Tags"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a tag",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TagNoId" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Tag" },
+                "examples": { "Tag": { "$ref": "#/components/examples/Tag" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "List tags",
+        "tags": ["Tags"],
+        "security": [{ "Bearer": [] }],
+        "description": "Get a list of tags with filtering, sorting and offsetting.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[name]",
+            "in": "query",
+            "description": "Filter by the name of the tag.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "filter[createdAtRange]",
+            "in": "query",
+            "description": "Created at lower bound. If you want a range, send this parameter twice with [min] and [max]. If you send it once it will be interpreted as a lower bound.",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Sort the results. Default timestamp_DESC.",
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/TagSort" }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Skip the first n results. Default 0.",
+            "required": false,
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Limit the number of results. Default 50.",
+            "required": false,
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TagList" },
+                "examples": { "Tags": { "$ref": "#/components/examples/TagList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/tag/{id}": {
+      "delete": {
+        "summary": "Delete a tag",
+        "tags": ["Tags"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a tag.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the tag",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find a tag",
+        "tags": ["Tags"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a tag by ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the tag",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Tag" },
+                "examples": { "Tag": { "$ref": "#/components/examples/Tag" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an tag",
+        "tags": ["Tags"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a tag",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the tag",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TagNoId" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Tag" },
+                "examples": { "Tag": { "$ref": "#/components/examples/Tag" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/task/batch": {
+      "post": {
+        "summary": "Make batch operations on tasks",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Make batch operations on tasks",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TaskBatchInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskFindAndUpdateAll" },
+                "examples": { "Task": { "$ref": "#/components/examples/TaskFindAndUpdateAll" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/task": {
+      "post": {
+        "summary": "Create a task",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Create a task",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TaskInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" },
+                "examples": { "Task": { "$ref": "#/components/examples/Task" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/task/{id}": {
+      "delete": {
+        "summary": "Delete a task",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Delete a task.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the task",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Ok" },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "get": {
+        "summary": "Find a task",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Find a task by ID",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the task",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskResponse" },
+                "examples": { "Task": { "$ref": "#/components/examples/Task" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      },
+      "put": {
+        "summary": "Update an task",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Update a task",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the task",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TaskInput" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Task" },
+                "examples": { "Task": { "$ref": "#/components/examples/Task" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/task/query": {
+      "post": {
+        "summary": "Query tasks",
+        "tags": ["Tasks"],
+        "security": [{ "Bearer": [] }],
+        "description": "Query tasks. It accepts filters, sorting options and pagination.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/TaskQuery" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TaskList" },
+                "examples": { "Task": { "$ref": "#/components/examples/TaskList" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    },
+    "/tenant/{tenantId}/enrichment/member/{id}": {
+      "put": {
+        "summary": "Enrich a member",
+        "tags": ["Members"],
+        "security": [{ "Bearer": [] }],
+        "description": "Enrich a member.",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "description": "Your workspace/tenant ID",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "The ID of the member",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MemberResponse" },
+                "examples": { "Member": { "$ref": "#/components/examples/MemberFind" } }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Too many requests" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": { "Bearer": { "type": "http", "scheme": "bearer" } },
+    "schemas": {
+      "MemberType": { "type": "string", "enum": ["member"] },
+      "MemberScore": { "type": "integer", "minimum": -1, "maximum": 10 },
+      "MemberSort": {
+        "type": "string",
+        "enum": [
+          "activitiesCount_ASC",
+          "activitiesCount_DESC",
+          "score_ASC",
+          "score_ASC",
+          "joinedAt_ASC",
+          "joinedAt_DESC",
+          "createdAt_ASC",
+          "createdAt_DESC",
+          "organisation_ASC",
+          "organisation_DESC",
+          "location_ASC",
+          "location_DESC"
+        ]
+      },
+      "ActivitySort": {
+        "type": "string",
+        "enum": [
+          "timestamp_DESC",
+          "timestamp_ASC",
+          "createdAt_DESC",
+          "createdAt_ASC",
+          "score_DESC",
+          "score_ASC",
+          "type_DESC",
+          "type_ASC",
+          "platform_DESC",
+          "platform_ASC",
+          "createdBy_DESC",
+          "createdBy_ASC"
+        ]
+      },
+      "ConversationSort": {
+        "type": "string",
+        "enum": [
+          "createdAt_DESC",
+          "createdAt_ASC",
+          "activityCount_DESC",
+          "activityCount_ASC",
+          "platform_DESC",
+          "platform_ASC",
+          "channel_DESC",
+          "channel_ASC",
+          "createdBy_DESC",
+          "createdBy_ASC"
+        ]
+      },
+      "TagSort": {
+        "type": "string",
+        "enum": ["name_ASC", "name_DESC", "createdAt_DESC", "createdAt_ASC"]
+      },
+      "MemberAttributeSettingsSort": {
+        "type": "string",
+        "enum": [
+          "label_ASC",
+          "label_DESC",
+          "type_ASC",
+          "type_DESC",
+          "createdAt_DESC",
+          "createdAt_ASC"
+        ]
+      },
+      "ActivityRelationsInput": {
+        "description": "Relations of an activity.",
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "description": "Tasks associated with the activity",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TaskNoId" }
+          }
+        }
+      },
+      "ActivityUpsertInput": {
+        "required": ["memberId"],
+        "description": "An activity performed by a member of your community. The member is sent as an ID.",
+        "allOf": [
+          { "$ref": "#/components/schemas/ActivityNoId" },
+          { "$ref": "#/components/schemas/ActivityRelationsInput" }
+        ],
+        "properties": {
+          "memberId": { "description": "The ID of the member that performed the activity" }
+        }
+      },
+      "ActivityUpsertWithMemberInput": {
+        "type": "object",
+        "description": "An activity performed by a member of your community. The member is sent as a whole object.",
+        "allOf": [
+          { "$ref": "#/components/schemas/ActivityNoId" },
+          { "$ref": "#/components/schemas/ActivityRelationsInput" }
+        ],
+        "properties": { "member": { "$ref": "#/components/schemas/MemberNoId" } }
+      },
+      "ActivityNoId": {
+        "description": "An activity performed by a member of your community.",
+        "type": "object",
+        "required": ["type", "platform", "timestamp", "sourceId"],
+        "properties": {
+          "type": { "description": "Type of activity", "type": "string" },
+          "timestamp": {
+            "description": "Date and time when the activity took place",
+            "type": "string",
+            "format": "date-time"
+          },
+          "platform": {
+            "description": "Platform on which the activity took place",
+            "type": "string"
+          },
+          "title": { "description": "Title of the activity", "type": "string" },
+          "body": { "description": "Body of the activity", "type": "string" },
+          "channel": { "description": "Channel of the activity", "type": "string" },
+          "sentiment": {
+            "description": "Sentiment of the activity",
+            "type": "object",
+            "properties": {
+              "sentiment": {
+                "description": "Default sentiment score. <br/>Computed by mapping (positive - negative) from 0 to 100",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100
+              },
+              "label": {
+                "description": "Sentiment label",
+                "type": "string",
+                "enum": ["positive", "negative", "neutral", "mixed"]
+              },
+              "positive": {
+                "description": "Positive sentiment score",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "negative": {
+                "description": "Negative sentiment score",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "neutral": {
+                "description": "Neutral sentiment score",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "mixed": {
+                "description": "Mixed sentiment score. Mixed contains both positive and negative sentiments",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            }
+          },
+          "sourceId": {
+            "description": "The id of the activity in the platform (e.g. the id of the message in Discord)",
+            "type": "string"
+          },
+          "sourceParentId": {
+            "description": "The id of the parent activity in the platform (e.g. the id of the parent message in Discord)",
+            "type": "string"
+          },
+          "parentId": {
+            "description": "Id of the parent activity, if the activity has a parent",
+            "type": "string",
+            "format": "uuid"
+          },
+          "score": { "description": "Score associated with the activity", "type": "number" },
+          "isContribution": {
+            "description": "Whether the activity was a contribution",
+            "type": "boolean"
+          },
+          "attributes": {
+            "description": "Extra attributes of the activity",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "createdAt": {
+            "description": "Date the activity was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the activity was last updated",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "ActivityNoId" }
+      },
+      "FilterType": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [{ "type": "string" }, { "$ref": "#/components/schemas/FilterType" }]
+        }
+      },
+      "ActivityQuery": {
+        "description": "All the parameters you can use to query activitys.",
+        "properties": {
+          "filter": {
+            "description": "Filter. Please refer to filter docs.",
+            "type": "string",
+            "format": "blob"
+          },
+          "orderBy": {
+            "type": "string",
+            "enum": [
+              "activitiesCount_DESC",
+              "score_ASC",
+              "score_ASC",
+              "joinedAt_ASC",
+              "joinedAt_DESC",
+              "createdAt_ASC",
+              "createdAt_DESC",
+              "organisation_ASC",
+              "organisation_DESC",
+              "location_ASC",
+              "location_DESC"
+            ]
+          },
+          "limit": {
+            "description": "Limit the number of records returned. Default is 10.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 10
+          },
+          "offset": {
+            "description": "Offset the number of records returned. Default is 0.",
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "Activity": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/ActivityNoId" }],
+        "properties": { "id": { "description": "The unique identifier for an activity." } }
+      },
+      "ActivityRelationsResponse": {
+        "description": "Relations of an activity.",
+        "type": "object",
+        "properties": {
+          "member": {
+            "description": "Member that performed the activity",
+            "$ref": "#/components/schemas/Member"
+          },
+          "tasks": {
+            "description": "Tasks associated with the activity.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Task" }
+          }
+        }
+      },
+      "ActivityResponse": {
+        "description": "An activity performed by a member.",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Activity" },
+          { "$ref": "#/components/schemas/ActivityRelationsResponse" }
+        ]
+      },
+      "ActivityList": {
+        "description": "List and count of activities.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of activities",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ActivityResponse" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "ActivitiesList" }
+      },
+      "AutomationCreateInput": {
+        "type": "object",
+        "description": "Data to create a new automation.",
+        "required": ["type", "trigger", "settings"],
+        "properties": {
+          "type": { "$ref": "#/components/schemas/AutomationType" },
+          "trigger": { "$ref": "#/components/schemas/AutomationTrigger" },
+          "settings": { "$ref": "#/components/schemas/AutomationSettings" }
+        }
+      },
+      "AutomationUpdateInput": {
+        "type": "object",
+        "description": "Data to update an existing automation.",
+        "required": ["trigger", "settings", "state"],
+        "properties": {
+          "trigger": { "$ref": "#/components/schemas/AutomationTrigger" },
+          "settings": { "$ref": "#/components/schemas/AutomationSettings" },
+          "state": { "$ref": "#/components/schemas/AutomationState" }
+        }
+      },
+      "AutomationType": { "description": "Automation type", "type": "string", "enum": ["webhook"] },
+      "AutomationState": {
+        "description": "Automation state",
+        "type": "string",
+        "enum": ["active", "disabled"]
+      },
+      "AutomationTrigger": {
+        "description": "What will trigger an automation",
+        "type": "string",
+        "enum": ["new_activity", "new_member"]
+      },
+      "AutomationExecutionState": {
+        "description": "What was the state of the automation execution",
+        "type": "string",
+        "enum": ["success", "error"]
+      },
+      "WebhookAutomationSettings": {
+        "description": "Settings used by automation with type webhook",
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": { "description": "URL to POST webhook data to", "type": "string", "format": "uri" }
+        }
+      },
+      "NewActivityAutomationSettings": {
+        "description": "Settings used by automation that is triggered by new activities",
+        "type": "object",
+        "required": ["types", "platforms", "keywords", "teamMemberActivities"],
+        "properties": {
+          "types": {
+            "description": "If activity type matches any of these we should trigger this automation",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "platforms": {
+            "description": "If activity came from any of these platforms we should trigger this automation",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "keywords": {
+            "description": "If activity content contains any of these keywords we should trigger this automation",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "teamMemberActivities": {
+            "description": "If activity came from any of our team members - should we trigger automation or not?",
+            "type": "boolean"
+          }
+        }
+      },
+      "AutomationSettings": {
+        "description": "Settings based on automation type and trigger - you need to provide union object of both automation type based settings and trigger based settings",
+        "type": "object",
+        "anyOf": [
+          { "$ref": "#/components/schemas/WebhookAutomationSettings" },
+          { "$ref": "#/components/schemas/NewActivityAutomationSettings" }
+        ]
+      },
+      "Automation": {
+        "type": "object",
+        "required": ["id", "type", "tenantId", "trigger", "settings", "state", "createdAt"],
+        "properties": {
+          "id": { "description": "Automation unique ID", "type": "string", "format": "uuid" },
+          "type": { "$ref": "#/components/schemas/AutomationType" },
+          "tenantId": {
+            "description": "Automation tenant unique ID",
+            "type": "string",
+            "format": "uuid"
+          },
+          "trigger": { "$ref": "#/components/schemas/AutomationTrigger" },
+          "settings": { "$ref": "#/components/schemas/AutomationSettings" },
+          "state": { "$ref": "#/components/schemas/AutomationState" },
+          "createdAt": {
+            "description": "When was automation created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastExecutionAt": {
+            "description": "When was automation last executed",
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastExecutionState": {
+            "description": "State of the last automation execution",
+            "$ref": "#/components/schemas/AutomationExecutionState"
+          },
+          "lastExecutionError": {
+            "description": "Error information if last automation execution failed",
+            "type": "object"
+          }
+        }
+      },
+      "AutomationPage": {
+        "type": "object",
+        "required": ["rows", "count", "offset", "limit"],
+        "properties": {
+          "rows": {
+            "description": "Array of automations that were fetched",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Automation" }
+          },
+          "count": { "description": "How many total automations there are", "type": "integer" },
+          "offset": {
+            "description": "What offset was used when preparing this response",
+            "type": "integer"
+          },
+          "limit": {
+            "description": "What limit was used when preparing this response",
+            "type": "integer"
+          }
+        }
+      },
+      "AutomationExecution": {
+        "type": "object",
+        "required": ["id", "automationId", "state", "executedAt", "eventId", "payload"],
+        "properties": {
+          "id": {
+            "description": "Automation execution unique ID",
+            "type": "string",
+            "format": "uuid"
+          },
+          "automationId": {
+            "description": "Automation unique ID",
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "description": "Automation execution state",
+            "$ref": "#/components/schemas/AutomationExecutionState"
+          },
+          "error": {
+            "description": "If execution was not successful this object will contain error information",
+            "type": "object"
+          },
+          "executedAt": {
+            "description": "Automation execution timestamp",
+            "type": "string",
+            "format": "date-time"
+          },
+          "eventId": {
+            "description": "Unique ID of the event that triggered this automation execution.",
+            "type": "string"
+          },
+          "payload": {
+            "description": "Payload that was sent when this execution was processed",
+            "type": "object"
+          }
+        }
+      },
+      "AutomationExecutionPage": {
+        "type": "object",
+        "required": ["rows", "count", "offset", "limit"],
+        "properties": {
+          "rows": {
+            "description": "Automation Execution List",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AutomationExecution" }
+          },
+          "count": { "description": "How many items are there in total", "type": "integer" },
+          "offset": {
+            "description": "What offset was used when preparing this response",
+            "type": "integer"
+          },
+          "limit": {
+            "description": "What limit was used when preparing this response",
+            "type": "integer"
+          }
+        }
+      },
+      "ConversationNoId": {
+        "type": "object",
+        "required": ["platform", "slug", "tenantId"],
+        "description": "A conversation is a group of activities. Some attributes, like slug, are mostly used in public pages.",
+        "properties": {
+          "title": { "description": "Title of the conversation", "type": "string" },
+          "slug": { "description": "Unique slug of the conversation", "type": "string" },
+          "published": {
+            "description": "Whether the conversation is publicaly visible from open pages.",
+            "type": "boolean",
+            "default": false
+          },
+          "conversationStarter": {
+            "description": "The conversation starter activity",
+            "type": "object",
+            "additionalProperties": { "$ref": "#/components/schemas/Activity" }
+          },
+          "memberCount": {
+            "description": "Number of participating members in the conversation.",
+            "type": "integer"
+          },
+          "lastActive": {
+            "description": "Last activity time in the conversation",
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "description": "Date the conversation was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the conversation was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "description": "Your workspace/tenant id",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "xml": { "name": "Conversation" }
+      },
+      "Conversation": {
+        "allOf": [{ "$ref": "#/components/schemas/ConversationNoId" }],
+        "properties": {
+          "id": { "description": "Unique identifier of the conversation", "type": "string" },
+          "activities": {
+            "description": "List of IDs of the activities in the conversation",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "ConversationList": {
+        "type": "object",
+        "properties": {
+          "rows": { "type": "array", "items": { "$ref": "#/components/schemas/Conversation" } },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        }
+      },
+      "MemberPlatformHelper": {
+        "type": "object",
+        "required": ["platform"],
+        "properties": {
+          "platform": {
+            "type": "string",
+            "description": "Platform for which to check member existence."
+          }
+        }
+      },
+      "MemberOrganizations": {
+        "type": "object",
+        "properties": {
+          "organizations": {
+            "description": "Organizations associated with the member. Each element in the array is the name of the organization, or an organization object. If the organization does not exist, it will be created.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OrganizationNoId" }
+          }
+        }
+      },
+      "MemberOrganizationsUpdate": {
+        "type": "object",
+        "properties": {
+          "organizations": {
+            "description": "Organizations associated with the member. Each element in the array is the name of the organization, or an organization object. If the organization does not exist, it will be created.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MemberInputRelations": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "description": "Tags associated with the member. Each element in the array is the ID of the tag.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "tasks": {
+            "description": "Tasks associated with the member. Each element in the array is the ID of the task.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "notes": {
+            "description": "Notes associated with the member. Each element in the array is the ID of the note.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "activities": {
+            "description": "Activities associated with the member. Each element in the array is the ID of the activity.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MemberUpsertInput": {
+        "allOf": [
+          { "$ref": "#/components/schemas/MemberPlatformHelper" },
+          { "$ref": "#/components/schemas/MemberNoId" },
+          { "$ref": "#/components/schemas/MemberOrganizations" },
+          { "$ref": "#/components/schemas/MemberInputRelations" }
+        ]
+      },
+      "MemberUpdateInput": {
+        "allOf": [
+          { "$ref": "#/components/schemas/MemberPlatformHelper" },
+          { "$ref": "#/components/schemas/MemberNoId" },
+          { "$ref": "#/components/schemas/MemberInputRelations" },
+          { "$ref": "#/components/schemas/MemberOrganizationsUpdate" }
+        ]
+      },
+      "MemberNoId": {
+        "description": "A member of your community.",
+        "type": "object",
+        "required": ["username"],
+        "properties": {
+          "username": {
+            "description": "Usernames of the member in each platform. Exactly one for each platform in which the member is active. <br/>Example: ```{ github: 'iamgilfoyle', discord: 'gilfoyle '}```",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "displayName": { "description": "UI friendly name of the member", "type": "string" },
+          "emails": {
+            "description": "Email addresses of the member",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "joinedAt": {
+            "description": "Date of joining the community",
+            "type": "string",
+            "format": "date-time"
+          },
+          "score": {
+            "description": "Engagement score of the member. From 0 to 10. Set -1 for not yet calculated.",
+            "type": "number"
+          },
+          "reach": {
+            "description": "Reach of the member in each platform. At most one for each platform in which the member is active. <br/>Example: ```{ github: 10, twitter: 250, total: 260 }```",
+            "type": "object",
+            "properties": {
+              "total": { "description": "Sum of all the platform reaches.", "type": "number" }
+            },
+            "additionalProperties": true
+          },
+          "attributes": {
+            "description": "Attributes associated to the member. Each attribute must be an object with it's value for each platform, and a default.  <br/>For example: ```{\"location\": {\"github\": \"San Francisco\", \"twitter\": \"California\", \"default\": \"San Francisco\"}}```",
+            "type": "object",
+            "additionalProperties": { "$ref": "#/components/schemas/MemberAttribute" }
+          },
+          "createdAt": {
+            "description": "Date the member was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the member was last updated",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "Member" }
+      },
+      "MemberAttribute": {
+        "description": "A key for each platform.  <br/>- ```default``` is the value that will be displayed by default in the app <br/>- ```custom``` is the value that will be displayed if the user has set a custom value for the attribute",
+        "type": "object",
+        "properties": {
+          "default": {
+            "description": "Default value for the attribute. This is set automatically according to <a target=\"_blank\" href=\"https://crowd.dev\">crowd.dev</a> rules.",
+            "type": "string"
+          },
+          "custom": {
+            "description": "Custom value for the attribute. This is optionally set by the user. It will always be picked as the default when sent.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "MemberQuery": {
+        "description": "All the parameters you can use to query members.",
+        "properties": {
+          "filter": {
+            "description": "Filter. Please refer to filter docs.",
+            "type": "string",
+            "format": "blob"
+          },
+          "orderBy": {
+            "type": "string",
+            "enum": [
+              "activityCount_ASC",
+              "activityCount_DESC",
+              "score_ASC",
+              "score_DESC",
+              "joinedAt_ASC",
+              "joinedAt_DESC",
+              "createdAt_ASC",
+              "createdAt_DESC",
+              "organisation_ASC",
+              "organisation_DESC",
+              "location_ASC",
+              "location_DESC"
+            ]
+          },
+          "limit": {
+            "description": "Limit the number of records returned. Default is 10.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 10
+          },
+          "offset": {
+            "description": "Offset the number of records returned. Default is 0.",
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "Member": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/MemberNoId" }],
+        "properties": {
+          "id": { "description": "The unique identifier for a member of your community." },
+          "activityCount": {
+            "description": "Number of activities performed by the member.",
+            "type": "integer"
+          },
+          "lastActivity": {
+            "description": "Timestamp, type and platform of the last activity performed by the member.",
+            "type": "object",
+            "properties": {
+              "type": { "description": "Type of the last activity", "type": "string" },
+              "timestamp": {
+                "description": "Date and time of the last activity",
+                "type": "string",
+                "format": "date-time"
+              },
+              "platform": { "description": "Platform of the last activity", "type": "string" }
+            }
+          },
+          "averageSentiment": {
+            "description": "Average sentiment of the member. From 0 to 100.",
+            "type": "number"
+          },
+          "identities": {
+            "description": "List of platforms the member has identities in.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "activeOn": {
+            "description": "List of platforms the member is active on.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "MemberRelationsResponse": {
+        "description": "Relations of a member.",
+        "type": "object",
+        "properties": {
+          "tags": {
+            "description": "Tags associated with the member.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tag" }
+          },
+          "notes": {
+            "description": "Notes associated with the member.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Note" }
+          },
+          "tasks": {
+            "description": "Tasks associated with the member.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Task" }
+          },
+          "organizations": {
+            "description": "Organizations associated with the member.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Organization" }
+          }
+        }
+      },
+      "MemberResponse": {
+        "description": "A member of your community.",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Member" },
+          { "$ref": "#/components/schemas/MemberRelationsResponse" }
+        ]
+      },
+      "MemberList": {
+        "description": "List and count of members.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of members",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MemberResponse" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "MembersList" }
+      },
+      "NoteInputRelations": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the note. Each element in the array is the ID of the member.",
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "NoteInput": {
+        "allOf": [
+          { "$ref": "#/components/schemas/NoteNoId" },
+          { "$ref": "#/components/schemas/NoteInputRelations" }
+        ]
+      },
+      "NoteNoId": {
+        "description": "A created note.",
+        "type": "object",
+        "properties": {
+          "body": { "description": "The body of the note.", "type": "string", "format": "blob" },
+          "createdAt": {
+            "description": "Date the note was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the note was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "Note" }
+      },
+      "NoteQuery": {
+        "description": "All the parameters you can use to query notes.",
+        "properties": {
+          "filter": {
+            "description": "Filter. Please refer to filter docs.",
+            "type": "string",
+            "format": "blob"
+          },
+          "orderBy": { "type": "string", "enum": ["createdAt_ASC", "createdAt_DESC"] },
+          "limit": {
+            "description": "Limit the number of records returned. Default is 10.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 10
+          },
+          "offset": {
+            "description": "Offset the number of records returned. Default is 0.",
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "Note": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/NoteNoId" }],
+        "properties": {
+          "id": { "description": "The ID of the note." },
+          "body": { "description": "The body of the note.", "type": "string", "format": "blob" }
+        }
+      },
+      "NoteRelationsResponse": {
+        "description": "Relations of a note.",
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the note.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Member" }
+          }
+        }
+      },
+      "NoteResponse": {
+        "description": "A note of your community.",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Note" },
+          { "$ref": "#/components/schemas/NoteRelationsResponse" }
+        ]
+      },
+      "NoteList": {
+        "description": "List and count of notes.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of notes",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/NoteResponse" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "NotesList" }
+      },
+      "OrganizationInputRelations": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the organization. Each element in the array is the ID of the member.",
+            "type": "array",
+            "items": { "type": "string", "format": "uuid" }
+          }
+        }
+      },
+      "OrganizationInput": {
+        "allOf": [
+          { "$ref": "#/components/schemas/OrganizationNoId" },
+          { "$ref": "#/components/schemas/OrganizationInputRelations" }
+        ]
+      },
+      "OrganizationNoId": {
+        "description": "A created organization.",
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "description": "The name of the organization.", "type": "string" },
+          "url": { "description": "The URL of the organization.", "type": "string" },
+          "description": {
+            "description": "A short description of the organization.",
+            "type": "string",
+            "format": "blob"
+          },
+          "logo": { "description": "A URL for logo of the organization.", "type": "string" },
+          "emails": {
+            "description": "The emails for contacting the organization.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "phoneNumbers": {
+            "description": "The phone numbers for contacting for the organization.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "parentUrl": {
+            "description": "The URL of the parent organization if it has one (for example if it has been acquired).",
+            "type": "string"
+          },
+          "tags": {
+            "description": "Tags associated with the organization.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "twitter": {
+            "description": "Twitter information for the organization.",
+            "type": "object",
+            "properties": {
+              "handle": {
+                "description": "The Twitter handle for the organization.",
+                "type": "string"
+              },
+              "id": { "description": "The Twitter ID for the organization.", "type": "string" },
+              "bio": { "description": "The Twitter bio for the organization.", "type": "string" },
+              "followers": {
+                "description": "The number of followers on Twitter.",
+                "type": "integer"
+              },
+              "location": {
+                "description": "The Twitter location for the organization.",
+                "type": "string"
+              },
+              "site": {
+                "description": "The website linked to the organization's Twitter profile.",
+                "type": "string"
+              },
+              "avatar": {
+                "description": "The URL for the organization's Twitter avatar.",
+                "type": "string"
+              }
+            }
+          },
+          "employees": {
+            "description": "The number of employees of the organization.",
+            "type": "integer"
+          },
+          "revenueRange": {
+            "description": "The estimated revenue range of the organization.",
+            "type": "object",
+            "properties": {
+              "min": {
+                "description": "The minimum estimated revenue of the organization.",
+                "type": "integer"
+              },
+              "max": {
+                "description": "The maximum estimated revenue of the organization.",
+                "type": "integer"
+              }
+            }
+          },
+          "linkedin": {
+            "description": "LinkedIn information for the organization.",
+            "type": "object",
+            "properties": {
+              "handle": {
+                "description": "The LinkedIn handle for the organization.",
+                "type": "string"
+              }
+            }
+          },
+          "crunchbase": {
+            "description": "Crunchbase information for the organization.",
+            "type": "object",
+            "properties": {
+              "handle": {
+                "description": "The Crunchbase handle for the organization.",
+                "type": "string"
+              }
+            }
+          },
+          "activeOn": {
+            "description": "List of platforms the organization members are active on.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "identities": {
+            "description": "List of platforms the organization members have identities in.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "memberCount": {
+            "description": "Number of members organization has.",
+            "type": "integer"
+          },
+          "createdAt": {
+            "description": "Date the organization was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the organization was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "Organization" }
+      },
+      "OrganizationQuery": {
+        "description": "All the parameters you can use to query organizations.",
+        "properties": {
+          "filter": {
+            "description": "Filter. Please refer to filter docs.",
+            "type": "string",
+            "format": "blob"
+          },
+          "orderBy": {
+            "type": "string",
+            "enum": [
+              "createdAt_ASC",
+              "createdAt_DESC",
+              "memberCount_ASC",
+              "memberCount_DESC",
+              "activityCount_ASC",
+              "activityCount_DESC",
+              "joinedAt_ASC",
+              "joinedAt_DESC",
+              "lastActive_ASC",
+              "lastActive_DESC"
+            ]
+          },
+          "limit": {
+            "description": "Limit the number of records returned. Default is 10.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 10
+          },
+          "offset": {
+            "description": "Offset the number of records returned. Default is 0.",
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "Organization": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/OrganizationNoId" }],
+        "properties": {
+          "id": { "description": "The ID of the organization." },
+          "body": {
+            "description": "The body of the organization.",
+            "type": "string",
+            "format": "blob"
+          }
+        }
+      },
+      "OrganizationRelationsResponse": {
+        "description": "Relations of a organization.",
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the organization.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Member" }
+          },
+          "activeOn": {
+            "description": "The platforms where the organization is active.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "identities": {
+            "description": "The list of identities of the members in the organization.",
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "lastActive": {
+            "description": "The last time the organization was active.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "joinedAt": {
+            "description": "The date the first member from the organization joined the community.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "OrganizationResponse": {
+        "description": "A organization of your community.",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Organization" },
+          { "$ref": "#/components/schemas/OrganizationRelationsResponse" }
+        ]
+      },
+      "OrganizationList": {
+        "description": "List and count of organizations.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of organizations",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OrganizationResponse" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "OrganizationsList" }
+      },
+      "TagNoId": {
+        "description": "A tag associated with a member.",
+        "type": "object",
+        "required": ["name", "tenantId"],
+        "properties": {
+          "name": { "description": "The name of the tag", "type": "string" },
+          "createdAt": {
+            "description": "Date the tag was created",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the tag was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "tenantId": {
+            "description": "Your workspace/tenant id",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "xml": { "name": "Tag" }
+      },
+      "Tag": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/TagNoId" }],
+        "properties": { "id": { "description": "The unique identifier for a tag." } }
+      },
+      "TagList": {
+        "description": "List and count of tags.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of tags",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Tag" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "TagsList" }
+      },
+      "TaskInputRelations": {
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the task. Each element in the array is the ID of the member.",
+            "type": "array",
+            "items": { "type": "string", "format": "uuid" }
+          },
+          "activities": {
+            "description": "Activities associated with the task. Each element in the array is the ID of the activity.",
+            "type": "array",
+            "items": { "type": "string", "format": "uuid" }
+          },
+          "assignees": {
+            "description": "Users assigned with the task. Each element in the array is the ID of the user.",
+            "type": "string",
+            "format": "uuid",
+            "default": null
+          }
+        }
+      },
+      "TaskInput": {
+        "allOf": [
+          { "$ref": "#/components/schemas/TaskNoId" },
+          { "$ref": "#/components/schemas/TaskInputRelations" }
+        ]
+      },
+      "TaskBatchInput": {
+        "type": "object",
+        "properties": {
+          "operation": {
+            "description": "Batch operation name.",
+            "type": "string",
+            "enum": ["findAndUpdateAll"]
+          },
+          "payload": {
+            "type": "object",
+            "description": "Payload to send to the batch operation",
+            "properties": {
+              "filter": {
+                "description": "Filter to select the task entities. Please refer to filter docs.",
+                "type": "string",
+                "format": "blob"
+              },
+              "update": {
+                "description": "key value object with desired updated fields.",
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "TaskNoId": {
+        "description": "A created task.",
+        "type": "object",
+        "properties": {
+          "name": { "description": "The name of the task.", "type": "string" },
+          "body": { "description": "The body of the task.", "type": "string", "format": "blob" },
+          "status": {
+            "description": "The status of the task.",
+            "type": "string",
+            "enum": ["in-progress", "done"],
+            "default": null
+          },
+          "createdAt": {
+            "description": "Date the task was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the task was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "Task" }
+      },
+      "TaskQuery": {
+        "description": "All the parameters you can use to query tasks.",
+        "properties": {
+          "filter": {
+            "description": "Filter. Please refer to filter docs.",
+            "type": "string",
+            "format": "blob"
+          },
+          "orderBy": { "type": "string", "enum": ["createdAt_ASC", "createdAt_DESC"] },
+          "limit": {
+            "description": "Limit the number of records returned. Default is 10.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 200,
+            "default": 10
+          },
+          "offset": {
+            "description": "Offset the number of records returned. Default is 0.",
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+          }
+        }
+      },
+      "Task": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/TaskNoId" }],
+        "properties": {
+          "id": { "description": "The ID of the task." },
+          "body": { "description": "The body of the task.", "type": "string", "format": "blob" }
+        }
+      },
+      "TaskRelationsResponse": {
+        "description": "Relations of a task.",
+        "type": "object",
+        "properties": {
+          "members": {
+            "description": "Members associated with the task.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Member" }
+          },
+          "activities": {
+            "description": "Activities associated with the task.",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Activity" }
+          },
+          "assignedTo": {
+            "description": "The workspace member assigned to the task.",
+            "$ref": "#/components/schemas/Member"
+          }
+        }
+      },
+      "TaskResponse": {
+        "description": "A task of your community.",
+        "type": "object",
+        "allOf": [
+          { "$ref": "#/components/schemas/Task" },
+          { "$ref": "#/components/schemas/TaskRelationsResponse" }
+        ]
+      },
+      "TaskList": {
+        "description": "List and count of tasks.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of tasks",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TaskResponse" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "TasksList" }
+      },
+      "TaskFindAndUpdateAll": {
+        "description": "Returns number of tasks updated",
+        "type": "object",
+        "properties": {
+          "rowsUpdated": { "description": "Number of tasks updated", "type": "integer" }
+        }
+      },
+      "ActivityTypesCreateInput": {
+        "description": "An activity type.",
+        "properties": {
+          "type": {
+            "description": "Human-friendly type of the activity. Default and short displays will set to this and key will be generated using this value."
+          }
+        }
+      },
+      "ActivityTypesUpdateInput": {
+        "description": "An activity type.",
+        "properties": {
+          "type": {
+            "description": "Human-friendly type of the activity. Default and short displays will set to this and key will be generated using this value."
+          }
+        }
+      },
+      "ActivityTypeDisplayOptions": {
+        "type": "object",
+        "required": ["default", "short", "channel"],
+        "description": "Activity type display options.",
+        "properties": {
+          "default": {
+            "description": "Default display of an activity type. Used in the activity module in the app.",
+            "type": "string"
+          },
+          "short": {
+            "description": "Short display version of an activity type. Used in the member list -> last activity.",
+            "type": "string"
+          },
+          "channel": {
+            "description": "Channel display of an activity type. Used in Dashboard -> trending conversations.",
+            "type": "string"
+          }
+        },
+        "xml": { "name": "ActivityTypeDisplayOptions" }
+      },
+      "ActivityTypes": {
+        "type": "object",
+        "properties": {
+          "custom": {
+            "type": "object",
+            "description": "Custom activity types defined by the user.",
+            "additionalProperties": { "$ref": "#/components/schemas/ActivityTypeDisplayOptions" }
+          },
+          "default": {
+            "type": "object",
+            "description": "Default activity types used by the integrations.",
+            "additionalProperties": { "$ref": "#/components/schemas/ActivityTypeDisplayOptions" }
+          }
+        }
+      },
+      "MemberAttributeSettingsCreateInput": {
+        "description": "A member attribute.",
+        "allOf": [{ "$ref": "#/components/schemas/MemberAttributeSettingsNoId" }]
+      },
+      "MemberAttributeSettingsUpdateInput": {
+        "description": "A member attribute.",
+        "properties": {
+          "label": {
+            "description": "Human-friendly name of the attribute. Label is unique in workspaces.",
+            "type": "string"
+          },
+          "show": {
+            "description": "Whether to show the member attribute in the web app or not.",
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "MemberAttributeSettingsNoId": {
+        "type": "object",
+        "required": ["label", "type"],
+        "description": "A member attribute that can be created dynamically.",
+        "properties": {
+          "label": {
+            "description": "Human-friendly name of the attribute. Label is unique in workspaces.",
+            "type": "string"
+          },
+          "name": {
+            "description": "Camel-case code friendly name of the attribute. If ommited, name will be generated from the label. Name is unique in workspaces.",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of the attribute's value",
+            "type": "string",
+            "enum": ["boolean", "number", "email", "string", "url", "date"]
+          },
+          "canDelete": {
+            "description": "If set to false, member attribute can not be deleted in future requests.",
+            "type": "boolean",
+            "default": false
+          },
+          "show": {
+            "description": "Whether to show the member attribute in the web app or not.",
+            "type": "boolean",
+            "default": true
+          },
+          "createdAt": {
+            "description": "Date the member attribute was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "description": "Date the member attribute was last updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "xml": { "name": "MemberAttributeSettings" }
+      },
+      "MemberAttributeSettings": {
+        "type": "object",
+        "allOf": [{ "$ref": "#/components/schemas/MemberAttributeSettingsNoId" }],
+        "properties": { "id": { "description": "The attribute settings ID." } }
+      },
+      "MemberAttributeSettingsList": {
+        "description": "List and count member attribute settings.",
+        "type": "object",
+        "properties": {
+          "rows": {
+            "description": "List of member attribute settings",
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/MemberAttributeSettings" }
+          },
+          "count": { "description": "Count", "type": "integer" },
+          "limit": { "description": "Limit of records returned", "type": "integer" },
+          "offset": { "description": "Offset, for pagination", "type": "integer" }
+        },
+        "xml": { "name": "MemberAttributeSettingsList" }
+      }
+    },
+    "examples": {
+      "ActivityUpsert": {
+        "value": {
+          "id": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+          "type": "message",
+          "timestamp": "2020-05-27T15:13:30.000Z",
+          "platform": "discord",
+          "isContribution": true,
+          "score": 1,
+          "sourceId": "1234",
+          "sourceParentId": null,
+          "attributes": { "reactions": 43 },
+          "channel": "dev",
+          "body": "It's not magic. It's talend and sweat.",
+          "title": null,
+          "url": "discord.gg/1234",
+          "sentiment": {
+            "label": "negative",
+            "mixed": 1.1410574428737164,
+            "neutral": 11.00325882434845,
+            "negative": 85.99738478660583,
+            "positive": 1.8582981079816818,
+            "sentiment": 2
+          },
+          "importHash": null,
+          "createdAt": "2022-10-03T15:18:11.294Z",
+          "updatedAt": "2022-10-03T15:21:49.402Z",
+          "deletedAt": null,
+          "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+          "conversationId": null,
+          "parentId": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "member": {
+            "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+            "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+            "attributes": {
+              "bio": {
+                "github": "Systems engineer at Pied Piper",
+                "default": "It's not magic. It's talent and sweat",
+                "twitter": "It's not magic. It's talent and sweat"
+              },
+              "url": {
+                "github": "https://github.com/gilfoyle",
+                "default": "https://t.co/g",
+                "twitter": "https://t.co/g"
+              },
+              "location": {
+                "custom": "Erlich's house",
+                "github": "Palo alto",
+                "default": "Erlich's house"
+              }
+            },
+            "displayName": "Gilfoyle",
+            "email": "gilfoyle@piedpiper.io",
+            "score": -1,
+            "joinedAt": "2022-10-03T15:17:03.540Z",
+            "importHash": null,
+            "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+            "createdAt": "2022-10-03T15:17:03.547Z",
+            "updatedAt": "2022-10-03T15:17:27.073Z",
+            "deletedAt": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "parent": null,
+          "tasks": []
+        }
+      },
+      "ActivityFind": {
+        "value": {
+          "id": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+          "type": "pull_request-closed",
+          "timestamp": "2021-07-27T20:20:30.000Z",
+          "platform": "github",
+          "isContribution": true,
+          "score": 10,
+          "sourceId": "gh_1",
+          "sourceParentId": null,
+          "attributes": {},
+          "channel": "piedpiper",
+          "body": "Last one to finish the code sprint! But I will have fewer bugs than Gilfoyle.",
+          "title": "Code sprint over!",
+          "url": "github.com/piedpiper/piedpier",
+          "sentiment": {
+            "label": "positive",
+            "mixed": 0.7594161201268435,
+            "neutral": 39.13898766040802,
+            "negative": 12.336093187332153,
+            "positive": 47.76550233364105,
+            "sentiment": 79
+          },
+          "createdAt": "2022-10-03T15:36:43.775Z",
+          "updatedAt": "2022-10-03T15:39:38.199Z",
+          "deletedAt": null,
+          "memberId": "2effc566-1932-44f3-a821-2d692933a953",
+          "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+          "parentId": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "member": {
+            "id": "2effc566-1932-44f3-a821-2d692933a953",
+            "username": { "github": "dinesh", "twitter": "dinesh.chugtai" },
+            "attributes": {
+              "bio": {
+                "github": "Lead developer at Pied Piper",
+                "default": "Pakistani Denzel. Tesla and gold chain owner.",
+                "twitter": "Pakistani Denzel. Tesla and gold chain owner."
+              },
+              "url": {
+                "github": "https://github.com/dinesh",
+                "default": "https://t.co/d",
+                "twitter": "https://t.co/d"
+              },
+              "location": {
+                "custom": "Silicon Valley",
+                "github": "Palo alto",
+                "default": "Silicon Valley"
+              }
+            },
+            "displayName": "Dinesh",
+            "email": "dinesh@piedpiper.io",
+            "score": 9,
+            "joinedAt": "2022-10-03T15:30:55.672Z",
+            "importHash": null,
+            "reach": { "total": 100, "github": 60, "twitter": 40 },
+            "createdAt": "2022-10-03T15:30:55.679Z",
+            "updatedAt": "2022-10-03T15:30:55.679Z",
+            "deletedAt": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "parent": null,
+          "tasks": []
+        }
+      },
+      "ActivityFind2": {
+        "value": {
+          "id": "73aa13b7-1ef9-4987-a273-e560edff94ca",
+          "type": "pull_request-comment",
+          "timestamp": "2021-07-27T20:22:30.000Z",
+          "platform": "github",
+          "isContribution": true,
+          "score": 3,
+          "sourceId": "gh_2",
+          "sourceParentId": "gh_1",
+          "attributes": {},
+          "channel": "piedpiper",
+          "body": "I will never underestimate my talents again.",
+          "title": null,
+          "url": "github.com/piedpiper/piedpier",
+          "sentiment": {
+            "label": "positive",
+            "mixed": 14.308956265449524,
+            "neutral": 14.437079429626465,
+            "negative": 9.826807677745819,
+            "positive": 61.42715811729431,
+            "sentiment": 86
+          },
+          "importHash": null,
+          "createdAt": "2022-10-03T15:38:05.847Z",
+          "updatedAt": "2022-10-03T15:46:34.610Z",
+          "deletedAt": null,
+          "memberId": "2effc566-1932-44f3-a821-2d692933a953",
+          "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+          "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "member": {
+            "id": "2effc566-1932-44f3-a821-2d692933a953",
+            "username": { "github": "dinesh", "twitter": "dinesh.chugtai" },
+            "attributes": {
+              "bio": {
+                "github": "Lead developer at Pied Piper",
+                "default": "Pakistani Denzel. Tesla and gold chain owner.",
+                "twitter": "Pakistani Denzel. Tesla and gold chain owner."
+              },
+              "url": {
+                "github": "https://github.com/dinesh",
+                "default": "https://t.co/d",
+                "twitter": "https://t.co/d"
+              },
+              "location": {
+                "custom": "Silicon Valley",
+                "github": "Palo alto",
+                "default": "Silicon Valley"
+              }
+            },
+            "displayName": "Dinesh",
+            "email": "dinesh@piedpiper.io",
+            "score": -1,
+            "joinedAt": "2022-10-03T15:30:55.672Z",
+            "importHash": null,
+            "reach": { "total": 100, "github": 60, "twitter": 40 },
+            "createdAt": "2022-10-03T15:30:55.679Z",
+            "updatedAt": "2022-10-03T15:30:55.679Z",
+            "deletedAt": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "parent": {
+            "id": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+            "type": "pull_request-closed",
+            "timestamp": "2021-07-27T20:22:30.000Z",
+            "platform": "github",
+            "isContribution": true,
+            "score": 10,
+            "sourceId": "gh_1",
+            "sourceParentId": null,
+            "attributes": {},
+            "channel": "piedpiper",
+            "body": "Last one to finish the code sprint! But I will have less bugs than Gilfoyle.",
+            "title": "Code sprint over!",
+            "url": "github.com/piedpiper/piedpier",
+            "sentiment": {
+              "label": "positive",
+              "mixed": 0.7594161201268435,
+              "neutral": 39.13898766040802,
+              "negative": 12.336093187332153,
+              "positive": 47.76550233364105,
+              "sentiment": 79
+            },
+            "importHash": null,
+            "createdAt": "2022-10-03T15:36:43.775Z",
+            "updatedAt": "2022-10-03T15:39:38.199Z",
+            "deletedAt": null,
+            "memberId": "2effc566-1932-44f3-a821-2d692933a953",
+            "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+            "parentId": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "tasks": []
+        }
+      },
+      "ActivityFind3": {
+        "value": {
+          "id": "2dcbe40e-36e0-4929-ab21-a30467fd9a65",
+          "type": "pull_request-comment",
+          "timestamp": "2021-07-27T20:23:30.000Z",
+          "platform": "github",
+          "isContribution": true,
+          "score": 3,
+          "sourceId": "gh_3",
+          "sourceParentId": "gh_1",
+          "attributes": {},
+          "channel": "piedpiper",
+          "body": "Don't worry. I will continue to do it for you.",
+          "title": null,
+          "url": "github.com/piedpiper/piedpier",
+          "sentiment": {
+            "label": "positive",
+            "mixed": 2.9098065569996834,
+            "neutral": 25.578168034553528,
+            "negative": 2.241993509232998,
+            "positive": 69.27002668380737,
+            "sentiment": 97
+          },
+          "importHash": null,
+          "createdAt": "2022-10-03T15:47:20.151Z",
+          "updatedAt": "2022-10-03T15:47:20.220Z",
+          "deletedAt": null,
+          "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+          "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+          "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "member": {
+            "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+            "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+            "attributes": {
+              "bio": {
+                "github": "Systems engineer at Pied Piper",
+                "default": "It's not magic. It's talent and sweat",
+                "twitter": "It's not magic. It's talent and sweat"
+              },
+              "url": {
+                "github": "https://github.com/gilfoyle",
+                "default": "https://t.co/g",
+                "twitter": "https://t.co/g"
+              },
+              "location": {
+                "custom": "Erlich's house",
+                "github": "Palo alto",
+                "default": "Erlich's house"
+              }
+            },
+            "displayName": "Gilfoyle",
+            "email": "gilfoyle@piedpiper.io",
+            "score": -1,
+            "joinedAt": "2022-10-03T15:17:03.540Z",
+            "importHash": null,
+            "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+            "createdAt": "2022-10-03T15:17:03.547Z",
+            "updatedAt": "2022-10-03T15:17:27.073Z",
+            "deletedAt": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "parent": {
+            "id": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+            "type": "pull_request-closed",
+            "timestamp": "2021-07-27T20:22:30.000Z",
+            "platform": "github",
+            "isContribution": true,
+            "score": 10,
+            "sourceId": "gh_1",
+            "sourceParentId": null,
+            "attributes": {},
+            "channel": "piedpiper",
+            "body": "Last one to finish the code sprint! But I will have less bugs than Gilfoyle.",
+            "title": "Code sprint over!",
+            "url": "github.com/piedpiper/piedpier",
+            "sentiment": {
+              "label": "positive",
+              "mixed": 0.7594161201268435,
+              "neutral": 39.13898766040802,
+              "negative": 12.336093187332153,
+              "positive": 47.76550233364105,
+              "sentiment": 79
+            },
+            "importHash": null,
+            "createdAt": "2022-10-03T15:36:43.775Z",
+            "updatedAt": "2022-10-03T15:39:38.199Z",
+            "deletedAt": null,
+            "memberId": "2effc566-1932-44f3-a821-2d692933a953",
+            "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+            "parentId": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "tasks": []
+        }
+      },
+      "ActivityList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/ActivityFind" },
+            { "$ref": "#/components/examples/ActivityFind2" },
+            { "$ref": "#/components/examples/ActivityFind3" }
+          ],
+          "count": 3,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "Automation": {
+        "value": {
+          "id": "b3297f3b-6924-4e92-80e7-ef2e0d87a120",
+          "type": "webhook",
+          "tenantId": "a3297f3b-6924-4e92-80e7-ef2e0d87a120",
+          "trigger": "new_activity",
+          "settings": { "url": "https://webhook.url/new_activities" },
+          "createdAt": "2022-03-29T09:22:31.989Z"
+        }
+      },
+      "AutomationPage": {
+        "value": {
+          "count": 1,
+          "offset": 0,
+          "limit": 10,
+          "rows": [
+            {
+              "id": "b3297f3b-6924-4e92-80e7-ef2e0d87a120",
+              "type": "webhook",
+              "tenantId": "a3297f3b-6924-4e92-80e7-ef2e0d87a120",
+              "trigger": "new_activity",
+              "settings": { "url": "https://webhook.url/new_activities" },
+              "createdAt": "2022-03-29T09:22:31.989Z"
+            }
+          ]
+        }
+      },
+      "AutomationExecutionPage": {
+        "value": {
+          "count": 1,
+          "offset": 0,
+          "limit": 10,
+          "rows": [
+            {
+              "id": "b3297f3b-6924-4e92-80e7-ef2e0d87a120",
+              "automationId": "a3297f3b-6924-4e92-80e7-ef2e0d87a120",
+              "state": "success",
+              "executedAt": "2022-03-29T09:22:31.989Z",
+              "eventId": "a3297f3b-6924-4e92-80e7-ef2e0d87a121",
+              "payload": [
+                {
+                  "id": "a3297f3b-6924-4e92-80e7-ef2e0d87a121",
+                  "type": "comment",
+                  "timestamp": "2022-03-29T09:22:31.989Z",
+                  "platform": "twitter"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "Conversation": {
+        "value": {
+          "id": "24bdea79-3125-4950-bb38-07fa4a555012",
+          "title": "Best of dinesh and Gilfoyle",
+          "slug": "best-of-dinesh-and-gilfoyle",
+          "published": true,
+          "createdAt": "2022-10-05T12:21:53.271Z",
+          "updatedAt": "2022-10-05T12:21:53.271Z",
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "activities": [
+            {
+              "id": "89a136ed-336d-4586-8842-790775465212",
+              "type": "message",
+              "timestamp": "2020-06-27T14:13:30.000Z",
+              "platform": "discord",
+              "isContribution": true,
+              "score": 1,
+              "sourceId": "d42",
+              "sourceParentId": null,
+              "attributes": {},
+              "channel": "piedpiper",
+              "body": "Sooner or later Gilfoyle's servers are going to fail and then it's all done",
+              "title": null,
+              "url": "github.com/piedpiper/piedpier",
+              "sentiment": {
+                "label": "negative",
+                "mixed": 3.6482997238636017,
+                "neutral": 19.5749893784523,
+                "negative": 75.36468505859375,
+                "positive": 1.4120269566774368,
+                "sentiment": 2
+              },
+              "importHash": null,
+              "createdAt": "2022-10-05T12:09:44.414Z",
+              "updatedAt": "2022-10-05T12:21:53.279Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+              "parentId": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "member": {
+                "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                "attributes": {
+                  "bio": {
+                    "github": "Systems engineer at Pied Piper",
+                    "default": "It's not magic. It's talent and sweat",
+                    "twitter": "It's not magic. It's talent and sweat"
+                  },
+                  "url": {
+                    "github": "https://github.com/gilfoyle",
+                    "default": "https://t.co/g",
+                    "twitter": "https://t.co/g"
+                  },
+                  "location": {
+                    "custom": "Erlich's house",
+                    "github": "Palo alto",
+                    "default": "Erlich's house"
+                  }
+                },
+                "displayName": "Gilfoyle",
+                "email": "gilfoyle@piedpiper.io",
+                "score": 8,
+                "joinedAt": "2022-10-03T15:17:03.540Z",
+                "importHash": null,
+                "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                "createdAt": "2022-10-03T15:17:03.547Z",
+                "updatedAt": "2022-10-05T11:40:32.560Z",
+                "deletedAt": null,
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+              }
+            },
+            {
+              "id": "c39dc046-da1d-4a25-8624-6b78aad00f30",
+              "type": "message",
+              "timestamp": "2020-06-27T15:13:30.000Z",
+              "platform": "discord",
+              "isContribution": true,
+              "score": 1,
+              "sourceId": "2345",
+              "sourceParentId": "1234",
+              "attributes": { "reactions": 68 },
+              "channel": "dev",
+              "body": "My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.",
+              "title": null,
+              "url": "discord.gg/2345",
+              "sentiment": {
+                "label": "negative",
+                "mixed": 5.963129922747612,
+                "neutral": 20.673033595085144,
+                "negative": 69.99874711036682,
+                "positive": 3.365083411335945,
+                "sentiment": 5
+              },
+              "importHash": null,
+              "createdAt": "2022-10-03T15:19:30.415Z",
+              "updatedAt": "2022-10-05T12:21:53.279Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+              "parentId": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "member": {
+                "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                "attributes": {
+                  "bio": {
+                    "github": "Systems engineer at Pied Piper",
+                    "default": "It's not magic. It's talent and sweat",
+                    "twitter": "It's not magic. It's talent and sweat"
+                  },
+                  "url": {
+                    "github": "https://github.com/gilfoyle",
+                    "default": "https://t.co/g",
+                    "twitter": "https://t.co/g"
+                  },
+                  "location": {
+                    "custom": "Erlich's house",
+                    "github": "Palo alto",
+                    "default": "Erlich's house"
+                  }
+                },
+                "displayName": "Gilfoyle",
+                "email": "gilfoyle@piedpiper.io",
+                "score": 8,
+                "joinedAt": "2022-10-03T15:17:03.540Z",
+                "importHash": null,
+                "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                "createdAt": "2022-10-03T15:17:03.547Z",
+                "updatedAt": "2022-10-05T11:40:32.560Z",
+                "deletedAt": null,
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+              }
+            }
+          ],
+          "conversationStarter": {
+            "id": "89a136ed-336d-4586-8842-790775465212",
+            "type": "message",
+            "timestamp": "2020-06-27T14:13:30.000Z",
+            "platform": "discord",
+            "isContribution": true,
+            "score": 1,
+            "sourceId": "d42",
+            "sourceParentId": null,
+            "attributes": {},
+            "channel": "piedpiper",
+            "body": "Sooner or later Gilfoyle's servers are going to fail and then it's all done",
+            "title": null,
+            "url": "github.com/piedpiper/piedpier",
+            "sentiment": {
+              "label": "negative",
+              "mixed": 3.6482997238636017,
+              "neutral": 19.5749893784523,
+              "negative": 75.36468505859375,
+              "positive": 1.4120269566774368,
+              "sentiment": 2
+            },
+            "importHash": null,
+            "createdAt": "2022-10-05T12:09:44.414Z",
+            "updatedAt": "2022-10-05T12:21:53.279Z",
+            "deletedAt": null,
+            "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+            "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+            "parentId": null,
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "member": {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": 8,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-05T11:40:32.560Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          },
+          "activityCount": 2,
+          "memberCount": 2,
+          "platform": "discord",
+          "channel": "piedpiper",
+          "lastActive": "2020-06-27T15:13:30.000Z"
+        }
+      },
+      "ConversationList": {
+        "value": {
+          "rows": [
+            {
+              "id": "291af008-7717-457e-9242-f5c507c8987b",
+              "title": "Code sprint over!",
+              "slug": "code-sprint-over",
+              "published": false,
+              "createdAt": "2022-10-03T15:38:05.900Z",
+              "updatedAt": "2022-10-03T15:38:05.900Z",
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "platform": "github",
+              "activityCount": 3,
+              "lastActive": "2021-07-27T20:23:30.000Z",
+              "conversationStarter": {
+                "id": "89a136ed-336d-4586-8842-790775465212",
+                "type": "message",
+                "timestamp": "2020-06-27T14:13:30.000Z",
+                "platform": "discord",
+                "isContribution": true,
+                "score": 1,
+                "sourceId": "d42",
+                "sourceParentId": null,
+                "attributes": {},
+                "channel": "piedpiper",
+                "body": "Sooner or later Gilfoyle's servers are going to fail and then it's all done",
+                "title": null,
+                "url": "github.com/piedpiper/piedpier",
+                "sentiment": {
+                  "label": "negative",
+                  "mixed": 3.6482997238636017,
+                  "neutral": 19.5749893784523,
+                  "negative": 75.36468505859375,
+                  "positive": 1.4120269566774368,
+                  "sentiment": 2
+                },
+                "importHash": null,
+                "createdAt": "2022-10-05T12:09:44.414Z",
+                "updatedAt": "2022-10-05T12:21:53.279Z",
+                "deletedAt": null,
+                "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+                "parentId": null,
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "member": {
+                  "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                  "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                  "attributes": {
+                    "bio": {
+                      "github": "Systems engineer at Pied Piper",
+                      "default": "It's not magic. It's talent and sweat",
+                      "twitter": "It's not magic. It's talent and sweat"
+                    },
+                    "url": {
+                      "github": "https://github.com/gilfoyle",
+                      "default": "https://t.co/g",
+                      "twitter": "https://t.co/g"
+                    },
+                    "location": {
+                      "custom": "Erlich's house",
+                      "github": "Palo alto",
+                      "default": "Erlich's house"
+                    }
+                  },
+                  "displayName": "Gilfoyle",
+                  "email": "gilfoyle@piedpiper.io",
+                  "score": 8,
+                  "joinedAt": "2022-10-03T15:17:03.540Z",
+                  "importHash": null,
+                  "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                  "createdAt": "2022-10-03T15:17:03.547Z",
+                  "updatedAt": "2022-10-05T11:40:32.560Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              },
+              "lastReplies": [
+                {
+                  "id": "c39dc046-da1d-4a25-8624-6b78aad00f30",
+                  "type": "message",
+                  "timestamp": "2020-06-27T15:13:30.000Z",
+                  "platform": "discord",
+                  "isContribution": true,
+                  "score": 1,
+                  "sourceId": "2345",
+                  "sourceParentId": "1234",
+                  "attributes": { "reactions": 68 },
+                  "channel": "dev",
+                  "body": "My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.",
+                  "title": null,
+                  "url": "discord.gg/2345",
+                  "sentiment": {
+                    "label": "negative",
+                    "mixed": 5.963129922747612,
+                    "neutral": 20.673033595085144,
+                    "negative": 69.99874711036682,
+                    "positive": 3.365083411335945,
+                    "sentiment": 5
+                  },
+                  "importHash": null,
+                  "createdAt": "2022-10-03T15:19:30.415Z",
+                  "updatedAt": "2022-10-05T12:21:53.279Z",
+                  "deletedAt": null,
+                  "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                  "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+                  "parentId": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "member": {
+                    "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                    "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                    "attributes": {
+                      "bio": {
+                        "github": "Systems engineer at Pied Piper",
+                        "default": "It's not magic. It's talent and sweat",
+                        "twitter": "It's not magic. It's talent and sweat"
+                      },
+                      "url": {
+                        "github": "https://github.com/gilfoyle",
+                        "default": "https://t.co/g",
+                        "twitter": "https://t.co/g"
+                      },
+                      "location": {
+                        "custom": "Erlich's house",
+                        "github": "Palo alto",
+                        "default": "Erlich's house"
+                      }
+                    },
+                    "displayName": "Gilfoyle",
+                    "email": "gilfoyle@piedpiper.io",
+                    "score": 8,
+                    "joinedAt": "2022-10-03T15:17:03.540Z",
+                    "importHash": null,
+                    "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                    "createdAt": "2022-10-03T15:17:03.547Z",
+                    "updatedAt": "2022-10-05T11:40:32.560Z",
+                    "deletedAt": null,
+                    "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                    "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                    "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                  }
+                }
+              ],
+              "memberCount": 2,
+              "channel": null
+            },
+            {
+              "id": "24bdea79-3125-4950-bb38-07fa4a555012",
+              "title": "Best of dinesh and Gilfoyle",
+              "slug": "best-of-dinesh-and-gilfoyle",
+              "published": true,
+              "createdAt": "2022-10-05T12:21:53.271Z",
+              "updatedAt": "2022-10-05T12:21:53.271Z",
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "platform": "discord",
+              "activityCount": 1,
+              "lastActive": "2020-06-29T15:13:30.000Z",
+              "conversationStarter": {
+                "id": "89a136ed-336d-4586-8842-790775465212",
+                "type": "message",
+                "timestamp": "2020-05-27T14:13:30.000Z",
+                "platform": "discord",
+                "isContribution": true,
+                "score": 1,
+                "sourceId": "d42",
+                "sourceParentId": null,
+                "attributes": {},
+                "channel": "piedpiper",
+                "body": "Best of Dinesh and gilfoyle",
+                "title": null,
+                "url": "github.com/piedpiper/piedpier",
+                "sentiment": {
+                  "label": "negative",
+                  "mixed": 1.6482997238636017,
+                  "neutral": 12.5749893784523,
+                  "negative": 62.36468505859375,
+                  "positive": 1.4120269566774368,
+                  "sentiment": 2
+                },
+                "importHash": null,
+                "createdAt": "2022-10-05T12:09:44.414Z",
+                "updatedAt": "2022-10-05T12:21:53.279Z",
+                "deletedAt": null,
+                "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+                "parentId": null,
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "member": {
+                  "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                  "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                  "attributes": {
+                    "bio": {
+                      "github": "Systems engineer at Pied Piper",
+                      "default": "It's not magic. It's talent and sweat",
+                      "twitter": "It's not magic. It's talent and sweat"
+                    },
+                    "url": {
+                      "github": "https://github.com/gilfoyle",
+                      "default": "https://t.co/g",
+                      "twitter": "https://t.co/g"
+                    },
+                    "location": {
+                      "custom": "Erlich's house",
+                      "github": "Palo alto",
+                      "default": "Erlich's house"
+                    }
+                  },
+                  "displayName": "Gilfoyle",
+                  "email": "gilfoyle@piedpiper.io",
+                  "score": 8,
+                  "joinedAt": "2022-10-03T15:17:03.540Z",
+                  "importHash": null,
+                  "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                  "createdAt": "2022-10-03T15:17:03.547Z",
+                  "updatedAt": "2022-10-05T11:40:32.560Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              },
+              "lastReplies": [
+                {
+                  "id": "c39dc046-da1d-4a25-8624-6b78aad00f30",
+                  "type": "message",
+                  "timestamp": "2020-06-29T15:13:30.000Z",
+                  "platform": "discord",
+                  "isContribution": true,
+                  "score": 1,
+                  "sourceId": "2345",
+                  "sourceParentId": "1234",
+                  "attributes": { "reactions": 68 },
+                  "channel": "dev",
+                  "body": "A very last reply to the conversation.",
+                  "title": null,
+                  "url": "discord.gg/2345",
+                  "sentiment": {
+                    "label": "negative",
+                    "mixed": 5.963129922747612,
+                    "neutral": 20.673033595085144,
+                    "negative": 69.99874711036682,
+                    "positive": 3.365083411335945,
+                    "sentiment": 5
+                  },
+                  "importHash": null,
+                  "createdAt": "2022-10-03T15:19:30.415Z",
+                  "updatedAt": "2022-10-05T12:21:53.279Z",
+                  "deletedAt": null,
+                  "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                  "conversationId": "24bdea79-3125-4950-bb38-07fa4a555012",
+                  "parentId": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "member": {
+                    "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                    "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+                    "attributes": {
+                      "bio": {
+                        "github": "Systems engineer at Pied Piper",
+                        "default": "It's not magic. It's talent and sweat",
+                        "twitter": "It's not magic. It's talent and sweat"
+                      },
+                      "url": {
+                        "github": "https://github.com/gilfoyle",
+                        "default": "https://t.co/g",
+                        "twitter": "https://t.co/g"
+                      },
+                      "location": {
+                        "custom": "Erlich's house",
+                        "github": "Palo alto",
+                        "default": "Erlich's house"
+                      }
+                    },
+                    "displayName": "Gilfoyle",
+                    "email": "gilfoyle@piedpiper.io",
+                    "score": 8,
+                    "joinedAt": "2022-10-03T15:17:03.540Z",
+                    "importHash": null,
+                    "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+                    "createdAt": "2022-10-03T15:17:03.547Z",
+                    "updatedAt": "2022-10-05T11:40:32.560Z",
+                    "deletedAt": null,
+                    "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                    "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                    "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                  }
+                }
+              ],
+              "memberCount": 2,
+              "channel": "dev"
+            }
+          ],
+          "count": 2,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "MemberUpsert": {
+        "value": {
+          "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+          "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+          "attributes": {
+            "bio": {
+              "github": "Systems engineer at Pied Piper",
+              "default": "It's not magic. It's talent and sweat",
+              "twitter": "It's not magic. It's talent and sweat"
+            },
+            "url": {
+              "github": "https://github.com/gilfoyle",
+              "default": "https://t.co/g",
+              "twitter": "https://t.co/g"
+            },
+            "location": {
+              "custom": "Erlich's house",
+              "github": "Palo alto",
+              "default": "Erlich's house"
+            }
+          },
+          "displayName": "Gilfoyle",
+          "email": "gilfoyle@piedpiper.io",
+          "score": -1,
+          "joinedAt": "2022-10-03T15:17:03.540Z",
+          "importHash": null,
+          "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+          "createdAt": "2022-10-03T15:17:03.547Z",
+          "updatedAt": "2022-10-03T15:17:27.073Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+        }
+      },
+      "MemberFind": {
+        "value": {
+          "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+          "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+          "attributes": {
+            "bio": {
+              "github": "Systems engineer at Pied Piper",
+              "default": "It's not magic. It's talent and sweat",
+              "twitter": "It's not magic. It's talent and sweat"
+            },
+            "url": {
+              "github": "https://github.com/gilfoyle",
+              "default": "https://t.co/g",
+              "twitter": "https://t.co/g"
+            },
+            "location": {
+              "custom": "Erlich's house",
+              "github": "Palo alto",
+              "default": "Erlich's house"
+            }
+          },
+          "displayName": "Gilfoyle",
+          "email": "gilfoyle@piedpiper.io",
+          "score": 8,
+          "joinedAt": "2022-10-03T15:17:03.540Z",
+          "importHash": null,
+          "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+          "createdAt": "2022-10-03T15:17:03.547Z",
+          "updatedAt": "2022-10-05T11:40:32.560Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "activities": [
+            {
+              "id": "2dcbe40e-36e0-4929-ab21-a30467fd9a65",
+              "type": "pull_request-comment",
+              "timestamp": "2021-07-27T20:23:30.000Z",
+              "platform": "github",
+              "isContribution": true,
+              "score": 3,
+              "sourceId": "gh_3",
+              "sourceParentId": "gh_1",
+              "attributes": {},
+              "channel": "piedpiper",
+              "body": "Don't worry. I will continue to do it for you.",
+              "title": null,
+              "url": "github.com/piedpiper/piedpier",
+              "sentiment": {
+                "label": "positive",
+                "mixed": 2.9098065569996834,
+                "neutral": 25.578168034553528,
+                "negative": 2.241993509232998,
+                "positive": 69.27002668380737,
+                "sentiment": 97
+              },
+              "importHash": null,
+              "createdAt": "2022-10-03T15:47:20.151Z",
+              "updatedAt": "2022-10-03T15:47:20.220Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+              "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            },
+            {
+              "id": "c39dc046-da1d-4a25-8624-6b78aad00f30",
+              "type": "message",
+              "timestamp": "2020-06-27T15:13:30.000Z",
+              "platform": "discord",
+              "isContribution": true,
+              "score": 1,
+              "sourceId": "2345",
+              "sourceParentId": "1234",
+              "attributes": { "reactions": 68 },
+              "channel": "dev",
+              "body": "My servers could handle 10x the traffic, if they weren't busy apologizing for your sh*t codebase.",
+              "title": null,
+              "url": "discord.gg/2345",
+              "sentiment": {
+                "label": "negative",
+                "mixed": 5.963129922747612,
+                "neutral": 20.673033595085144,
+                "negative": 69.99874711036682,
+                "positive": 3.365083411335945,
+                "sentiment": 5
+              },
+              "importHash": null,
+              "createdAt": "2022-10-03T15:19:30.415Z",
+              "updatedAt": "2022-10-03T15:26:02.599Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": null,
+              "parentId": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            },
+            {
+              "id": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+              "type": "message",
+              "timestamp": "2020-05-27T15:13:30.000Z",
+              "platform": "discord",
+              "isContribution": true,
+              "score": 1,
+              "sourceId": "1234",
+              "sourceParentId": null,
+              "attributes": { "reactions": 43 },
+              "channel": "dev",
+              "body": "It's not magic. It's talend and sweat.",
+              "title": null,
+              "url": "discord.gg/1234",
+              "sentiment": {
+                "label": "negative",
+                "mixed": 1.1410574428737164,
+                "neutral": 11.00325882434845,
+                "negative": 85.99738478660583,
+                "positive": 1.8582981079816818,
+                "sentiment": 2
+              },
+              "importHash": null,
+              "createdAt": "2022-10-03T15:18:11.294Z",
+              "updatedAt": "2022-10-03T15:21:49.402Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": null,
+              "parentId": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ],
+          "lastActivity": {
+            "id": "2dcbe40e-36e0-4929-ab21-a30467fd9a65",
+            "type": "pull_request-comment",
+            "timestamp": "2021-07-27T20:23:30.000Z",
+            "platform": "github",
+            "isContribution": true,
+            "score": 3,
+            "sourceId": "gh_3",
+            "sourceParentId": "gh_1",
+            "attributes": {},
+            "channel": "piedpiper",
+            "body": "Don't worry. I will continue to do it for you.",
+            "title": null,
+            "url": "github.com/piedpiper/piedpier",
+            "sentiment": {
+              "label": "positive",
+              "mixed": 2.9098065569996834,
+              "neutral": 25.578168034553528,
+              "negative": 2.241993509232998,
+              "positive": 69.27002668380737,
+              "sentiment": 97
+            },
+            "importHash": null,
+            "createdAt": "2022-10-03T15:47:20.151Z",
+            "updatedAt": "2022-10-03T15:47:20.220Z",
+            "deletedAt": null,
+            "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+            "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+            "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+            "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+            "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+            "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+          },
+          "lastActive": "2021-07-27T20:23:30.000Z",
+          "activityCount": 3,
+          "averageSentiment": 34.67,
+          "tags": [
+            {
+              "id": "38807625-6302-47b5-9f35-58566ddec83b",
+              "name": "developer",
+              "importHash": null,
+              "createdAt": "2022-10-05T11:41:20.162Z",
+              "updatedAt": "2022-10-05T11:41:20.162Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            },
+            {
+              "id": "dca36c33-38cd-4e68-8ba8-515167e00971",
+              "name": "attended-hooli-con",
+              "importHash": null,
+              "createdAt": "2022-10-05T11:42:17.414Z",
+              "updatedAt": "2022-10-05T11:42:17.414Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ],
+          "organizations": [
+            {
+              "id": "31bff99a-2eac-49f5-b015-cba95aa6e530",
+              "name": "Pied Piper",
+              "url": "https://piedpiper.io",
+              "description": "The new internet",
+              "parentUrl": null,
+              "emails": ["richard@piedpiper.io", "hello@piedpiper.io"],
+              "phoneNumbers": null,
+              "logo": null,
+              "tags": ["new-internet", "making-the-world-a-better-place", "not-like-hooli"],
+              "twitter": {
+                "bio": "The internet we deserve",
+                "handle": "PiedPiper",
+                "location": "The valley",
+                "followers": 5000,
+                "following": 20
+              },
+              "linkedin": { "handle": "company/PiedPiper" },
+              "crunchbase": { "handle": "company/PiedPiper" },
+              "employees": 50,
+              "revenueRange": { "max": 50, "min": 10 },
+              "importHash": null,
+              "createdAt": "2022-10-03T16:15:21.812Z",
+              "updatedAt": "2022-10-03T16:15:21.812Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ],
+          "tasks": [],
+          "notes": [],
+          "noMerge": [],
+          "toMerge": []
+        }
+      },
+      "MemberList": {
+        "value": {
+          "rows": [
+            {
+              "id": "2effc566-1932-44f3-a821-2d692933a953",
+              "username": { "github": "dinesh", "twitter": "dinesh.chugtai" },
+              "attributes": {
+                "bio": {
+                  "github": "Lead developer at Pied Piper",
+                  "default": "Pakistani Denzel. Tesla and gold chain owner.",
+                  "twitter": "Pakistani Denzel. Tesla and gold chain owner."
+                },
+                "url": {
+                  "github": "https://github.com/dinesh",
+                  "default": "https://t.co/d",
+                  "twitter": "https://t.co/d"
+                },
+                "location": {
+                  "custom": "Silicon Valley",
+                  "github": "Palo alto",
+                  "default": "Silicon Valley"
+                }
+              },
+              "displayName": "Dinesh",
+              "email": "dinesh@piedpiper.io",
+              "score": 9,
+              "joinedAt": "2022-10-03T15:30:55.672Z",
+              "importHash": null,
+              "reach": { "total": 100, "github": 60, "twitter": 40 },
+              "createdAt": "2022-10-03T15:30:55.679Z",
+              "updatedAt": "2022-10-05T11:39:58.095Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "identities": ["github", "twitter"],
+              "activeOn": ["github"],
+              "activityCount": "2",
+              "lastActive": "2021-07-27T20:22:30.000Z",
+              "averageSentiment": "82.50",
+              "noMerge": [],
+              "toMerge": [],
+              "lastActivity": {
+                "id": "73aa13b7-1ef9-4987-a273-e560edff94ca",
+                "type": "pull_request-comment",
+                "timestamp": "2021-07-27T20:22:30.000Z",
+                "platform": "github",
+                "isContribution": true,
+                "score": 3,
+                "sourceId": "gh_2",
+                "sourceParentId": "gh_1",
+                "attributes": {},
+                "channel": "piedpiper",
+                "body": "I will never underestimate my talents again.",
+                "title": null,
+                "url": "github.com/piedpiper/piedpier",
+                "sentiment": {
+                  "label": "positive",
+                  "mixed": 14.308956265449524,
+                  "neutral": 14.437079429626465,
+                  "negative": 9.826807677745819,
+                  "positive": 61.42715811729431,
+                  "sentiment": 86
+                },
+                "importHash": null,
+                "createdAt": "2022-10-03T15:38:05.847Z",
+                "updatedAt": "2022-10-03T15:46:34.610Z",
+                "deletedAt": null,
+                "memberId": "2effc566-1932-44f3-a821-2d692933a953",
+                "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+                "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+              },
+              "organizations": [
+                {
+                  "id": "31bff99a-2eac-49f5-b015-cba95aa6e530",
+                  "name": "Pied Piper",
+                  "url": "https://piedpiper.io",
+                  "description": "The new internet",
+                  "parentUrl": null,
+                  "emails": ["richard@piedpiper.io", "hello@piedpiper.io"],
+                  "phoneNumbers": null,
+                  "logo": null,
+                  "tags": ["new-internet", "making-the-world-a-better-place", "not-like-hooli"],
+                  "twitter": {
+                    "bio": "The internet we deserve",
+                    "handle": "PiedPiper",
+                    "location": "The valley",
+                    "followers": 5000,
+                    "following": 20
+                  },
+                  "linkedin": { "handle": "company/PiedPiper" },
+                  "crunchbase": { "handle": "company/PiedPiper" },
+                  "employees": 50,
+                  "revenueRange": { "max": 50, "min": 10 },
+                  "importHash": null,
+                  "createdAt": "2022-10-03T16:15:21.812Z",
+                  "updatedAt": "2022-10-03T16:15:21.812Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              ],
+              "tags": [
+                {
+                  "id": "38807625-6302-47b5-9f35-58566ddec83b",
+                  "name": "developer",
+                  "importHash": null,
+                  "createdAt": "2022-10-05T11:41:20.162Z",
+                  "updatedAt": "2022-10-05T11:41:20.162Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              ]
+            },
+            {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": 8,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-05T11:40:32.560Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "activityCount": "3",
+              "lastActive": "2021-07-27T20:23:30.000Z",
+              "averageSentiment": "34.67",
+              "noMerge": [],
+              "toMerge": [],
+              "lastActivity": {
+                "id": "2dcbe40e-36e0-4929-ab21-a30467fd9a65",
+                "type": "pull_request-comment",
+                "timestamp": "2021-07-27T20:23:30.000Z",
+                "platform": "github",
+                "isContribution": true,
+                "score": 3,
+                "sourceId": "gh_3",
+                "sourceParentId": "gh_1",
+                "attributes": {},
+                "channel": "piedpiper",
+                "body": "Don't worry. I will continue to do it for you.",
+                "title": null,
+                "url": "github.com/piedpiper/piedpier",
+                "sentiment": {
+                  "label": "positive",
+                  "mixed": 2.9098065569996834,
+                  "neutral": 25.578168034553528,
+                  "negative": 2.241993509232998,
+                  "positive": 69.27002668380737,
+                  "sentiment": 97
+                },
+                "importHash": null,
+                "createdAt": "2022-10-03T15:47:20.151Z",
+                "updatedAt": "2022-10-03T15:47:20.220Z",
+                "deletedAt": null,
+                "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+                "conversationId": "291af008-7717-457e-9242-f5c507c8987b",
+                "parentId": "462ddc6b-5672-43b2-9018-4e3fd7332228",
+                "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+              },
+              "organizations": [
+                {
+                  "id": "31bff99a-2eac-49f5-b015-cba95aa6e530",
+                  "name": "Pied Piper",
+                  "url": "https://piedpiper.io",
+                  "description": "The new internet",
+                  "parentUrl": null,
+                  "emails": ["richard@piedpiper.io", "hello@piedpiper.io"],
+                  "phoneNumbers": null,
+                  "logo": null,
+                  "tags": ["new-internet", "making-the-world-a-better-place", "not-like-hooli"],
+                  "twitter": {
+                    "bio": "The internet we deserve",
+                    "handle": "PiedPiper",
+                    "location": "The valley",
+                    "followers": 5000,
+                    "following": 20
+                  },
+                  "linkedin": { "handle": "company/PiedPiper" },
+                  "crunchbase": { "handle": "company/PiedPiper" },
+                  "employees": 50,
+                  "revenueRange": { "max": 50, "min": 10 },
+                  "importHash": null,
+                  "createdAt": "2022-10-03T16:15:21.812Z",
+                  "updatedAt": "2022-10-03T16:15:21.812Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              ],
+              "tags": [
+                {
+                  "id": "38807625-6302-47b5-9f35-58566ddec83b",
+                  "name": "developer",
+                  "importHash": null,
+                  "createdAt": "2022-10-05T11:41:20.162Z",
+                  "updatedAt": "2022-10-05T11:41:20.162Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                },
+                {
+                  "id": "dca36c33-38cd-4e68-8ba8-515167e00971",
+                  "name": "attended-hooli-con",
+                  "importHash": null,
+                  "createdAt": "2022-10-05T11:42:17.414Z",
+                  "updatedAt": "2022-10-05T11:42:17.414Z",
+                  "deletedAt": null,
+                  "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+                  "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+                  "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+                }
+              ]
+            }
+          ],
+          "count": 2,
+          "offset": 0,
+          "limit": 10
+        }
+      },
+      "Note2": {
+        "value": {
+          "id": "39c850f6-fb96-4d16-8e8c-cd7072e33925",
+          "body": "Refused to have a user feedback call",
+          "importHash": null,
+          "createdAt": "2022-10-03T16:00:57.867Z",
+          "updatedAt": "2022-10-03T16:00:57.867Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [
+            {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": -1,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-03T15:17:27.073Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ]
+        }
+      },
+      "Note": {
+        "value": {
+          "id": "196c07da-14e0-419e-bd9a-5f15c721a694",
+          "body": "Likes frunks",
+          "importHash": null,
+          "createdAt": "2022-10-05T11:58:30.977Z",
+          "updatedAt": "2022-10-05T11:58:30.977Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [
+            {
+              "id": "2effc566-1932-44f3-a821-2d692933a953",
+              "username": { "github": "dinesh", "twitter": "dinesh.chugtai" },
+              "attributes": {
+                "bio": {
+                  "github": "Lead developer at Pied Piper",
+                  "default": "Pakistani Denzel. Tesla and gold chain owner.",
+                  "twitter": "Pakistani Denzel. Tesla and gold chain owner."
+                },
+                "url": {
+                  "github": "https://github.com/dinesh",
+                  "default": "https://t.co/d",
+                  "twitter": "https://t.co/d"
+                },
+                "location": {
+                  "custom": "Silicon Valley",
+                  "github": "Palo alto",
+                  "default": "Silicon Valley"
+                }
+              },
+              "displayName": "Dinesh",
+              "email": "dinesh@piedpiper.io",
+              "score": 9,
+              "joinedAt": "2022-10-03T15:30:55.672Z",
+              "importHash": null,
+              "reach": { "total": 100, "github": 60, "twitter": 40 },
+              "createdAt": "2022-10-03T15:30:55.679Z",
+              "updatedAt": "2022-10-05T11:39:58.095Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ]
+        }
+      },
+      "NoteList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/Note" },
+            { "$ref": "#/components/examples/Note2" }
+          ],
+          "count": 2,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "OrganizationCreate": {
+        "value": {
+          "id": "31bff99a-2eac-49f5-b015-cba95aa6e530",
+          "name": "Pied Piper",
+          "url": "https://piedpiper.io",
+          "description": "The new internet",
+          "parentUrl": null,
+          "emails": ["richard@piedpiper.io", "hello@piedpiper.io"],
+          "phoneNumbers": null,
+          "logo": null,
+          "tags": ["new-internet", "making-the-world-a-better-place", "not-like-hooli"],
+          "twitter": {
+            "bio": "The internet we deserve",
+            "handle": "PiedPiper",
+            "location": "The valley",
+            "followers": 5000,
+            "following": 20
+          },
+          "linkedin": { "handle": "company/PiedPiper" },
+          "crunchbase": { "handle": "company/PiedPiper" },
+          "employees": 50,
+          "revenueRange": { "max": 50, "min": 10 },
+          "importHash": null,
+          "createdAt": "2022-10-03T16:15:21.812Z",
+          "updatedAt": "2022-10-03T16:15:21.812Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "memberCount": 2,
+          "activityCount": 4
+        }
+      },
+      "Organization": {
+        "value": {
+          "id": "31bff99a-2eac-49f5-b015-cba95aa6e530",
+          "name": "Pied Piper",
+          "url": "https://piedpiper.io",
+          "description": "The new internet",
+          "parentUrl": null,
+          "emails": ["richard@piedpiper.io", "hello@piedpiper.io"],
+          "phoneNumbers": null,
+          "logo": null,
+          "tags": ["new-internet", "making-the-world-a-better-place", "not-like-hooli"],
+          "identities": ["github", "twitter"],
+          "activeOn": ["github"],
+          "lastActive": "2022-10-03T16:15:21.812Z",
+          "joinedAt": "2022-05-03T11:16:32.812Z",
+          "twitter": {
+            "bio": "The internet we deserve",
+            "handle": "PiedPiper",
+            "location": "The valley",
+            "followers": 5000,
+            "following": 20
+          },
+          "linkedin": { "handle": "company/PiedPiper" },
+          "crunchbase": { "handle": "company/PiedPiper" },
+          "employees": 50,
+          "revenueRange": { "max": 50, "min": 10 },
+          "importHash": null,
+          "createdAt": "2022-10-03T16:15:21.812Z",
+          "updatedAt": "2022-10-03T16:15:21.812Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "memberCount": 2,
+          "activityCount": 4
+        }
+      },
+      "Organization2": {
+        "value": {
+          "id": "65257687-0bfa-498e-8b2f-53559f41522b",
+          "name": "Hooli",
+          "url": "https://hooli.xyz",
+          "description": "Hooli is an international corporation founded by Gavin Belson and Peter Gregory",
+          "parentUrl": null,
+          "emails": ["gavin@hooli.xyz"],
+          "phoneNumbers": null,
+          "logo": null,
+          "tags": ["hooli", "tethics", "not-google"],
+          "identities": ["devto", "github", "twitter"],
+          "activeOn": ["devto"],
+          "lastActive": "2022-10-04",
+          "joinedAt": "2020-01-30",
+          "twitter": {
+            "bio": "Hooli is an international corporation founded by Gavin Belson and Peter Gregory",
+            "handle": "hooli",
+            "location": "Menlo Park",
+            "followers": 500000,
+            "following": 0
+          },
+          "linkedin": { "handle": "company/Hooli" },
+          "crunchbase": { "handle": "company/Hooli" },
+          "employees": 4000,
+          "revenueRange": { "max": 500, "min": 100 },
+          "importHash": null,
+          "createdAt": "2022-10-05T12:03:11.228Z",
+          "updatedAt": "2022-10-05T12:03:11.228Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "memberCount": 0,
+          "activityCount": 0
+        }
+      },
+      "OrganizationList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/Organization" },
+            { "$ref": "#/components/examples/Organization2" }
+          ],
+          "count": 2,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "Tag": {
+        "value": {
+          "id": "dca36c33-38cd-4e68-8ba8-515167e00971",
+          "name": "attended-hooli-con",
+          "importHash": null,
+          "createdAt": "2022-10-05T11:42:17.414Z",
+          "updatedAt": "2022-10-05T11:42:17.414Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [
+            {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": 8,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-05T11:40:32.560Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ]
+        }
+      },
+      "Tag2": {
+        "value": {
+          "id": "38807625-6302-47b5-9f35-58566ddec83b",
+          "name": "developer",
+          "createdAt": "2022-10-05T11:41:20.162Z",
+          "updatedAt": "2022-10-05T11:41:20.162Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [
+            {
+              "id": "2effc566-1932-44f3-a821-2d692933a953",
+              "username": { "github": "dinesh", "twitter": "dinesh.chugtai" },
+              "attributes": {
+                "bio": {
+                  "github": "Lead developer at Pied Piper",
+                  "default": "Pakistani Denzel. Tesla and gold chain owner.",
+                  "twitter": "Pakistani Denzel. Tesla and gold chain owner."
+                },
+                "url": {
+                  "github": "https://github.com/dinesh",
+                  "default": "https://t.co/d",
+                  "twitter": "https://t.co/d"
+                },
+                "location": {
+                  "custom": "Silicon Valley",
+                  "github": "Palo alto",
+                  "default": "Silicon Valley"
+                }
+              },
+              "displayName": "Dinesh",
+              "email": "dinesh@piedpiper.io",
+              "score": 9,
+              "joinedAt": "2022-10-03T15:30:55.672Z",
+              "reach": { "total": 100, "github": 60, "twitter": 40 },
+              "createdAt": "2022-10-03T15:30:55.679Z",
+              "updatedAt": "2022-10-05T11:39:58.095Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            },
+            {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": 8,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-05T11:40:32.560Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ]
+        }
+      },
+      "TagList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/Tag" },
+            { "$ref": "#/components/examples/Tag2" }
+          ],
+          "count": 2,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "Task": {
+        "value": {
+          "id": "8a127785-f11d-4102-804d-5b79ccddd4cc",
+          "name": "Ask for tips on building a new Anton",
+          "body": null,
+          "status": null,
+          "dueDate": "2022-05-27T15:13:30.000Z",
+          "importHash": null,
+          "createdAt": "2022-10-03T16:00:18.701Z",
+          "updatedAt": "2022-10-03T16:00:18.701Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "assignedToId": null,
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [
+            {
+              "id": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "username": { "github": "gilfoyle", "twitter": "gilfoyle" },
+              "attributes": {
+                "bio": {
+                  "github": "Systems engineer at Pied Piper",
+                  "default": "It's not magic. It's talent and sweat",
+                  "twitter": "It's not magic. It's talent and sweat"
+                },
+                "url": {
+                  "github": "https://github.com/gilfoyle",
+                  "default": "https://t.co/g",
+                  "twitter": "https://t.co/g"
+                },
+                "location": {
+                  "custom": "Erlich's house",
+                  "github": "Palo alto",
+                  "default": "Erlich's house"
+                }
+              },
+              "displayName": "Gilfoyle",
+              "email": "gilfoyle@piedpiper.io",
+              "score": -1,
+              "joinedAt": "2022-10-03T15:17:03.540Z",
+              "importHash": null,
+              "reach": { "total": 10000, "github": 5000, "twitter": 5000 },
+              "createdAt": "2022-10-03T15:17:03.547Z",
+              "updatedAt": "2022-10-03T15:17:27.073Z",
+              "deletedAt": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ],
+          "activities": []
+        }
+      },
+      "Task2": {
+        "value": {
+          "id": "ef22fb05-a41b-472e-9917-a4d10d19fcc6",
+          "name": "Ask if we can use as quote",
+          "body": null,
+          "status": null,
+          "dueDate": "2022-08-27T00:00:00.000Z",
+          "importHash": null,
+          "createdAt": "2022-10-05T11:55:55.606Z",
+          "updatedAt": "2022-10-05T11:55:55.606Z",
+          "deletedAt": null,
+          "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+          "assignedToId": null,
+          "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+          "members": [],
+          "activities": [
+            {
+              "id": "782b426d-adc8-4fb4-a4ee-ab0bb07ffca0",
+              "type": "message",
+              "timestamp": "2020-05-27T15:13:30.000Z",
+              "platform": "discord",
+              "isContribution": true,
+              "score": 1,
+              "sourceId": "1234",
+              "sourceParentId": null,
+              "attributes": { "reactions": 43 },
+              "channel": "dev",
+              "body": "It's not magic. It's talend and sweat.",
+              "title": null,
+              "url": "discord.gg/1234",
+              "sentiment": {
+                "label": "negative",
+                "mixed": 1.1410574428737164,
+                "neutral": 11.00325882434845,
+                "negative": 85.99738478660583,
+                "positive": 1.8582981079816818,
+                "sentiment": 2
+              },
+              "importHash": null,
+              "createdAt": "2022-10-03T15:18:11.294Z",
+              "updatedAt": "2022-10-03T15:21:49.402Z",
+              "deletedAt": null,
+              "memberId": "ab7a9fe9-4576-46b1-a710-8b8eaeff87a5",
+              "conversationId": null,
+              "parentId": null,
+              "tenantId": "8642a2bd-965e-4acd-be8c-dfedc83ef0af",
+              "createdById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75",
+              "updatedById": "debc3c7f-4c5d-4bec-9130-17bb0aea8b75"
+            }
+          ]
+        }
+      },
+      "TaskList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/Task" },
+            { "$ref": "#/components/examples/Task2" }
+          ],
+          "count": 2,
+          "limit": 10,
+          "offset": 0
+        }
+      },
+      "TaskFindAndUpdateAll": { "value": { "rowsUpdated": 5 } },
+      "ActivityTypes": {
+        "value": {
+          "default": {
+            "github": {
+              "discussion-started": {
+                "default": "started a discussion in {channel}",
+                "short": "started a discussion",
+                "channel": "{channel}"
+              },
+              "discussion-comment": {
+                "default": "commented on a discussion in {channel}",
+                "short": "commented on a discussion",
+                "channel": "{channel}"
+              },
+              "fork": { "default": "forked {channel}", "short": "forked", "channel": "{channel}" },
+              "issues-closed": {
+                "default": "closed an issue in {channel}",
+                "short": "closed an issue",
+                "channel": "{channel}"
+              },
+              "issues-opened": {
+                "default": "opened a new issue in {channel}",
+                "short": "opened an issue",
+                "channel": "{channel}"
+              },
+              "issue-comment": {
+                "default": "commented on an issue in {channel}",
+                "short": "commented on an issue",
+                "channel": "{channel}"
+              },
+              "pull_request-closed": {
+                "default": "closed a pull request in {channel}",
+                "short": "closed a pull request",
+                "channel": "{channel}"
+              },
+              "pull_request-opened": {
+                "default": "opened a new pull request in {channel}",
+                "short": "opened a pull request",
+                "channel": "{channel}"
+              },
+              "pull_request-comment": {
+                "default": "commented on a pull request in {channel}",
+                "short": "commented on a pull request",
+                "channel": "{channel}"
+              },
+              "star": {
+                "default": "starred {channel}",
+                "short": "starred",
+                "channel": "{channel}"
+              },
+              "unstar": {
+                "default": "unstarred {channel}",
+                "short": "unstarred",
+                "channel": "{channel}"
+              }
+            },
+            "devto": {
+              "comment": {
+                "default": "commented on <a href=\"{attributes.articleUrl}\" class=\"truncate max-w-2xs\">{attributes.articleTitle}</a>",
+                "short": "commented",
+                "channel": "<a href=\"{attributes.articleUrl}\" class=\"truncate max-w-2xs\">{attributes.articleTitle}</a>"
+              }
+            },
+            "discord": {
+              "joined_guild": {
+                "default": "joined server",
+                "short": "joined server",
+                "channel": ""
+              },
+              "message": {
+                "default": "sent a message in <span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span>",
+                "short": "sent a message",
+                "channel": "<span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span>"
+              },
+              "thread_started": {
+                "default": "started a new thread",
+                "short": "started a new thread",
+                "channel": ""
+              },
+              "thread_message": {
+                "default": "replied to a message in thread <span class=\"text-brand-500 truncate max-w-2xs\">#{channel}</span> -> <span class=\"text-brand-500\">{attributes.parentChannel}</span>",
+                "short": "replied to a message",
+                "channel": "<span class=\"text-brand-500 truncate max-w-2xs\">thread #{channel}</span> -> <span class=\"text-brand-500\">#{attributes.parentChannel}</span>"
+              }
+            },
+            "hackernews": {
+              "comment": {
+                "default": "commented on <a href=\"{attributes.parentUrl}\" target=\"_blank\">{attributes.parentTitle}</a>",
+                "short": "commented",
+                "channel": "{channel}"
+              },
+              "post": {
+                "default": "posted mentioning {channel}",
+                "short": "posted",
+                "channel": "{channel}"
+              }
+            },
+            "linkedin": {
+              "comment": {
+                "default": "commented on a post <a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>",
+                "short": "commented",
+                "channel": "<a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>"
+              },
+              "message": { "default": "sent a message", "short": "sent a message", "channel": "" },
+              "reaction": {
+                "default": "reacted with <img src=\"/images/integrations/linkedin-reactions/{attributes.reactionType}.svg\"> on a post <a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>",
+                "short": "reacted",
+                "channel": "<a href=\"{attributes.postUrl}\" target=\"_blank\">{attributes.postBody}</a>"
+              }
+            },
+            "reddit": {
+              "comment": {
+                "default": "commented in subreddit <a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>",
+                "short": "commented on a post",
+                "channel": "<a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>"
+              },
+              "post": {
+                "default": "posted in subreddit <a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>",
+                "short": "posted in subreddit",
+                "channel": "<a href=\"https://reddit.com/r/{channel}\" target=\"_blank\">r/{channel}</a>"
+              }
+            },
+            "slack": {
+              "channel_joined": {
+                "default": "joined channel {channel}",
+                "short": "joined channel",
+                "channel": "{channel}"
+              },
+              "message": {
+                "default": "sent a message in {channel}",
+                "short": "sent a message",
+                "channel": "{channel}"
+              }
+            },
+            "twitter": {
+              "hashtag": { "default": "posted a tweet", "short": "posted a tweet", "channel": "" },
+              "follow": { "default": "followed you", "short": "followed you", "channel": "" },
+              "mention": {
+                "default": "mentioned you in a tweet",
+                "short": "mentioned you",
+                "channel": ""
+              }
+            },
+            "stackoverflow": {
+              "question": {
+                "default": "Asked a question {self}",
+                "short": "asked a question",
+                "channel": ""
+              },
+              "answer": {
+                "default": "Answered a question {self}",
+                "short": "answered a question",
+                "channel": ""
+              }
+            }
+          },
+          "custom": {
+            "other": {
+              "attended-a-meeting": {
+                "short": "Attended a meeting",
+                "channel": "",
+                "default": "Attended a meeting"
+              },
+              "asked-question-in-webinar": {
+                "default": "Asked question in webinar",
+                "short": "Asked question in webinar",
+                "channel": ""
+              }
+            }
+          }
+        }
+      },
+      "MemberAttributeSettings": {
+        "value": {
+          "id": "9eaedce9-1f3a-4a75-adc8-e475cbc47553'",
+          "type": "string",
+          "canDelete": false,
+          "show": true,
+          "label": "Url",
+          "name": "url",
+          "createdAt": "2022-09-07",
+          "updatedAt": "2022-09-07",
+          "tenantId": "fcd5b9cc-144b-4687-8fd9-34818f35e70d"
+        }
+      },
+      "MemberAttributeSettings2": {
+        "value": {
+          "id": "13bb9e12-c371-44ad-8806-0678c2f53dd1",
+          "type": "boolean",
+          "canDelete": false,
+          "show": true,
+          "label": "is Hireable",
+          "name": "isHireable",
+          "createdAt": "2022-09-07",
+          "updatedAt": "2022-09-07",
+          "tenantId": "fcd5b9cc-144b-4687-8fd9-34818f35e70d"
+        }
+      },
+      "MemberAttributeSettingsList": {
+        "value": {
+          "rows": [
+            { "$ref": "#/components/examples/MemberAttributeSettings" },
+            { "$ref": "#/components/examples/MemberAttributeSettings2" }
+          ],
+          "count": 2
+        }
+      }
+    }
+  },
+  "tags": [
+    { "name": "Members", "description": "Everything about members" },
+    { "name": "Member Attributes", "description": "Settings for member's attributes" },
+    { "name": "Activities", "description": "Everything about activities" },
+    { "name": "Organizations", "description": "Everything about organizations" },
+    { "name": "Conversations", "description": "Everything about conversations" },
+    { "name": "Tags", "description": "Everything about tags" },
+    { "name": "Automations", "description": "Everything about automations" },
+    { "name": "Notes", "description": "Everything about notes" }
+  ]
+}

--- a/backend/src/api/premium/enrichment/memberEnrich.ts
+++ b/backend/src/api/premium/enrichment/memberEnrich.ts
@@ -25,7 +25,7 @@ const log = getServiceLogger()
  * @response 404 - Not found
  * @response 429 - Too many requests
  */
- 
+
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberEdit)
 

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -1321,7 +1321,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           tenant: context.integration.tenantId,
           username: author.user.login,
           platform: PlatformType.GITHUB,
-          channel: repo.name,
+          channel: repo.url,
           url: `https://github.com/${repo.owner}/${repo.name}.git`,
           body: record.commit.message,
           type: 'authored-commit',

--- a/backend/src/serverless/integrations/types/regularTypes.ts
+++ b/backend/src/serverless/integrations/types/regularTypes.ts
@@ -6,6 +6,7 @@ export type Repo = {
   available?: boolean
   fork?: boolean
   private?: boolean
+  cloneUrl?: string
 }
 
 export type Repos = Array<Repo>

--- a/backend/src/serverless/integrations/types/regularTypes.ts
+++ b/backend/src/serverless/integrations/types/regularTypes.ts
@@ -4,6 +4,8 @@ export type Repo = {
   createdAt: string
   owner: string
   available?: boolean
+  fork?: boolean
+  private?: boolean
 }
 
 export type Repos = Array<Repo>

--- a/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
@@ -33,6 +33,7 @@ const parseRepos = (repositories: any): Repos => {
       name: repo.name,
       fork: repo.fork,
       private: repo.private,
+      cloneUrl: repo.clone_url,
     })
   }
 
@@ -56,7 +57,6 @@ export const getInstalledRepositories = async (installToken: string): Promise<Re
       hasMorePages = data.total_count && data.total_count > 0 && data.total_count > repos.length
       page += 1
     }
-
     return repos.filter((repo) => !IS_GITHUB_COMMIT_DATA_ENABLED || !(repo.fork || repo.private))
   } catch (err: any) {
     log.error(err, 'Error fetching installed repositories!')

--- a/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
@@ -57,9 +57,7 @@ export const getInstalledRepositories = async (installToken: string): Promise<Re
       page += 1
     }
 
-    return repos.filter(
-      (repo) => !IS_GITHUB_COMMIT_DATA_ENABLED || !(repo.fork || repo.private),
-    )
+    return repos.filter((repo) => !IS_GITHUB_COMMIT_DATA_ENABLED || !(repo.fork || repo.private))
   } catch (err: any) {
     log.error(err, 'Error fetching installed repositories!')
     throw err

--- a/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
@@ -1,6 +1,9 @@
 import { getServiceChildLogger } from '@crowd/logging'
 import axios, { AxiosRequestConfig } from 'axios'
 import { Repos } from '../../../types/regularTypes'
+import { GITHUB_CONFIG } from '../../../../../conf'
+
+const IS_GITHUB_COMMIT_DATA_ENABLED = GITHUB_CONFIG.isCommitDataEnabled === 'true'
 
 const log = getServiceChildLogger('getInstalledRepositories')
 
@@ -28,6 +31,8 @@ const parseRepos = (repositories: any): Repos => {
       owner: repo.owner.login,
       createdAt: repo.created_at,
       name: repo.name,
+      fork: repo.fork,
+      private: repo.private,
     })
   }
 
@@ -52,7 +57,9 @@ export const getInstalledRepositories = async (installToken: string): Promise<Re
       page += 1
     }
 
-    return repos
+    return repos.filter(
+      (repo) => !IS_GITHUB_COMMIT_DATA_ENABLED || !(repo.fork || repo.private),
+    )
   } catch (err: any) {
     log.error(err, 'Error fetching installed repositories!')
     throw err

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -291,6 +291,21 @@ export default class IntegrationService {
 
       const repos = await getInstalledRepositories(installToken)
 
+      // If the git integration is configured, we add the repos to the git config
+      let isGitintegrationConfigured
+      try {
+        await this.findByPlatform(PlatformType.GIT)
+        isGitintegrationConfigured = true
+      } catch (err) {
+        isGitintegrationConfigured = false
+      }
+      if (isGitintegrationConfigured) {
+        const gitRemotes = await this.gitGetRemotes()
+        await this.gitConnectOrUpdate({
+          remotes: [...gitRemotes.default, ...repos.map((repo) => repo.cloneUrl)],
+        })
+      }
+
       integration = await this.createOrUpdate(
         {
           platform: PlatformType.GITHUB,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6108fc3</samp>

This pull request adds a feature flag and a filter for fetching commit data from GitHub repositories in the `getInstalledRepositories` function. It also updates the `Repo` type and fixes a formatting issue in the `memberEnrich` endpoint.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6108fc3</samp>

> _`Commit data` is the source of our power_
> _We filter out the `forks` and the `private`_
> _We control the feature with a `flag`_
> _We unleash the fury of the `getInstalledRepositories`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6108fc3</samp>

*  Add feature flag and logic for fetching commit data from GitHub repositories ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-3d2263abe55db5c7cd6734fecef0f91d9f3ff5b57ee8e1cfb0a50e6f34e61263R7-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8L4-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8R34-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8L55-R62))
  - Define `Repo` type with optional `fork` and `private` properties to indicate repository status ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-3d2263abe55db5c7cd6734fecef0f91d9f3ff5b57ee8e1cfb0a50e6f34e61263R7-R8))
  - Import `GITHUB_CONFIG` from `conf` module and assign `IS_GITHUB_COMMIT_DATA_ENABLED` constant based on its `isCommitDataEnabled` property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8L4-R7))
  - Parse `fork` and `private` properties from GitHub API response and include them in `Repo` objects returned by `parseRepos` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8R34-R35))
  - Filter out forks and private repositories from `repos` array returned by `getInstalledRepositories` function if `IS_GITHUB_COMMIT_DATA_ENABLED` is true ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-b9e4a146be784b89791e5cc70249d4a0513bf52f2ef16879eb530656d701eef8L55-R62))
* Remove extra blank line after JSDoc comment for `memberEnrich` API endpoint ([link](https://github.com/CrowdDotDev/crowd.dev/pull/959/files?diff=unified&w=0#diff-0e0370e24ed15d7b48dd05dc5a5a7685f00f68afce5b841599e92e945935b833L28-R28))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
