### PR TITLE
Add missing return in a StackOverflow functino

### DIFF
--- a/services/libs/integrations/src/integrations/stackoverflow/api/getQuestionsByKeywords.ts
+++ b/services/libs/integrations/src/integrations/stackoverflow/api/getQuestionsByKeywords.ts
@@ -89,6 +89,8 @@ async function getQuestions(
         return response
       }
     }
+
+    return response
   } catch (err) {
     ctx.log.error({ err, input }, 'Error while getting StackOverflow questions by keywords')
     throw err


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7d27b2</samp>

Updated `getQuestionsByKeywords` function to return full response object from StackOverflow API. This enables better handling of metadata and pagination in the caller.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d7d27b2</samp>

> _`getQuestionsByKeywords`_
> _Returns more than questions now_
> _Autumn of data_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d7d27b2</samp>

* Return response object from StackOverflow API call to access metadata and pagination ([link](https://github.com/CrowdDotDev/crowd.dev/pull/973/files?diff=unified&w=0#diff-fc4a70ac8186d374861254e5de7e108e5e9835bc241bdbc283dd7d01c6ac681dR92-R93))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
