### PR TITLE
Hotfix Reddit

### DIFF
--- a/services/libs/integrations/src/integrations/reddit/processStream.ts
+++ b/services/libs/integrations/src/integrations/reddit/processStream.ts
@@ -35,15 +35,19 @@ async function recursiveCommentParser(
 
     // Each stream has at most 99 children to expand. If there are more, we make more than one stream.
     for (const chunk of partition(comment.children, 99)) {
-      await ctx.publishStream<IRedditMoreCommentsStreamData>(
-        `${RedditStreamType.MORE_COMMENTS}:${metadata.postId}:${chunk.join(',')}`,
-        {
-          channel: metadata.channel,
-          postId: metadata.postId,
-          children: chunk,
-        },
-      )
+      if (chunk.length > 0) {
+        await ctx.publishStream<IRedditMoreCommentsStreamData>(
+          `${RedditStreamType.MORE_COMMENTS}:${metadata.postId}:${chunk.join(',')}`,
+          {
+            channel: metadata.channel,
+            postId: metadata.postId,
+            children: chunk,
+          },
+        )
+      }
     }
+
+    return
   }
 
   // Otherwise, we have a proper comment


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74fa7a2</samp>

Fix a bug in `processStream.ts` that could create empty streams for Reddit comments. Add a return statement for clarity.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 74fa7a2</samp>

> _`chunk` not empty?_
> _Publish stream for children_
> _No return, autumn wind_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74fa7a2</samp>

*  Prevent creating streams with empty children in Reddit integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/974/files?diff=unified&w=0#diff-69d45db158b6b59e6ec004b0869aacac6735c49b3399dcff4364817fb51d2c5cL38-R50))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
