### PR TITLE
Add member and display object to activity's parent

### DIFF
--- a/backend/src/database/repositories/__tests__/conversationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/conversationRepository.test.ts
@@ -7,6 +7,7 @@ import Error404 from '../../../errors/Error404'
 import { PlatformType } from '@crowd/types'
 import { generateUUIDv1 } from '@crowd/common'
 import { populateSegments } from '../../utils/segmentTestUtils'
+import { UNKNOWN_ACTIVITY_TYPE_DISPLAY } from '@crowd/integrations'
 
 const db = null
 
@@ -473,10 +474,12 @@ describe('ConversationRepository tests', () => {
         lastReplies: [
           {
             ...SequelizeTestUtils.objectWithoutKey(activity2Created, ['tasks']),
+            parent: SequelizeTestUtils.objectWithoutKey(activity2Created.parent, ['display']),
             member: memberReturnedWithinConversations,
           },
           {
             ...SequelizeTestUtils.objectWithoutKey(activity3Created, ['tasks']),
+            parent: SequelizeTestUtils.objectWithoutKey(activity3Created.parent, ['display']),
             member: memberReturnedWithinConversations,
           },
         ],

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -611,6 +611,12 @@ class ActivityRepository {
       {
         model: options.database.activity,
         as: 'parent',
+        include: [
+          {
+            model: options.database.member,
+            as: 'member',
+          }
+        ],
       },
       {
         model: options.database.member,
@@ -739,6 +745,13 @@ class ActivityRepository {
       record,
       SegmentRepository.getActivityTypes(options),
     )
+
+    if(output.parent) {
+      output.parent.display = ActivityDisplayService.getDisplayOptions(
+        output.parent,
+        SegmentRepository.getActivityTypes(options),
+      )
+    }
 
     output.tasks = await record.getTasks({
       transaction,

--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -615,7 +615,7 @@ class ActivityRepository {
           {
             model: options.database.member,
             as: 'member',
-          }
+          },
         ],
       },
       {
@@ -746,7 +746,7 @@ class ActivityRepository {
       SegmentRepository.getActivityTypes(options),
     )
 
-    if(output.parent) {
+    if (output.parent) {
       output.parent.display = ActivityDisplayService.getDisplayOptions(
         output.parent,
         SegmentRepository.getActivityTypes(options),


### PR DESCRIPTION
# Changes proposed ✍️
In `activity/query` endpoint, add the following data to `parent` object:
- `member`
- `display`

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8484311</samp>

Enhance `ActivityRepository` to show more details in activity feed. Add `include` option to query and `display` property to `parent` object in `backend/src/database/repositories/activityRepository.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8484311</samp>

> _Sing, O Muse, of the skillful coder who enhanced_
> _The `ActivityRepository` class with wisdom and grace,_
> _Adding an `include` option to the `findAll` query_
> _And a `display` property to the `parent` object._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8484311</samp>

*  Include `member` model in `activity` query to display member name and avatar in activity feed ([link](https://github.com/CrowdDotDev/crowd.dev/pull/987/files?diff=unified&w=0#diff-987f06572bad79c47ef62d518a7a4e419dda775d942d365da55dc5509acf5291R614-R619))
*  Add `display` property to `parent` object of `output` object to show formatted text and icon for parent activity in activity feed ([link](https://github.com/CrowdDotDev/crowd.dev/pull/987/files?diff=unified&w=0#diff-987f06572bad79c47ef62d518a7a4e419dda775d942d365da55dc5509acf5291R749-R755))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
