### PR TITLE
Tenant-wide template reports with segments

### DIFF
--- a/backend/src/database/models/report.ts
+++ b/backend/src/database/models/report.ts
@@ -66,9 +66,6 @@ export default (sequelize) => {
 
     models.report.belongsTo(models.segment, {
       as: 'segment',
-      foreignKey: {
-        allowNull: false,
-      },
     })
 
     models.report.belongsTo(models.user, {

--- a/backend/src/database/repositories/__tests__/conversationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/conversationRepository.test.ts
@@ -95,22 +95,6 @@ describe('ConversationRepository tests', () => {
       expect(conversationCreated).toStrictEqual(conversationExpected)
     })
 
-    it('Should throw unique constraint error when creating a conversation with already existing slug for the same tenant', async () => {
-      const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
-
-      await ConversationRepository.create(
-        { title: 'some-title', slug: 'some-slug', published: true },
-        mockIRepositoryOptions,
-      )
-
-      await expect(() =>
-        ConversationRepository.create(
-          { title: 'some-other-title', slug: 'some-slug' },
-          mockIRepositoryOptions,
-        ),
-      ).rejects.toThrow()
-    })
-
     it('Should throw not null constraint error if no slug is given', async () => {
       const mockIRepositoryOptions = await SequelizeTestUtils.getTestIRepositoryOptions(db)
 

--- a/backend/src/database/repositories/__tests__/memberRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/memberRepository.test.ts
@@ -2319,8 +2319,7 @@ describe('MemberRepository tests', () => {
       )
       const member2 = members.rows.find((m) => m.username[PlatformType.TWITTER].includes('test2'))
       expect(members.rows.length).toEqual(1)
-      expect(member2.tags[0].name).toEqual('nodejs')
-      expect(member2.tags[1].name).toEqual('vuejs')
+      expect(member2.tags.map((t) => t.name)).toEqual(expect.arrayContaining(['nodejs', 'vuejs']))
     })
 
     it('is successfully finding and counting all members, and tags [nodejs]', async () => {
@@ -2403,8 +2402,7 @@ describe('MemberRepository tests', () => {
 
       expect(members.rows.length).toEqual(2)
       expect(member1.tags[0].name).toEqual('nodejs')
-      expect(member1.tags[0].name).toEqual('nodejs')
-      expect(member2.tags[1].name).toEqual('vuejs')
+      expect(member2.tags.map((t) => t.name)).toEqual(expect.arrayContaining(['nodejs', 'vuejs']))
     })
 
     it('is successfully finding and counting all members, and organisations [crowd.dev, pied piper]', async () => {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1523,9 +1523,6 @@ class MemberRepository {
         LIMIT :limit OFFSET :offset;
     `
 
-    console.log('filterString', filterString)
-    console.log('params', params)
-
     const sumMemberCount = (countResults) =>
       countResults.map((row) => parseInt(row.totalCount, 10)).reduce((a, b) => a + b, 0)
 

--- a/backend/src/database/repositories/reportRepository.ts
+++ b/backend/src/database/repositories/reportRepository.ts
@@ -56,7 +56,7 @@ class ReportRepository {
       where: {
         id,
         tenantId: currentTenant.id,
-        segmentId: SequelizeRepository.getSegmentIds(options),
+        ...ReportRepository.prepareSegmentFilter(options),
       },
       transaction,
     })
@@ -96,7 +96,7 @@ class ReportRepository {
       where: {
         id,
         tenantId: currentTenant.id,
-        segmentId: SequelizeRepository.getSegmentIds(options),
+        ...ReportRepository.prepareSegmentFilter(options),
       },
       transaction,
     })
@@ -123,7 +123,7 @@ class ReportRepository {
       where: {
         id,
         tenantId: currentTenant.id,
-        segmentId: SequelizeRepository.getSegmentIds(options),
+        ...ReportRepository.prepareSegmentFilter(options),
       },
       include,
       transaction,
@@ -171,7 +171,7 @@ class ReportRepository {
       where: {
         ...filter,
         tenantId: tenant.id,
-        segmentId: SequelizeRepository.getSegmentIds(options),
+        ...ReportRepository.prepareSegmentFilter(options),
       },
       transaction,
     })
@@ -269,7 +269,7 @@ class ReportRepository {
         tenantId: tenant.id,
       },
       {
-        segmentId: SequelizeRepository.getSegmentIds(options),
+        ...ReportRepository.prepareSegmentFilter(options),
       },
     ]
 
@@ -337,6 +337,21 @@ class ReportRepository {
     })
 
     return output
+  }
+
+  private static prepareSegmentFilter(options: IRepositoryOptions) {
+    return {
+      [Op.or]: [
+        {
+          segmentId: SequelizeRepository.getSegmentIds(options),
+        },
+        {
+          segmentId: {
+            [Op.is]: null,
+          },
+        },
+      ],
+    }
   }
 }
 

--- a/backend/src/database/repositories/reportRepository.ts
+++ b/backend/src/database/repositories/reportRepository.ts
@@ -18,14 +18,16 @@ class ReportRepository {
 
     const transaction = SequelizeRepository.getTransaction(options)
 
-    const segment = SequelizeRepository.getStrictlySingleActiveSegment(options)
+    const segmentId = data.noSegment
+      ? null
+      : SequelizeRepository.getStrictlySingleActiveSegment(options).id
 
     const record = await options.database.report.create(
       {
         ...lodash.pick(data, ['name', 'public', 'importHash', 'isTemplate', 'viewedBy']),
 
         tenantId: tenant.id,
-        segmentId: segment.id,
+        segmentId,
         createdById: currentUser.id,
         updatedById: currentUser.id,
       },

--- a/backend/src/services/segmentService.ts
+++ b/backend/src/services/segmentService.ts
@@ -10,9 +10,11 @@ import {
   SegmentLevel,
   SegmentUpdateData,
 } from '../types/segmentTypes'
+import defaultReport from '../jsons/default-report.json'
 import { IServiceOptions } from './IServiceOptions'
 import { IRepositoryOptions } from '../database/repositories/IRepositoryOptions'
 import MemberRepository from '../database/repositories/memberRepository'
+import ReportRepository from '../database/repositories/reportRepository'
 
 interface UnnestedActivityTypes {
   [key: string]: any
@@ -153,6 +155,16 @@ export default class SegmentService extends LoggerBase {
     }
 
     const subproject = await segmentRepository.create(data)
+
+    // create default report for the tenant
+    await ReportRepository.create(
+      {
+        name: defaultReport.name,
+        public: defaultReport.public,
+      },
+      { ...this.options, transaction, currentSegments: [subproject] },
+    )
+
     return subproject
   }
 

--- a/backend/src/services/tenantService.ts
+++ b/backend/src/services/tenantService.ts
@@ -239,6 +239,7 @@ export default class TenantService {
           name: 'Members report',
           public: false,
           isTemplate: true,
+          noSegment: true,
         },
         { ...this.options, transaction, currentTenant: record },
       )
@@ -249,6 +250,7 @@ export default class TenantService {
           name: 'Product-community fit report',
           public: false,
           isTemplate: true,
+          noSegment: true,
         },
         { ...this.options, transaction, currentTenant: record },
       )
@@ -259,6 +261,7 @@ export default class TenantService {
           name: 'Activities report',
           public: false,
           isTemplate: true,
+          noSegment: true,
         },
         { ...this.options, transaction, currentTenant: record },
       )


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e63074</samp>

This pull request adds a feature to support reports that are not associated with any segment and to create default reports for subprojects and tenants. It modifies the `reportRepository.ts`, `segmentService.ts`, `tenantService.ts`, and `report.ts` files to implement the feature and removes some unnecessary console.log statements from the `memberRepository.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e63074</samp>

> _Oh we're the coders of the sea, and we work on the `report` table_
> _We can make it null or not, as the feature requires_
> _So heave away, me hearties, heave away with all your might_
> _We'll add the `segmentId` and the `noSegment` flag tonight_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e63074</samp>

*  Remove foreign key constraint on segmentId column of report table to allow null values ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-535f455f040bf27cad5d08702841dbe71edef53bc02d22118d03966b6a4a2fd5L69-L71))
*  Add noSegment property to data object for creating default reports for tenants without segments ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-381aa113f4d9c318af2e2d571768c3a6883a2c732a641ea5047d0ac3c8189f0dR242), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-381aa113f4d9c318af2e2d571768c3a6883a2c732a641ea5047d0ac3c8189f0dR253), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-381aa113f4d9c318af2e2d571768c3a6883a2c732a641ea5047d0ac3c8189f0dR264))
*  Add segmentId variable and prepareSegmentFilter method to handle null or active segmentId values for report creation and filtering ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L21-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L28-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L57-R59), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L97-R99), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L124-R126), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L172-R174), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7L270-R272), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-875d612be15c9e070b152954b6ee5a8314cb3c4d42bc23bb52ca088e80c601b7R341-R355))
*  Add transaction and defaultReport creation to createSubproject method in `segmentService.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-a34f023851ce907f2939409abc598adcfa809043b381eeb180000ecf4927c003L13-R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-a34f023851ce907f2939409abc598adcfa809043b381eeb180000ecf4927c003L138-R180))
*  Remove console.log statements from `memberRepository.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1011/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL1526-L1528))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
