### PR TITLE
Custom opensearch mappings fix

### DIFF
--- a/services/libs/opensearch/src/fieldTranslator.ts
+++ b/services/libs/opensearch/src/fieldTranslator.ts
@@ -27,8 +27,16 @@ export default abstract class FieldTranslator {
 
   setTranslationMaps(): void {
     for (const key of Object.keys(this.translations)) {
-      this.crowdToOpensearchMap.set(key, this.translations[key])
-      this.opensearchToCrowdMap.set(this.translations[key], key)
+      if (this.model.fieldExists(key) && this.model.getField(key).customTranslation) {
+        this.crowdToOpensearchMap.set(key, this.model.getField(key).customTranslation.toOpensearch)
+        this.opensearchToCrowdMap.set(
+          this.model.getField(key).customTranslation.fromOpensearch,
+          key,
+        )
+      } else {
+        this.crowdToOpensearchMap.set(key, this.translations[key])
+        this.opensearchToCrowdMap.set(this.translations[key], key)
+      }
     }
   }
 

--- a/services/libs/opensearch/src/memberTranslator.ts
+++ b/services/libs/opensearch/src/memberTranslator.ts
@@ -18,11 +18,7 @@ export default class MemberTranslator extends FieldTranslator {
 
     // set translations for static fields
     this.translations = Object.keys(fields).reduce((acc, f) => {
-      if (fields[f].customOpensourceDestination) {
-        acc[f] = fields[f].customOpensourceDestination
-      } else {
-        acc[f] = `${fields[f].type}_${f}`
-      }
+      acc[f] = `${fields[f].type}_${f}`
       return acc
     }, {})
 
@@ -61,6 +57,9 @@ export default class MemberTranslator extends FieldTranslator {
     this.translations.username = 'string_username'
 
     this.setTranslationMaps()
+
+    // fix for colliding translations of id -> uuid_memberId (members) and id -> uuid_id (organizations, tags)
+    this.opensearchToCrowdMap.set('uuid_id', 'id')
   }
 
   private attributeTypeToOpenSearchPrefix(type: MemberAttributeType): string {

--- a/services/libs/opensearch/src/models/members.ts
+++ b/services/libs/opensearch/src/models/members.ts
@@ -6,7 +6,10 @@ export class MembersOpensearch extends OpensearchModelBase {
   fields: Record<string, OpensearchField> = {
     id: {
       type: OpensearchFieldType.UUID,
-      customOpensourceDestination: 'uuid_memberId',
+      customTranslation: {
+        toOpensearch: 'uuid_memberId',
+        fromOpensearch: 'uuid_memberId',
+      },
     },
     tenantId: {
       type: OpensearchFieldType.UUID,
@@ -31,7 +34,10 @@ export class MembersOpensearch extends OpensearchModelBase {
     },
     reach: {
       type: OpensearchFieldType.INT,
-      customOpensourceDestination: 'int_totalReach',
+      customTranslation: {
+        toOpensearch: 'int_totalReach',
+        fromOpensearch: 'int_totalReach',
+      },
     },
     numberOfOpenSourceContributions: {
       type: OpensearchFieldType.INT,
@@ -56,7 +62,10 @@ export class MembersOpensearch extends OpensearchModelBase {
     },
     identities: {
       type: OpensearchFieldType.OBJECT_ARR,
-      // customOpensourceDestination: 'obj_arr_identities.string_platform',
+      customTranslation: {
+        toOpensearch: 'obj_arr_identities.string_platform',
+        fromOpensearch: 'obj_arr_identities',
+      },
     },
     attributes: {
       type: OpensearchFieldType.OBJECT,
@@ -69,7 +78,10 @@ export class MembersOpensearch extends OpensearchModelBase {
     },
     tags: {
       type: OpensearchFieldType.OBJECT_ARR,
-      // customOpensourceDestination: 'obj_arr_tags.uuid_id',
+      customTranslation: {
+        toOpensearch: 'obj_arr_tags.uuid_id',
+        fromOpensearch: 'obj_arr_tags',
+      },
     },
     organizations: {
       type: OpensearchFieldType.OBJECT_ARR,

--- a/services/libs/types/src/opensearch.ts
+++ b/services/libs/types/src/opensearch.ts
@@ -24,9 +24,14 @@ export interface MemberStaticFieldsTranslation {
   identities: string
 }
 
+export interface CustomOpensearchTranslation {
+  fromOpensearch: string
+  toOpensearch: string
+}
+
 export interface OpensearchField {
   type: string
-  customOpensourceDestination?: string
+  customTranslation?: CustomOpensearchTranslation
   dynamic?: boolean
   realType?: string
 }


### PR DESCRIPTION
# Changes proposed ✍️
- Now custom opensource mappings both accept to and from translations. This is helpful when we need to query an exact field of an object array, but we want to get the full object back from opensearch

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0647c5</samp>

This pull request improves the translation between Crowd and Opensearch by introducing a new `customTranslation` property for fields that need special handling. It also refactors the `MemberTranslator` class to avoid field collisions and improve code quality. The changes affect the `opensearch.ts`, `members.ts`, `memberTranslator.ts`, and `fieldTranslator.ts` files.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0647c5</samp>

> _Sing, O Muse, of the skillful coder who modified the code_
> _To make the fields of Crowd and Opensearch more harmonious_
> _He added `customTranslation` to the `OpensearchField` interface_
> _And gave the power to the models to define their own mappings_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0647c5</samp>

*  Add `customTranslation` property to `OpensearchField` interface to allow for custom field mappings between Crowd and Opensearch ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-b97a6562a008552a30780b3fe858c12b0f7dde3b90a3c91725646b81325e416bL27-R34))
*  Refactor `MemberTranslator` class to inherit from `FieldTranslator` class and move static field translations to parent class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-ecf1077590813f8523586631ddbbfa65de0b255da98316cb3696fca043d437cfL21-R21))
*  Fix `id` and `uuid_id` field collision in `MemberTranslator` class by setting reverse translation for `uuid_id` to `id` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-ecf1077590813f8523586631ddbbfa65de0b255da98316cb3696fca043d437cfR60-R62))
*  Update `MembersOpensearch` model to use `customTranslation` property for `id`, `reach`, `identities`, and `tags` fields ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-8fd6656e69381e433e99ee240675afaf9b2b531274d99670ab720dff6e322cabL9-R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-8fd6656e69381e433e99ee240675afaf9b2b531274d99670ab720dff6e322cabL34-R40), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-8fd6656e69381e433e99ee240675afaf9b2b531274d99670ab720dff6e322cabL59-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-8fd6656e69381e433e99ee240675afaf9b2b531274d99670ab720dff6e322cabL72-R84))
*  Modify `setTranslationMaps` method in `FieldTranslator` class to check for custom translations in model and use them instead of default translations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1019/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0L30-R39))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
