### PR TITLE
Match words in the middle when searching project-groups segments

### DIFF
--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -57,7 +57,13 @@ cube(`Members`, {
 
     MembersActivities: {
       measures: [Members.count],
-      dimensions: [Members.tenantId, Members.isTeamMember, Members.isBot, Members.isOrganization, Segments.id],
+      dimensions: [
+        Members.tenantId,
+        Members.isTeamMember,
+        Members.isBot,
+        Members.isOrganization,
+        Segments.id,
+      ],
       timeDimension: Activities.date,
       granularity: `day`,
       refreshKey: {

--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -467,7 +467,7 @@ class SegmentRepository extends RepositoryBase<
       {
         replacements: {
           tenantId: this.currentTenant.id,
-          name: `${criteria.filter?.name}%`,
+          name: `%${criteria.filter?.name}%`,
           status: criteria.filter?.status,
         },
         type: QueryTypes.SELECT,


### PR DESCRIPTION
# Changes proposed ✍️

### What
When searching for project-groups through a search field we match words in the middle of a name.
I.e. when searching `ello` both project groups `Hello` and `ello` should match, not only `ello`.

It was already done for projects and subprojects, but project-groups somehow slipped through the cracks.

Fixes https://linear.app/crowddotdev/issue/C-1589/search-issues

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e57fa70</samp>

Improved segment name search by using wildcards in SQL query. Modified `name` parameter in `segmentRepository.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e57fa70</samp>

> _`name` parameter_
> _now has wildcards both sides_
> _searching in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e57fa70</samp>

*  Allow partial matching of segment names by using wildcards in SQL query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1021/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL470-R470))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
