### PR TITLE
Fix : Wrong pagination for platform filter in member detail page 

### DIFF
--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -263,6 +263,7 @@ const fetchActivities = async () => {
 
   if (!isEqual(filter, filterToApply)) {
     activities.length = 0;
+    offset.value = 0
     noMore.value = false;
   }
 
@@ -319,7 +320,6 @@ watch(query, (newValue, oldValue) => {
 
 watch(platform, async (newValue, oldValue) => {
   if (newValue !== oldValue) {
-    offset.value = 0
     await fetchActivities();
   }
 });

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -319,6 +319,7 @@ watch(query, (newValue, oldValue) => {
 
 watch(platform, async (newValue, oldValue) => {
   if (newValue !== oldValue) {
+    offset.value = 0
     await fetchActivities();
   }
 });


### PR DESCRIPTION
# Changes proposed ✍️

Fixes #990 

### What

When platform changes, offset value was not getting reset thus user was not able to see all activities


### How
Set offset to 0 when platform value changes 

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec363a4</samp>

* Reset offset value to zero on component creation to fetch most recent activities ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1023/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8R322))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screehshots to the PR description for relevant FE changes
- [x] New backend functionality has been unit-tested.
- [x] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
