### PR TITLE
Members search query emails wildcard way

### DIFF
--- a/frontend/src/modules/member/config/filters/main.ts
+++ b/frontend/src/modules/member/config/filters/main.ts
@@ -35,7 +35,7 @@ export const memberSearchFilter: SearchFilterConfig = {
       {
         or: [
           { displayName: { textContains: value } },
-          { emails: { contains: [value] } },
+          { emails: { like: value } },
         ],
       },
     ];


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4bdf187</samp>

Changed the member search filter to use partial email matching for email addresses. This improves the user experience and usability of the `frontend/src/modules/member/config/filters/main.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4bdf187</samp>

> _`memberSearchFilter`_
> _Emails like spring blossoms_
> _Partial matches work_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4bdf187</samp>

* Use the `like` operator for email filtering in `memberSearchFilter` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1024/files?diff=unified&w=0#diff-9764bba874a0ee03488cf483fab4b7144d11c402793e69730e1a5508f1451535L38-R38))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
