### PR TITLE
Disable automations

### DIFF
--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -27,6 +27,7 @@ import { integrationDataCheckerWorker } from './integration-data-checker/integra
 import { refreshSampleDataWorker } from './integration-data-checker/refreshSampleDataWorker'
 import { mergeSuggestionsWorker } from './merge-suggestions/mergeSuggestionsWorker'
 import { BulkorganizationEnrichmentWorker } from './bulk-enrichment/bulkOrganizationEnrichmentWorker'
+import { API_CONFIG } from '../../../conf'
 
 /**
  * Worker factory for spawning different microservices
@@ -77,6 +78,9 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
     }
 
     case 'automation-process':
+      if (API_CONFIG.edition === 'lfx-ee') {
+        return {}
+      }
       const automationProcessRequest = event as ProcessAutomationMessage
 
       switch (automationProcessRequest.automationType) {
@@ -103,6 +107,9 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
       }
 
     case 'automation':
+      if (API_CONFIG.edition === 'lfx-ee') {
+        return {}
+      }
       const automationRequest = event as AutomationMessage
 
       switch (automationRequest.trigger) {

--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-case-declarations */
+import { Edition } from '@crowd/types'
 import { weeklyAnalyticsEmailsWorker } from './analytics/workers/weeklyAnalyticsEmailsWorker'
 import {
   AutomationMessage,
@@ -78,7 +79,7 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
     }
 
     case 'automation-process':
-      if (API_CONFIG.edition === 'lfx-ee') {
+      if (API_CONFIG.edition === Edition.LFXEE) {
         return {}
       }
       const automationProcessRequest = event as ProcessAutomationMessage
@@ -107,7 +108,7 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
       }
 
     case 'automation':
-      if (API_CONFIG.edition === 'lfx-ee') {
+      if (API_CONFIG.edition === Edition.LFXEE) {
         return {}
       }
       const automationRequest = event as AutomationMessage

--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { Edition } from '@crowd/types'
+import { Edition } from '../../../types/common'
 import { weeklyAnalyticsEmailsWorker } from './analytics/workers/weeklyAnalyticsEmailsWorker'
 import {
   AutomationMessage,

--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -79,7 +79,7 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
     }
 
     case 'automation-process':
-      if (API_CONFIG.edition === Edition.LFXEE) {
+      if (API_CONFIG.edition === Edition.LFX) {
         return {}
       }
       const automationProcessRequest = event as ProcessAutomationMessage

--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { Edition } from '../../../types/common'
+import { Edition } from '@crowd/types'
 import { weeklyAnalyticsEmailsWorker } from './analytics/workers/weeklyAnalyticsEmailsWorker'
 import {
   AutomationMessage,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8895ee0</samp>

Updated `workerFactory` function to respect edition constraints. Disabled workers and cron workers for `lfx-ee` edition.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8895ee0</samp>

> _No workers for the elite edition_
> _They don't deserve the power of `workerFactory`_
> _We resist the tyranny of `lfx-ee`_
> _We unleash the cron workers of destiny_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8895ee0</samp>

*  Prevent worker creation on lfx-ee platform by returning empty objects based on API_CONFIG.edition ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1031/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1031/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R81-R83), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1031/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R110-R112))
* Import API_CONFIG from conf module in `workerFactory.ts` to access edition property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1031/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R30))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
