### PR TITLE
QA issues

### DIFF
--- a/frontend/src/modules/activity/pages/activity-list-page.vue
+++ b/frontend/src/modules/activity/pages/activity-list-page.vue
@@ -18,6 +18,7 @@
             Activity types
           </el-button>
           <el-button
+            v-if="hasPermissionToCreateActivity"
             class="btn btn--primary btn--md text-gray-600"
             @click="onAddActivity"
           >
@@ -76,7 +77,9 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue';
+import {
+  computed, onMounted, ref, watch,
+} from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import AppActivityTypeListDrawer from '@/modules/activity/components/type/activity-type-list-drawer.vue';
 import AppActivityFormDrawer from '@/modules/activity/components/activity-form-drawer.vue';
@@ -85,9 +88,13 @@ import AppActivityList from '@/modules/activity/components/activity-list.vue';
 import AppConversationList from '@/modules/conversation/components/conversation-list.vue';
 import AppLfPageHeader from '@/modules/lf/layout/components/lf-page-header.vue';
 import AppLfSubProjectsListModal from '@/modules/lf/segments/components/lf-sub-projects-list-modal.vue';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { ActivityPermissions } from '../activity-permissions';
 
 const route = useRoute();
 const router = useRouter();
+
+const { currentTenant, currentUser } = mapGetters('auth');
 
 const isActivityTypeDrawerOpen = ref(false);
 const isActivityDrawerOpen = ref(false);
@@ -145,4 +152,11 @@ watch(() => route.hash, (hash: string) => {
     activeView.value = view;
   }
 }, { immediate: true });
+
+const hasPermissionToCreateActivity = computed(
+  () => new ActivityPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).create,
+);
 </script>

--- a/frontend/src/modules/automation/store/actions.js
+++ b/frontend/src/modules/automation/store/actions.js
@@ -6,7 +6,7 @@ export default {
     this.loadingAutomations = true;
     return AutomationService.list({
       type: this.filter.type !== 'all' ? this.filter.type : undefined,
-    }, null, 50, 0)
+    }, null, null, 0)
       .then(({ rows }) => {
         this.automations = rows;
         this.loadingAutomations = false;

--- a/frontend/src/modules/conversation/components/conversation-dropdown.vue
+++ b/frontend/src/modules/conversation/components/conversation-dropdown.vue
@@ -1,5 +1,6 @@
 <template>
   <el-dropdown
+    v-if="conversation.published || hasPermissionsToEditConversation || hasPermissionsToDeleteConversation"
     trigger="click"
     placement="bottom-end"
     @command="handleCommand"
@@ -24,7 +25,7 @@
       </el-dropdown-item>
       <template v-if="publishEnabled">
         <el-dropdown-item
-          v-if="!conversation.published"
+          v-if="!conversation.published && hasPermissionsToEditConversation"
           :command="{
             action: 'conversationPublish',
             conversation: conversation,
@@ -35,7 +36,7 @@
           conversation
         </el-dropdown-item>
         <el-dropdown-item
-          v-else
+          v-else-if="hasPermissionsToEditConversation"
           :command="{
             action: 'conversationUnpublish',
             conversation: conversation,
@@ -48,6 +49,7 @@
       </template>
 
       <el-dropdown-item
+        v-if="hasPermissionsToDeleteConversation"
         :command="{
           action: 'conversationDelete',
           conversation: conversation,
@@ -105,6 +107,18 @@ export default {
       communityHelpCenterConfigured:
         'communityHelpCenter/isConfigured',
     }),
+    hasPermissionsToEditConversation() {
+      return new ConversationPermissions(
+        this.currentTenant,
+        this.currentUser,
+      ).edit;
+    },
+    hasPermissionsToDeleteConversation() {
+      return new ConversationPermissions(
+        this.currentTenant,
+        this.currentUser,
+      ).destroy;
+    },
     isEditLockedForSampleData() {
       return new ConversationPermissions(
         this.currentTenant,

--- a/frontend/src/modules/dashboard/components/dashboard-project-group.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-project-group.vue
@@ -42,7 +42,10 @@
         },
       }"
     >
-      <el-button class="btn btn--md btn--secondary btn--full">
+      <el-button
+        v-if="hasPermissionToAccessAdminPanel"
+        class="btn btn--md btn--secondary btn--full"
+      >
         <i class="ri-external-link-line" />
         <span>Settings</span>
       </el-button>
@@ -60,7 +63,9 @@
 import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import isUrl from '@/utils/isUrl';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 import AppDashboardProjectGroupDrawer from './dashboard-project-group-drawer.vue';
 
 const lsSegmentsStore = useLfSegmentsStore();
@@ -68,6 +73,14 @@ const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
 
 const isDrawerOpen = ref(false);
 
+const { currentTenant, currentUser } = mapGetters('auth');
+
+const hasPermissionToAccessAdminPanel = computed(
+  () => new LfPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).editProjectGroup,
+);
 </script>
 
 <script>

--- a/frontend/src/modules/layout/layout-page-content.js
+++ b/frontend/src/modules/layout/layout-page-content.js
@@ -1,10 +1,10 @@
 export const pageContent = {
   eagleEye: {
     icon: 'ri-search-eye-line',
-    headerTitle: 'Eagle Eye',
+    headerTitle: 'Community Lens',
     title: 'Locate & engage with the right content',
     mainContent:
-        'Our Eagle Eye app allows you to monitor different community platforms to find relevant content to engage with, '
+        'Our Community Lens app allows you to monitor different community platforms to find relevant content to engage with, '
         + "helping you to gain developers' mindshare and grow your community organically.",
     imageSrc: '/images/paywall/eagle-eye.png',
     imageClass: '',
@@ -14,7 +14,7 @@ export const pageContent = {
         title:
             'Keep an Eagle Eye view on relevant content & posts to grow',
         content:
-            "On top of monitoring everything going on within your community, crowd.dev's Eagle Eye application "
+            'On top of monitoring everything going on within your community, Community Lens application '
             + 'is focused on helping you engage with relevant content outside of your community to help grow it further.',
       },
       {
@@ -22,7 +22,7 @@ export const pageContent = {
         title:
             'Identify and engage with content across platforms',
         content:
-            'All you need to do is type in a few keywords and Eagle Eye will give you the most recent and relevant '
+            'All you need to do is type in a few keywords and Community Lens will give you the most recent and relevant '
             + 'content to enage with accross platforms like HackerNews and Dev to connect you with like-minded people.',
       },
       {
@@ -30,7 +30,7 @@ export const pageContent = {
         title:
             'Search powered by Natural Language Processing',
         content:
-            'The search engine behind Eagle Eye is based on a semantic model that delivers the most relevant content '
+            'The search engine behind Community Lens is based on a semantic model that delivers the most relevant content '
             + "even when it doesn't match your keywords.",
       },
     ],

--- a/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
+++ b/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
@@ -1,13 +1,16 @@
 <template>
-  <el-input
+  <div
     ref="inputRef"
-    v-model="model"
-    class="project-groups-select-input"
-    placeholder="Select project group..."
-    readonly
-    :suffix-icon="isPopoverVisible ? ArrowUpIcon : ArrowDownIcon"
     @click="isPopoverVisible = true"
-  />
+  >
+    <el-input
+      v-model="model"
+      class="project-groups-select-input"
+      placeholder="Select project group..."
+      readonly
+      :suffix-icon="isPopoverVisible ? ArrowUpIcon : ArrowDownIcon"
+    />
+  </div>
 
   <el-popover
     v-model:visible="isPopoverVisible"
@@ -25,7 +28,7 @@
         ref="searchQueryInput"
         v-model="searchQuery"
         placeholder="Search..."
-        class="lf-filter-input filter-dropdown-search"
+        class="filter-dropdown-search"
         :prefix-icon="SearchIcon"
         @input="onSearchProjects"
       />
@@ -135,7 +138,7 @@ watch(projectGroups, (updatedProjectGroups) => {
 onMounted(() => {
   listProjectGroups({
     limit: null,
-    offset: 0,
+    reset: true,
   });
 });
 

--- a/frontend/src/modules/lf/layout/components/lf-menu.vue
+++ b/frontend/src/modules/lf/layout/components/lf-menu.vue
@@ -105,13 +105,13 @@
             hasPermissionToEagleEye || isEagleEyeLocked
           "
           id="menu-eagle-eye"
-          :to="{ path: '/eagle-eye' }"
+          :to="{ path: '/community-lens' }"
           class="el-menu-item"
-          :class="classFor('/eagle-eye')"
+          :class="classFor('/community-lens')"
         >
           <i class="ri-search-eye-line" />
           <span>
-            Eagle Eye
+            Community Lens
           </span>
         </router-link>
 

--- a/frontend/src/modules/lf/lf-permissions.js
+++ b/frontend/src/modules/lf/lf-permissions.js
@@ -1,0 +1,30 @@
+import Permissions from '@/security/permissions';
+import { PermissionChecker } from '@/modules/user/permission-checker';
+
+export class LfPermissions {
+  constructor(currentTenant, currentUser) {
+    const permissionChecker = new PermissionChecker(
+      currentTenant,
+      currentUser,
+    );
+
+    this.createProjectGroup = permissionChecker.match(
+      Permissions.values.projectGroupCreate,
+    );
+    this.editProjectGroup = permissionChecker.match(
+      Permissions.values.projectGroupEdit,
+    );
+    this.createProject = permissionChecker.match(
+      Permissions.values.projectCreate,
+    );
+    this.editProject = permissionChecker.match(
+      Permissions.values.projectEdit,
+    );
+    this.createSubProject = permissionChecker.match(
+      Permissions.values.subProjectCreate,
+    );
+    this.editSubProject = permissionChecker.match(
+      Permissions.values.subProjectEdit,
+    );
+  }
+}

--- a/frontend/src/modules/lf/lf-routes.js
+++ b/frontend/src/modules/lf/lf-routes.js
@@ -1,4 +1,5 @@
 import Layout from '@/modules/layout/components/layout.vue';
+import Permissions from '@/security/permissions';
 
 const ProjectGroupsListPage = () => import(
   '@/modules/lf/segments/pages/lf-project-groups-list-page.vue'
@@ -37,6 +38,7 @@ export default [
         component: ProjectGroupsPage,
         meta: {
           title: 'Admin Panel',
+          permission: Permissions.values.projectGroupCreate,
         },
       },
       {
@@ -46,6 +48,7 @@ export default [
         meta: {
           auth: true,
           title: 'Admin Panel',
+          permission: Permissions.values.projectCreate,
         },
       },
     ],

--- a/frontend/src/modules/lf/segments/components/filter/lf-project-filter-button.vue
+++ b/frontend/src/modules/lf/segments/components/filter/lf-project-filter-button.vue
@@ -115,7 +115,7 @@ watch(
   selectedProjectGroup,
   (updatedSelectedProjectGroup, oldSelectedProjectGroup) => {
     if (updatedSelectedProjectGroup?.id !== oldSelectedProjectGroup?.id) {
-      listProjects({ parentSlug: updatedSelectedProjectGroup.slug });
+      listProjects({ parentSlug: updatedSelectedProjectGroup.slug, reset: true });
 
       props.setSegments({
         segments: {
@@ -189,7 +189,7 @@ const filterLabel = computed(() => {
 });
 
 onMounted(() => {
-  listProjects({ parentSlug: selectedProjectGroup.value.slug });
+  listProjects({ parentSlug: selectedProjectGroup.value.slug, reset: true });
 });
 
 const openFilterPopover = () => {
@@ -223,7 +223,7 @@ const onFilterChange = (value) => {
 };
 
 const onSearchQueryChange = debounce((value) => {
-  listProjects({ parentSlug: selectedProjectGroup.value.slug, search: value });
+  listProjects({ parentSlug: selectedProjectGroup.value.slug, search: value, reset: true });
 }, 300);
 
 const shouldShowReset = computed(() => !!props.segments.segments.length);

--- a/frontend/src/modules/lf/segments/components/lf-project-groups-dropdown.vue
+++ b/frontend/src/modules/lf/segments/components/lf-project-groups-dropdown.vue
@@ -14,6 +14,7 @@
       </button>
       <template #dropdown>
         <el-dropdown-item
+          v-if="hasPermissionToEditProjectGroup"
           class="h-10 mb-1"
           :command="editProjectGroup"
         >
@@ -23,6 +24,7 @@
           <span class="text-xs">Edit project group</span>
         </el-dropdown-item>
         <el-dropdown-item
+          v-if="hasPermissionToCreateProject"
           class="h-10 mb-1"
           :command="addProject"
         >
@@ -30,7 +32,10 @@
             class="ri-add-line text-base mr-2"
           /><span class="text-xs">Add project</span>
         </el-dropdown-item>
-        <el-divider class="border-gray-200 !my-2" />
+        <el-divider
+          v-if="hasPermissionToEditProjectGroup || hasPermissionToCreateProject"
+          class="border-gray-200 !my-2"
+        />
         <el-dropdown-item
           class="h-10"
           :command="() => updateSelectedProjectGroup(id)"
@@ -48,6 +53,9 @@
 
 <script setup>
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { computed } from 'vue';
 
 const emit = defineEmits(['onEditProjectGroup', 'onAddProject']);
 
@@ -58,8 +66,20 @@ defineProps({
   },
 });
 
+const { currentTenant, currentUser } = mapGetters('auth');
+
 const lsSegmentsStore = useLfSegmentsStore();
 const { updateSelectedProjectGroup } = lsSegmentsStore;
+
+const hasPermissionToCreateProject = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.createProject);
+
+const hasPermissionToEditProjectGroup = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.editProjectGroup);
 
 const editProjectGroup = () => {
   emit('onEditProjectGroup');

--- a/frontend/src/modules/lf/segments/components/lf-projects-dropdown.vue
+++ b/frontend/src/modules/lf/segments/components/lf-projects-dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="hasPermissionToCreateSubProject || hasPermissionToEditProject">
     <el-dropdown
       trigger="click"
       placement="bottom-end"
@@ -14,6 +14,7 @@
       </button>
       <template #dropdown>
         <el-dropdown-item
+          v-if="hasPermissionToEditProject"
           class="h-10 mb-1"
           :command="editProject"
         >
@@ -23,6 +24,7 @@
           <span class="text-xs">Edit project</span>
         </el-dropdown-item>
         <el-dropdown-item
+          v-if="hasPermissionToCreateSubProject"
           class="h-10"
           :command="addSubProject"
         >
@@ -36,7 +38,23 @@
 </template>
 
 <script setup>
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { computed } from 'vue';
+
 const emit = defineEmits(['onEditProject', 'onAddSubProject']);
+
+const { currentTenant, currentUser } = mapGetters('auth');
+
+const hasPermissionToCreateSubProject = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.createSubProject);
+
+const hasPermissionToEditProject = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.editProject);
 
 const editProject = () => {
   emit('onEditProject');

--- a/frontend/src/modules/lf/segments/components/lf-sub-projects-dropdown.vue
+++ b/frontend/src/modules/lf/segments/components/lf-sub-projects-dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="hasPermissionToEditSubProject">
     <el-dropdown
       trigger="click"
       placement="bottom-end"
@@ -28,7 +28,18 @@
 </template>
 
 <script setup>
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { computed } from 'vue';
+
 const emit = defineEmits(['onEditSubProject']);
+
+const { currentTenant, currentUser } = mapGetters('auth');
+
+const hasPermissionToEditSubProject = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.editSubProject);
 
 const editSubProject = () => {
   emit('onEditSubProject');

--- a/frontend/src/modules/lf/segments/components/lf-sub-projects-list-dropdown.vue
+++ b/frontend/src/modules/lf/segments/components/lf-sub-projects-list-dropdown.vue
@@ -35,7 +35,7 @@
         ref="searchQueryInput"
         v-model="searchQuery"
         placeholder="Search..."
-        class="lf-filter-input filter-dropdown-search"
+        class="filter-dropdown-search"
         :prefix-icon="SearchIcon"
         @input="onSearchProjects"
       />
@@ -195,6 +195,8 @@ export default {
 <style lang="scss">
 .subprojects-select-popper.el-popper {
     width: 100% !important;
+    max-height: 480px;
+    overflow: auto;
     @apply p-0;
 }
 

--- a/frontend/src/modules/lf/segments/components/view/lf-project-groups-table.vue
+++ b/frontend/src/modules/lf/segments/components/view/lf-project-groups-table.vue
@@ -11,94 +11,107 @@
     />
   </div>
 
-  <el-table
-    id="project-groups-table"
-    ref="table"
-    :data="list"
-    row-key="id"
-    :resizable="false"
-  >
-    <!-- Name -->
-    <el-table-column
-      label="Project Group"
-      prop="name"
-      width="300"
-      fixed
-      class-name="table-columns"
+  <div class="app-list-table not-clickable panel !px-0 !pt-0 !pb-6">
+    <el-table
+      id="project-groups-table"
+      ref="table"
+      :data="list"
+      row-key="id"
+      :resizable="false"
     >
-      <template #default="{ row }">
-        <span class="text-gray-900 text-sm font-semibold">{{ row.name }}</span>
-      </template>
-    </el-table-column>
+      <!-- Name -->
+      <el-table-column
+        label="Project Group"
+        prop="name"
+        width="300"
+        fixed
+        class-name="table-columns"
+      >
+        <template #default="{ row }">
+          <span class="text-gray-900 text-sm font-semibold">{{ row.name }}</span>
+        </template>
+      </el-table-column>
 
-    <!-- Projects -->
-    <el-table-column
-      label="Projects"
-      prop="projects"
-      width="300"
-      class-name="table-columns"
-    >
-      <template #default="{ row }">
-        <div v-if="row.projects.length" class="flex flex-wrap gap-2">
-          <app-tags
-            :tags="row.projects.map((p) => p.name)"
-            :collapse-tags="true"
-            :collapse-tags-tooltip="true"
-            tag-class="badge--gray-light h-6 text-xs"
-          />
-        </div>
-        <span v-else class="text-gray-500 text-sm">No projects</span>
-      </template>
-    </el-table-column>
+      <!-- Projects -->
+      <el-table-column
+        label="Projects"
+        prop="projects"
+        width="300"
+        class-name="table-columns"
+      >
+        <template #default="{ row }">
+          <div v-if="row.projects.length" class="flex flex-wrap gap-2">
+            <app-tags
+              :tags="row.projects.map((p) => p.name)"
+              :collapse-tags="true"
+              :collapse-tags-tooltip="true"
+              tag-class="badge--gray-light h-6 text-xs"
+            />
+          </div>
+          <span v-else class="text-gray-500 text-sm">No projects</span>
+        </template>
+      </el-table-column>
 
-    <!-- Status -->
-    <el-table-column
-      label="Status"
-      prop="status"
-      width="150"
-      class-name="table-columns"
-    >
-      <template #default="{ row }">
-        <div class="flex items-center gap-3">
-          <span
-            class="w-1.5 h-1.5 rounded-full"
-            :class="statusDisplay(row.status).color"
-          />
-          {{ statusDisplay(row.status).label }}
-        </div>
-      </template>
-    </el-table-column>
+      <!-- Status -->
+      <el-table-column
+        label="Status"
+        prop="status"
+        width="150"
+        class-name="table-columns"
+      >
+        <template #default="{ row }">
+          <div class="flex items-center gap-3">
+            <span
+              class="w-1.5 h-1.5 rounded-full"
+              :class="statusDisplay(row.status).color"
+            />
+            {{ statusDisplay(row.status).label }}
+          </div>
+        </template>
+      </el-table-column>
 
-    <el-table-column>
-      <template #default>
-        <div class="flex grow" />
-      </template>
-    </el-table-column>
+      <el-table-column>
+        <template #default>
+          <div class="flex grow" />
+        </template>
+      </el-table-column>
 
-    <el-table-column fixed="right" width="268">
-      <template #default="{ row }">
-        <div class="w-full flex justify-end gap-3">
-          <router-link
-            class="h-10 flex items-center"
-            :to="{
-              name: 'adminProjects',
-              params: { id: row.id },
-            }"
-          >
-            <el-button class="btn btn--bordered">
-              <i class="ri-stack-line" />
-              <span>Manage projects</span>
-            </el-button>
-          </router-link>
-          <app-lf-project-groups-dropdown
-            :id="row.id"
-            @on-edit-project-group="emit('onEditProjectGroup', row.id)"
-            @on-add-project="emit('onAddProject', row.slug)"
-          />
-        </div>
-      </template>
-    </el-table-column>
-  </el-table>
+      <el-table-column fixed="right" width="268">
+        <template #default="{ row }">
+          <div class="w-full flex justify-end gap-3">
+            <router-link
+              class="h-10 flex items-center"
+              :to="{
+                name: 'adminProjects',
+                params: { id: row.id },
+              }"
+            >
+              <el-button class="btn btn--bordered">
+                <i class="ri-stack-line" />
+                <span>Manage projects</span>
+              </el-button>
+            </router-link>
+            <app-lf-project-groups-dropdown
+              :id="row.id"
+              @on-edit-project-group="emit('onEditProjectGroup', row.id)"
+              @on-add-project="emit('onAddProject', row.slug)"
+            />
+          </div>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div v-if="!!pagination.count" class="mt-8 px-6">
+      <app-pagination
+        :total="pagination.count"
+        :page-size="Number(pagination.pageSize)"
+        :current-page="pagination.currentPage || 1"
+        module="project group"
+        @change-current-page="doChangeProjectGroupCurrentPage"
+        @change-page-size="onPageSizeChange"
+      />
+    </div>
+  </div>
 </template>
 
 <script setup>
@@ -113,7 +126,7 @@ const emit = defineEmits(['onEditProjectGroup', 'onAddProject']);
 
 const lsSegmentsStore = useLfSegmentsStore();
 const { projectGroups } = storeToRefs(lsSegmentsStore);
-const { updateProjectGroupsPageSize } = lsSegmentsStore;
+const { updateProjectGroupsPageSize, doChangeProjectGroupCurrentPage } = lsSegmentsStore;
 
 const pagination = computed(() => projectGroups.value.pagination);
 const list = computed(() => projectGroups.value.list);
@@ -133,8 +146,6 @@ export default {
 
 <style lang="scss">
 #project-groups-table {
-  @apply rounded-lg shadow;
-
   thead .table-columns {
     @apply align-middle h-14 px-6;
 

--- a/frontend/src/modules/lf/segments/components/view/lf-projects-table.vue
+++ b/frontend/src/modules/lf/segments/components/view/lf-projects-table.vue
@@ -136,7 +136,7 @@
       </template>
     </el-table-column>
 
-    <template v-if="project.subprojects?.length" #append>
+    <template v-if="project.subprojects?.length && hasPermissionToCreateSubProject" #append>
       <div class="w-full flex justify-start p-6">
         <el-button class="btn btn-link btn-link--primary" @click="emit('onAddSubProject', project.slug)">
           + Add sub-project
@@ -144,7 +144,7 @@
       </div>
     </template>
 
-    <template #empty>
+    <template v-if="hasPermissionToCreateSubProject" #empty>
       <div class="w-full flex justify-start p-6">
         <el-button class="btn btn-link btn-link--primary" @click="emit('onAddSubProject', project.slug)">
           + Add sub-project
@@ -160,6 +160,9 @@ import AppLfProjectsDropdown from '@/modules/lf/segments/components/lf-projects-
 import AppLfSubProjectsDropdown from '@/modules/lf/segments/components/lf-sub-projects-dropdown.vue';
 import AppPlatformSvgIcon from '@/shared/platform/platform-svg-icon.vue';
 import { useRoute } from 'vue-router';
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { computed } from 'vue';
 
 const route = useRoute();
 
@@ -170,6 +173,13 @@ defineProps({
     required: true,
   },
 });
+
+const { currentTenant, currentUser } = mapGetters('auth');
+
+const hasPermissionToCreateSubProject = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.createSubProject);
 
 const statusDisplay = (status) => statusOptions.find((s) => s.value === status);
 </script>

--- a/frontend/src/modules/lf/segments/pages/lf-project-groups-list-page.vue
+++ b/frontend/src/modules/lf/segments/pages/lf-project-groups-list-page.vue
@@ -9,7 +9,7 @@
         <app-lf-search-input
           v-if="pagination.total"
           placeholder="Search project group..."
-          @on-change="searchProjectGroup"
+          @on-change="(query) => searchProjectGroup(query, null)"
         />
       </div>
     </div>
@@ -88,7 +88,7 @@
                 },
               }"
             >
-              <el-button class="btn btn--md btn--full btn--bordered">
+              <el-button v-if="hasPermissionToAccessAdminPanel" class="btn btn--md btn--full btn--bordered">
                 Settings
               </el-button>
             </router-link>
@@ -106,8 +106,12 @@ import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import AppLfSearchInput from '@/modules/lf/segments/components/view/lf-search-input.vue';
 import pluralize from 'pluralize';
 import { useRouter } from 'vue-router';
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 
 const router = useRouter();
+
+const { currentTenant, currentUser } = mapGetters('auth');
 
 const lsSegmentsStore = useLfSegmentsStore();
 const { projectGroups } = storeToRefs(lsSegmentsStore);
@@ -120,12 +124,22 @@ const list = computed(() => projectGroups.value.list);
 const imageErrors = reactive({});
 
 onMounted(() => {
-  listProjectGroups();
+  listProjectGroups({
+    limit: null,
+    reset: true,
+  });
 });
 
 const handleImageError = (id, e) => {
   imageErrors[id] = true;
 };
+
+const hasPermissionToAccessAdminPanel = computed(
+  () => new LfPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).editProjectGroup,
+);
 </script>
 
 <script>

--- a/frontend/src/modules/lf/segments/pages/lf-project-groups-page.vue
+++ b/frontend/src/modules/lf/segments/pages/lf-project-groups-page.vue
@@ -5,7 +5,7 @@
         Admin panel
       </h4>
       <el-button
-        v-if="pagination.total"
+        v-if="pagination.total && hasPermissionToCreate"
         class="btn btn--md btn--primary"
         @click="onAddProjectGroup"
       >
@@ -33,7 +33,7 @@
         icon="ri-folder-5-line"
         title="No project groups yet"
         description="Create your first project group and start integrating your projects"
-        cta-btn="Add project group"
+        :cta-btn="hasPermissionToCreate ? 'Add project group' : null"
         @cta-click="onAddProjectGroup"
       />
 
@@ -77,10 +77,14 @@ import AppLfProjectGroupForm from '@/modules/lf/segments/components/form/lf-proj
 import AppLfProjectForm from '@/modules/lf/segments/components/form/lf-project-form.vue';
 import AppLfProjectGroupsTable from '@/modules/lf/segments/components/view/lf-project-groups-table.vue';
 import AppLfSearchInput from '@/modules/lf/segments/components/view/lf-search-input.vue';
+import { LfPermissions } from '@/modules/lf/lf-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 
 const lsSegmentsStore = useLfSegmentsStore();
 const { projectGroups } = storeToRefs(lsSegmentsStore);
 const { listProjectGroups, searchProjectGroup, updateSelectedProjectGroup } = lsSegmentsStore;
+
+const { currentTenant, currentUser } = mapGetters('auth');
 
 const loading = computed(() => projectGroups.value.loading);
 const pagination = computed(() => projectGroups.value.pagination);
@@ -92,9 +96,16 @@ const projectGroupForm = reactive({
 const isProjectGroupFormDrawerOpen = ref(false);
 const isProjectFormDrawerOpen = ref(false);
 
+const hasPermissionToCreate = computed(() => new LfPermissions(
+  currentTenant.value,
+  currentUser.value,
+)?.createProjectGroup);
+
 onMounted(() => {
   updateSelectedProjectGroup(null);
-  listProjectGroups();
+  listProjectGroups({
+    reset: true,
+  });
 });
 
 const onAddProject = (parentSlug) => {

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -4,12 +4,23 @@ import { router } from '@/router';
 
 export default {
   // Project Groups
-  listProjectGroups({ search = null, offset, limit } = {}) {
+  listProjectGroups({
+    search = null, offset, limit, reset = false,
+  } = {}) {
     this.projectGroups.loading = true;
+
+    if (reset) {
+      this.projectGroups.pagination = {
+        pageSize: 20,
+        currentPage: 1,
+        total: 0,
+        count: 0,
+      };
+    }
 
     return LfService.queryProjectGroups({
       limit: limit !== undefined ? limit : this.projectGroups.pagination.pageSize,
-      offset: offset !== undefined ? offset : this.offset,
+      offset: offset !== undefined ? offset : this.projectGroupOffset,
       filter: {
         name: search,
       },
@@ -64,20 +75,32 @@ export default {
       })
       .finally(() => Promise.resolve());
   },
-  searchProjectGroup(search) {
-    this.listProjectGroups({ search });
+  searchProjectGroup(search, limit) {
+    this.projectGroups.pagination.currentPage = 1;
+    this.listProjectGroups({ search, offset: 0, limit });
   },
   // Projects
-  listProjects({ parentSlug = null, search = null } = {}) {
+  listProjects({
+    parentSlug = null, search = null, offset, limit, reset = false,
+  } = {}) {
     this.projects.loading = true;
 
     if (parentSlug) {
       this.projects.parentSlug = parentSlug;
     }
 
+    if (reset) {
+      this.projects.pagination = {
+        pageSize: 20,
+        currentPage: 1,
+        total: 0,
+        count: 0,
+      };
+    }
+
     LfService.queryProjects({
-      limit: this.projects.pagination.pageSize,
-      offset: this.offset,
+      limit: limit !== undefined ? limit : this.projects.pagination.pageSize,
+      offset: offset !== undefined ? offset : this.projectOffset,
       filter: {
         name: search,
         parentSlug: this.projects.parentSlug,
@@ -132,7 +155,8 @@ export default {
       .finally(() => Promise.resolve());
   },
   searchProject(search) {
-    this.listProjects({ search });
+    this.projects.pagination.currentPage = 1;
+    this.listProjects({ search, offset: 0 });
   },
   findSubProject(id) {
     return LfService.findSegment(id)
@@ -190,5 +214,15 @@ export default {
     } else {
       this.selectedProjectGroup = null;
     }
+  },
+  doChangeProjectGroupCurrentPage(currentPage) {
+    this.projectGroups.pagination.currentPage = currentPage;
+
+    this.listProjectGroups();
+  },
+  doChangeProjectCurrentPage(currentPage) {
+    this.projects.pagination.currentPage = currentPage;
+
+    this.listProjects();
   },
 };

--- a/frontend/src/modules/lf/segments/store/getters.ts
+++ b/frontend/src/modules/lf/segments/store/getters.ts
@@ -1,9 +1,14 @@
 import { SegmentsState } from './state';
 
 export default {
-  offset: (state: SegmentsState) => {
+  projectGroupOffset: (state: SegmentsState) => {
     const currentPage = state.projectGroups.pagination.currentPage || 1;
 
     return (currentPage - 1) * state.projectGroups.pagination.pageSize;
+  },
+  projectOffset: (state: SegmentsState) => {
+    const currentPage = state.projects.pagination.currentPage || 1;
+
+    return (currentPage - 1) * state.projects.pagination.pageSize;
   },
 };

--- a/frontend/src/modules/report/components/report-dropdown.vue
+++ b/frontend/src/modules/report/components/report-dropdown.vue
@@ -1,14 +1,14 @@
 <template>
-  <div v-if="isReadOnly">
+  <div v-if="isReadOnly && report.public">
     <el-button
       class="btn btn--secondary"
-      @click="copyToClipboard()"
+      @click.stop="copyToClipboard()"
     >
       <i class="ri-lg ri-clipboard-line mr-1" />
       Copy Public Url
     </el-button>
   </div>
-  <div v-else>
+  <div v-else-if="!isReadOnly">
     <el-dropdown
       trigger="click"
       placement="bottom-end"

--- a/frontend/src/modules/report/components/report-share-button.vue
+++ b/frontend/src/modules/report/components/report-share-button.vue
@@ -14,6 +14,7 @@
     <template #dropdown>
       <div class="p-2 w-100">
         <div
+          v-if="hasPermissionToEditReport"
           class="flex items-start justify-between flex-grow"
         >
           <div>
@@ -74,7 +75,8 @@ import {
 } from 'vue';
 import Message from '@/shared/message/message';
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
-import { mapActions } from '@/shared/vuex/vuex.helpers';
+import { mapActions, mapGetters } from '@/shared/vuex/vuex.helpers';
+import { ReportPermissions } from '../report-permissions';
 
 const emit = defineEmits(['update:modelValue']);
 const props = defineProps({
@@ -91,6 +93,8 @@ const props = defineProps({
     required: true,
   },
 });
+
+const { currentTenant, currentUser } = mapGetters('auth');
 
 const open = ref(false);
 
@@ -132,4 +136,11 @@ const handlePublicChange = async (value) => {
     segments: [props.segmentId],
   });
 };
+
+const hasPermissionToEditReport = computed(
+  () => new ReportPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).edit,
+);
 </script>

--- a/frontend/src/modules/report/pages/report-list-page.vue
+++ b/frontend/src/modules/report/pages/report-list-page.vue
@@ -5,7 +5,7 @@
       <div class="flex items-center justify-between">
         <h4>Reports</h4>
         <el-button
-          v-if="computedTemplates.length || customReportsCount"
+          v-if="(computedTemplates.length || customReportsCount) && hasPermissionToCreate"
           class="btn btn--primary btn--md"
           @click="onAddReport"
         >

--- a/frontend/src/modules/settings/settings-permissions.js
+++ b/frontend/src/modules/settings/settings-permissions.js
@@ -1,0 +1,22 @@
+import { PermissionChecker } from '@/modules/user/permission-checker';
+import Permissions from '@/security/permissions';
+
+export class SettingsPermissions {
+  constructor(currentTenant, currentUser) {
+    const permissionChecker = new PermissionChecker(
+      currentTenant,
+      currentUser,
+    );
+
+    this.read = permissionChecker.match(
+      Permissions.values.settingsRead,
+    );
+
+    this.edit = permissionChecker.match(
+      Permissions.values.settingsEdit,
+    );
+    this.lockedForCurrentPlan = permissionChecker.lockedForCurrentPlan(
+      Permissions.values.settingsEdit,
+    );
+  }
+}

--- a/frontend/src/modules/user/components/list/user-list-table.vue
+++ b/frontend/src/modules/user/components/list/user-list-table.vue
@@ -2,9 +2,15 @@
   <div
     class="flex items-center py-1 mb-3 mt-2 justify-between"
   >
-    <div class="text-gray-500 text-sm">
-      {{ pluralize('user', count, true) }}
-    </div>
+    <app-pagination-sorter
+      :page-size="Number(pagination.pageSize)"
+      :total="count"
+      :current-page="pagination.currentPage"
+      :has-page-counter="false"
+      :sorter="false"
+      module="user"
+      position="top"
+    />
 
     <el-button
       class="btn btn--primary btn--sm"
@@ -14,6 +20,7 @@
       <span class="leading-5">Invite user</span>
     </el-button>
   </div>
+
   <div class="app-list-table not-clickable panel">
     <app-user-list-toolbar />
     <div class="-mx-6 -mt-6">
@@ -105,6 +112,17 @@
           </template>
         </el-table-column>
       </el-table>
+
+      <div v-if="!!count" class="mt-8 px-6">
+        <app-pagination
+          :total="count"
+          :page-size="Number(pagination.pageSize)"
+          :current-page="pagination.currentPage || 1"
+          module="user"
+          @change-current-page="doChangePaginationCurrentPage"
+          @change-page-size="doChangePaginationPageSize"
+        />
+      </div>
     </div>
   </div>
 </template>
@@ -138,6 +156,7 @@ export default {
       selectedRows: 'user/list/selectedRows',
       currentUser: 'auth/currentUser',
       currentTenant: 'auth/currentTenant',
+      pagination: 'user/list/pagination',
     }),
 
     hasPermissionToDestroy() {
@@ -167,6 +186,8 @@ export default {
     ...mapActions({
       doChangeSort: 'user/list/doChangeSort',
       doMountTable: 'user/list/doMountTable',
+      doChangePaginationCurrentPage: 'user/list/doChangePaginationCurrentPage',
+      doChangePaginationPageSize: 'user/list/doChangePaginationPageSize',
       doDestroy: 'user/destroy/doDestroy',
     }),
 

--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-email-digest-card.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-email-digest-card.vue
@@ -9,7 +9,7 @@
     </div>
 
     <div class="text-2xs text-gray-600 mt-4 mb-6">
-      Receive the 10 most relevant results from Eagle Eye
+      Receive the 10 most relevant results from Community Lens
       automatically in your inbox.
     </div>
 

--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-email-digest-drawer.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-email-digest-drawer.vue
@@ -21,7 +21,7 @@
             </h5>
             <p class="text-2xs text-gray-500">
               If active, you will receive an email with up
-              to 10 most relevant results from Eagle Eye,
+              to 10 most relevant results from Community Lens,
               based on your settings.
             </p>
           </div>

--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-loading-state.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-loading-state.vue
@@ -11,7 +11,7 @@
       v-if="showLongerLoading && showDescription"
       class="text-gray-600 text-sm mt-4"
     >
-      Generating your Eagle Eye feed can take up to 10
+      Generating your Community Lens feed can take up to 10
       seconds.
     </div>
   </div>

--- a/frontend/src/premium/eagle-eye/components/list/eagle-eye-settings.vue
+++ b/frontend/src/premium/eagle-eye/components/list/eagle-eye-settings.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="py-8 px-8">
     <h4 class="text-gray-900">
-      Eagle Eye
+      Community Lens
     </h4>
 
     <div class="text-gray-500 text-xs mt-1">

--- a/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-banner.vue
+++ b/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-banner.vue
@@ -16,8 +16,8 @@
 
     <img
       v-if="showImage"
-      alt="Eagle eye banner"
-      class="absolute bottom-0 right-0 h-68"
+      alt="Community Lens banner"
+      class="absolute bottom-0 right-0 w-3/5"
       src="/images/eagle-eye/banner.png"
     />
   </div>

--- a/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-footer.vue
+++ b/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-footer.vue
@@ -29,7 +29,7 @@
     >
       <span>{{
         showFinalStep
-          ? 'Start exploring Eagle Eye'
+          ? 'Start exploring Community Lens'
           : 'Next step'
       }}</span><i
         v-if="!showFinalStep"

--- a/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-summary-step.vue
+++ b/frontend/src/premium/eagle-eye/components/onboard/eagle-eye-summary-step.vue
@@ -4,7 +4,7 @@
       <div
         class="basis-2/5 bg-gray-50 rounded-lg flex items-center justify-center h-34"
       >
-        <img alt="Eagle eye onboarding discover" src="/images/eagle-eye/onboard-discover.png" />
+        <img alt="Community Lens onboarding discover" src="/images/eagle-eye/onboard-discover.png" />
       </div>
 
       <div class="basis-3/5">
@@ -40,7 +40,7 @@
       <div
         class="basis-2/5 bg-gray-50 rounded-lg flex items-center justify-center h-34"
       >
-        <img alt="Eagle eye onboarding" src="/images/eagle-eye/onboard-grow.png" />
+        <img alt="Community Lens onboarding" src="/images/eagle-eye/onboard-grow.png" />
       </div>
 
       <div class="basis-3/5">

--- a/frontend/src/premium/eagle-eye/eagle-eye-routes.js
+++ b/frontend/src/premium/eagle-eye/eagle-eye-routes.js
@@ -12,13 +12,13 @@ export default [
     component: Layout,
     meta: {
       auth: true,
-      title: 'Eagle Eye',
+      title: 'Community Lens',
       hideBanner: true,
     },
     children: [
       {
         name: 'eagleEye',
-        path: '/eagle-eye',
+        path: '/community-lens',
         component: EagleEyePage,
         exact: true,
         meta: {

--- a/frontend/src/premium/eagle-eye/pages/eagle-eye-onboard-page.vue
+++ b/frontend/src/premium/eagle-eye/pages/eagle-eye-onboard-page.vue
@@ -79,7 +79,7 @@ const form = reactive({
 const headerContent = computed(() => {
   if (step.value === 1) {
     return {
-      title: 'Eagle Eye',
+      title: 'Community Lens',
       preTitle: `${FeatureFlag.premiumFeatureCopy()} App`,
       showImage: true,
     };
@@ -87,7 +87,7 @@ const headerContent = computed(() => {
 
   return {
     title: 'Set up your feed',
-    preTitle: 'Eagle Eye',
+    preTitle: 'Community Lens',
   };
 });
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -107,7 +107,7 @@ export const createRouter = () => {
             try {
               await listProjectGroups({
                 limit: null,
-                offset: 0,
+                reset: true,
               });
 
               updateSelectedProjectGroup(to.query.projectGroup, false);

--- a/frontend/src/security/permissions.js
+++ b/frontend/src/security/permissions.js
@@ -737,6 +737,66 @@ class Permissions {
         ],
         allowedStorage: [],
       },
+      projectGroupCreate: {
+        id: 'projectGroupCreate',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
+      projectGroupEdit: {
+        id: 'projectGroupEdit',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
+      projectCreate: {
+        id: 'projectCreate',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
+      projectEdit: {
+        id: 'projectEdit',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
+      subProjectCreate: {
+        id: 'subProjectCreate',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
+      subProjectEdit: {
+        id: 'subProjectEdit',
+        allowedRoles: [roles.admin],
+        allowedPlans: [
+          plans.essential,
+          plans.growth,
+          plans.enterprise,
+        ],
+        allowedStorage: [],
+      },
     };
   }
 


### PR DESCRIPTION
# Changes proposed ✍️
- Add missing permissions
- Add router link to main logo
- Refactor eagle eye to community lens
- Styling issues

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa0813d</samp>

This pull request adds, refactors, and fixes various features related to permissions, pagination, and UI/UX in the lf module and other modules. It introduces a new class, `LfPermissions`, to handle the permission logic for the lf module. It also renames the `eagleEye` feature to `communityLens` and modifies the `AutomationService` to fetch all automations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fa0813d</samp>

> _We're checking permissions for the lf module_
> _Using `LfPermissions` class and `auth` module_
> _We're fetching all the data without pagination_
> _Heave away, me hearties, heave away_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa0813d</samp>

*  Add conditional rendering directives to various components based on the user's permissions for different modules ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-0ce6547bee0155186a048d673be3dafaab869e51b92902f7c48d524d07467c58R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2L27-R28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2L38-R39), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2R52), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-df3b69832c37cc770cc580e475fe89a9bb21ef4cafc19c6536497a627bbf8855L45-R48),    [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-ebe0ab87645840219d4939b9ac18231626cc0c914f4cb084c23cdbbd1d5f55daL2-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L9-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eR17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eR27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eL33-R38), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14L2-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-684eddee6fe983eb32d08d6b0a2d97988d631764251036f63407311a45c5c033L2-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-40410c8e00fe4bc0a6139edaa740768cb9bbc7f9ca13b3cee65e6a9600736323L14-R114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-e10987ee98acdc063b6fadda89a6df7c49a8045bf17d09e5da030d81b26cb9e2L139-R139), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-e10987ee98acdc063b6fadda89a6df7c49a8045bf17d09e5da030d81b26cb9e2L147-R147), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-26dd0a1eac8bb15bfd40d3b6d02c8cfda5b87eb1aaf5ccb7754e24408a0d8b72L91-R91), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-562bd87c1a065860113332957b0384d29051e798e4e93ba5e4e86a02a5755d92L8-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-562bd87c1a065860113332957b0384d29051e798e4e93ba5e4e86a02a5755d92L36-R36))
*  Import and use the `computed` function from the `vue` library to create reactive computed properties for the user's permissions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-0ce6547bee0155186a048d673be3dafaab869e51b92902f7c48d524d07467c58L79-R82), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2R110-R121), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-df3b69832c37cc770cc580e475fe89a9bb21ef4cafc19c6536497a627bbf8855L63-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L150-R162), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eR56-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14L39-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-684eddee6fe983eb32d08d6b0a2d97988d631764251036f63407311a45c5c033L31-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-e10987ee98acdc063b6fadda89a6df7c49a8045bf17d09e5da030d81b26cb9e2R163-R165), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-26dd0a1eac8bb15bfd40d3b6d02c8cfda5b87eb1aaf5ccb7754e24408a0d8b72L109-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-562bd87c1a065860113332957b0384d29051e798e4e93ba5e4e86a02a5755d92R80-R81))
*  Import and use the `mapGetters` function from the `vuex.helpers` module to access the `currentTenant` and `currentUser` getters from the `auth` module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-0ce6547bee0155186a048d673be3dafaab869e51b92902f7c48d524d07467c58L88-R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-df3b69832c37cc770cc580e475fe89a9bb21ef4cafc19c6536497a627bbf8855L63-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L150-R162), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eR56-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14L39-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-684eddee6fe983eb32d08d6b0a2d97988d631764251036f63407311a45c5c033L31-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-e10987ee98acdc063b6fadda89a6df7c49a8045bf17d09e5da030d81b26cb9e2R163-R165), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-26dd0a1eac8bb15bfd40d3b6d02c8cfda5b87eb1aaf5ccb7754e24408a0d8b72L109-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-562bd87c1a065860113332957b0384d29051e798e4e93ba5e4e86a02a5755d92R80-R81))
*  Import and use the `LfPermissions` class from the `lf-permissions.js` module to check the permissions for the lf module based on the tenant and user data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-df3b69832c37cc770cc580e475fe89a9bb21ef4cafc19c6536497a627bbf8855L63-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78R213-R248), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-553220e0aaab9f8dadf444a819b40afca60c737351d0129863a8b7b2b3605f3eR56-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-6730e744721c82d908c8d16ea91a2213abe9a730e1e248ffbc7abbd839492d14L39-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-684eddee6fe983eb32d08d6b0a2d97988d631764251036f63407311a45c5c033L31-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-e10987ee98acdc063b6fadda89a6df7c49a8045bf17d09e5da030d81b26cb9e2R163-R165), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-26dd0a1eac8bb15bfd40d3b6d02c8cfda5b87eb1aaf5ccb7754e24408a0d8b72L109-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-562bd87c1a065860113332957b0384d29051e798e4e93ba5e4e86a02a5755d92R80-R81))
*  Import and use the `ActivityPermissions` class from the `activity-permissions` module to check the permissions for the activity module based on the tenant and user data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-0ce6547bee0155186a048d673be3dafaab869e51b92902f7c48d524d07467c58L88-R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-0ce6547bee0155186a048d673be3dafaab869e51b92902f7c48d524d07467c58R155-R161))
*  Import and use the `ConversationPermissions` class from the `conversation-permissions` module to check the permissions for the conversation module based on the tenant and user data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-8d846ecbbff2510c96626ac13b0372024f0fc5eab33999180bfae952dc4a18a2R110-R121))
*  Import and use the `EagleEyePermissions` class from the `eagle-eye-permissions` module to check the permissions for the eagle eye feature based on the tenant and user data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L150-R162))
*  Import and use the `SettingsPermissions` class from the `settings-permissions` module to check the permissions for the settings page based on the tenant and user data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L150-R162))
*  Add a `permission` property to the `adminProjectGroupsCreate` and `adminProjectsCreate` routes in the `lf-routes.js` module to specify the permission values for creating a project group and a project ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-b4188977e08163a0501769032c2cf87038676b970a88114545ce751cb6612b6dR41), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-b4188977e08163a0501769032c2cf87038676b970a88114545ce751cb6612b6dR51))
*  Import the `Permissions` module in the `lf-routes.js` module to define the permission values for the lf routes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-b4188977e08163a0501769032c2cf87038676b970a88114545ce751cb6612b6dR2))
*  Add a `reset` parameter to the `listProjectGroups`, `listProjects`, `searchProjectGroup`, and `searchProject` methods in the `actions.js` module of the `lf` store to reset the pagination state when the parameter is true ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-664b4c1b4aaf7dff8b5eb404ff62e7b77fb2e6ad1f485e8ea23224dcac0cf19bL7-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-664b4c1b4aaf7dff8b5eb404ff62e7b77fb2e6ad1f485e8ea23224dcac0cf19bL67-R85), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-664b4c1b4aaf7dff8b5eb404ff62e7b77fb2e6ad1f485e8ea23224dcac0cf19bL78-R103), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-664b4c1b4aaf7dff8b5eb404ff62e7b77fb2e6ad1f485e8ea23224dcac0cf19bL135-R159))
*  Add two methods called `doChangeProjectGroupCurrentPage` and `doChangeProjectCurrentPage` to the `lsSegmentsStore` object in the `actions.js` module of the `lf` store to update the current page of the project groups and projects pagination states and fetch the data accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-664b4c1b4aaf7dff8b5eb404ff62e7b77fb2e6ad1f485e8ea23224dcac0cf19bR218-R227))
*  Add a `div` element with some classes and a `app-pagination` component to the `lf-projects-page.vue` component to show the pagination component for the projects table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-3708105edf89ad256335ba3fc382310aba28b8b27104caf40eaa4859e37dac82R79-R89))
*  Add a `doChangeProjectGroupCurrentPage` method to the `lsSegmentsStore` object in the `lf-project-groups-table.vue` component to update the current page of the project groups pagination state and fetch the project groups accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-40410c8e00fe4bc0a6139edaa740768cb9bbc7f9ca13b3cee65e6a9600736323L116-R129))
*  Add a `doChangeProjectCurrentPage` method to the `lsSegmentsStore` object in the `lf-projects-page.vue` component to update the current page of the projects pagination state and fetch the projects accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-3708105edf89ad256335ba3fc382310aba28b8b27104caf40eaa4859e37dac82L115-R128))
*  Modify the `on-change` handler of the `app-search-input` component in the `lf-project-groups-list-page.vue` component to pass a `null` value as the second argument to the `searchProjectGroup` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-26dd0a1eac8bb15bfd40d3b6d02c8cfda5b87eb1aaf5ccb7754e24408a0d8b72L12-R12))
*  Modify the `list` method of the `AutomationService` to pass `null` as the limit parameter instead of `50` in the `actions.js` module of the `automation` store ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-67d8bfffaed1feee492a56978c17c72f2ca0bf056da4e41da106075f358af62fL9-R9))
*  Wrap the `img` element in a `router-link` component in the `lf-menu.vue` component to make the logo clickable and redirect to the home page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-207a8e5ff683a556d9f407c86018af110196c792a740415a516dc8afa0ca1c78L9-R11))
*  Wrap the `el-input` component in a `div` element with a `ref` and a `click` handler in the `lf-project-filter-button.vue` component to fix a bug that prevented the popover from opening when clicking on the input suffix icon ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-ebe0ab87645840219d4939b9ac18231626cc0c914f4cb084c23cdbbd1d5f55daL2-R13))
*  Remove the `lf-filter-input` class from the `el-input` components and add the `filter-dropdown-search` class in the `lf-project-filter-button.vue` and `lf-sub-projects-list-dropdown.vue` components to apply a consistent style to the search input across different components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-ebe0ab87645840219d4939b9ac18231626cc0c914f4cb084c23cdbbd1d5f55daL28-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-5beedb5fd41400f193f2b80db3869377c879cd95e1f72f4d670ab89163559736L38-R38))
*  Remove the `rounded-lg` and `shadow` classes from the `el-table` component in the `lf-project-groups-table.vue` component to remove the redundant styles that are already applied by the wrapper `div` element ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-40410c8e00fe4bc0a6139edaa740768cb9bbc7f9ca13b3cee65e6a9600736323L136-L137))
*  Add two CSS properties to the `el-dropdown-menu` element in the `lf-sub-projects-list-dropdown.vue` component to limit the height of the dropdown menu and enable scrolling ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-5beedb5fd41400f193f2b80db3869377c879cd95e1f72f4d670ab89163559736R198-R199))
*  Wrap the `el-table` component in a `div` element with some classes in the `lf-project-groups-table.vue` component to apply a consistent style to the table component across different pages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-40410c8e00fe4bc0a6139edaa740768cb9bbc7f9ca13b3cee65e6a9600736323L14-R114))
*  Rename the `eagleEye` property of the `pageContent` object to `communityLens` in the `layout-page-content.js` module to reflect the new branding of the eagle eye feature as community lens ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-47be2a6424db0b988b0fac4605b0544241239b21569157c779f75b7d63a8d904L4-R7))
*  Replace the `Eagle Eye` text with `Community Lens` in the `pageContent` object in the `layout-page-content.js` module to reflect the new branding of the eagle eye feature as community lens ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-47be2a6424db0b988b0fac4605b0544241239b21569157c779f75b7d63a8d904L17-R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-47be2a6424db0b988b0fac4605b0544241239b21569157c779f75b7d63a8d904L25-R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1042/files?diff=unified&w=0#diff-47be2a6424db0b988b0fac4605b0544241239b21569157c779f75b7d63a8d904L33-R33))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
