### PR TITLE
Update past activities with affiliations

### DIFF
--- a/backend/src/database/repositories/memberSegmentAffiliationRepository.ts
+++ b/backend/src/database/repositories/memberSegmentAffiliationRepository.ts
@@ -54,6 +54,8 @@ class MemberSegmentAffiliationRepository extends RepositoryBase<
       },
     )
 
+    await this.updateAffiliation(data.memberId, data.segmentId, data.organizationId)
+
     return this.findById(affiliationInsertResult[0][0].id)
   }
 
@@ -151,6 +153,27 @@ class MemberSegmentAffiliationRepository extends RepositoryBase<
     )
 
     return records
+  }
+
+  private async updateAffiliation(memberId, segmentId, organizationId) {
+    const transaction = this.transaction
+
+    const query = `
+      UPDATE activities
+      SET "organizationId" = :organizationId
+      WHERE "memberId" = :memberId
+        AND "segmentId" = :segmentId
+    `
+
+    await this.options.database.sequelize.query(query, {
+      replacements: {
+        memberId,
+        segmentId,
+        organizationId,
+      },
+      type: QueryTypes.UPDATE,
+      transaction,
+    })
   }
 }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0c7c4c</samp>

Added a function to `MemberSegmentAffiliationRepository` to update the organizationId of activities based on member segment affiliations. This ensures the activities are properly associated with the organization that owns the segment.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f0c7c4c</samp>

> _To link activities with precision_
> _We need to update their organization_
> _So we added a function_
> _That does the conjunction_
> _Of member, segment, and affiliation_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0c7c4c</samp>

*  Update the organizationId of activities when creating or updating a member segment affiliation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1044/files?diff=unified&w=0#diff-fc23c07648700d719fde5a85daa6195b99925a7b465e413c45ac3c7a95b4799aR57-R58))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
