### PR TITLE
Add fallback query to GitHub integration commits

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1049,7 +1049,6 @@ class MemberRepository {
     attributesSettings = [] as AttributeData[],
     segments: string[] = [],
   ): Promise<PageData<IActiveMemberData>> {
-
     const tenant = SequelizeRepository.getCurrentTenant(options)
 
     const segmentsEnabled = await isFeatureEnabled(FeatureFlag.SEGMENTS, options)
@@ -1108,9 +1107,9 @@ class MemberRepository {
             },
             {
               term: {
-                uuid_tenantId: tenant.id
-              }
-            }
+                uuid_tenantId: tenant.id,
+              },
+            },
           ],
         },
       },

--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -45,6 +45,9 @@ import PullRequestReviewThreadCommentsQuery from '../../usecases/github/graphql/
 import PullRequestCommitsQuery, {
   PullRequestCommit,
 } from '../../usecases/github/graphql/pullRequestCommits'
+import PullRequestCommitsQueryNoAdditions, {
+  PullRequestCommitNoAdditions,
+} from '../../usecases/github/graphql/pullRequestCommitsNoAdditions'
 import IntegrationRunRepository from '../../../../database/repositories/integrationRunRepository'
 import { IntegrationRunState } from '../../../../types/integrationRunTypes'
 import IntegrationStreamRepository from '../../../../database/repositories/integrationStreamRepository'
@@ -302,7 +305,24 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           context.integration.token,
         )
 
-        result = await pullRequestCommitsQuery.getSinglePage(stream.metadata.page)
+        try {
+          result = await pullRequestCommitsQuery.getSinglePage(stream.metadata.page)
+        } catch (err) {
+          context.logger.warn(
+            {
+              err,
+              repo,
+              pullRequestNumber,
+            },
+            'Error while fetching pull request commits. Trying again without additions.',
+          )
+          const pullRequestCommitsQueryNoAdditions = new PullRequestCommitsQueryNoAdditions(
+            repo,
+            pullRequestNumber,
+            context.integration.token,
+          )
+          result = await pullRequestCommitsQueryNoAdditions.getSinglePage(stream.metadata.page)
+        }
         break
       case GithubStreamType.ISSUES:
         const issuesQuery = new IssuesQuery(repo, context.integration.token)
@@ -1317,7 +1337,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     context: IStepContext,
   ): Promise<AddActivitiesSingle[]> {
     const out: AddActivitiesSingle[] = []
-    const data = records[0] as PullRequestCommit
+    const data = records[0] as PullRequestCommit | PullRequestCommitNoAdditions
     const commits = data.repository.pullRequest.commits.nodes
 
     for (const record of commits) {
@@ -1339,9 +1359,10 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           sourceParentId: `${data.repository.pullRequest.id}`,
           timestamp: moment(record.commit.authoredDate).utc().toDate(),
           attributes: {
-            insertions: record.commit.additions,
-            deletions: record.commit.deletions,
-            lines: record.commit.additions - record.commit.deletions,
+            insertions: 'additions' in record.commit ? record.commit.additions : 0,
+            deletions: 'additions' in record.commit ? record.commit.deletions : 0,
+            lines:
+              'additions' in record.commit ? record.commit.additions - record.commit.deletions : 0,
             isMerge: record.commit.parents.totalCount > 1,
             isMainBranch: false,
           },

--- a/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
@@ -1,0 +1,117 @@
+import { Repo } from '../../../types/regularTypes'
+import BaseQuery from './baseQuery'
+
+export interface PullRequestCommitNoAdditions {
+  repository: {
+    pullRequest: {
+      id: string
+      number: number
+      baseRefName: string
+      headRefName: string
+      commits: {
+        pageInfo: {
+          hasPreviousPage: boolean
+          startCursor: string
+        }
+        nodes: {
+          commit: {
+            authoredDate: string
+            committedDate: string
+            changedFiles: number
+            deletions: number
+            oid: string
+            message: string
+            url: string
+            parents: {
+              totalCount: number
+            }
+            authors: {
+              nodes: {
+                user: {
+                  login: string
+                  name: string
+                  avatarUrl: string
+                  id: string
+                  isHireable: boolean
+                  twitterUsername: string | null
+                  url: string
+                  websiteUrl: string | null
+                  email: string
+                  bio: string
+                  company: string
+                  location: string | null
+                  followers: {
+                    totalCount: number
+                  }
+                }
+              }[]
+            }
+          }
+        }[]
+      }
+    }
+  }
+}
+
+/* eslint class-methods-use-this: 0 */
+class PullRequestCommitsQueryNoAdditions extends BaseQuery {
+  repo: Repo
+
+  constructor(
+    repo: Repo,
+    pullRequestNumber: string,
+    githubToken: string,
+    perPage: number = 100,
+    maxAuthors: number = 1,
+  ) {
+    const pullRequestCommitsQuery = `{
+      repository(name: "${repo.name}", owner: "${repo.owner}") {
+        pullRequest(number: ${pullRequestNumber}) {
+          id
+          number
+          baseRefName
+          headRefName
+          commits(first: ${perPage}, \${beforeCursor}) {
+            pageInfo ${BaseQuery.PAGE_SELECT}
+            nodes {
+              commit {
+                authoredDate
+                committedDate
+                changedFiles
+                deletions
+                oid
+                message
+                url
+                parents(first: 2) {
+                	totalCount
+                }
+                authors(first: ${maxAuthors}) {
+                  nodes {
+                    user ${BaseQuery.USER_SELECT}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`
+
+    super(githubToken, pullRequestCommitsQuery, 'pullRequestCommits', perPage)
+
+    this.repo = repo
+  }
+
+  // Override the getEventData method to process commit details
+  getEventData(result) {
+    const commitData = result as PullRequestCommitNoAdditions
+
+    return {
+      hasPreviousPage: result.repository?.pullRequest?.commits?.pageInfo?.hasPreviousPage,
+      startCursor: result.repository?.pullRequest?.commits?.pageInfo?.startCursor,
+      data: [commitData], // returning an array to match the parseActivities function
+    }
+  }
+}
+
+export default PullRequestCommitsQueryNoAdditions


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e49b595</samp>

This pull request improves the robustness and consistency of the Github integration service by adding a fallback query for pull request commits. The new query omits the `additions` field, which can cause errors for large commits, and the service handles the missing data accordingly. The changes affect the `backend/src/serverless/integrations` folder, mainly the `githubIntegrationService.ts` and `pullRequestCommitsNoAdditions.ts` files.
​
copilot:poem

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e49b595</samp>

*  Add a new class `PullRequestCommitsQueryNoAdditions` to fetch pull request commits without the additions field ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1048/files?diff=unified&w=0#diff-25f050294a5f0b7f4daf4dfb5a7725b468a78fd974cb7bfe602adc8655872a23R1-R117))
*  Handle query errors due to large additions field and retry with the new class in `GithubIntegrationService.fetchStream` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1048/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L305-R325))
*  Allow `parseActivities` to accept both types of commit records and use zero as default for missing additions field ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1048/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L1320-R1340), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1048/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L1342-R1365))
*  Import the new class in `githubIntegrationService.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1048/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30R48-R50))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
