### PR TITLE
Fix changeFiles in GitHub commits query

### DIFF
--- a/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommits.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommits.ts
@@ -18,7 +18,7 @@ export interface PullRequestCommit {
             authoredDate: string
             committedDate: string
             additions: number
-            changedFiles: number
+            changedFilesIfAvailable: number
             deletions: number
             oid: string
             message: string
@@ -79,7 +79,7 @@ class PullRequestCommitsQuery extends BaseQuery {
                 authoredDate
                 committedDate
                 additions
-                changedFiles
+                changedFilesIfAvailable
                 deletions
                 oid
                 message

--- a/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
@@ -17,7 +17,7 @@ export interface PullRequestCommitNoAdditions {
           commit: {
             authoredDate: string
             committedDate: string
-            changedFiles: number
+            changedFilesIfAvailable: number
             deletions: number
             oid: string
             message: string
@@ -77,7 +77,7 @@ class PullRequestCommitsQueryNoAdditions extends BaseQuery {
               commit {
                 authoredDate
                 committedDate
-                changedFiles
+                changedFilesIfAvailable
                 deletions
                 oid
                 message


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f45f34</samp>

Renamed some properties and variables in `pullRequestCommits.ts` and `pullRequestCommitsNoAdditions.ts` to better handle missing data for pull request metrics. This improves the readability and reliability of the code that fetches and processes GitHub pull request commits.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f45f34</samp>

> _Oh, we're the coders of the sea, and we work with git and glee_
> _We refactor and we rename, to make our code more clear and sane_
> _So heave away, me hearties, heave away_
> _We changed `changedFiles` to `changedFilesIfAvailable`, hooray!_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f45f34</samp>

*  Rename `changedFiles` to `changedFilesIfAvailable` in interfaces and queries for pull request commits ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1053/files?diff=unified&w=0#diff-e9f7ec3ae0f8b2609474c796d50a817f54573e0cff70b60ecfa9098fe52a2a6dL21-R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1053/files?diff=unified&w=0#diff-e9f7ec3ae0f8b2609474c796d50a817f54573e0cff70b60ecfa9098fe52a2a6dL82-R82), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1053/files?diff=unified&w=0#diff-25f050294a5f0b7f4daf4dfb5a7725b468a78fd974cb7bfe602adc8655872a23L20-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1053/files?diff=unified&w=0#diff-25f050294a5f0b7f4daf4dfb5a7725b468a78fd974cb7bfe602adc8655872a23L80-R80))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
