### PR TITLE
Small fixes for GitHub integration

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -1360,9 +1360,11 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           timestamp: moment(record.commit.authoredDate).utc().toDate(),
           attributes: {
             insertions: 'additions' in record.commit ? record.commit.additions : 0,
-            deletions: 'additions' in record.commit ? record.commit.deletions : 0,
+            deletions: 'deletions' in record.commit ? record.commit.deletions : 0,
             lines:
-              'additions' in record.commit ? record.commit.additions - record.commit.deletions : 0,
+              'additions' in record.commit && 'deletions' in record.commit
+                ? record.commit.additions - record.commit.deletions
+                : 0,
             isMerge: record.commit.parents.totalCount > 1,
             isMainBranch: false,
           },
@@ -1864,6 +1866,10 @@ export class GithubIntegrationService extends IntegrationServiceBase {
     const out: AddActivitiesSingle[] = []
 
     for (const record of records) {
+      if (!('author' in record)) {
+        // eslint-disable-next-line no-continue
+        continue
+      }
       const commentId = record.id
       const member = await GithubIntegrationService.parseMember(record.author, context)
 

--- a/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
+++ b/backend/src/serverless/integrations/usecases/github/graphql/pullRequestCommitsNoAdditions.ts
@@ -18,7 +18,6 @@ export interface PullRequestCommitNoAdditions {
             authoredDate: string
             committedDate: string
             changedFilesIfAvailable: number
-            deletions: number
             oid: string
             message: string
             url: string
@@ -78,7 +77,6 @@ class PullRequestCommitsQueryNoAdditions extends BaseQuery {
                 authoredDate
                 committedDate
                 changedFilesIfAvailable
-                deletions
                 oid
                 message
                 url


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1e00ef</samp>

Improved GitHub integration by fixing a bug in `GithubIntegrationService` and optimizing the GraphQL query for pull request commits.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1e00ef</samp>

> _To process GitHub commit data_
> _They fixed a bug and added a check that's great_
> _They also removed `deletions`_
> _From some GraphQL selections_
> _To simplify the model and reduce the weight_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1e00ef</samp>

*  Fix bug in `GithubIntegrationService` that assigned wrong value to `deletions` attribute of commit ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1054/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L1363-R1367))
*  Add safety check to `GithubIntegrationService` to skip records without `author` property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1054/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30R1869-R1872))
*  Remove `deletions` property from `PullRequestCommitNoAdditions` interface and query to reduce data requested from GitHub API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1054/files?diff=unified&w=0#diff-25f050294a5f0b7f4daf4dfb5a7725b468a78fd974cb7bfe602adc8655872a23L21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1054/files?diff=unified&w=0#diff-25f050294a5f0b7f4daf4dfb5a7725b468a78fd974cb7bfe602adc8655872a23L81))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
