### PR TITLE
Fix pagination mapping for view more

### DIFF
--- a/frontend/src/shared/modules/filters/services/filter-query.service.ts
+++ b/frontend/src/shared/modules/filters/services/filter-query.service.ts
@@ -53,7 +53,14 @@ export const filterQueryService = () => {
   function setQuery(value: Filter) {
     const query: Record<string, any> = {};
     if (value) {
-      Object.entries(value).forEach(([key, filterValue]) => {
+      const mappedValue = {
+        ...value,
+        pagination: {
+          page: value.pagination?.page || 1,
+          perPage: value.pagination?.perPage || 20,
+        },
+      };
+      Object.entries(mappedValue).forEach(([key, filterValue]) => {
         if (typeof filterValue === 'object') {
           Object.entries(filterValue).forEach(([subKey, subFilterValue]) => {
             const value = setQueryValue(subFilterValue);

--- a/frontend/src/shared/modules/filters/services/filter-query.service.ts
+++ b/frontend/src/shared/modules/filters/services/filter-query.service.ts
@@ -50,17 +50,17 @@ export const filterQueryService = () => {
   }
 
   // Prepares query object to be only one level nested for query params to be more readable
-  function setQuery(value: Filter) {
+  function setQuery(filter: Filter) {
     const query: Record<string, any> = {};
-    if (value) {
-      const mappedValue = {
-        ...value,
+    if (filter) {
+      const mappedFilter = {
+        ...filter,
         pagination: {
-          page: value.pagination?.page || 1,
-          perPage: value.pagination?.perPage || 20,
+          page: filter.pagination?.page || 1,
+          perPage: filter.pagination?.perPage || 20,
         },
       };
-      Object.entries(mappedValue).forEach(([key, filterValue]) => {
+      Object.entries(mappedFilter).forEach(([key, filterValue]) => {
         if (typeof filterValue === 'object') {
           Object.entries(filterValue).forEach(([subKey, subFilterValue]) => {
             const value = setQueryValue(subFilterValue);


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4a1584</samp>

Added default pagination values to filter query service. This prevents errors when sending queries to the backend API and avoids modifying the original query object.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c4a1584</samp>

> _`setQuery` adds_
> _pagination defaults now_
> _no mutation - spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4a1584</samp>

*  Add default pagination values to query object in `setQuery` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1058/files?diff=unified&w=0#diff-93e013cf14555da0428b9838ad887f1d49c15a25d8fcedfce46f8601e2983311L56-R63))
*  Use spread operator to avoid mutating original value argument in `setQuery` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1058/files?diff=unified&w=0#diff-93e013cf14555da0428b9838ad887f1d49c15a25d8fcedfce46f8601e2983311L56-R63))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
