### PR TITLE
Fixed negative sentiment filter values on members page

### DIFF
--- a/frontend/src/modules/member/config/filters/avgSentiment/config.ts
+++ b/frontend/src/modules/member/config/filters/avgSentiment/config.ts
@@ -17,12 +17,12 @@ const avgSentiment: MultiSelectFilterConfig = {
   },
   itemLabelRenderer(
     value: MultiSelectFilterValue,
-    options: MultiSelectFilterOptions
+    options: MultiSelectFilterOptions,
   ): string {
     return itemLabelRendererByType[FilterConfigType.MULTISELECT](
       'Avg. sentiment',
       value,
-      options
+      options,
     );
   },
   apiFilterRenderer({ value, include }: MultiSelectFilterValue): any[] {

--- a/frontend/src/modules/member/config/filters/avgSentiment/config.ts
+++ b/frontend/src/modules/member/config/filters/avgSentiment/config.ts
@@ -15,20 +15,31 @@ const avgSentiment: MultiSelectFilterConfig = {
   options: {
     options,
   },
-  itemLabelRenderer(value: MultiSelectFilterValue, options: MultiSelectFilterOptions): string {
-    return itemLabelRendererByType[FilterConfigType.MULTISELECT]('Avg. sentiment', value, options);
+  itemLabelRenderer(
+    value: MultiSelectFilterValue,
+    options: MultiSelectFilterOptions
+  ): string {
+    return itemLabelRendererByType[FilterConfigType.MULTISELECT](
+      'Avg. sentiment',
+      value,
+      options
+    );
   },
   apiFilterRenderer({ value, include }: MultiSelectFilterValue): any[] {
     const filter = {
       or: [
-        ...(value.includes('positive') ? [{ averageSentiment: { gte: 67 } }] : []),
-        ...(value.includes('negative') ? [{ averageSentiment: { lt: 33 } }] : []),
-        ...(value.includes('neutral') ? [{ averageSentiment: { between: [33, 67] } }] : []),
+        ...(value.includes('positive')
+          ? [{ averageSentiment: { gte: 67 } }]
+          : []),
+        ...(value.includes('negative')
+          ? [{ averageSentiment: { lte: 33 } }]
+          : []),
+        ...(value.includes('neutral')
+          ? [{ averageSentiment: { between: [33, 67] } }]
+          : []),
       ],
     };
-    return [
-      (include ? filter : { not: filter }),
-    ];
+    return [include ? filter : { not: filter }];
   },
 };
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7227c3</samp>

Reformatted code for a filter component that selects members by average sentiment. The file `frontend/src/modules/member/config/filters/avgSentiment/config.ts` was updated to follow the project's style guide.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e7227c3</samp>

> _Code is neat and clear_
> _Filter for crowd sentiment_
> _Autumn leaves change hue_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7227c3</samp>

* Reformat code to improve readability and follow style guide ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1060/files?diff=unified&w=0#diff-f6a92526859e5edb064aa18470e2fb61648877ed9721c01726a9c5aee1b92921L18-R42))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
