### PR TITLE
Improve alerting in the new framework

### DIFF
--- a/services/apps/data_sink_worker/config/custom-environment-variables.json
+++ b/services/apps/data_sink_worker/config/custom-environment-variables.json
@@ -17,5 +17,8 @@
     "region": "CROWD_COMPREHEND_AWS_REGION",
     "accessKeyId": "CROWD_COMPREHEND_AWS_ACCESS_KEY_ID",
     "secretAccessKey": "CROWD_COMPREHEND_AWS_SECRET_ACCESS_KEY"
+  },
+  "slackAlerting": {
+    "url": "CROWD_SLACK_ALERTING_URL"
   }
 }

--- a/services/apps/data_sink_worker/package-lock.json
+++ b/services/apps/data_sink_worker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@crowd/data-sink-worker",
       "version": "1.0.0",
       "dependencies": {
+        "@crowd/alerting": "file:../../libs/alerting",
         "@crowd/common": "file:../../libs/common",
         "@crowd/conversations": "file:../../libs/conversations",
         "@crowd/database": "file:../../libs/database",
@@ -37,7 +38,22 @@
         "prettier": "^2.8.8"
       }
     },
+    "../../libs/alerting": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/node": "^20.3.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.11",
+        "@typescript-eslint/parser": "^5.59.11",
+        "axios": "^1.4.0",
+        "eslint": "^8.42.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.1.3"
+      }
+    },
     "../../libs/common": {
+      "name": "@crowd/common",
       "version": "1.0.0",
       "dependencies": {
         "uuid": "^9.0.0"
@@ -54,6 +70,7 @@
       }
     },
     "../../libs/conversations": {
+      "name": "@crowd/conversations",
       "version": "1.0.0",
       "dependencies": {
         "@crowd/common": "file:../common",
@@ -75,6 +92,7 @@
       }
     },
     "../../libs/database": {
+      "name": "@crowd/database",
       "version": "1.0.0",
       "dependencies": {
         "@crowd/common": "file:../common",
@@ -93,15 +111,18 @@
       }
     },
     "../../libs/integrations": {
+      "name": "@crowd/integrations",
       "version": "1.0.0",
       "dependencies": {
         "@crowd/common": "file:../common",
         "@crowd/logging": "file:../logging",
         "@crowd/types": "file:../types",
         "axios": "^1.4.0",
+        "he": "^1.2.0",
         "sanitize-html": "^2.10.0"
       },
       "devDependencies": {
+        "@types/he": "^1.2.0",
         "@types/node": "^18.16.3",
         "@types/sanitize-html": "^2.9.0",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -114,6 +135,7 @@
       }
     },
     "../../libs/logging": {
+      "name": "@crowd/logging",
       "version": "1.0.0",
       "dependencies": {
         "@crowd/common": "file:../common",
@@ -134,6 +156,7 @@
       }
     },
     "../../libs/sentiment": {
+      "name": "@crowd/sentiment",
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-comprehend": "^3.335.0",
@@ -152,6 +175,7 @@
       }
     },
     "../../libs/sqs": {
+      "name": "@crowd/sqs",
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.332.0",
@@ -172,6 +196,7 @@
       }
     },
     "../../libs/types": {
+      "name": "@crowd/types",
       "version": "1.0.0",
       "devDependencies": {
         "@types/node": "^18.16.3",
@@ -195,6 +220,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@crowd/alerting": {
+      "resolved": "../../libs/alerting",
+      "link": true
     },
     "node_modules/@crowd/common": {
       "resolved": "../../libs/common",
@@ -2580,6 +2609,20 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
+    "@crowd/alerting": {
+      "version": "file:../../libs/alerting",
+      "requires": {
+        "@types/node": "^20.3.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.11",
+        "@typescript-eslint/parser": "^5.59.11",
+        "axios": "^1.4.0",
+        "eslint": "^8.42.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.1.3"
+      }
+    },
     "@crowd/common": {
       "version": "file:../../libs/common",
       "requires": {
@@ -2635,6 +2678,7 @@
         "@crowd/common": "file:../common",
         "@crowd/logging": "file:../logging",
         "@crowd/types": "file:../types",
+        "@types/he": "^1.2.0",
         "@types/node": "^18.16.3",
         "@types/sanitize-html": "^2.9.0",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -2643,6 +2687,7 @@
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "he": "^1.2.0",
         "prettier": "^2.8.8",
         "sanitize-html": "^2.10.0",
         "typescript": "^5.0.4"

--- a/services/apps/data_sink_worker/package.json
+++ b/services/apps/data_sink_worker/package.json
@@ -26,6 +26,7 @@
     "@crowd/sentiment": "file:../../libs/sentiment",
     "@crowd/sqs": "file:../../libs/sqs",
     "@crowd/types": "file:../../libs/types",
+    "@crowd/alerting": "file:../../libs/alerting",
     "@types/config": "^3.3.0",
     "@types/node": "^18.16.3",
     "config": "^3.3.9",

--- a/services/apps/data_sink_worker/src/conf/index.ts
+++ b/services/apps/data_sink_worker/src/conf/index.ts
@@ -3,6 +3,10 @@ import { ISqsClientConfig } from '@crowd/sqs'
 import { ISentimentClientConfig } from '@crowd/sentiment'
 import config from 'config'
 
+export interface ISlackAlertingConfig {
+  url: string
+}
+
 let sqsConfig: ISqsClientConfig
 export const SQS_CONFIG = (): ISqsClientConfig => {
   if (sqsConfig) return sqsConfig
@@ -17,6 +21,14 @@ export const DB_CONFIG = (): IDatabaseConfig => {
 
   dbConfig = config.get<IDatabaseConfig>('db')
   return dbConfig
+}
+
+let slackAlertingConfig: ISlackAlertingConfig
+export const SLACK_ALERTING_CONFIG = (): ISlackAlertingConfig => {
+  if (slackAlertingConfig) return slackAlertingConfig
+
+  slackAlertingConfig = config.get<ISlackAlertingConfig>('slackAlerting')
+  return slackAlertingConfig
 }
 
 let sentimentConfigInitialized = false

--- a/services/apps/data_sink_worker/src/repo/dataSink.data.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.data.ts
@@ -11,6 +11,11 @@ export interface IResultData {
   tenantId: string
   integrationId: string
   platform: PlatformType
+
+  hasSampleData: boolean
+  plan: string
+  isTrialPlan: boolean
+  name: string
 }
 
 export interface IFailedResultData {

--- a/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
@@ -11,16 +11,20 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
   private readonly getResultInfoQuery = `
     select r.id,
            r.state,
-           r.data,
-           
+           r.data, 
            r."tenantId",
            r."runId",
            r."streamId",
            r."apiDataId",
            r."integrationId",
-           i.platform
+           i.platform,
+           t."hasSampleData", 
+           t."plan",
+           t."isTrialPlan",
+           t."name"
     from integration.results r
         inner join integrations i on r."integrationId" = i.id
+        inner join tenants t on t.id = r."tenantId"
     where r.id = $(resultId)
   `
   public async getResultInfo(resultId: string): Promise<IResultData | null> {

--- a/services/apps/integration_data_worker/config/custom-environment-variables.json
+++ b/services/apps/integration_data_worker/config/custom-environment-variables.json
@@ -18,5 +18,8 @@
     "password": "CROWD_REDIS_PASSWORD",
     "host": "CROWD_REDIS_HOST",
     "port": "CROWD_REDIS_PORT"
+  },
+  "slackAlerting": {
+    "url": "CROWD_SLACK_ALERTING_URL"
   }
 }

--- a/services/apps/integration_data_worker/package-lock.json
+++ b/services/apps/integration_data_worker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@crowd/integration-data-worker",
       "version": "1.0.0",
       "dependencies": {
+        "@crowd/alerting": "file:../../libs/alerting",
         "@crowd/common": "file:../../libs/common",
         "@crowd/database": "file:../../libs/database",
         "@crowd/integrations": "file:../../libs/integrations",
@@ -31,6 +32,20 @@
         "eslint-plugin-prettier": "^4.2.1",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.8"
+      }
+    },
+    "../../libs/alerting": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/node": "^20.3.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.11",
+        "@typescript-eslint/parser": "^5.59.11",
+        "axios": "^1.4.0",
+        "eslint": "^8.42.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.1.3"
       }
     },
     "../../libs/common": {
@@ -85,9 +100,11 @@
         "@crowd/logging": "file:../logging",
         "@crowd/types": "file:../types",
         "axios": "^1.4.0",
+        "he": "^1.2.0",
         "sanitize-html": "^2.10.0"
       },
       "devDependencies": {
+        "@types/he": "^1.2.0",
         "@types/node": "^18.16.3",
         "@types/sanitize-html": "^2.9.0",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -225,6 +242,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@crowd/alerting": {
+      "resolved": "../../libs/alerting",
+      "link": true
     },
     "node_modules/@crowd/common": {
       "resolved": "../../libs/common",
@@ -2388,6 +2409,20 @@
         "regenerator-runtime": "^0.13.11"
       }
     },
+    "@crowd/alerting": {
+      "version": "file:../../libs/alerting",
+      "requires": {
+        "@types/node": "^20.3.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.11",
+        "@typescript-eslint/parser": "^5.59.11",
+        "axios": "^1.4.0",
+        "eslint": "^8.42.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.1.3"
+      }
+    },
     "@crowd/common": {
       "version": "file:../../libs/common",
       "requires": {
@@ -2474,6 +2509,7 @@
         "@crowd/common": "file:../common",
         "@crowd/logging": "file:../logging",
         "@crowd/types": "file:../types",
+        "@types/he": "^1.2.0",
         "@types/node": "^18.16.3",
         "@types/sanitize-html": "^2.9.0",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
@@ -2482,6 +2518,7 @@
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "he": "^1.2.0",
         "prettier": "^2.8.8",
         "sanitize-html": "^2.10.0",
         "typescript": "^5.0.4"

--- a/services/apps/integration_data_worker/package.json
+++ b/services/apps/integration_data_worker/package.json
@@ -23,6 +23,7 @@
     "@crowd/redis": "file:../../libs/redis",
     "@crowd/sqs": "file:../../libs/sqs",
     "@crowd/types": "file:../../libs/types",
+    "@crowd/alerting": "file:../../libs/alerting",
     "@types/config": "^3.3.0",
     "@types/node": "^18.16.3",
     "config": "^3.3.9",

--- a/services/apps/integration_data_worker/src/conf/index.ts
+++ b/services/apps/integration_data_worker/src/conf/index.ts
@@ -7,6 +7,10 @@ export interface IWorkerSettings {
   maxDataRetries: number
 }
 
+export interface ISlackAlertingConfig {
+  url: string
+}
+
 let workerSettings: IWorkerSettings
 export const WORKER_SETTINGS = (): IWorkerSettings => {
   if (workerSettings) return workerSettings
@@ -37,6 +41,14 @@ export const REDIS_CONFIG = (): IRedisConfiguration => {
 
   redisConfig = config.get<IRedisConfiguration>('redis')
   return redisConfig
+}
+
+let slackAlertingConfig: ISlackAlertingConfig
+export const SLACK_ALERTING_CONFIG = (): ISlackAlertingConfig => {
+  if (slackAlertingConfig) return slackAlertingConfig
+
+  slackAlertingConfig = config.get<ISlackAlertingConfig>('slackAlerting')
+  return slackAlertingConfig
 }
 
 const platformMap: Map<string, unknown | null> = new Map()

--- a/services/apps/integration_data_worker/src/repo/integrationData.data.ts
+++ b/services/apps/integration_data_worker/src/repo/integrationData.data.ts
@@ -16,4 +16,9 @@ export interface IApiDataInfo {
   state: IntegrationStreamDataState
   data: unknown
   retries: number
+
+  hasSampleData: boolean
+  plan: string
+  isTrialPlan: boolean
+  name: string
 }

--- a/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
+++ b/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
@@ -28,10 +28,15 @@ export default class IntegrationDataRepository extends RepositoryBase<Integratio
             d.id,
             d.state,
             d.data,
+            t."hasSampleData",
+            t."plan",
+            t."isTrialPlan",
+            t."name",
             coalesce(d.retries, 0) as retries
       from integration."apiData" d
               inner join integrations i on d."integrationId" = i.id
               inner join integration.runs r on r.id = d."runId"
+              inner join tenants t on t.id = d."tenantId"
       where d.id = $(dataId);
   `
 

--- a/services/apps/integration_data_worker/src/service/integrationDataService.ts
+++ b/services/apps/integration_data_worker/src/service/integrationDataService.ts
@@ -5,8 +5,9 @@ import IntegrationDataRepository from '../repo/integrationData.repo'
 import { IActivityData, IntegrationResultType, IntegrationRunState } from '@crowd/types'
 import { addSeconds, singleOrDefault } from '@crowd/common'
 import { INTEGRATION_SERVICES, IProcessDataContext } from '@crowd/integrations'
-import { WORKER_SETTINGS, PLATFORM_CONFIG } from '@/conf'
+import { WORKER_SETTINGS, PLATFORM_CONFIG, SLACK_ALERTING_CONFIG } from '@/conf'
 import { DataSinkWorkerEmitter, IntegrationStreamWorkerEmitter } from '@crowd/sqs'
+import { SlackAlertTypes, sendSlackAlert } from '@crowd/alerting'
 
 export default class IntegrationDataService extends LoggerBase {
   private readonly repo: IntegrationDataRepository
@@ -185,6 +186,26 @@ export default class IntegrationDataService extends LoggerBase {
             maxRetries: WORKER_SETTINGS().maxDataRetries,
           },
         )
+
+        await sendSlackAlert({
+          slackURL: SLACK_ALERTING_CONFIG().url,
+          alertType: SlackAlertTypes.DATA_WORKER_ERROR,
+          integration: {
+            id: dataInfo.integrationId,
+            platform: dataInfo.integrationType,
+            tenantId: dataInfo.tenantId,
+            apiDataId: dataInfo.id,
+          },
+          userContext: {
+            currentTenant: {
+              name: dataInfo.name,
+              plan: dataInfo.plan,
+              isTrial: dataInfo.isTrialPlan,
+            },
+          },
+          log: this.log,
+          frameworkVersion: 'new',
+        })
       }
     } finally {
       await this.repo.touchRun(dataInfo.runId)

--- a/services/libs/alerting/src/integrations.ts
+++ b/services/libs/alerting/src/integrations.ts
@@ -4,6 +4,8 @@ import { Logger } from '@crowd/logging'
 export enum SlackAlertTypes {
   DATA_CHECKER = 'data-checker',
   INTEGRATION_ERROR = 'integration-error',
+  DATA_WORKER_ERROR = 'data-worker-error',
+  SINK_WORKER_ERROR = 'sink-worker-error',
 }
 
 interface SendSlackAlertInput {
@@ -20,6 +22,8 @@ interface SlackIntegrationType {
   platform: string
   tenantId: string
   id: string
+  apiDataId?: string
+  resultId?: string
 }
 
 interface SlackUserContextType {
@@ -149,7 +153,9 @@ function getBlocks(
             type: 'section',
             text: {
               type: 'mrkdwn',
-              text: `${isPayingCustomer ? '🚨' : '✋🏼'} *Integration onboarding failed* ${
+              text: `${
+                isPayingCustomer ? '🚨' : '✋🏼'
+              } *Integration streams failed (onboarding or incremental)* ${
                 isPayingCustomer ? '🚨' : ''
               }`,
             },
@@ -180,6 +186,114 @@ function getBlocks(
               {
                 type: 'mrkdwn',
                 text: `*Integration ID:*\n${integration.id}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Framework Version:*\n${frameworkVersion}`,
+              },
+            ],
+          },
+        ],
+      }
+    case SlackAlertTypes.DATA_WORKER_ERROR:
+      return {
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `${
+                isPayingCustomer ? '🚨' : '✋🏼'
+              } *Integration data worker failed (parsing API data into activities)* ${
+                isPayingCustomer ? '🚨' : ''
+              }`,
+            },
+          },
+          {
+            type: 'section',
+            fields: [
+              {
+                type: 'mrkdwn',
+                text: `*Tenant Name:*\n${tenantName}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Paying customer:* ${isPayingCustomer ? payingCustomerMarker : '❌'}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Platform:*\n${integration.platform}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: ' ',
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Tenant ID:*\n${integration.tenantId}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Integration ID:*\n${integration.id}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*API Data ID:*\n${integration.apiDataId}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Framework Version:*\n${frameworkVersion}`,
+              },
+            ],
+          },
+        ],
+      }
+    case SlackAlertTypes.SINK_WORKER_ERROR:
+      return {
+        blocks: [
+          {
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `${isPayingCustomer ? '🚨' : '✋🏼'} *Data sink worker failed (upsert in db) * ${
+                isPayingCustomer ? '🚨' : ''
+              }`,
+            },
+          },
+          {
+            type: 'section',
+            fields: [
+              {
+                type: 'mrkdwn',
+                text: `*Tenant Name:*\n${tenantName}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Paying customer:* ${isPayingCustomer ? payingCustomerMarker : '❌'}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Platform:*\n${integration.platform}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: ' ',
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Tenant ID:*\n${integration.tenantId}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Integration ID:*\n${integration.id}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*Result ID:*\n${integration.resultId}`,
+              },
+              {
+                type: 'mrkdwn',
+                text: `*API Data ID:*\n${integration.apiDataId}`,
               },
               {
                 type: 'mrkdwn',


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2febbb</samp>

This pull request implements Slack alerting for integration errors in the `data_sink_worker` and `integration_data_worker` apps. It adds the `@crowd/alerting` and `he` libraries as dependencies, and modifies the configuration, data, repo, and service modules to enable and customize the alerting feature. It also fixes a SQL bug and improves the data quality for integrations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a2febbb</samp>

> _`SlackAlerting` added_
> _Integration errors shown_
> _Autumn leaves of data_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a2febbb</samp>

*  Add Slack alerting for integration errors in data worker and sink worker apps ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-62b14cab6415fc5976640522e032b57bcd3ca7ec49e1ca246b43dc6843776f03R20-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55L40-R56), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2612-R2625), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2681), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2690), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5R29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-46683faeedcb48cb29ef160b80d9aa481d964f780a52ecfa42b249d6d3f586cbR6-R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-46683faeedcb48cb29ef160b80d9aa481d964f780a52ecfa42b249d6d3f586cbR26-R33), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-e29380fc70a8bb77de4d8a5f826fca2ba75dedf01761d8aaa1a39b1df1be6042R14-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L21-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR7-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR107-R127), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-b871fa8d801480b90dd794c2e411e5f22b07983d854ea448f0ca87d59fe1f542R21-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR37-R50), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR246-R249), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2412-R2425), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2512), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2521), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-356df5ace11b7af626f46f92d3c7528003c8671a0a55bb3f4d9e175877a9900dR26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-4b20e920a4c6c53b5986e60ca295bf36e8446d7c652b4a2ef5c2b4f27d7385dfR10-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-4b20e920a4c6c53b5986e60ca295bf36e8446d7c652b4a2ef5c2b4f27d7385dfR46-R53), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-d9ec954a58e87e919a0f37ed9d90e81b84faf5b8b235493c4d69ed5cb4983810R19-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-21267776815b1a718da34dc9ad833ea27be064ba2ede0c1535f218f6492ba093L31-R39), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980L8-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980R189-R208), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R7-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R25-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R198-R305))
  * Add a new configuration property for slackAlerting in `custom-environment-variables.json` files of both apps, which contains the URL for sending Slack alerts ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-62b14cab6415fc5976640522e032b57bcd3ca7ec49e1ca246b43dc6843776f03R20-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-b871fa8d801480b90dd794c2e411e5f22b07983d854ea448f0ca87d59fe1f542R21-R23))
  * Add a dependency on the `@crowd/alerting` library in `package.json` and `package-lock.json` files of both apps, which contains the logic for sending Slack alerts ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2612-R2625), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2681), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2690), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5R29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2412-R2425), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2512), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2521), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-356df5ace11b7af626f46f92d3c7528003c8671a0a55bb3f4d9e175877a9900dR26))
  * Add a reference to the `../../libs/alerting` folder in `package-lock.json` files of both apps, which contains the source code for the `@crowd/alerting` library ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55L40-R56), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR37-R50))
  * Add a link to the `node_modules/@crowd/alerting` folder in `package-lock.json` files of both apps, which is used to resolve the dependency on the `@crowd/alerting` library ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R224-R227), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR246-R249))
  * Add an interface for the slackAlerting configuration in `conf/index.ts` files of both apps, which contains the URL for sending Slack alerts ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-46683faeedcb48cb29ef160b80d9aa481d964f780a52ecfa42b249d6d3f586cbR6-R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-4b20e920a4c6c53b5986e60ca295bf36e8446d7c652b4a2ef5c2b4f27d7385dfR10-R13))
  * Add a function to get the slackAlerting configuration from the config module in `conf/index.ts` files of both apps, which reads the configuration from the environment variables ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-46683faeedcb48cb29ef160b80d9aa481d964f780a52ecfa42b249d6d3f586cbR26-R33), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-4b20e920a4c6c53b5986e60ca295bf36e8446d7c652b4a2ef5c2b4f27d7385dfR46-R53))
  * Add some properties to the data interfaces in `repo` modules of both apps, which are used to store information about the tenant, such as the name, plan, and sample data status ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-e29380fc70a8bb77de4d8a5f826fca2ba75dedf01761d8aaa1a39b1df1be6042R14-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-d9ec954a58e87e919a0f37ed9d90e81b84faf5b8b235493c4d69ed5cb4983810R19-R23))
  * Add a join to the tenants table and select some columns from it in `repo` modules of both apps, which are used to fetch the tenant information for the integration data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L21-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-21267776815b1a718da34dc9ad833ea27be064ba2ede0c1535f218f6492ba093L31-R39))
  * Add some imports to the `service` modules of both apps, such as the slackAlerting configuration, the sendSlackAlert function, and the SlackAlertTypes enum ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR7-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980L8-R10))
  * Add a call to the sendSlackAlert function in the catch block of the main functions in `service` modules of both apps, which are used to send a Slack alert when an error occurs while processing or upserting the integration data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR107-R127), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980R189-R208))
  * Add two new values to the SlackAlertTypes enum in `integrations.ts` file of the `@crowd/alerting` library, which are used to identify the types of alerts for the data worker and the sink worker errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R7-R8))
  * Add two new properties to the SlackIntegrationType interface in `integrations.ts` file of the `@crowd/alerting` library, which are used to store the apiDataId and the resultId of the integration data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R25-R26))
  * Add two new cases to the getBlocks function in `integrations.ts` file of the `@crowd/alerting` library, which are used to construct the blocks for the Slack alert message for the data worker and the sink worker errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4R198-R305))
* Improve the data quality for integrations by decoding HTML entities in the integration data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55L102-R125), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcL88-R107))
  * Add the `he` library and its types as dependencies to the `@crowd/integrations` library in `package-lock.json` files of both apps, which are used to decode HTML entities in the integration data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55L102-R125), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcL88-R107))
  * Add the `he` library and its types as dependencies to both apps in `package.json` and `package-lock.json` files, which are used to provide type definitions and access to the `he` library ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2681), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R2690), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2512), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-cc35e7f6b57d31608e307c0b15e3da2dd60d768e736dbe7eba8dd610ad330edcR2521))
* Fix some minor issues with the `package-lock.json` files and the SQL query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R73), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R95), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R159), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R178), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R199), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L14-R14))
  * Add the name property to the `@crowd` libraries in `package-lock.json` files of both apps, which are used to identify the libraries in the file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R73), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R95), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R159), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R178), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-8aa3cd9e50ce92953b384ae14cdc8ad8c57233ad01a26a09f3c4e9c0f6300b55R199))
  * Remove a trailing comma from the SQL query in `dataSink.repo.ts` file of the sink worker app, which is a minor fix to avoid syntax errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L14-R14))
* Modify the text of the alert message for the integration streams failed alert in `integrations.ts` file of the `@crowd/alerting` library, which is used to notify when an integration onboarding or incremental run fails ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4L152-R158))
  * Make the text more generic and consistent with the other alert types, which is part of the feature to improve the clarity and consistency of the alert messages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1061/files?diff=unified&w=0#diff-552f6533c30f87841da361268cd01adbbde013abd1e6ac04bdd11d34251581b4L152-R158))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
