### PR TITLE
Fix custom reports with segments

### DIFF
--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -445,10 +445,12 @@ const en = {
       },
       Activities: {
         count: '[Activities] Count',
+        cumulativeCount: '[Activities] Cumulative Count',
         type: '[Activities] Type',
         platform: '[Activities] Platform',
         date: '[Activities] Date',
         channel: '[Activities] Channel',
+        createdat: '[Activities] Created At',
       },
       Members: {
         count: '[Contributors] Count',
@@ -459,9 +461,12 @@ const en = {
         joinedAt: '[Contributors] Joined Date',
         averageTimeToFirstInteraction:
           '[Contributors] Avg. Time To First Interaction',
+        earliestJoinedAt: '[Contributors] Earliest Joined At',
+        createdat: '[Contributors] Created At',
       },
       MemberTags: {
         count: '[Contributors] # of Tags',
+        createdat: '[Contributors] # of Tags Created At',
       },
       Conversations: {
         count: '[Conversations] Count',
@@ -474,6 +479,7 @@ const en = {
       Tags: {
         name: '[Tags] Name',
         count: '[Tags] Count',
+        createdat: '[Tags] Created At',
       },
       Identities: {
         count: '[Identities] Count',
@@ -485,6 +491,8 @@ const en = {
       Segments: {
         count: '[Segments] Count',
         name: '[Segments] Name',
+        id: '[Segments] ID',
+        createdat: '[Segments] Created At',
       },
       Sentiment: {
         averageSentiment: '[Sentiment] Average',

--- a/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
@@ -5,193 +5,229 @@
     </div>
   </div>
   <div
+    v-if="segmentsFilter"
+    class="flex -mx-2 mb-2 items-center mt-2 widget-filter-container"
+  >
+    <div class="flex items-center mx-2">
+      <div class="grow">
+        <el-input
+          v-model="segmentsFilter.label"
+          class="first-filter"
+          type="text"
+          disabled
+        />
+      </div>
+
+      <div class="grow">
+        <el-input
+          v-model="segmentsFilter.operator"
+          class="second-filter"
+          type="text"
+          disabled
+        />
+      </div>
+
+      <div class="grow">
+        <el-input
+          v-model="segmentsFilter.value"
+          class="third-filter"
+          type="text"
+          disabled
+        />
+      </div>
+    </div>
+    <div class="pr-2 shrink">
+      <button
+        class="btn btn--transparent btn--md"
+        type="button"
+        disabled
+      >
+        <i class="ri-lg ri-delete-bin-line" />
+      </button>
+    </div>
+  </div>
+  <div
     v-if="!!computedFilters.length"
     class="widget-filter-container"
   >
-    <div class="mt-2">
-      <div class="flex -mx-2">
-        <div class="flex-1 grow h-0">
-          <div class="block leading-none mb-2" />
+    <div class="flex -mx-2">
+      <div class="flex-1 grow h-0">
+        <div class="block leading-none mb-2" />
+      </div>
+      <div class="flex-1 grow h-0">
+        <div class="block leading-none mb-2" />
+      </div>
+      <div class="flex-1 grow h-0">
+        <div class="block leading-none mb-2" />
+      </div>
+      <div class="shrink h-0">
+        <span class="w-1 block">&nbsp;</span>
+      </div>
+    </div>
+    <div
+      v-for="(filter, index) in localFilters"
+      :key="filter.id"
+      class="flex -mx-2 mb-2 items-center"
+    >
+      <div class="flex items-center mx-2">
+        <div class="grow">
+          <el-select
+            v-model="filter.select"
+            class="first-filter"
+            clearable
+            filterable
+            placeholder="Measure/dimension"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'first-option',
+                  value,
+                  index,
+                )
+            "
+          >
+            <el-option
+              v-for="item in computedFilters"
+              :key="item.value"
+              :value="item.value"
+              :label="item.label"
+              @mouseleave="onSelectMouseLeave"
+            />
+          </el-select>
         </div>
-        <div class="flex-1 grow h-0">
-          <div class="block leading-none mb-2" />
+
+        <div class="grow">
+          <el-select
+            v-model="filter.operator"
+            class="second-filter"
+            clearable
+            placeholder="Condition"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'second-option',
+                  value,
+                  index,
+                )
+            "
+          >
+            <el-option
+              v-for="actionItem in actionItems"
+              :key="actionItem.value"
+              :value="actionItem.value"
+              @mouseleave="onSelectMouseLeave"
+            >
+              {{ actionItem.text }}
+            </el-option>
+          </el-select>
         </div>
-        <div class="flex-1 grow h-0">
-          <div class="block leading-none mb-2" />
-        </div>
-        <div class="shrink h-0">
-          <span class="w-1 block">&nbsp;</span>
+
+        <div class="grow">
+          <el-select
+            v-if="filter.select === 'Activities.platform'"
+            v-model="filter.value"
+            class="third-filter"
+            placeholder="Value"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'third-option',
+                  value,
+                  index,
+                )
+            "
+          >
+            <el-option
+              v-for="integration of Object.keys(
+                activeIntegrationsList,
+              )"
+              :key="platformDetails(integration).name"
+              :label="platformDetails(integration).name"
+              :value="integration"
+              @mouseleave="onSelectMouseLeave"
+            />
+          </el-select>
+          <el-select
+            v-else-if="
+              filter.select === 'Activities.type'
+            "
+            v-model="filter.value"
+            class="third-filter"
+            placeholder="Value"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'third-option',
+                  value,
+                  index,
+                )
+            "
+          >
+            <el-option-group
+              v-for="group in computedActivityTypes"
+              :key="group.label.key"
+              :label="group.label.value"
+            >
+              <el-option
+                v-for="item in group.nestedOptions"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+            </el-option-group>
+          </el-select>
+          <el-select
+            v-else-if="filter.select === 'Members.score'"
+            v-model="filter.value"
+            class="third-filter"
+            placeholder="Value"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'third-option',
+                  value,
+                  index,
+                )
+            "
+          >
+            <el-option
+              v-for="engagementLevel of computedEngagementLevelTypes"
+              :key="engagementLevel.label"
+              :label="engagementLevel.label"
+              :value="engagementLevel.label"
+              @mouseleave="onSelectMouseLeave"
+            />
+          </el-select>
+          <el-input
+            v-else
+            v-model="filter.value"
+            class="third-filter"
+            type="text"
+            placeholder="Value"
+            @change="
+              (value) =>
+                handleFilterChange(
+                  'third-option',
+                  value,
+                  index,
+                )
+            "
+          />
         </div>
       </div>
-      <div
-        v-for="(filter, index) in localFilters"
-        :key="filter.id"
-        class="flex -mx-2 mb-2 items-center"
-      >
-        <div class="flex items-center mx-2">
-          <div class="grow">
-            <el-select
-              v-model="filter.select"
-              class="first-filter"
-              clearable
-              filterable
-              placeholder="Measure/dimension"
-              :disabled="filter.select === 'Segments.id'"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'first-option',
-                    value,
-                    index,
-                  )
-              "
-            >
-              <el-option
-                v-for="item in computedFilters"
-                :key="item.value"
-                :value="item.value"
-                :label="item.label"
-                @mouseleave="onSelectMouseLeave"
-              />
-            </el-select>
-          </div>
-
-          <div class="grow">
-            <el-select
-              v-model="filter.operator"
-              class="second-filter"
-              clearable
-              placeholder="Condition"
-              :disabled="filter.select === 'Segments.id'"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'second-option',
-                    value,
-                    index,
-                  )
-              "
-            >
-              <el-option
-                v-for="actionItem in actionItems"
-                :key="actionItem.value"
-                :value="actionItem.value"
-                @mouseleave="onSelectMouseLeave"
-              >
-                {{ actionItem.text }}
-              </el-option>
-            </el-select>
-          </div>
-
-          <div class="grow">
-            <el-select
-              v-if="filter.select === 'Activities.platform'"
-              v-model="filter.value"
-              class="third-filter"
-              placeholder="Value"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'third-option',
-                    value,
-                    index,
-                  )
-              "
-            >
-              <el-option
-                v-for="integration of Object.keys(
-                  activeIntegrationsList,
-                )"
-                :key="platformDetails(integration).name"
-                :label="platformDetails(integration).name"
-                :value="integration"
-                @mouseleave="onSelectMouseLeave"
-              />
-            </el-select>
-            <el-select
-              v-else-if="
-                filter.select === 'Activities.type'
-              "
-              v-model="filter.value"
-              class="third-filter"
-              placeholder="Value"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'third-option',
-                    value,
-                    index,
-                  )
-              "
-            >
-              <el-option-group
-                v-for="group in computedActivityTypes"
-                :key="group.label.key"
-                :label="group.label.value"
-              >
-                <el-option
-                  v-for="item in group.nestedOptions"
-                  :key="item.value"
-                  :label="item.label"
-                  :value="item.value"
-                />
-              </el-option-group>
-            </el-select>
-            <el-select
-              v-else-if="filter.select === 'Members.score'"
-              v-model="filter.value"
-              class="third-filter"
-              placeholder="Value"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'third-option',
-                    value,
-                    index,
-                  )
-              "
-            >
-              <el-option
-                v-for="engagementLevel of computedEngagementLevelTypes"
-                :key="engagementLevel.label"
-                :label="engagementLevel.label"
-                :value="engagementLevel.label"
-                @mouseleave="onSelectMouseLeave"
-              />
-            </el-select>
-            <el-input
-              v-else
-              v-model="filter.value"
-              class="third-filter"
-              type="text"
-              placeholder="Value"
-              :disabled="filter.select === 'Segments.id'"
-              @change="
-                (value) =>
-                  handleFilterChange(
-                    'third-option',
-                    value,
-                    index,
-                  )
-              "
-            />
-          </div>
-        </div>
-        <div class="pr-2 shrink">
-          <el-tooltip
-            content="Delete Filter"
-            placement="top"
+      <div class="pr-2 shrink">
+        <el-tooltip
+          content="Delete Filter"
+          placement="top"
+        >
+          <button
+            class="btn btn--transparent btn--md"
+            type="button"
+            @click.prevent="removeFilter(index)"
           >
-            <button
-              class="btn btn--transparent btn--md"
-              type="button"
-              :disabled="filter.select === 'Segments.id'"
-              @click.prevent="removeFilter(index)"
-            >
-              <i class="ri-lg ri-delete-bin-line" />
-            </button>
-          </el-tooltip>
-        </div>
+            <i class="ri-lg ri-delete-bin-line" />
+          </button>
+        </el-tooltip>
       </div>
     </div>
   </div>
@@ -271,22 +307,19 @@ export default {
           noDimension: [
             'Activities.platform',
             'Activities.type',
-            'Segments.name',
           ],
           Activities: [
             'Activities.platform',
             'Activities.type',
             'Activities.date',
-            'Segments.name',
           ],
           Members: [
             'Members.score',
             'Members.joinedAt',
             'Members.location',
             'Members.organization',
-            'Segments.name',
           ],
-          Tags: ['Tags.name', 'Segments.name'],
+          Tags: ['Tags.name'],
         },
         'Members.count': {
           noDimension: [
@@ -294,21 +327,18 @@ export default {
             'Members.joinedAt',
             'Members.location',
             'Members.organization',
-            'Segments.name',
           ],
           Activities: [
             'Activities.platform',
             'Activities.type',
             'Activities.date',
-            'Segments.name',
           ],
           Members: [
             'Members.score',
             'Members.location',
             'Members.organization',
-            'Segments.name',
           ],
-          Tags: ['Tags.name', 'Segments.name'],
+          Tags: ['Tags.name'],
         },
       },
       actionItems: [
@@ -346,7 +376,8 @@ export default {
         },
       ],
       localFilters: [],
-    }
+      segmentsFilter: null,
+    };
   },
   computed: {
     computedFilters() {
@@ -354,6 +385,7 @@ export default {
       const dimension = this.dimensions[0]
         ? this.dimensions[0].name.split('.')[0]
         : 'noDimension';
+
       return !measure
         ? []
         : this.availableDimensions.filter((d) => (this.measureDimensionFilters[
@@ -380,7 +412,8 @@ export default {
   },
   async created() {
     await this.doFetchIntegrations([this.segmentId]);
-    this.localFilters = this.initFilters() || [];
+    this.localFilters = this.initLocalFilters() || [];
+    this.segmentsFilter = this.initSegmentsFilter();
   },
   methods: {
     addFilter() {
@@ -398,7 +431,7 @@ export default {
     handleFilterChange(option, value, index) {
       this.syncFilters(option, value, index);
     },
-    initFilters() {
+    initLocalFilters() {
       if (!this.filters.length) {
         return [];
       }
@@ -418,13 +451,23 @@ export default {
           })
           // Remove this filter from options for now
           .filter(
-            (f) => f.select !== 'Members.isTeamMember',
+            (f) => f.select !== 'Members.isTeamMember' && f.select !== 'Segments.id' && f.select !== 'Members.isBot',
           )
       );
     },
+    initSegmentsFilter() {
+      const segmentsFilter = this.filters.find((filter) => filter.member.name === 'Segments.id');
+
+      return {
+        ...segmentsFilter,
+        select: segmentsFilter.member.name,
+        value: segmentsFilter.values,
+        label: '[Segments] ID',
+      };
+    },
     syncFilters(option, value, index) {
       const hasChangedFirstOption = option === 'first-option'
-        && this.filters?.[index]?.select !== value;
+        && this.localFilters?.[index]?.select !== value;
 
       const newFilters = this.localFilters
         .filter((filter) => [

--- a/frontend/src/modules/widget/components/cube/_query_builder/TimeDimensionSelect.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/TimeDimensionSelect.vue
@@ -54,13 +54,19 @@ export default {
     return {
       measureTimeDimensions: {
         'Activities.count': ['Activities.date'],
+        'Activities.cumulativeCount': ['Activities.createdat'],
+        'MemberTags.count': ['MemberTags.createdat'],
+        'Members.averageTimeToFirstInteraction': ['Members.createdat'],
         'Members.count': [
           'Members.joinedAt',
           'Activities.date',
         ],
+        'Members.cumulativeCount': ['Members.createdat'],
         'Conversations.count': ['Conversations.createdat'],
         'Sentiment.averageSentiment': ['Sentiment.date'],
         'Organizations.count': ['Organizations.createdat'],
+        'Segments.count': ['Segments.createdat'],
+        'Tags.count': ['Tags.createdat'],
       },
     };
   },
@@ -72,6 +78,15 @@ export default {
         : this.availableTimeDimensions.filter((t) => !!this.measureTimeDimensions[
           measure.name
         ]?.includes(t.name));
+    },
+  },
+  watch: {
+    measures: {
+      handler(newVal, oldVal) {
+        if (newVal?.[0]?.name !== oldVal?.[0]?.name) {
+          this.handleTimeChange(this.computedTimeDimensions[0].name);
+        }
+      },
     },
   },
   methods: {

--- a/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
@@ -319,13 +319,21 @@ export default {
       };
 
     const initialCharType = this.widget.settings?.chartType || 'line';
-    initialQuery.filters = [
-      {
+    const hasSegmentsFilter = initialQuery.filters?.some((filter) => filter.member === 'Segments.id');
+
+    if (!hasSegmentsFilter) {
+      const segmentsFilter = {
         member: 'Segments.id',
         operator: 'equals',
         values: [this.widget.segmentId],
-      },
-    ];
+      };
+
+      if (initialQuery.filters?.length) {
+        initialQuery.filters.push(segmentsFilter);
+      } else {
+        initialQuery.filters = [segmentsFilter];
+      }
+    }
 
     return {
       mapWidget,

--- a/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
@@ -94,19 +94,26 @@ export default {
         values: ['0'],
       };
 
-      const segments = {
-        member: 'Segments.id',
-        operator: 'equals',
-        values: this.subprojectId ? [this.subprojectId] : getSegmentsFromProjectGroup(selectedProjectGroup.value),
-      };
-
       if (!widgetQuery.filters) {
-        widgetQuery.filters = [isTeamMemberFilter, isBot, segments];
+        widgetQuery.filters = [isTeamMemberFilter, isBot];
       } else {
         widgetQuery.filters.push(isTeamMemberFilter);
         widgetQuery.filters.push(isBot);
-        widgetQuery.filters.push(segments);
       }
+
+      const hasSegmentsFilter = widgetQuery.filters?.some((filter) => filter.member === 'Segments.id');
+
+      if (!hasSegmentsFilter) {
+        const segmentsIds = this.subprojectId ? [this.subprojectId] : getSegmentsFromProjectGroup(selectedProjectGroup.value);
+        const segmentsFilter = {
+          member: 'Segments.id',
+          operator: 'equals',
+          values: segmentsIds,
+        };
+
+        widgetQuery.filters.push(segmentsFilter);
+      }
+
       return widgetQuery;
     },
   },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a00d71d</samp>

This pull request adds new measures and time dimensions to the widget query builder and the widget chart, and improves the logic for applying the segment filter to the widget chart query based on the widget or the project group settings. It modifies the `i18n` module, the `TimeDimensionSelect.vue` component, and the `widget-cube-builder.vue` and `widget-cube-renderer.vue` components.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a00d71d</samp>

> _Oh we are the coders of the widget chart_
> _We tweak the `initialQuery` and the `computedQuery` smart_
> _We add new measures and time dimensions to the `i18n` part_
> _And we heave away on the count of three, with the `measureTimeDimensions` at heart_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a00d71d</samp>

*  Add new labels for new measures and time dimensions in the `en` value of the `i18n` module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87L448-R453), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87L462-R469), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87R482), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87R494-R495))
*  Update the `measureTimeDimensions` object in the `TimeDimensionSelect.vue` component to map the new measures and time dimensions to the widget query builder ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-48a57128df008bb91d25e79b90f582650d37731fda552dd23a18b11de2f0ce10L57-R69))
*  Add a `watch` property to the `TimeDimensionSelect.vue` component to update the selected time dimension when the measure changes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-48a57128df008bb91d25e79b90f582650d37731fda552dd23a18b11de2f0ce10R83-R91))
*  Modify the `initialQuery` object in the `widget-cube-builder.vue` component to add a segment filter based on the widget or the project group settings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-622919f6445fc9b5bfe8b23bbf68b5bee28026636732ef375f8b714b73262a64L322-R337))
*  Modify the `computedQuery` computed property in the `widget-cube-renderer.vue` component to avoid duplicating the segment filter and to apply it based on the widget or the project group settings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1062/files?diff=unified&w=0#diff-77021f58ac2deb7a694e3f73c65dc57c5bce86b0871ce7cc738b380bb659fad7L97-R116))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
