### PR TITLE
Fix broken avatar

### DIFF
--- a/frontend/src/shared/avatar/avatar.vue
+++ b/frontend/src/shared/avatar/avatar.vue
@@ -6,7 +6,7 @@
       :style="computedStyle"
       :aria-label="computedInitials"
     >
-      <img :src="url" alt="">
+      <img v-if="url" :src="url" alt="">
     </div>
     <slot name="icon" />
   </div>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c93c34</samp>

Added a condition to render avatar images only if the `url` prop is valid. This fixes a bug where broken images were shown for empty or invalid `url` props in `avatar.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2c93c34</samp>

> _`v-if="url"` checks_
> _image source before render_
> _no broken avatars_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c93c34</samp>

*  Add conditional rendering for avatar image ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1064/files?diff=unified&w=0#diff-99a3d3e2098807ddc6d62148acd99541116b9fa24f5e08e490f4598628b6e901L9-R9))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
