### PR TITLE
Parse numbers returned from OpenSearch 

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1997,6 +1997,8 @@ class MemberRepository {
 
       row.identities = identities
       row.username = username
+      row.activeDaysCount = parseInt(row.activeDaysCount, 10)
+      row.activityCount = parseInt(row.activityCount, 10)
     }
 
     const memberIds = translatedRows.map((r) => r.id)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 562a027</samp>

Refactor `MemberRepository` to parse numeric fields as integers. This ensures consistent data types for the `Member` model and improves query performance and readability.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 562a027</samp>

> _Parse `activeDaysCount`_
> _And `activityCount` as ints_
> _Spring cleaning the code_

### Why
Because they were strings prefixed with 0
before:
![image](https://github.com/CrowdDotDev/crowd.dev/assets/59081450/8ced65e3-15f7-4eb7-9419-204d9214da0e)

after:
![image](https://github.com/CrowdDotDev/crowd.dev/assets/59081450/a2b7cad6-6d2a-4da9-9be5-5fca0fa940e5)


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 562a027</samp>

*  Parse `activeDaysCount` and `activityCount` as integers in `MemberRepository` to ensure consistent data types for `Member` model ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1067/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR2000-R2001))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screehshots to the PR description for relevant FE changes
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
