### PR TITLE
Add segment id to automation processing

### DIFF
--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -140,7 +140,6 @@ export default async (tenantId: string, activityId: string, segmentId: string): 
       log.info(`Found ${automations.length} automations to process!`)
       let activity = await ActivityRepository.findById(activityId, userContext)
 
-
       if (activity.member?.id) {
         const member = await MemberRepository.findById(activity.member.id, userContext)
         activity = {

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -140,6 +140,7 @@ export default async (tenantId: string, activityId: string, segmentId: string): 
       log.info(`Found ${automations.length} automations to process!`)
       let activity = await ActivityRepository.findById(activityId, userContext)
 
+
       if (activity.member?.id) {
         const member = await MemberRepository.findById(activity.member.id, userContext)
         activity = {

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -74,8 +74,7 @@ export default class ActivityService extends LoggerBase {
 
         return id
       })
-
-      await this.nodejsWorkerEmitter.processAutomationForNewActivity(tenantId, id)
+      await this.nodejsWorkerEmitter.processAutomationForNewActivity(tenantId, id, segmentId)
       const affectedIds = await this.conversationService.processActivity(tenantId, id)
 
       if (fireSync) {

--- a/services/libs/sqs/src/instances/nodejsWorker.ts
+++ b/services/libs/sqs/src/instances/nodejsWorker.ts
@@ -26,8 +26,12 @@ export class NodejsWorkerEmitter extends SqsQueueEmitter {
   public async processAutomationForNewActivity(
     tenantId: string,
     activityId: string,
+    segmentId: string,
   ): Promise<void> {
-    await this.sendMessage(tenantId, new NewActivityAutomationQueueMessage(tenantId, activityId))
+    await this.sendMessage(
+      tenantId,
+      new NewActivityAutomationQueueMessage(tenantId, activityId, segmentId),
+    )
   }
 
   public async processAutomationForNewMember(tenantId: string, memberId: string): Promise<void> {

--- a/services/libs/types/src/queue/nodejs_worker/index.ts
+++ b/services/libs/types/src/queue/nodejs_worker/index.ts
@@ -9,7 +9,11 @@ export class NewActivityAutomationQueueMessage implements IQueueMessage {
   public readonly trigger = 'new_activity'
   public readonly service = 'automation'
 
-  constructor(public readonly tenant: string, public readonly activityId: unknown) {}
+  constructor(
+    public readonly tenant: string,
+    public readonly activityId: unknown,
+    public readonly segmentId: string,
+  ) {}
 }
 
 export class NewMemberAutomationQueueMessage implements IQueueMessage {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfe73ea</samp>

This pull request adds the `segmentId` parameter to the automation workflow for new activities, which allows the automation service to access the segment information of the activity. The parameter is passed from the `activity.service.ts` file to the `nodejsWorker.ts` file, and stored in the `NewActivityAutomationQueueMessage` class.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfe73ea</samp>

> _`segmentId` added_
> _to automate new activity_
> _a queue message blooms_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfe73ea</samp>

*  Add segmentId parameter and property to pass segment information of activity to automation service and queue ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1068/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL77-R77), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1068/files?diff=unified&w=0#diff-98f86b19fbf90284571cf27923d8bb8641feff67b52316537bc1d057ea8400d6L29-R34), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1068/files?diff=unified&w=0#diff-a38d57e8544b19111d3a452735defd5426bfe74449d65cde38317bf86572cf79L12-R16))
*  Separate imports from rest of code with empty line in `newActivityWorker.ts` for code style consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1068/files?diff=unified&w=0#diff-38ef99903ebbf342c27ff354fbc7dfaa8727b41b09bbdef36f31f7d2a9dab7bbR143))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
