### PR TITLE
Remove img if src is not loaded

### DIFF
--- a/frontend/src/modules/organization/components/organization-name.vue
+++ b/frontend/src/modules/organization/components/organization-name.vue
@@ -8,16 +8,12 @@
           'bg-gray-50': !organization.logo,
         }"
       >
-        <img
-          v-if="organization.logo"
+        <app-avatar-image
           :src="organization.logo"
-          alt="Logo"
           class="max-h-8"
-        />
-        <i
-          v-else
-          class="ri-community-line text-lg text-gray-300 h-5"
-        />
+        >
+          <i class="ri-community-line text-lg text-gray-300 h-5" />
+        </app-avatar-image>
       </div>
     </div>
     <div class="overflow-hidden mr-6">
@@ -45,8 +41,9 @@
 </template>
 
 <script setup>
-import { defineProps, ref } from 'vue';
+import { ref } from 'vue';
 import AppOrganizationBadge from '@/modules/organization/components/organization-badge.vue';
+import AppAvatarImage from '@/shared/avatar-image/avatar-image.vue';
 
 defineProps({
   organization: {

--- a/frontend/src/shared/avatar-image/avatar-image.vue
+++ b/frontend/src/shared/avatar-image/avatar-image.vue
@@ -1,0 +1,25 @@
+<template>
+  <img
+    v-if="showImage"
+    :src="src"
+    alt="Avatar Logo"
+    @error="handleImageError"
+  >
+  <slot v-else />
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+  src: string,
+}>();
+
+const imageError = ref<boolean>(false);
+
+const showImage = computed(() => props.src && !imageError.value);
+
+const handleImageError = () => {
+  imageError.value = true;
+};
+</script>

--- a/frontend/src/shared/avatar/avatar.vue
+++ b/frontend/src/shared/avatar/avatar.vue
@@ -6,7 +6,12 @@
       :style="computedStyle"
       :aria-label="computedInitials"
     >
-      <img v-if="url" :src="url" alt="">
+      <img
+        v-if="url"
+        :src="url"
+        alt=""
+        @error="handleImageError"
+      >
     </div>
     <slot name="icon" />
   </div>
@@ -83,6 +88,11 @@ export default {
         .map((n) => n[0])
         .slice(0, 2)
         .join('');
+    },
+  },
+  methods: {
+    handleImageError(event) {
+      event.target.remove();
     },
   },
 };

--- a/frontend/src/shared/avatar/avatar.vue
+++ b/frontend/src/shared/avatar/avatar.vue
@@ -6,20 +6,22 @@
       :style="computedStyle"
       :aria-label="computedInitials"
     >
-      <img
-        v-if="url"
+      <app-avatar-image
         :src="url"
-        alt=""
-        @error="handleImageError"
-      >
+      />
     </div>
     <slot name="icon" />
   </div>
 </template>
 
 <script>
+import AppAvatarImage from '@/shared/avatar-image/avatar-image.vue';
+
 export default {
   name: 'AppAvatar',
+  components: {
+    AppAvatarImage,
+  },
   props: {
     entity: {
       type: Object,
@@ -88,11 +90,6 @@ export default {
         .map((n) => n[0])
         .slice(0, 2)
         .join('');
-    },
-  },
-  methods: {
-    handleImageError(event) {
-      event.target.remove();
     },
   },
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a114d9</samp>

Improved avatar component to handle image loading errors. Removed broken `img` elements from `frontend/src/shared/avatar/avatar.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a114d9</samp>

> _Oh we're the coders of the sea, and we work with skill and speed_
> _We handle errors gracefully, and we keep our DOMs so clean_
> _When an avatar fails to load, we don't let it spoil the show_
> _We remove the `img` element, and we sing this chorus as we go_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a114d9</samp>

*  Handle image loading errors in avatar component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1070/files?diff=unified&w=0#diff-99a3d3e2098807ddc6d62148acd99541116b9fa24f5e08e490f4598628b6e901L9-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1070/files?diff=unified&w=0#diff-99a3d3e2098807ddc6d62148acd99541116b9fa24f5e08e490f4598628b6e901R93-R97))
   - Add `@error` attribute to `img` element that calls `handleImageError` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1070/files?diff=unified&w=0#diff-99a3d3e2098807ddc6d62148acd99541116b9fa24f5e08e490f4598628b6e901L9-R14))
   - Define `handleImageError` method in `methods` section that removes `img` element from DOM ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1070/files?diff=unified&w=0#diff-99a3d3e2098807ddc6d62148acd99541116b9fa24f5e08e490f4598628b6e901R93-R97))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
