### PR TITLE
fixed where we update activityChannels (settings -> segments)

### DIFF
--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -50,7 +50,12 @@ export default class ActivityService extends LoggerBase {
         )
 
         if (activity.channel) {
-          await txSettingsRepo.createActivityChannel(tenantId, activity.platform, activity.channel)
+          await txSettingsRepo.createActivityChannel(
+            tenantId,
+            segmentId,
+            activity.platform,
+            activity.channel,
+          )
         }
 
         const id = await txRepo.create(tenantId, segmentId, {
@@ -119,7 +124,12 @@ export default class ActivityService extends LoggerBase {
         }
 
         if (toUpdate.channel) {
-          await txSettingsRepo.createActivityChannel(tenantId, original.platform, toUpdate.channel)
+          await txSettingsRepo.createActivityChannel(
+            tenantId,
+            segmentId,
+            original.platform,
+            toUpdate.channel,
+          )
         }
 
         if (!isObjectEmpty(toUpdate)) {

--- a/services/apps/data_sink_worker/src/service/settings.repo.ts
+++ b/services/apps/data_sink_worker/src/service/settings.repo.ts
@@ -58,13 +58,15 @@ export default class SettingsRepository extends RepositoryBase<SettingsRepositor
 
   public async createActivityChannel(
     tenantId: string,
+    segmentId: string,
     platform: string,
     channel: string,
   ): Promise<void> {
     const results = await this.db().one(
-      'select "activityChannels" from settings where "tenantId" = $(tenantId)',
+      'select "activityChannels" from segments where "tenantId" = $(tenantId) and id = $(segmentId)',
       {
         tenantId,
+        segmentId,
       },
     )
 
@@ -81,9 +83,10 @@ export default class SettingsRepository extends RepositoryBase<SettingsRepositor
     channels[platform].push(channel)
 
     const result = await this.db().result(
-      `update settings set "activityChannels" = $(channels) where "tenantId" = $(tenantId)`,
+      `update segments set "activityChannels" = $(channels) where "tenantId" = $(tenantId) and id = $(segmentId)`,
       {
         tenantId,
+        segmentId,
         channels,
       },
     )


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee24fc6</samp>

Added support for segmenting users by different criteria in the data sink worker service. Refactored `createActivityChannel` method to use `segmentId` instead of `tenantId` and moved it to `activity.service.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee24fc6</samp>

> _We create the channels of doom_
> _With `segmentId` we seal their fate_
> _We move and refactor the code_
> _To segment the users by hate_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee24fc6</samp>

*  Move and update `createActivityChannel` method to `activity.service.ts` file and query and update `segments` table instead of `settings` table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL53-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL122-R132), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-ffbf52c2c73ab31d3ba6cf3296d1606c9d18bf2d290a92b59bf725ec99259992L61-R69), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-ffbf52c2c73ab31d3ba6cf3296d1606c9d18bf2d290a92b59bf725ec99259992L84-R89))
* Add `segmentId` parameter to `createActivityChannel` method to identify the segment that the activity belongs to ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL53-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL122-R132), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1071/files?diff=unified&w=0#diff-ffbf52c2c73ab31d3ba6cf3296d1606c9d18bf2d290a92b59bf725ec99259992L84-R89))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] ~[Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.~
