### PR TITLE
don't update an activity if it was deleted

### DIFF
--- a/services/apps/data_sink_worker/src/bin/restart-result.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-result.ts
@@ -31,6 +31,7 @@ setImmediate(async () => {
     log.error(`Result ${resultId} not found!`)
     process.exit(1)
   } else {
+    await repo.resetFailedResults([resultId])
     await emitter.sendMessage(
       `results-${result.tenantId}-${result.platform}`,
       new ProcessIntegrationResultQueueMessage(result.id),

--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -38,11 +38,16 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
             channel,
             url,
             sentiment
-    from activities where "tenantId" = $(tenantId) and "sourceId" = $(sourceId)
+    from activities where "tenantId" = $(tenantId) and "segmentId" = $(segmentId) and "sourceId" = $(sourceId)
   `
-  public async findExisting(tenantId: string, sourceId: string): Promise<IDbActivity | null> {
+  public async findExisting(
+    tenantId: string,
+    segmentId: string,
+    sourceId: string,
+  ): Promise<IDbActivity | null> {
     const result = await this.db().oneOrNone(this.findExistingActivityQuery, {
       tenantId,
+      segmentId,
       sourceId,
     })
 

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -417,30 +417,32 @@ export default class ActivityService extends LoggerBase {
             )
           }
 
-          // just update the activity now
-          await txActivityService.update(
-            dbActivity.id,
-            tenantId,
-            segmentId,
-            {
-              type: activity.type,
-              isContribution: activity.isContribution,
-              score: activity.score,
-              sourceId: activity.sourceId,
-              sourceParentId: activity.sourceParentId,
-              memberId: dbActivity.memberId,
-              username,
-              attributes: activity.attributes || {},
-              body: activity.body,
-              title: activity.title,
-              channel: activity.channel,
-              url: activity.url,
-            },
-            dbActivity,
-            false,
-          )
+          if (!create) {
+            // just update the activity now
+            await txActivityService.update(
+              dbActivity.id,
+              tenantId,
+              segmentId,
+              {
+                type: activity.type,
+                isContribution: activity.isContribution,
+                score: activity.score,
+                sourceId: activity.sourceId,
+                sourceParentId: activity.sourceParentId,
+                memberId: dbActivity.memberId,
+                username,
+                attributes: activity.attributes || {},
+                body: activity.body,
+                title: activity.title,
+                channel: activity.channel,
+                url: activity.url,
+              },
+              dbActivity,
+              false,
+            )
 
-          activityId = dbActivity.id
+            activityId = dbActivity.id
+          }
         } else {
           this.log.trace('We did not find an existing activity. Creating a new one.')
 

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -325,18 +325,18 @@ export default class ActivityService extends LoggerBase {
         )
         const txIntegrationRepo = new IntegrationRepository(txStore, this.log)
 
-        // find existing activity
-        const dbActivity = await txRepo.findExisting(tenantId, activity.sourceId)
-
         const dbIntegration = await txIntegrationRepo.findById(integrationId)
         const segmentId = dbIntegration.segmentId
+
+        // find existing activity
+        const dbActivity = await txRepo.findExisting(tenantId, segmentId, activity.sourceId)
 
         let create = false
 
         if (dbActivity) {
           this.log.trace({ activityId: dbActivity.id }, 'Found existing activity. Updating it.')
           // process member data
-          let dbMember = await txMemberRepo.findMember(tenantId, platform, username)
+          let dbMember = await txMemberRepo.findMember(tenantId, segmentId, platform, username)
           if (dbMember) {
             // we found a member for the identity from the activity
             this.log.trace({ memberId: dbMember.id }, 'Found existing member.')
@@ -448,7 +448,7 @@ export default class ActivityService extends LoggerBase {
 
           // we don't have the activity yet in the database
           // check if we have a member for the identity from the activity
-          const dbMember = await txMemberRepo.findMember(tenantId, platform, username)
+          const dbMember = await txMemberRepo.findMember(tenantId, segmentId, platform, username)
           if (dbMember) {
             this.log.trace({ memberId: dbMember.id }, 'Found existing member.')
             await txMemberService.update(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33f55cd</samp>

Prevent updating existing activities in `ActivityService`. Add a check for the `create` flag in `activity.service.ts` to avoid overwriting activities that are already created by another workers.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 33f55cd</samp>

> _`create` is false_
> _avoid updating old activity_
> _autumn concurrency_

### Why
We updated the activity we just deleted because of member mismatch.

### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 33f55cd</samp>

*  Prevent updating an existing activity if the `create` flag is false ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1072/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL420-R445))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
