### PR TITLE
Prevent the while loop to be executing too long

### DIFF
--- a/backend/src/bin/jobs/checkStuckIntegrationRuns.ts
+++ b/backend/src/bin/jobs/checkStuckIntegrationRuns.ts
@@ -209,10 +209,13 @@ export const checkRuns = async (): Promise<void> => {
       }
     }
 
+    const lastCreatedAt = runs[runs.length - 1].createdAt
+
     runs = await runsRepo.findIntegrationsByState(
       [IntegrationRunState.PENDING, IntegrationRunState.PROCESSING],
       1,
       10,
+      lastCreatedAt,
     )
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2ef40f</samp>

Add pagination support to `getIntegrationRuns` function in `integrationRunRepository.ts`. This allows fetching integration runs by batches based on their creation date.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e2ef40f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to paginate the `getIntegrationRuns`_
> _By filtering them by date, with a dynamic query_
> _That used the `lastCreatedAt` as a boundary_

### Why
Because the rows are not always changed the results are most of the times the same so the while loops loops almost for ever.

### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2ef40f</samp>

*  Add `lastCreatedAt` parameter to `getIntegrationRuns` function to filter integration runs by maximum creation date ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1073/files?diff=unified&w=0#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4R62))
*  Build dynamic condition string based on `lastCreatedAt` parameter and append it to existing `where` clause with `and` operator ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1073/files?diff=unified&w=0#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4R73-R83))
*  Include condition string in SQL query in `where` clause in `backend/src/database/repositories/integrationRunRepository.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1073/files?diff=unified&w=0#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4L85-R97))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
