### PR TITLE
Bugfix/no memberid when triggering sync

### DIFF
--- a/services/apps/data_sink_worker/src/bin/restart-result.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-result.ts
@@ -10,11 +10,11 @@ const log = getServiceLogger()
 const processArguments = process.argv.slice(3)
 
 if (processArguments.length !== 1) {
-  log.error('Expected 1 argument: resultId')
+  log.error('Expected 1 argument: resultIds')
   process.exit(1)
 }
 
-const resultId = processArguments[0]
+const resultIds = processArguments[0].split(',')
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
@@ -25,16 +25,17 @@ setImmediate(async () => {
   const store = new DbStore(log, dbConnection)
 
   const repo = new DataSinkRepository(store, log)
-
-  const result = await repo.getResultInfo(resultId)
-  if (!result) {
-    log.error(`Result ${resultId} not found!`)
-    process.exit(1)
-  } else {
-    await repo.resetFailedResults([resultId])
-    await emitter.sendMessage(
-      `results-${result.tenantId}-${result.platform}`,
-      new ProcessIntegrationResultQueueMessage(result.id),
-    )
+  for (const resultId of resultIds) {
+    const result = await repo.getResultInfo(resultId)
+    if (!result) {
+      log.error(`Result ${resultId} not found!`)
+      process.exit(1)
+    } else {
+      await repo.resetFailedResults([resultId])
+      await emitter.sendMessage(
+        `results-${result.tenantId}-${result.platform}`,
+        new ProcessIntegrationResultQueueMessage(result.id),
+      )
+    }
   }
 })

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -371,8 +371,6 @@ export default class ActivityService extends LoggerBase {
               create = true
             }
 
-            memberId = dbMember.id
-
             // update the member
             await txMemberService.update(
               dbMember.id,
@@ -396,6 +394,8 @@ export default class ActivityService extends LoggerBase {
               // and use it's member id for the new activity
               dbActivity.memberId = dbMember.id
             }
+
+            memberId = dbMember.id
           } else {
             this.log.trace(
               'We did not find a member for the identity provided! Updating the one from db activity.',
@@ -425,6 +425,8 @@ export default class ActivityService extends LoggerBase {
               dbMember,
               false,
             )
+
+            memberId = dbActivity.memberId
           }
 
           if (!create) {

--- a/services/libs/conversations/src/repo/conversation.repo.ts
+++ b/services/libs/conversations/src/repo/conversation.repo.ts
@@ -47,7 +47,7 @@ export class ConversationRepository extends RepositoryBase<ConversationRepositor
     const id = generateUUIDv1()
 
     const results = await this.db().oneOrNone(
-      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId)`,
+      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId) and (enabled is null or enabled = true)`,
       {
         tenantId,
       },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b02aaa4</samp>

This pull request improves the handling of `memberId` in the `ActivityService` and the filtering of disabled conversation settings in the `ConversationRepository`. These changes aim to enhance the performance and accuracy of the data sink worker and the conversations library.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b02aaa4</samp>

> _We're the coders of the sea, we write queries and APIs_
> _We filter out the settings that are disabled or are lies_
> _We handle `memberId` with efficiency and care_
> _We pass it as a parameter, we don't leave it in the air_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b02aaa4</samp>

*  Remove unnecessary `memberId` assignment in `createActivity` method of `ActivityService` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1077/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL374-L375))
*  Add `memberId` assignment in `createActivity` method of `ActivityService` class and pass it to `publishActivity` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1077/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR397-R398))
*  Use `memberId` parameter in `publishActivity` method of `ActivityService` class to check `autoPublish` setting of member's conversation in `ConversationRepository` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1077/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR428-R429), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1077/files?diff=unified&w=0#diff-1676136fe81dc9e98855135a513fc17da4917c16a5dc71ee382a2dee6bdf1eaeL50-R50))
*  Modify SQL query in `getAutoPublishSetting` method of `ConversationRepository` class to filter out disabled conversation settings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1077/files?diff=unified&w=0#diff-1676136fe81dc9e98855135a513fc17da4917c16a5dc71ee382a2dee6bdf1eaeL50-R50))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
