### PR TITLE
API request body size limit increase

### DIFF
--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -151,6 +151,7 @@ setImmediate(async () => {
 
   app.use(
     bodyParser.json({
+      limit: '5mb',
       verify(req, res, buf) {
         const url = (<any>req).originalUrl
         if (url.startsWith('/webhooks/stripe') || url.startsWith('/webhooks/sendgrid')) {
@@ -162,7 +163,7 @@ setImmediate(async () => {
     }),
   )
 
-  app.use(bodyParser.urlencoded({ extended: true }))
+  app.use(bodyParser.urlencoded({ limit: '5mb', extended: true }))
 
   // Configure the Entity routes
   const routes = express.Router()


### PR DESCRIPTION
# Changes proposed ✍️
Some github webhook body payloads have a size > 100kb - These webhooks were failing because of the default body size limit coming from the `bodyParser`. This size is now increased to 5MB

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0bd1fbf</samp>

Increase API request body size limit for image uploads. Modify `backend/src/api/index.ts` to use `bodyParser` middleware with 5mb limit for JSON and URL-encoded requests.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0bd1fbf</samp>

> _We are the creators of the new world order_
> _We defy the limits of the `bodyParser`_
> _We unleash the power of the image upload_
> _We are the masters of the JSON and URL-encoded_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0bd1fbf</samp>

*  Increase the maximum request body size for JSON and URL-encoded requests to 5mb to support image uploading ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1079/files?diff=unified&w=0#diff-db37a00ab3571ac1d93dbd642853d57833cdb79efd86fc97af1b03d8d348ed49R154), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1079/files?diff=unified&w=0#diff-db37a00ab3571ac1d93dbd642853d57833cdb79efd86fc97af1b03d8d348ed49L165-R166)) in `backend/src/api/index.ts`

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
