### PR TITLE
Fix sample tenant permissions

### DIFF
--- a/frontend/src/security/permissions.js
+++ b/frontend/src/security/permissions.js
@@ -746,6 +746,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
       projectGroupEdit: {
         id: 'projectGroupEdit',
@@ -756,6 +757,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
       projectCreate: {
         id: 'projectCreate',
@@ -766,6 +768,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
       projectEdit: {
         id: 'projectEdit',
@@ -776,6 +779,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
       subProjectCreate: {
         id: 'subProjectCreate',
@@ -786,6 +790,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
       subProjectEdit: {
         id: 'subProjectEdit',
@@ -796,6 +801,7 @@ class Permissions {
           plans.enterprise,
         ],
         allowedStorage: [],
+        allowedSampleTenant: true,
       },
     };
   }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84606fc</samp>

This pull request introduces a new permission for accessing a sample tenant account. The permission is added to the `Permissions` class in `frontend/src/security/permissions.js` for all user roles.
​
copilot:poem

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84606fc</samp>

*  Add `allowedSampleTenant` property to `Permissions` class for different user roles ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R749), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R760), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R771), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R782), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R793), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1085/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6R804)) in `frontend/src/security/permissions.js`

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
