### PR TITLE
Prevent null values on `firstName` and `lastName` properties after OAuth authentication

### DIFF
--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -486,6 +486,8 @@ class AuthService {
         await UserRepository.update(
           user.id,
           {
+            firstName,
+            lastName,
             provider,
             providerId,
             emailVerified,

--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -474,7 +474,7 @@ class AuthService {
         track(
           'Signed in',
           {
-            google: true,
+            [provider]: true,
             email: user.email,
           },
           options,
@@ -514,7 +514,7 @@ class AuthService {
         track(
           'Signed up',
           {
-            google: true,
+            [provider]: true,
             email: user.email,
           },
           options,

--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -561,7 +561,7 @@ class AuthService {
         track(
           'Signed in',
           {
-            google: providerId.includes('google'),
+            [provider]: true,
             email: user.email,
           },
           options,
@@ -607,7 +607,7 @@ class AuthService {
         track(
           'Signed up',
           {
-            google: true,
+            [provider]: true,
             email: user.email,
           },
           options,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b618a06</samp>

Added Google and GitHub OAuth options for authentication and improved user data and analytics. Updated `authService.ts` to handle different providers and store user names.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b618a06</samp>

> _To sign in or up, you can choose_
> _Either Google or GitHub to use_
> _The `authService` file_
> _Has been changed for a while_
> _And it stores your name and the views_

### Why

A couple of fields, including firstName and lastName in the user profile become null when authenticated with Google/GitHub.

### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b618a06</samp>

* Replace the `google` property with a dynamic `[provider]` property in the analytics event payload for sign in and sign up events, to track the OAuth provider used by the user more accurately and consistently ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1100/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeL477-R477), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1100/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeL515-R517))
* Add the `firstName` and `lastName` properties to the user creation data, extracted from the OAuth profile of the user, to store and display the user's name in the application ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1100/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeR489-R490))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
