### PR TITLE
Explicitly fire automations in github webhooks API route

### DIFF
--- a/backend/src/api/webhooks/github.ts
+++ b/backend/src/api/webhooks/github.ts
@@ -35,7 +35,7 @@ export default async (req, res) => {
 
     await sendNodeWorkerMessage(
       integration.tenantId,
-      new NodeWorkerProcessWebhookMessage(integration.tenantId, result.id, undefined, true)),
+      new NodeWorkerProcessWebhookMessage(integration.tenantId, result.id, undefined, true),
     )
 
     await req.responseHandler.success(req, res, {}, 204)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f908a00</samp>

Added support for testing webhook integrations from the UI by passing a flag to the node worker message handler. Modified `backend/src/api/webhooks/github.ts` to set the flag for test messages.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f908a00</samp>

> _`sendNodeWorkerMessage`_
> _Adds a flag for test webhook_
> _Autumn of debugging_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f908a00</samp>

* Add a parameter to `sendNodeWorkerMessage` to indicate test messages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1108/files?diff=unified&w=0#diff-98fa25d5202ee5891c97ed11c7ebcb4197eded7a6741ccf6ec1879c1a7c3b859L38-R38))
* Use the parameter to create a `NodeWorkerProcessWebhookMessage` with a test flag ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1108/files?diff=unified&w=0#diff-98fa25d5202ee5891c97ed11c7ebcb4197eded7a6741ccf6ec1879c1a7c3b859L38-R38))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
