### PR TITLE
Fix invitation page

### DIFF
--- a/frontend/src/modules/auth/auth-routes.js
+++ b/frontend/src/modules/auth/auth-routes.js
@@ -14,7 +14,7 @@ export default [
     name: 'auth',
     path: '/auth',
     component: AuthLayout,
-    redirect: '/auth/signup',
+    redirect: '/auth/signin',
     children: [
       {
         name: 'signin',

--- a/frontend/src/modules/auth/pages/invitation-page.vue
+++ b/frontend/src/modules/auth/pages/invitation-page.vue
@@ -80,7 +80,7 @@ export default {
 
       if (!this.signedIn) {
         AuthInvitationToken.set(token);
-        router.push('/auth/signup');
+        router.push('/auth/signin');
         return;
       }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7bc35bf</samp>

Changed the default and token-based redirects for the `/auth` route to point to the `/auth/signin` page instead of the `/auth/signup` page. This improves the user experience for users who have an existing account or need a new invitation.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7bc35bf</samp>

> _`/auth` redirects_
> _to signin, not signup page_
> _a winter pruning_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7bc35bf</samp>

* Change the default redirect for the `/auth` route to the signin page instead of the signup page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1111/files?diff=unified&w=0#diff-fc507522736addf8c69c0ff6f6374be750b02016d97018423d12d042b89d9bccL17-R17))
* Update the `invitation-page.vue` component to redirect to the signin page instead of the signup page when handling the invitation token ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1111/files?diff=unified&w=0#diff-a92e3342755721e38e23478d3f3c43bb4e8d1f22a66a64756f85f7393b79c222L83-R83))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
