### PR TITLE
Terms and privacy

### DIFF
--- a/backend/src/api/auth/authSignUp.ts
+++ b/backend/src/api/auth/authSignUp.ts
@@ -1,6 +1,9 @@
 import AuthService from '../../services/auth/authService'
 
 export default async (req, res) => {
+  if(!req.body.acceptedTermsAndPrivacy){
+    return res.status(422).send({ error: 'Please accept terms of service and privacy policy' })
+  }
   const payload = await AuthService.signup(
     req.body.email,
     req.body.password,
@@ -8,8 +11,9 @@ export default async (req, res) => {
     req.body.tenantId,
     req.body.firstName,
     req.body.lastName,
+    req.body.acceptedTermsAndPrivacy,
     req,
   )
 
-  await req.responseHandler.success(req, res, payload)
+  return req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/auth/authSignUp.ts
+++ b/backend/src/api/auth/authSignUp.ts
@@ -1,7 +1,7 @@
 import AuthService from '../../services/auth/authService'
 
 export default async (req, res) => {
-  if(!req.body.acceptedTermsAndPrivacy){
+  if (!req.body.acceptedTermsAndPrivacy) {
     return res.status(422).send({ error: 'Please accept terms of service and privacy policy' })
   }
   const payload = await AuthService.signup(

--- a/backend/src/database/migrations/U1689235178__addTermsAndPrivacyColumn.sql
+++ b/backend/src/database/migrations/U1689235178__addTermsAndPrivacyColumn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."users" DROP COLUMN "acceptedTermsAndPrivacy";

--- a/backend/src/database/migrations/V1689235178__addTermsAndPrivacyColumn.sql
+++ b/backend/src/database/migrations/V1689235178__addTermsAndPrivacyColumn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public."users" ADD COLUMN "acceptedTermsAndPrivacy" BOOLEAN DEFAULT false;

--- a/backend/src/database/migrations/V1689235178__addTermsAndPrivacyColumn.sql
+++ b/backend/src/database/migrations/V1689235178__addTermsAndPrivacyColumn.sql
@@ -1,1 +1,1 @@
-ALTER TABLE public."users" ADD COLUMN "acceptedTermsAndPrivacy" BOOLEAN DEFAULT false;
+ALTER TABLE public."users" ADD COLUMN "acceptedTermsAndPrivacy" BOOLEAN DEFAULT true;

--- a/backend/src/database/models/user.ts
+++ b/backend/src/database/models/user.ts
@@ -97,7 +97,7 @@ export default (sequelize, DataTypes) => {
       },
       acceptedTermsAndPrivacy: {
         type: DataTypes.BOOLEAN,
-        defaultValue: false,
+        defaultValue: true,
       },
       importHash: {
         type: DataTypes.STRING(255),

--- a/backend/src/database/models/user.ts
+++ b/backend/src/database/models/user.ts
@@ -95,6 +95,10 @@ export default (sequelize, DataTypes) => {
       jwtTokenInvalidBefore: {
         type: DataTypes.DATE,
       },
+      acceptedTermsAndPrivacy: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false,
+      },
       importHash: {
         type: DataTypes.STRING(255),
         allowNull: true,

--- a/backend/src/database/repositories/userRepository.ts
+++ b/backend/src/database/repositories/userRepository.ts
@@ -104,6 +104,7 @@ export default class UserRepository {
         lastName: data.lastName,
         fullName: data.fullName,
         password: data.password,
+        acceptedTermsAndPrivacy: data.acceptedTermsAndPrivacy,
       },
       { transaction },
     )

--- a/backend/src/database/repositories/userRepository.ts
+++ b/backend/src/database/repositories/userRepository.ts
@@ -143,6 +143,7 @@ export default class UserRepository {
         firstName: data.firstName || null,
         lastName: data.lastName || null,
         phoneNumber: data.phoneNumber || null,
+        acceptedTermsAndPrivacy: data.acceptedTermsAndPrivacy || false,
         updatedById: currentUser.id,
       },
       { transaction },
@@ -663,6 +664,7 @@ export default class UserRepository {
       firstName,
       lastName,
       fullName,
+      acceptedTermsAndPrivacy: false,
     }
 
     const transaction = SequelizeRepository.getTransaction(options)

--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -28,6 +28,7 @@ class AuthService {
     tenantId,
     firstName,
     lastName,
+    acceptedTermsAndPrivacy,
     options: any = {},
   ) {
     const transaction = await SequelizeRepository.createTransaction(options)
@@ -126,6 +127,7 @@ class AuthService {
           fullName,
           password: hashedPassword,
           email,
+          acceptedTermsAndPrivacy,
         },
         {
           ...options,

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -570,6 +570,7 @@ const en = {
       fullName: 'Name',
       firstName: 'First name',
       lastName: 'Last name',
+      acceptedTermsAndPrivacy: 'Terms and privacy',
       status: 'Status',
       phoneNumber: 'Phone Number',
       role: 'Role',

--- a/frontend/src/middleware/auth/auth-guard.js
+++ b/frontend/src/middleware/auth/auth-guard.js
@@ -28,10 +28,17 @@ export default async function ({ to, store, router }) {
   }
   await store.dispatch('auth/doWaitUntilInit');
 
+  const currentUser = store.getters['auth/currentUser'];
+
   const permissionChecker = new PermissionChecker(
     store.getters['auth/currentTenant'],
-    store.getters['auth/currentUser'],
+    currentUser,
   );
+
+  if (!currentUser.acceptedTermsAndPrivacy) {
+    router.push({ path: '/auth/terms-and-privacy' });
+    return;
+  }
 
   if (!permissionChecker.isAuthenticated) {
     router.push({ path: '/auth/signin' });

--- a/frontend/src/middleware/auth/auth-guard.js
+++ b/frontend/src/middleware/auth/auth-guard.js
@@ -59,7 +59,7 @@ export default async function ({ to, store, router }) {
     router.push('/403');
     return;
   }
-
+  console.log(currentUser);
   if (!currentUser.acceptedTermsAndPrivacy) {
     router.push({ path: '/auth/terms-and-privacy' });
     return;

--- a/frontend/src/middleware/auth/auth-guard.js
+++ b/frontend/src/middleware/auth/auth-guard.js
@@ -35,11 +35,6 @@ export default async function ({ to, store, router }) {
     currentUser,
   );
 
-  if (!currentUser.acceptedTermsAndPrivacy) {
-    router.push({ path: '/auth/terms-and-privacy' });
-    return;
-  }
-
   if (!permissionChecker.isAuthenticated) {
     router.push({ path: '/auth/signin' });
     return;
@@ -62,6 +57,11 @@ export default async function ({ to, store, router }) {
       ))
   ) {
     router.push('/403');
+    return;
+  }
+
+  if (!currentUser.acceptedTermsAndPrivacy) {
+    router.push({ path: '/auth/terms-and-privacy' });
     return;
   }
 

--- a/frontend/src/modules/auth/auth-routes.js
+++ b/frontend/src/modules/auth/auth-routes.js
@@ -13,6 +13,7 @@ const ProfileFormPage = () => import('@/modules/auth/pages/profile-form-page.vue
 const PasswordResetPage = () => import('@/modules/auth/pages/password-reset-page.vue');
 const VerifyEmailPage = () => import('@/modules/auth/pages/verify-email-page.vue');
 const InvitationPage = () => import('@/modules/auth/pages/invitation-page.vue');
+const TermsAndPrivacyPage = () => import('@/modules/auth/pages/terms-and-privacy.vue');
 const EmptyPermissionsPage = () => import('@/modules/auth/pages/empty-permissions-page.vue');
 
 export default [
@@ -68,6 +69,12 @@ export default [
         path: 'invitation',
         component: InvitationPage,
         meta: { title: 'Invitation' },
+      },
+      {
+        name: 'terms-and-privacy',
+        path: 'terms-and-privacy',
+        component: TermsAndPrivacyPage,
+        meta: { title: 'Terms of service and privacy policy' },
       },
     ],
   },

--- a/frontend/src/modules/auth/auth-service.js
+++ b/frontend/src/modules/auth/auth-service.js
@@ -15,20 +15,10 @@ export class AuthService {
       .then((response) => response.data);
   }
 
-  static sendPasswordResetEmail(email) {
-    return authAxios
-      .post('/auth/send-password-reset-email', {
-        email,
-        tenantId: tenantSubdomain.isSubdomain
-          ? AuthCurrentTenant.get()
-          : undefined,
-      })
-      .then((response) => response.data);
-  }
-
   static registerWithEmailAndPassword(
     email,
     password,
+    acceptedTermsAndPrivacy,
     data = {},
   ) {
     const invitationToken = AuthInvitationToken.get();
@@ -39,6 +29,7 @@ export class AuthService {
         password,
         invitationToken,
         ...data,
+        acceptedTermsAndPrivacy,
         tenantId: tenantSubdomain.isSubdomain
           ? AuthCurrentTenant.get()
           : undefined,
@@ -48,6 +39,17 @@ export class AuthService {
 
         return response.data;
       });
+  }
+
+  static sendPasswordResetEmail(email) {
+    return authAxios
+      .post('/auth/send-password-reset-email', {
+        email,
+        tenantId: tenantSubdomain.isSubdomain
+          ? AuthCurrentTenant.get()
+          : undefined,
+      })
+      .then((response) => response.data);
   }
 
   static signinWithEmailAndPassword(email, password) {

--- a/frontend/src/modules/auth/pages/signup-page.vue
+++ b/frontend/src/modules/auth/pages/signup-page.vue
@@ -174,6 +174,70 @@
           </template>
         </el-form-item>
 
+        <el-form-item
+          :prop="fields.passwordConfirmation.name"
+          class="mb-0"
+        >
+          <label
+            for="passwordConfirmation"
+            class="text-xs mb-1 font-semibold leading-5"
+          >{{ fields.passwordConfirmation.label }}</label>
+          <el-input
+            id="passwordConfirmation"
+            v-model="
+              model[fields.passwordConfirmation.name]
+            "
+            autocomplete="disableauto"
+            :type="
+              display.passwordConfirm ? 'text' : 'password'
+            "
+          >
+            <template #suffix>
+              <span
+                class="ri-eye-line text-base text-gray-400 cursor-pointer"
+                @click="
+                  display.passwordConfirm = !display.passwordConfirm
+                "
+              />
+            </template>
+          </el-input>
+          <template #error="{ error }">
+            <div class="flex items-center mt-1">
+              <i
+                class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+              />
+              <span
+                class="pl-1 text-2xs text-red-500 leading-4.5"
+              >{{ error }}</span>
+            </div>
+          </template>
+        </el-form-item>
+
+        <el-form-item
+          :prop="fields.acceptedTermsAndPrivacy.name"
+          class="mb-0"
+        >
+          <el-checkbox
+            id="remember-me"
+            v-model="model[fields.acceptedTermsAndPrivacy.name]"
+          >
+            <span class="text-sm text-gray-900">
+              I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
+              and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+            </span>
+          </el-checkbox>
+          <template #error="{ error }">
+            <div class="flex items-center mt-1">
+              <i
+                class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+              />
+              <span
+                class="pl-1 text-2xs text-red-500 leading-4.5"
+              >{{ error }}</span>
+            </div>
+          </template>
+        </el-form-item>
+
         <el-form-item class="pt-4 mb-0">
           <el-button
             id="submit"

--- a/frontend/src/modules/auth/pages/signup-page.vue
+++ b/frontend/src/modules/auth/pages/signup-page.vue
@@ -178,7 +178,7 @@
           v-model="model[fields.acceptedTermsAndPrivacy.name]"
         >
           <span class="text-sm text-gray-900">
-            I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
+            I accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
             and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
           </span>
         </el-checkbox>

--- a/frontend/src/modules/auth/pages/signup-page.vue
+++ b/frontend/src/modules/auth/pages/signup-page.vue
@@ -174,69 +174,23 @@
           </template>
         </el-form-item>
 
-        <el-form-item
-          :prop="fields.passwordConfirmation.name"
-          class="mb-0"
+        <el-checkbox
+          id="remember-me"
+          v-model="model[fields.acceptedTermsAndPrivacy.name]"
         >
-          <label
-            for="passwordConfirmation"
-            class="text-xs mb-1 font-semibold leading-5"
-          >{{ fields.passwordConfirmation.label }}</label>
-          <el-input
-            id="passwordConfirmation"
-            v-model="
-              model[fields.passwordConfirmation.name]
-            "
-            autocomplete="disableauto"
-            :type="
-              display.passwordConfirm ? 'text' : 'password'
-            "
-          >
-            <template #suffix>
-              <span
-                class="ri-eye-line text-base text-gray-400 cursor-pointer"
-                @click="
-                  display.passwordConfirm = !display.passwordConfirm
-                "
-              />
-            </template>
-          </el-input>
-          <template #error="{ error }">
-            <div class="flex items-center mt-1">
-              <i
-                class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
-              />
-              <span
-                class="pl-1 text-2xs text-red-500 leading-4.5"
-              >{{ error }}</span>
-            </div>
-          </template>
-        </el-form-item>
-
-        <el-form-item
-          :prop="fields.acceptedTermsAndPrivacy.name"
-          class="mb-0"
-        >
-          <el-checkbox
-            id="remember-me"
-            v-model="model[fields.acceptedTermsAndPrivacy.name]"
-          >
-            <span class="text-sm text-gray-900">
-              I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
-              and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
-            </span>
-          </el-checkbox>
-          <template #error="{ error }">
-            <div class="flex items-center mt-1">
-              <i
-                class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
-              />
-              <span
-                class="pl-1 text-2xs text-red-500 leading-4.5"
-              >{{ error }}</span>
-            </div>
-          </template>
-        </el-form-item>
+          <span class="text-sm text-gray-900">
+            I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
+            and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+          </span>
+        </el-checkbox>
+        <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
+          <i
+            class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+          />
+          <span
+            class="pl-1 text-2xs text-red-500 leading-4.5"
+          >You have to accept terms of service and privacy policy before signing up</span>
+        </div>
 
         <el-form-item class="pt-4 mb-0">
           <el-button
@@ -310,12 +264,15 @@ export default {
         password: fields.password.forFormRules(),
         passwordConfirmation:
           fields.passwordConfirmation.forFormRules(),
+        acceptedTermsAndPrivacy:
+          fields.passwordConfirmation.forFormRules(),
       },
       model: {},
       display: {
         password: false,
         passwordConfirm: false,
       },
+      acceptTerms: false,
     };
   },
 
@@ -339,14 +296,22 @@ export default {
     ...mapActions('auth', ['doRegisterEmailAndPassword']),
 
     doSubmit() {
-      this.$refs.form.validate().then(() => this.doRegisterEmailAndPassword({
-        email: this.model.email,
-        password: this.model.password,
-        data: {
-          firstName: this.model.firstName,
-          lastName: this.model.lastName,
-        },
-      }));
+      this.acceptTerms = false;
+      this.$refs.form.validate().then(() => {
+        if (this.model.acceptedTermsAndPrivacy) {
+          this.doRegisterEmailAndPassword({
+            email: this.model.email,
+            password: this.model.password,
+            data: {
+              firstName: this.model.firstName,
+              lastName: this.model.lastName,
+            },
+            acceptedTermsAndPrivacy: this.model.acceptedTermsAndPrivacy,
+          });
+        } else {
+          this.acceptTerms = true;
+        }
+      });
     },
 
     socialOauthLink(provider) {

--- a/frontend/src/modules/auth/pages/signup-page.vue
+++ b/frontend/src/modules/auth/pages/signup-page.vue
@@ -175,7 +175,6 @@
         </el-form-item>
 
         <el-checkbox
-          id="remember-me"
           v-model="model[fields.acceptedTermsAndPrivacy.name]"
         >
           <span class="text-sm text-gray-900">

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -1,25 +1,34 @@
 <template>
   <div>
     <h3 class="text-2xl leading-12 font-semibold mb-1">
-      Terms of service & privacy policy
+      Accept terms of service & privacy policy
     </h3>
     <div class="pt-10">
-      <el-checkbox
-        id="remember-me"
-        v-model="model[fields.acceptedTermsAndPrivacy.name]"
-      >
-        <span class="text-sm text-gray-900">
-          I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
-          and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
-        </span>
-      </el-checkbox>
-      <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
-        <i
-          class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
-        />
-        <span
-          class="pl-1 text-2xs text-red-500 leading-4.5"
-        >You have to accept terms of service and privacy policy before continuing</span>
+      <div class="pb-4">
+        <el-checkbox
+          id="remember-me"
+          v-model="model[fields.acceptedTermsAndPrivacy.name]"
+        >
+          <span class="text-sm text-gray-900" /><span class="text-sm text-gray-900">  I accept the <a
+            href="https://www.crowd.dev/terms-of-use"
+            target="_blank"
+            rel="noopener noreferrer"
+          >terms of service</a>
+            and <a
+              href="https://www.crowd.dev/privacy-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >privacy policy</a>.
+          </span>
+        </el-checkbox>
+        <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
+          <i
+            class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+          />
+          <span
+            class="pl-1 text-2xs text-red-500 leading-4.5"
+          >You have to accept terms of service and privacy policy before continuing</span>
+        </div>
       </div>
 
       <el-button

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -3,9 +3,6 @@
     <h3 class="text-2xl leading-12 font-semibold mb-1">
       Terms of service & privacy policy
     </h3>
-    <!--    <p class="text-gray-500 text-xs leading-5">-->
-    <!--      You have to accept terms of service and privacy policy before continuing-->
-    <!--    </p>-->
     <div class="pt-10">
       <el-form
         ref="form"
@@ -50,10 +47,9 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex';
+import { mapActions } from 'vuex';
 import { UserModel } from '@/modules/user/user-model';
 import config from '@/config';
-import { passwordConfirmRules } from '@/modules/auth/auth-helpers';
 import { AuthService } from '@/modules/auth/auth-service';
 
 const { fields } = UserModel;
@@ -64,16 +60,14 @@ export default {
     return {
       model: {},
       acceptTerms: false,
+      loading: false,
     };
   },
 
   computed: {
-    ...mapGetters('auth', ['loading']),
-
     fields() {
       return fields;
     },
-
   },
 
   methods: {
@@ -81,13 +75,17 @@ export default {
 
     doSubmit() {
       if (this.model.acceptedTermsAndPrivacy) {
+        this.loading = true;
         AuthService.updateProfile({
           acceptedTermsAndPrivacy: this.model.acceptedTermsAndPrivacy,
         })
           .then(() => this.doRefreshCurrentUser())
           .then(() => {
             this.$router.push('/');
-          });
+          })
+          .finally(() => {
+            this.loading = false;
+          })
       } else {
         this.acceptTerms = true;
       }

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -46,9 +46,8 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapGetters } from "vuex";
 import { UserModel } from '@/modules/user/user-model';
-import config from '@/config';
 import { AuthService } from '@/modules/auth/auth-service';
 
 const { fields } = UserModel;
@@ -64,9 +63,16 @@ export default {
   },
 
   computed: {
+    ...mapGetters('auth', ['currentUser']),
     fields() {
       return fields;
     },
+  },
+
+  mounted() {
+    if (!this.currentUser) {
+      this.$router.push('/auth/signin');
+    }
   },
 
   methods: {
@@ -88,10 +94,6 @@ export default {
       } else {
         this.acceptTerms = true;
       }
-    },
-
-    socialOauthLink(provider) {
-      return `${config.backendUrl}/auth/social/${provider}`;
     },
   },
 };

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -4,44 +4,34 @@
       Terms of service & privacy policy
     </h3>
     <div class="pt-10">
-      <el-form
-        ref="form"
-        :model="model"
-        class="form mb-2"
-        label-position="left"
-        label-width="0px"
-        @submit.prevent="doSubmit"
+      <el-checkbox
+        id="remember-me"
+        v-model="model[fields.acceptedTermsAndPrivacy.name]"
       >
-        <el-checkbox
-          id="remember-me"
-          v-model="model[fields.acceptedTermsAndPrivacy.name]"
-        >
-          <span class="text-sm text-gray-900">
-            I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
-            and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
-          </span>
-        </el-checkbox>
-        <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
-          <i
-            class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
-          />
-          <span
-            class="pl-1 text-2xs text-red-500 leading-4.5"
-          >You have to accept terms of service and privacy policy before continuing</span>
-        </div>
+        <span class="text-sm text-gray-900">
+          I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
+          and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+        </span>
+      </el-checkbox>
+      <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
+        <i
+          class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+        />
+        <span
+          class="pl-1 text-2xs text-red-500 leading-4.5"
+        >You have to accept terms of service and privacy policy before continuing</span>
+      </div>
 
-        <el-form-item class="pt-4 mb-0">
-          <el-button
-            id="submit"
-            :loading="loading"
-            :disabled="!model[fields.acceptedTermsAndPrivacy.name]"
-            native-type="submit"
-            class="w-full btn btn--primary btn--lg"
-          >
-            Continue
-          </el-button>
-        </el-form-item>
-      </el-form>
+      <el-button
+        id="submit"
+        :loading="loading"
+        :disabled="!model[fields.acceptedTermsAndPrivacy.name]"
+        native-type="submit"
+        class="w-full btn btn--primary btn--lg"
+        @click="doSubmit"
+      >
+        Continue
+      </el-button>
     </div>
   </div>
 </template>
@@ -85,7 +75,7 @@ export default {
           })
           .finally(() => {
             this.loading = false;
-          })
+          });
       } else {
         this.acceptTerms = true;
       }

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
     <h3 class="text-2xl leading-12 font-semibold mb-1">
-      Accept terms of service & privacy policy
+      Terms of service & privacy policy
     </h3>
-    <p class="text-gray-500 text-xs leading-5">
-      You have to accept terms of service and privacy policy before continuing
-    </p>
+    <!--    <p class="text-gray-500 text-xs leading-5">-->
+    <!--      You have to accept terms of service and privacy policy before continuing-->
+    <!--    </p>-->
     <div class="pt-10">
       <el-form
         ref="form"
@@ -37,6 +37,7 @@
           <el-button
             id="submit"
             :loading="loading"
+            :disabled="!model[fields.acceptedTermsAndPrivacy.name]"
             native-type="submit"
             class="w-full btn btn--primary btn--lg"
           >
@@ -53,6 +54,7 @@ import { mapGetters, mapActions } from 'vuex';
 import { UserModel } from '@/modules/user/user-model';
 import config from '@/config';
 import { passwordConfirmRules } from '@/modules/auth/auth-helpers';
+import { AuthService } from '@/modules/auth/auth-service';
 
 const { fields } = UserModel;
 
@@ -75,25 +77,20 @@ export default {
   },
 
   methods: {
-    ...mapActions('auth', ['doRegisterEmailAndPassword']),
+    ...mapActions('auth', ['doRefreshCurrentUser']),
 
     doSubmit() {
-      this.acceptTerms = false;
-      this.$refs.form.validate().then(() => {
-        if (this.model.acceptedTermsAndPrivacy) {
-          this.doRegisterEmailAndPassword({
-            email: this.model.email,
-            password: this.model.password,
-            data: {
-              firstName: this.model.firstName,
-              lastName: this.model.lastName,
-            },
-            acceptedTermsAndPrivacy: this.model.acceptedTermsAndPrivacy,
+      if (this.model.acceptedTermsAndPrivacy) {
+        AuthService.updateProfile({
+          acceptedTermsAndPrivacy: this.model.acceptedTermsAndPrivacy,
+        })
+          .then(() => this.doRefreshCurrentUser())
+          .then(() => {
+            this.$router.push('/');
           });
-        } else {
-          this.acceptTerms = true;
-        }
-      });
+      } else {
+        this.acceptTerms = true;
+      }
     },
 
     socialOauthLink(provider) {

--- a/frontend/src/modules/auth/pages/terms-and-privacy.vue
+++ b/frontend/src/modules/auth/pages/terms-and-privacy.vue
@@ -1,0 +1,104 @@
+<template>
+  <div>
+    <h3 class="text-2xl leading-12 font-semibold mb-1">
+      Accept terms of service & privacy policy
+    </h3>
+    <p class="text-gray-500 text-xs leading-5">
+      You have to accept terms of service and privacy policy before continuing
+    </p>
+    <div class="pt-10">
+      <el-form
+        ref="form"
+        :model="model"
+        class="form mb-2"
+        label-position="left"
+        label-width="0px"
+        @submit.prevent="doSubmit"
+      >
+        <el-checkbox
+          id="remember-me"
+          v-model="model[fields.acceptedTermsAndPrivacy.name]"
+        >
+          <span class="text-sm text-gray-900">
+            I hereby accept the <a href="https://www.crowd.dev/terms-of-use" target="_blank" rel="noopener noreferrer">terms of service</a>
+            and <a href="https://www.crowd.dev/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+          </span>
+        </el-checkbox>
+        <div v-if="acceptTerms && !model[fields.acceptedTermsAndPrivacy.name]" class="flex items-center mt-1">
+          <i
+            class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
+          />
+          <span
+            class="pl-1 text-2xs text-red-500 leading-4.5"
+          >You have to accept terms of service and privacy policy before continuing</span>
+        </div>
+
+        <el-form-item class="pt-4 mb-0">
+          <el-button
+            id="submit"
+            :loading="loading"
+            native-type="submit"
+            class="w-full btn btn--primary btn--lg"
+          >
+            Continue
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex';
+import { UserModel } from '@/modules/user/user-model';
+import config from '@/config';
+import { passwordConfirmRules } from '@/modules/auth/auth-helpers';
+
+const { fields } = UserModel;
+
+export default {
+  name: 'AppSignupPage',
+  data() {
+    return {
+      model: {},
+      acceptTerms: false,
+    };
+  },
+
+  computed: {
+    ...mapGetters('auth', ['loading']),
+
+    fields() {
+      return fields;
+    },
+
+  },
+
+  methods: {
+    ...mapActions('auth', ['doRegisterEmailAndPassword']),
+
+    doSubmit() {
+      this.acceptTerms = false;
+      this.$refs.form.validate().then(() => {
+        if (this.model.acceptedTermsAndPrivacy) {
+          this.doRegisterEmailAndPassword({
+            email: this.model.email,
+            password: this.model.password,
+            data: {
+              firstName: this.model.firstName,
+              lastName: this.model.lastName,
+            },
+            acceptedTermsAndPrivacy: this.model.acceptedTermsAndPrivacy,
+          });
+        } else {
+          this.acceptTerms = true;
+        }
+      });
+    },
+
+    socialOauthLink(provider) {
+      return `${config.backendUrl}/auth/social/${provider}`;
+    },
+  },
+};
+</script>

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -87,12 +87,15 @@ export default {
 
   doRegisterEmailAndPassword(
     { commit },
-    { email, password, data = {} },
+    {
+      email, password, data = {}, acceptedTermsAndPrivacy,
+    },
   ) {
     commit('AUTH_START');
     return AuthService.registerWithEmailAndPassword(
       email,
       password,
+      acceptedTermsAndPrivacy,
       data,
     )
       .then((token) => {

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -126,6 +126,10 @@ const fields = {
     'createdAtRange',
     label('createdAtRange'),
   ),
+  acceptedTermsAndPrivacy: new BooleanField(
+    'acceptedTermsAndPrivacy',
+    label('acceptedTermsAndPrivacy'),
+  ),
   roleUser: new GenericField('roleUser', label('roleUser')),
 };
 

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -129,6 +129,9 @@ const fields = {
   acceptedTermsAndPrivacy: new BooleanField(
     'acceptedTermsAndPrivacy',
     label('acceptedTermsAndPrivacy'),
+    {
+      required: true,
+    },
   ),
   roleUser: new GenericField('roleUser', label('roleUser')),
 };

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -126,6 +126,7 @@ const fields = {
     'createdAtRange',
     label('createdAtRange'),
   ),
+  roleUser: new GenericField('roleUser', label('roleUser')),
   acceptedTermsAndPrivacy: new BooleanField(
     'acceptedTermsAndPrivacy',
     label('acceptedTermsAndPrivacy'),
@@ -133,7 +134,6 @@ const fields = {
       required: true,
     },
   ),
-  roleUser: new GenericField('roleUser', label('roleUser')),
 };
 
 export class UserModel extends GenericModel {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6003e7a</samp>

This pull request implements a new feature that requires users to accept the terms and privacy policy of the platform when signing up. It adds a new page, a checkbox, and a validation rule to the frontend, and a new column, a property, and a validation logic to the backend. It also adds the necessary migrations, models, repositories, services, actions, middleware, and translations to support the feature.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6003e7a</samp>

> _Oh we're the coders of the sea, and we work with skill and glee_
> _We add features to the auth, to respect the users' path_
> _We need consent for terms and privacy, so we check the `acceptedTermsAndPrivacy`_
> _Heave away, me hearties, heave away, heave away_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6003e7a</samp>

*  Add a validation check to the authSignUp endpoint to ensure that the request body has a property acceptedTermsAndPrivacy that is truthy, and return a 422 error if not (`backend/src/api/auth/authSignUp.ts`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-c0d05eb4d7cf90b40c9d7762322d538e3f9f02fd9029dd13d68850cc4a52ecf2R4-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-c0d05eb4d7cf90b40c9d7762322d538e3f9f02fd9029dd13d68850cc4a52ecf2L11-R18))
* Add a new column acceptedTermsAndPrivacy to the users table in the database, with a default value of true, and a corresponding rollback migration script (`backend/src/database/migrations/V1689235178__addTermsAndPrivacyColumn.sql`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-70405f7793b043b649c014e01c275c3aa614a2574cf45822761c80a8da3d58b6L1-L-1), `backend/src/database/migrations/U1689235178__addTermsAndPrivacyColumn.sql`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-6bfa5c70306495e292290b4d586294177a2a575c40d825a08530f8d4004e69dbR1))
* Add the acceptedTermsAndPrivacy property to the user model definition, the user model's create and update methods, and the soft-delete logic (`backend/src/database/models/user.ts`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-4e28069e7daef52565350f106d646c55782cc8e6d6116c41fd7740047f665247R98-R101), `backend/src/database/repositories/userRepository.ts`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9555b647a84703df075fcbd0c730b992e06d88e42d4102819ec1d60b3a7a675eR107), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9555b647a84703df075fcbd0c730b992e06d88e42d4102819ec1d60b3a7a675eR146), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9555b647a84703df075fcbd0c730b992e06d88e42d4102819ec1d60b3a7a675eR667))
* Add the acceptedTermsAndPrivacy parameter to the signUp method of the authService class, and pass it to the userRepository.create method (`backend/src/services/auth/authService.ts`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeR31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeR130))
* Add a condition to the auth-guard middleware that redirects the user to the terms-and-privacy page if they have not accepted the terms and privacy policy (`frontend/src/middleware/auth/auth-guard.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-fc8e2de64ded5c5a61930794e4bdd50c725951c173b22833df97e2b6e307f64bL31-R42))
* Add a new route for the terms-and-privacy path, with the TermsAndPrivacyPage component and a meta title (`frontend/src/modules/auth/auth-routes.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-fc507522736addf8c69c0ff6f6374be750b02016d97018423d12d042b89d9bccR16), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-fc507522736addf8c69c0ff6f6374be750b02016d97018423d12d042b89d9bccR73-R78))
* Add a new component file for the terms-and-privacy page, with a template, a script, and a style section, that displays the terms and privacy policy and collects the user's consent (`frontend/src/modules/auth/pages/terms-and-privacy.vue`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-27a665ee4403c1e803d1cf473c13f8e0c3984e49188f9b7e76fb85ac0d2e3347R1-R101))
* Add a checkbox element to the signup-page.vue component, with a v-model binding to the acceptedTermsAndPrivacy property of the model object, and a text span with links to the terms of service and privacy policy (`frontend/src/modules/auth/pages/signup-page.vue`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-583ea076be1f7d8d4901ce4705e7099bd4fdb989dbc9c45342fed7eac260ed92R177-R194))
* Add a validation rule, a data property, and a condition to the signup-page.vue component, to validate, track, and handle the user's consent before submitting the form (`frontend/src/modules/auth/pages/signup-page.vue`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-583ea076be1f7d8d4901ce4705e7099bd4fdb989dbc9c45342fed7eac260ed92R267-R268), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-583ea076be1f7d8d4901ce4705e7099bd4fdb989dbc9c45342fed7eac260ed92R275), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-583ea076be1f7d8d4901ce4705e7099bd4fdb989dbc9c45342fed7eac260ed92L278-R314))
* Add the acceptedTermsAndPrivacy parameter to the registerWithEmailAndPassword method of the authService class, and pass it to the authAxios.post method (`frontend/src/modules/auth/auth-service.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-b492030f92c8e05b88fbf58bb1fd74c92f3275d7748af1cea0db88e9d4078a9dL18-R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-b492030f92c8e05b88fbf58bb1fd74c92f3275d7748af1cea0db88e9d4078a9dR32))
* Add the acceptedTermsAndPrivacy parameter to the doRegisterEmailAndPassword action of the auth module's store, and pass it to the authService.registerWithEmailAndPassword method (`frontend/src/modules/auth/store/actions.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L90-R92), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R98))
* Add a new field definition for the acceptedTermsAndPrivacy property of the user model, with a type, a label, and a required rule (`frontend/src/modules/user/user-model.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-b6b75b69c63070201830d91dddfdf6206935de13ed9e3f94d828812b11ababecR129-R135))
* Add the acceptedTermsAndPrivacy property to the en object of the i18n module, for the translation of the checkbox label (`frontend/src/i18n/en.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87R573))
* Move the sendPasswordResetEmail method of the authService class to a different position in the file, for readability and consistency (`frontend/src/modules/auth/auth-service.js`, [link](https://github.com/CrowdDotDev/crowd.dev/pull/1116/files?diff=unified&w=0#diff-b492030f92c8e05b88fbf58bb1fd74c92f3275d7748af1cea0db88e9d4078a9dR44-R54))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
