### PR TITLE
Check null values in the emails list when showing merge suggestion

### DIFF
--- a/frontend/src/modules/member/components/suggestions/member-merge-suggestions-details.vue
+++ b/frontend/src/modules/member/components/suggestions/member-merge-suggestions-details.vue
@@ -198,7 +198,7 @@
           </a>
         </div>
         <a
-          v-for="email of member.emails?.filter((e) => e.length)"
+          v-for="email of member.emails?.filter((e) => e && e.length)"
           :key="email"
           :href="`mailto:${email}`"
           class="pb-2 pt-3 flex items-center text-gray-900"


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcdec9b</samp>

Fixed a bug in the member merge suggestions component that caused errors when displaying email links for members with missing or empty emails. Updated the filter condition in `member-merge-suggestions-details.vue` to handle null or undefined values.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fcdec9b</samp>

> _`filter` checks email_
> _no null or empty values_
> _links render in fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fcdec9b</samp>

*  Fix filter condition for member emails to avoid errors when rendering links ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1118/files?diff=unified&w=0#diff-af76e3e6c2b89b1661e63cd1d807c6511ac73022db9b711943aee35fe8d5718dL201-R201))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
