### PR TITLE
Custom reports widget settings

### DIFF
--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -445,6 +445,7 @@ const en = {
       },
       Activities: {
         count: '[Activities] Count',
+        cumulativeCount: '[Activities] Cumulative Count',
         type: '[Activities] Type',
         platform: '[Activities] Platform',
         date: '[Activities] Date',
@@ -457,8 +458,6 @@ const en = {
         location: '[Members] Location',
         organization: '[Members] Organization',
         joinedAt: '[Members] Joined Date',
-        averageTimeToFirstInteraction:
-          '[Members] Avg. Time To First Interaction',
       },
       MemberTags: {
         count: '[Members] # of Tags',

--- a/frontend/src/modules/widget/components/cube/_query_builder/DimensionSelect.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/DimensionSelect.vue
@@ -20,7 +20,7 @@
       >
         <el-option
           v-for="item in translatedOptions(
-            computedDimensions,
+            computedDimensions, 'No dimension',
           )"
           :key="item.value"
           :value="item.value"
@@ -148,13 +148,21 @@ export default {
         return [];
       }
 
-      return this.availableDimensions.filter((t) => !!this.measureDimensions[
+      const isCumulative = measure.name.includes('cumulative');
+
+      const parsedDimensions = this.availableDimensions.filter((t) => !!this.measureDimensions[
         measure.name
       ]?.includes(t.name));
+
+      if (isCumulative) {
+        return [{}].concat(parsedDimensions);
+      }
+
+      return parsedDimensions;
     },
     value: {
       get() {
-        return this.translatedOptions(this.dimensions).map(
+        return this.translatedOptions(this.dimensions, 'No dimension').map(
           (i) => i.name,
         )?.[0];
       },

--- a/frontend/src/modules/widget/components/cube/_query_builder/DimensionSelect.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/DimensionSelect.vue
@@ -73,6 +73,17 @@ export default {
           'Segments.name',
           'Tags.name',
         ],
+        'Activities.cumulativeCount': [
+          'Activities.platform',
+          'Activities.type',
+          'Activities.date',
+          'Activities.channel',
+          'Members.score',
+          'Members.location',
+          'Members.joinedAt',
+          'Members.organization',
+          'Tags.name',
+        ],
         'Members.count': [
           'Activities.platform',
           'Activities.type',
@@ -82,7 +93,17 @@ export default {
           'Members.location',
           'Members.joinedAt',
           'Members.organization',
-          'Segments.name',
+          'Tags.name',
+        ],
+        'Members.cumulativeCount': [
+          'Activities.platform',
+          'Activities.type',
+          'Activities.date',
+          'Activities.channel',
+          'Members.score',
+          'Members.location',
+          'Members.joinedAt',
+          'Members.organization',
           'Tags.name',
         ],
         'Conversations.count': [
@@ -99,48 +120,65 @@ export default {
           'Members.location',
           'Members.joinedAt',
           'Members.organization',
-          'Segments.name',
           'Tags.name',
         ],
         'Sentiment.averageSentiment': ['Sentiment.platform'],
+        'Organizations.count': [
+          'Activities.platform',
+          'Activities.type',
+          'Activities.date',
+          'Activities.channel',
+          'Members.score',
+          'Members.location',
+          'Members.joinedAt',
+          'Members.organization',
+          'Organizations.createdat',
+          'Tags.name',
+        ],
+        'MemberTags.count': [],
+        'Tags.count': [],
       },
     };
   },
   computed: {
     computedDimensions() {
-      const measure = this.measures[0];
-      return !measure
-        ? []
-        : this.availableDimensions.filter((t) => !!this.measureDimensions[
-          measure.name
-        ]?.includes(t.name));
+      const measure = this.measures?.[0];
+
+      if (!measure) {
+        return [];
+      }
+
+      return this.availableDimensions.filter((t) => !!this.measureDimensions[
+        measure.name
+      ]?.includes(t.name));
     },
     value: {
       get() {
-        const measure = this.measures[0];
-
-        // Select first option by default if measure changes
-        if (measure) {
-          const hasOption = this.measureDimensions[
-            measure.name
-          ]?.includes(this.dimensions?.[0]?.name);
-
-          if (
-            !hasOption
-            && this.measureDimensions[measure.name]?.[0]
-          ) {
-            this.setDimensions([
-              this.measureDimensions[measure.name][0],
-            ]);
-          }
-        }
-
         return this.translatedOptions(this.dimensions).map(
           (i) => i.name,
         )?.[0];
       },
       set(value) {
         return this.setDimensions([value]);
+      },
+    },
+  },
+
+  watch: {
+    measures: {
+      // Select first option by default if measure changes
+      handler(updatedMeasures, previousMeasures) {
+        if (updatedMeasures?.[0].name !== previousMeasures?.[0].name) {
+          if (
+            this.computedDimensions?.[0]
+          ) {
+            this.setDimensions([
+              this.computedDimensions[0].name,
+            ]);
+          } else {
+            this.setDimensions([]);
+          }
+        }
       },
     },
   },

--- a/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/FilterComponent.vue
@@ -228,6 +228,7 @@ import { onSelectMouseLeave } from '@/utils/select';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import { ActivityModel } from '@/modules/activity/activity-model';
 import { MemberModel } from '@/modules/member/member-model';
+import isEqual from 'lodash/isEqual';
 
 const { fields: activityFields } = ActivityModel;
 const { fields: memberFields } = MemberModel;
@@ -449,8 +450,17 @@ export default {
         JSON.parse(JSON.stringify(this.filters))
           .map((f) => {
             const filter = f;
+            const { values } = filter;
 
-            [filter.value] = f.values;
+            if (filter.member.name === 'Members.score') {
+              const parsedValues = values.map((v) => Number(v));
+              const engagement = this.computedEngagementLevelTypes.find((t) => isEqual(t.value, parsedValues))?.label;
+
+              filter.value = engagement;
+            } else {
+              [filter.value] = values;
+            }
+
             filter.select = f.member.name;
 
             delete filter.member;

--- a/frontend/src/modules/widget/components/cube/_query_builder/MeasureSelect.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/MeasureSelect.vue
@@ -16,7 +16,7 @@
       @change="onSelectChange"
     >
       <el-option
-        v-for="item in translatedOptions(availableMeasures)"
+        v-for="item in translatedOptions(filteredAvailableMeasures)"
         :key="item.value"
         :label="item.label"
         :value="item.value"
@@ -56,6 +56,16 @@ export default {
     return {
       selectedMeasure: [],
     };
+  },
+  computed: {
+    filteredAvailableMeasures() {
+      return this.availableMeasures.filter(
+        (m) => m.name !== 'Identities.count'
+          && m.name !== 'Segments.count'
+          && m.name !== 'Members.earliestJoinedAt'
+          && m.name !== 'Members.averageTimeToFirstInteraction',
+      );
+    },
   },
   methods: {
     onSelectMouseLeave,

--- a/frontend/src/modules/widget/components/cube/_query_builder/TimeDimensionSelect.vue
+++ b/frontend/src/modules/widget/components/cube/_query_builder/TimeDimensionSelect.vue
@@ -53,25 +53,60 @@ export default {
   data() {
     return {
       measureTimeDimensions: {
-        'Activities.count': ['Activities.date'],
+        'Activities.count': [
+          'Activities.date',
+        ],
+        'Activities.cumulativeCount': [
+          'Activities.date',
+        ],
+        'Conversations.count': [
+          'Conversations.createdat',
+        ],
         'Members.count': [
           'Members.joinedAt',
           'Activities.date',
         ],
-        'Conversations.count': ['Conversations.createdat'],
-        'Sentiment.averageSentiment': ['Sentiment.date'],
-        'Organizations.count': ['Organizations.createdat'],
+        'Members.cumulativeCount': [
+          'Members.joinedAt',
+          'Activities.date',
+        ],
+        'Sentiment.averageSentiment': [
+          'Sentiment.date',
+        ],
+        'Organizations.count': [
+          'Organizations.createdat',
+        ],
+        'MemberTags.count': [],
+        'Tags.count': [],
       },
     };
   },
   computed: {
     computedTimeDimensions() {
       const measure = this.measures[0];
-      return !measure
-        ? []
-        : this.availableTimeDimensions.filter((t) => !!this.measureTimeDimensions[
-          measure.name
-        ]?.includes(t.name));
+
+      if (!measure) {
+        return [];
+      }
+
+      return this.availableTimeDimensions.filter((t) => !!this.measureTimeDimensions[
+        measure.name
+      ]?.includes(t.name));
+    },
+  },
+  watch: {
+    measures: {
+      handler(updatedMeasures, previousMeasures) {
+        if (updatedMeasures?.[0].name !== previousMeasures?.[0].name) {
+          if (
+            this.computedTimeDimensions?.[0]
+          ) {
+            this.handleTimeChange(this.computedTimeDimensions[0].name);
+          } else {
+            this.handleTimeChange();
+          }
+        }
+      },
     },
   },
   methods: {

--- a/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
@@ -66,11 +66,7 @@
                 <MeasureSelect
                   :translated-options="translatedOptions"
                   :measures="measures"
-                  :available-measures="
-                    availableMeasures.filter(
-                      (m) => m.name !== 'Identities.count',
-                    )
-                  "
+                  :available-measures="availableMeasures"
                   :set-measures="setMeasures"
                 />
               </div>

--- a/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-builder.vue
@@ -376,11 +376,11 @@ export default {
         settings,
       };
     },
-    translatedOptions(list) {
+    translatedOptions(list, fallback) {
       return list.map((i) => ({
         ...i,
         value: i.name,
-        label: i18n(`widget.cubejs.${i.name}`),
+        label: i.name ? i18n(`widget.cubejs.${i.name}`) : fallback || '',
       }));
     },
     handleAdditionalSettingsClick() {

--- a/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube-renderer.vue
@@ -72,23 +72,28 @@ export default {
     query() {
       // Exclude team members in all queries
       const widgetQuery = this.widget.settings.query;
-      const isTeamMemberFilter = {
-        member: 'Members.isTeamMember',
-        operator: 'equals',
-        values: ['0'],
-      };
-      const isBot = {
-        member: 'Members.isBot',
-        operator: 'equals',
-        values: ['0'],
-      };
+      const filters = widgetQuery.filters || [];
 
-      if (!widgetQuery.filters) {
-        widgetQuery.filters = [isTeamMemberFilter, isBot];
-      } else {
-        widgetQuery.filters.push(isTeamMemberFilter);
-        widgetQuery.filters.push(isBot);
+      const hasTeamMemberFilter = filters.some((f) => f.member === 'Members.isTeamMember');
+      const hasBotFilter = filters.some((f) => f.member === 'Members.isBot');
+
+      if (!hasTeamMemberFilter) {
+        filters.push({
+          member: 'Members.isTeamMember',
+          operator: 'equals',
+          values: ['0'],
+        });
       }
+
+      if (!hasBotFilter) {
+        filters.push({
+          member: 'Members.isBot',
+          operator: 'equals',
+          values: ['0'],
+        });
+      }
+
+      widgetQuery.filters = filters;
 
       return widgetQuery;
     },

--- a/frontend/src/modules/widget/components/cube/widget-cube.vue
+++ b/frontend/src/modules/widget/components/cube/widget-cube.vue
@@ -134,11 +134,11 @@ export default {
       return this.widget.settings.chartType || 'line';
     },
     subtitle() {
-      const granularity = this.widget.settings.query.timeDimensions.length > 0
+      const granularity = this.widget.settings.query.timeDimensions?.length > 0
         ? this.widget.settings.query.timeDimensions[0]
           .granularity
         : null;
-      const dateRange = this.widget.settings.query.timeDimensions.length > 0
+      const dateRange = this.widget.settings.query.timeDimensions?.length > 0
         ? this.widget.settings.query.timeDimensions[0]
           .dateRange || 'All time'
         : null;


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0640ee</samp>

This pull request improves the frontend components for the cube.js widget builder and renderer. It adds support for cumulative measures and their dimensions, removes unsupported or obsolete measures and dimensions, implements default filters to exclude team members and bots from the queries, and refactors some of the component logic to enhance readability and performance. It also updates the `en` locale file with translation keys for the frontend.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e0640ee</samp>

> _This pull request is quite a refactor_
> _Of the `widget-cube` and its factors_
> _It handles time and filters_
> _And some translation helpers_
> _To make the cube.js queries faster_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0640ee</samp>

*  Add and remove translation keys for the `en` locale file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87R448), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87L460-L461))
*  Add and remove dimensions and filter categories for various measures in the `DimensionSelect` and `FilterComponent` components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L23-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8R76-R86), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L85-R108), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L102-R139), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L111-R190), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L266), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L272), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L279-R297), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L289), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L295), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L301-R335))
*  Add and remove time dimensions for various measures in the `TimeDimensionSelect` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-48a57128df008bb91d25e79b90f582650d37731fda552dd23a18b11de2f0ce10L56-R80), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-48a57128df008bb91d25e79b90f582650d37731fda552dd23a18b11de2f0ce10L70-R111))
*  Filter out some measures that are not relevant or supported by the backend in the `MeasureSelect` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-5fb01985cb8218107059ea623da4f15edfa1f4fe12faa3e2697ddd55c2842e20L19-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-5fb01985cb8218107059ea623da4f15edfa1f4fe12faa3e2697ddd55c2842e20R60-R69), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-622919f6445fc9b5bfe8b23bbf68b5bee28026636732ef375f8b714b73262a64L69-R69))
*  Add a fallback argument to handle undefined names for cumulative measures in the `translatedOptions` method in the `DimensionSelect` and `widget-cube-builder` components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L23-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-622919f6445fc9b5bfe8b23bbf68b5bee28026636732ef375f8b714b73262a64L383-R383))
*  Add a `defaultFilters` property to store the filters that exclude team members and bots from the queries in the `FilterComponent` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L341-R373))
*  Add `watch` handlers to update the dimension and filter values when the measure changes in the `DimensionSelect`, `FilterComponent`, and `TimeDimensionSelect` components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L111-R190), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558R412-R422), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-48a57128df008bb91d25e79b90f582650d37731fda552dd23a18b11de2f0ce10L70-R111))
*  Refactor the `computedDimensions` and `computedTimeDimensions` computed properties to simplify the logic and handle cumulative measures in the `DimensionSelect` and `FilterComponent` components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-346e282dfcaa9aa273eb6bdc37a785fd6ff261e7f9d6761c4efdea30c2e3a9a8L111-R190), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L349-R396))
*  Modify the `syncFilters` and `handleFilterChange` methods to add the team members and bots filters to the `defaultFilters` array instead of emitting them as options in the `FilterComponent` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L411-R474), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f5ee8726211bd4c476165fde97623419c3d731f40b5b55a58fa126f5a11c7558L448-R511))
*  Refactor the `widgetQuery` computed property to check and add the team members and bots filters to the query in the `widget-cube-renderer` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-77021f58ac2deb7a694e3f73c65dc57c5bce86b0871ce7cc738b380bb659fad7L75-R97))
*  Add optional chaining operators to handle undefined time dimensions in the `subtitle` computed property in the `widget-cube` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1126/files?diff=unified&w=0#diff-f1f42681d0677bd8e758902875e2afaec1a447a5ba0dc41a9d27bb4e9a6e44b1L137-R141))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
