### PR TITLE
Coalesce createdById and updatedById when inserting into conversationSettings

### DIFF
--- a/services/libs/conversations/src/repo/conversation.repo.ts
+++ b/services/libs/conversations/src/repo/conversation.repo.ts
@@ -62,7 +62,7 @@ export class ConversationRepository extends RepositoryBase<ConversationRepositor
     const now = new Date()
     const result = await this.db().result(
       `insert into "conversationSettings"(id, "tenantId", "createdAt", "updatedAt", "createdById")
-       values ($(id), $(tenantId), $(now), $(now), (select "createdById" from tenants where id = $(tenantId) limit 1));`,
+       values ($(id), $(tenantId), $(now), $(now), (select coalesce("createdById", "updatedById") as "createdById" from tenants where id = $(tenantId) limit 1));`,
       {
         id,
         tenantId,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef022d6</samp>

Fixed a bug in `conversation.repo.ts` that caused an error when inserting a conversation setting for a tenant with no `createdById`. Used the SQL coalesce function to select either the `createdById` or the `updatedById` from the tenants table as the `createdById` for the conversation setting.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ef022d6</samp>

> _`coalesce` used_
> _to avoid null references_
> _autumn of settings_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef022d6</samp>

*  Modify SQL query for inserting conversation setting to use coalesce function for `createdById` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1138/files?diff=unified&w=0#diff-1676136fe81dc9e98855135a513fc17da4917c16a5dc71ee382a2dee6bdf1eaeL65-R65))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
