### PR TITLE
integration fetching on automations

### DIFF
--- a/frontend/src/modules/automation/components/automation-form.vue
+++ b/frontend/src/modules/automation/components/automation-form.vue
@@ -139,8 +139,8 @@
 
 <script setup>
 import {
-  computed, defineProps, defineEmits, reactive, ref, watch,
-} from 'vue';
+  computed, defineProps, defineEmits, reactive, ref, watch, onMounted
+} from "vue";
 import AppDrawer from '@/shared/drawer/drawer.vue';
 import { required } from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
@@ -154,6 +154,7 @@ import { useAutomationStore } from '@/modules/automation/store';
 import Message from '@/shared/message/message';
 import { i18n } from '@/i18n';
 import formChangeDetector from '@/shared/form/form-change';
+import { useStore } from "vuex";
 
 const props = defineProps({
   modelValue: {
@@ -176,6 +177,9 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'update:automation']);
 
 const { createAutomation, updateAutomation, getAutomations } = useAutomationStore();
+
+const store = useStore();
+const fetchIntegrations = () => store.dispatch('integration/doFetch');
 
 const isDrawerOpen = computed({
   get() {
@@ -287,6 +291,14 @@ const doSubmit = () => {
   }
 };
 
+onMounted(() => {
+  fetchIntegrations();
+  storeUnsubscribe.value = store.subscribeAction((action) => {
+    if (action.type === 'auth/doRefreshCurrentUser') {
+      fetchIntegrations();
+    }
+  });
+});
 </script>
 
 <script>

--- a/frontend/src/modules/automation/components/automation-form.vue
+++ b/frontend/src/modules/automation/components/automation-form.vue
@@ -139,8 +139,8 @@
 
 <script setup>
 import {
-  computed, defineProps, defineEmits, reactive, ref, watch, onMounted
-} from "vue";
+  computed, defineProps, defineEmits, reactive, ref, watch, onMounted,
+} from 'vue';
 import AppDrawer from '@/shared/drawer/drawer.vue';
 import { required } from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
@@ -154,7 +154,7 @@ import { useAutomationStore } from '@/modules/automation/store';
 import Message from '@/shared/message/message';
 import { i18n } from '@/i18n';
 import formChangeDetector from '@/shared/form/form-change';
-import { useStore } from "vuex";
+import { useStore } from 'vuex';
 
 const props = defineProps({
   modelValue: {
@@ -293,11 +293,6 @@ const doSubmit = () => {
 
 onMounted(() => {
   fetchIntegrations();
-  storeUnsubscribe.value = store.subscribeAction((action) => {
-    if (action.type === 'auth/doRefreshCurrentUser') {
-      fetchIntegrations();
-    }
-  });
 });
 </script>
 

--- a/frontend/src/modules/automation/pages/automation-list-page.vue
+++ b/frontend/src/modules/automation/pages/automation-list-page.vue
@@ -109,6 +109,7 @@
 
     <!-- Add/Edit Webhook form drawer -->
     <app-automation-form
+      v-if="openAutomationForm"
       v-model="openAutomationForm"
       v-model:automation="editAutomation"
       :type="automationFormType"


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce1053a</samp>

The pull request improves the user experience of creating and editing automations by fetching the latest integrations from the backend and rendering the `automation-form` component only when needed. It modifies the `automation-form.vue` and `automation-list-page.vue` files in the frontend.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ce1053a</samp>

> _`v-if` is the gate to the form of doom_
> _Only the chosen ones can enter the room_
> _Integrations from the abyss, they rise and fall_
> _`automation-form` will summon them all_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce1053a</samp>

*  Import and use `onMounted` and `useStore` functions to fetch and update integrations for automation form ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1140/files?diff=unified&w=0#diff-af7fc74427fed918806899a913627e78a4b2ba57a2987413892b717ae0c38ef9L142-R143), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1140/files?diff=unified&w=0#diff-af7fc74427fed918806899a913627e78a4b2ba57a2987413892b717ae0c38ef9R157), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1140/files?diff=unified&w=0#diff-af7fc74427fed918806899a913627e78a4b2ba57a2987413892b717ae0c38ef9R181-R183), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1140/files?diff=unified&w=0#diff-af7fc74427fed918806899a913627e78a4b2ba57a2987413892b717ae0c38ef9R294-R301))
* Add `v-if` directive to conditionally render `automation-form` component in `automation-list-page` component based on `openAutomationForm` prop ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1140/files?diff=unified&w=0#diff-c8fc825d29cfce46804a71d0e0a086343f1f4ba4f8810c40c52d6fb00384708bR112))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
