### PR TITLE
Add process-data script

### DIFF
--- a/services/apps/integration_data_worker/src/bin/process-data.ts
+++ b/services/apps/integration_data_worker/src/bin/process-data.ts
@@ -1,0 +1,42 @@
+import { DB_CONFIG, SQS_CONFIG } from '@/conf'
+import IntegrationDataRepository from '@/repo/integrationData.repo'
+import { DbStore, getDbConnection } from '@crowd/database'
+import { getServiceLogger } from '@crowd/logging'
+import { IntegrationDataWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import { IntegrationStreamDataState } from '@crowd/types'
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(2)
+
+if (processArguments.length !== 1) {
+  log.error('Expected 1 argument: dataId')
+  process.exit(1)
+}
+
+const dataIds = processArguments[0].split(',')
+
+setImmediate(async () => {
+  const sqsClient = getSqsClient(SQS_CONFIG())
+  const emitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  await emitter.init()
+
+  const dbConnection = getDbConnection(DB_CONFIG(), 1)
+  const store = new DbStore(log, dbConnection)
+  const repo = new IntegrationDataRepository(store, log)
+
+  for (const dataId of dataIds) {
+    const info = await repo.getDataInfo(dataId)
+
+    if (info) {
+      if (info.state !== IntegrationStreamDataState.PENDING) {
+        await repo.resetStream(dataId)
+      }
+
+      await emitter.triggerDataProcessing(info.tenantId, info.integrationType, dataId)
+    } else {
+      log.error({ dataId }, 'Data stream not found!')
+      process.exit(1)
+    }
+  }
+})

--- a/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
+++ b/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
@@ -236,4 +236,22 @@ export default class IntegrationDataRepository extends RepositoryBase<Integratio
 
     this.checkUpdateRowCount(result.rowCount, 1)
   }
+
+  public async resetStream(dataId: string): Promise<void> {
+    const result = await this.db().result(
+      `update integration."apiData"
+       set  state = $(state),
+            error = null,
+            "delayedUntil" = null,
+            "processedAt" = null,
+            "updatedAt" = now()
+       where id = $(dataId)`,
+      {
+        dataId,
+        state: IntegrationStreamState.PENDING,
+      },
+    )
+
+    this.checkUpdateRowCount(result.rowCount, 1)
+  }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f43b9e</samp>

Added a `resetStream` method to `IntegrationDataRepo` to update the database record of an apiData stream and mark it as pending for processing. This is part of a feature that enables users to retry failed or delayed streams from the integration dashboard.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f43b9e</samp>

> _`resetStream` method_
> _Clears and updates apiData_
> _A fresh start for spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f43b9e</samp>

*  Add `resetStream` method to `IntegrationDataRepo` class to update apiData record state and clear error and delay fields ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1141/files?diff=unified&w=0#diff-21267776815b1a718da34dc9ad833ea27be064ba2ede0c1535f218f6492ba093R239-R256))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
