### PR TITLE
Add `dateStart` and `dateEnd` to primary key for `memberOrganizations`

### DIFF
--- a/backend/src/database/migrations/U1689846910__affiliations-primary-key.sql
+++ b/backend/src/database/migrations/U1689846910__affiliations-primary-key.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "memberOrganizations" DROP CONSTRAINT "memberOrganizations_pkey";
+ALTER TABLE "memberOrganizations" DROP COLUMN "id";
+DROP INDEX "memberOrganizations_unique";
+
+DELETE
+FROM "memberOrganizations"
+WHERE ctid NOT IN (
+    SELECT MIN(ctid)
+    FROM "memberOrganizations"
+    GROUP BY "memberId", "organizationId"
+);
+
+ALTER TABLE "memberOrganizations" ADD PRIMARY KEY ("memberId", "organizationId");
+

--- a/backend/src/database/migrations/V1689846910__affiliations-primary-key.sql
+++ b/backend/src/database/migrations/V1689846910__affiliations-primary-key.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "memberOrganizations" DROP CONSTRAINT "memberOrganizations_pkey";
+ALTER TABLE "memberOrganizations" ADD COLUMN "id" UUID NOT NULL DEFAULT uuid_generate_v4();
+ALTER TABLE "memberOrganizations" ADD PRIMARY KEY (id);
+ALTER TABLE "memberOrganizations" ADD UNIQUE ("memberId", "organizationId", "dateStart", "dateEnd");
+

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3245,8 +3245,7 @@ class MemberRepository {
     const query = `
       INSERT INTO "memberOrganizations" ("memberId", "organizationId", "createdAt", "updatedAt", "title", "dateStart", "dateEnd")
       VALUES (:memberId, :organizationId, NOW(), NOW(), :title, :dateStart, :dateEnd)
-      ON CONFLICT ("memberId", "organizationId") DO UPDATE
-      SET "title" = :title, "dateStart" = :dateStart, "dateEnd" = :dateEnd
+      ON CONFLICT ("memberId", "organizationId", "dateStart", "dateEnd") DO NOTHING
     `
 
     await seq.query(query, {


### PR DESCRIPTION
To allow for multiple employments in the same org during different times

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95d4586</samp>

This pull request changes the primary key of the `memberOrganizations` table from `id` to `memberId` and `organizationId`, and updates the `MemberRepository` class accordingly. This simplifies the data model and avoids unnecessary columns and indexes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 95d4586</samp>

> _`memberOrganizations`_
> _Simpler schema, less columns_
> _Spring cleaning the data_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95d4586</samp>

*  Simplify the data model and avoid unnecessary columns and indexes for the `memberOrganizations` table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1150/files?diff=unified&w=0#diff-93c255675b81a1fbe94b4995b93aee320115075cdcb1d413d119d74f2c8c8041R1-R14))
* Align the application logic with the new database schema and prevent any unwanted data changes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1150/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3248-R3248))
* Ensure data integrity and consistency in case the previous changes cause any issues or conflicts ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1150/files?diff=unified&w=0#diff-df5c01c67c57d84ac1eca1d8fdc77e279e4dbc88fe6849c2bb9c7d747f2f4010R1-R5))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
