### PR TITLE
Integrate lfx header with refactored authentication logic (#1151)

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,8 +1,14 @@
 <template>
-  <div v-show="!loading" id="app">
+  <div id="app">
     <div class="sm:hidden md:block lg:block">
       <lfx-header-v2 v-if="showLfxMenu" id="lfx-header" product="Community Management" />
-      <router-view v-slot="{ Component }">
+      <div v-if="!isAuthenticated" class="flex items-center bg-white h-screen w-screen justify-center">
+        <div
+          v-loading="true"
+          class="app-page-spinner h-20 w-20 !relative !min-h-20 custom"
+        />
+      </div>
+      <router-view v-show="!loading" v-slot="{ Component }">
         <transition>
           <div>
             <component :is="Component" />
@@ -25,6 +31,7 @@ import AppResizePage from '@/modules/layout/pages/resize-page.vue';
 import { FeatureFlag } from '@/featureFlag';
 import config from '@/config';
 import { AuthToken } from '@/modules/auth/auth-token';
+import { Auth0Service } from '@/shared/services/auth0.service';
 
 export default {
   name: 'App',
@@ -37,6 +44,7 @@ export default {
     ...mapGetters({
       loadingInit: 'auth/loadingInit',
       currentTenant: 'auth/currentTenant',
+      isAuthenticated: 'auth/isAuthenticated',
     }),
     ...mapState({
       featureFlag: (state) => state.tenant.featureFlag,
@@ -55,6 +63,7 @@ export default {
   },
 
   async created() {
+    await Auth0Service.init();
     await this.doInit();
 
     FeatureFlag.init(this.currentTenant);
@@ -94,4 +103,9 @@ export default {
 
 <style lang="scss">
 @import 'assets/scss/index.scss';
+
+.app-page-spinner.custom .el-loading-spinner .circular {
+  height: 12rem;
+  width: 12rem;
+}
 </style>

--- a/frontend/src/middleware/auth/auth-guard.js
+++ b/frontend/src/middleware/auth/auth-guard.js
@@ -1,6 +1,7 @@
 import { PermissionChecker } from '@/modules/user/permission-checker';
 import config from '@/config';
 import { tenantSubdomain } from '@/modules/tenant/tenant-subdomain';
+import { Auth0Service } from '@/shared/services/auth0.service';
 
 function isGoingToIntegrationsPage(to) {
   return to.name === 'integration';
@@ -34,8 +35,11 @@ export default async function ({ to, store, router }) {
     currentUser,
   );
 
-  if (!permissionChecker.isAuthenticated) {
+  const isAuthenticated = await Auth0Service.isAuthenticated();
+
+  if (!permissionChecker.isAuthenticated || !isAuthenticated) {
     router.push({ path: '/auth/signin' });
+    Auth0Service.localLogout();
     return;
   }
 

--- a/frontend/src/middleware/auth/unauth-guard.js
+++ b/frontend/src/middleware/auth/unauth-guard.js
@@ -13,7 +13,7 @@ import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
  * @param router
  * @returns {Promise<*>}
  */
-export default function ({ to, router }) {
+export default async function ({ to, router }) {
   if (!to.meta || !to.meta.unauth) {
     return;
   }

--- a/frontend/src/modules/auth/auth-routes.js
+++ b/frontend/src/modules/auth/auth-routes.js
@@ -1,4 +1,3 @@
-import Layout from '@/modules/layout/components/layout.vue';
 import AuthLayout from '@/modules/auth/layouts/auth-layout.vue';
 
 const SigninPage = () => import('@/modules/auth/pages/signin-page.vue');

--- a/frontend/src/modules/auth/pages/callback.vue
+++ b/frontend/src/modules/auth/pages/callback.vue
@@ -17,9 +17,9 @@ const { doSigninWithAuth0 } = mapActions('auth');
 onMounted(() => {
   Auth0Service.handleAuth()
     .then(() => {
-      const { idToken } = Auth0Service.authData();
-
-      return doSigninWithAuth0(idToken);
+      Auth0Service.authData().then((token) => {
+        doSigninWithAuth0(token);
+      });
     })
     .catch(() => {
       Auth0Service.logout();

--- a/frontend/src/modules/auth/pages/signin-page.vue
+++ b/frontend/src/modules/auth/pages/signin-page.vue
@@ -12,8 +12,8 @@ import { Auth0Service } from '@/shared/services/auth0.service';
 
 export default {
   name: 'AppSigninPage',
-  created() {
-    Auth0Service.loginWithRedirect();
+  async created() {
+    await Auth0Service.loginWithRedirect();
   },
 };
 </script>

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -40,6 +40,10 @@ export default {
     }
   },
 
+  authenticate({ commit }) {
+    commit('AUTHENTICATE');
+  },
+
   doWaitUntilInit({ getters }) {
     if (!getters.loadingInit) {
       return Promise.resolve();

--- a/frontend/src/modules/auth/store/getters.js
+++ b/frontend/src/modules/auth/store/getters.js
@@ -3,6 +3,7 @@ import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
 import { tenantSubdomain } from '@/modules/tenant/tenant-subdomain';
 
 export default {
+  isAuthenticated: (state) => state.isAuthenticated,
   currentUser: (state) => state.currentUser,
   currentTenant: (state) => state.currentTenant,
   currentTenantUser: (state) => {

--- a/frontend/src/modules/auth/store/mutations.js
+++ b/frontend/src/modules/auth/store/mutations.js
@@ -9,6 +9,10 @@ export default {
     );
   },
 
+  AUTHENTICATE(state) {
+    state.isAuthenticated = true;
+  },
+
   AUTH_START(state) {
     state.loading = true;
   },

--- a/frontend/src/modules/auth/store/state.js
+++ b/frontend/src/modules/auth/store/state.js
@@ -9,4 +9,5 @@ export default () => ({
   loadingPasswordChange: false,
   loadingUpdateProfile: false,
   loading: false,
+  isAuthenticated: false,
 });

--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -33,6 +33,7 @@ export default {
     ...mapGetters({
       currentUser: 'auth/currentUser',
       currentTenant: 'auth/currentTenant',
+      isAuthenticated: 'auth/isAuthenticated',
       menu: 'layout/menuCollapsed',
     }),
   },
@@ -58,20 +59,26 @@ export default {
         }
       },
     },
+    isAuthenticated: {
+      immediate: true,
+      async handler(value) {
+        if (value) {
+          try {
+            const user = await Auth0Service.getUser();
+            const lfxHeader = document.getElementById('lfx-header');
+
+            if (lfxHeader) {
+              lfxHeader.authuser = user;
+            }
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      },
+    },
   },
 
   async mounted() {
-    try {
-      const user = await Auth0Service.getUser();
-      const lfxHeader = document.getElementById('lfx-header');
-
-      if (lfxHeader) {
-        lfxHeader.authuser = user;
-      }
-    } catch (e) {
-      console.error(e);
-    }
-
     identify(this.currentUser);
     this.initPendo();
   },

--- a/frontend/src/shared/types/LocalStorage.ts
+++ b/frontend/src/shared/types/LocalStorage.ts
@@ -1,6 +1,0 @@
-export enum LocalStorageEnum {
-  ID_TOKEN = 'crowd_id_token',
-  ACCESS_TOKEN = 'crowd_access_token',
-  AUTH_PROFILE = 'crowd_auth_profile',
-  ID_TOKEN_EXPIRATION = 'crowd_id_token_expiration',
-}


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1e6d08</samp>

The pull request adds Auth0 authentication and authorization to the frontend app, using cookies and refresh tokens instead of local storage. It modifies the app, layout, auth, and middleware components and files to integrate the Auth0 service and client, and to display the user data and authentication state. It also deletes the unused `LocalStorage.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f1e6d08</samp>

> _The app needed some authentication_
> _So they used Auth0 for verification_
> _They added `async` and `isAuthenticated`_
> _And cookies and tokens were validated_
> _Now the layout shows the user information_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1e6d08</samp>

*  Enable Auth0 authentication using cookies and refresh tokens ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003L2-R11),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R34),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R47),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R66),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R106-R110),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc8e2de64ded5c5a61930794e4bdd50c725951c173b22833df97e2b6e307f64bR4),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc8e2de64ded5c5a61930794e4bdd50c725951c173b22833df97e2b6e307f64bL37-R42),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-283fc55e0acc672defafb2260ff415dfd24d97be63aedc27e672511b18a5c06eL16-R16),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc507522736addf8c69c0ff6f6374be750b02016d97018423d12d042b89d9bccL1),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-a933dfd93424a7a962d6cb4c6e55601efafd9d01882118dac9ba087ad3ac95b5L20-R22),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d540583828a2bd9fe431fbe7bb1b9f421fed34fc3b34efc49f21cc247f58f219L15-R16),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R43-R46),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4e3b3098a18a16ca6eea0a6a49d6a72979488af0cd89c9bf0a4b4087b6cd5741R6),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eR12-R15),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4d3ce3aa8457b30dc4a05aba036c6097583f727e2c5948a00dc232e297f9524eR12),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR36),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bL61-R81),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-3d5774914e8126ba7a274bf40f12b98412ea65760f1bdee43ed85e12b53950ddL1-R4),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-3d5774914e8126ba7a274bf40f12b98412ea65760f1bdee43ed85e12b53950ddL18-R70),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-c87b20842c3381b71e952d3389064f34f2ec4928df3453f49d6018bf93a08164))
  * Move `v-show="!loading"` directive from root div to `router-view` component in `app.vue` to prevent rendering before authentication check ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003L2-R11))
  * Add loading spinner div and CSS style in `app.vue` to show while verifying authentication ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R106-R110))
  * Import `Auth0Service` from shared services folder in `app.vue` and `auth-guard.js` to use its methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R34),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc8e2de64ded5c5a61930794e4bdd50c725951c173b22833df97e2b6e307f64bR4))
  * Add `isAuthenticated` getter to computed properties in `app.vue` and `layout.vue` to access authentication state from auth store module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R47),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR36))
  * Call `Auth0Service.init()` in created hook of `app.vue` to initialize Auth0 client and check authentication status ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-e57ce48fce61efad33780eabdfed4f8cf08d7cd2f335ec53ab495502a85b8003R66))
  * Add `isAuthenticated` method to auth guard middleware in `auth-guard.js` to check Auth0 authentication and redirect to signin page if not authenticated ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc8e2de64ded5c5a61930794e4bdd50c725951c173b22833df97e2b6e307f64bL37-R42))
  * Add `async` keyword to unauth guard middleware in `unauth-guard.js` and created hook of `signin-page.vue` to make them compatible with async methods of `Auth0Service` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-283fc55e0acc672defafb2260ff415dfd24d97be63aedc27e672511b18a5c06eL16-R16),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d540583828a2bd9fe431fbe7bb1b9f421fed34fc3b34efc49f21cc247f58f219L15-R16))
  * Remove `Layout` component from auth routes file in `auth-routes.js` as it is not needed for signin and callback pages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-fc507522736addf8c69c0ff6f6374be750b02016d97018423d12d042b89d9bccL1))
  * Simplify `handleAuth` method in `callback.vue` to only handle Auth0 redirect callback and change `authData` method to use promise instead of synchronous return value ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-a933dfd93424a7a962d6cb4c6e55601efafd9d01882118dac9ba087ad3ac95b5L20-R22))
  * Add `authenticate` action to auth store module in `actions.js` to dispatch `AUTHENTICATE` mutation when authenticated with Auth0 ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R43-R46))
  * Add `isAuthenticated` getter to auth store module in `getters.js` to return authentication state from store ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4e3b3098a18a16ca6eea0a6a49d6a72979488af0cd89c9bf0a4b4087b6cd5741R6))
  * Add `AUTHENTICATE` mutation to auth store module in `mutations.js` to set authentication state to true when authenticated with Auth0 ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eR12-R15))
  * Add `isAuthenticated` state to auth store module in `state.js` to store authentication state as boolean value ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-4d3ce3aa8457b30dc4a05aba036c6097583f727e2c5948a00dc232e297f9524eR12))
  * Add `isAuthenticated` watcher to `layout.vue` to handle changes in authentication state and update lfx-header component with user data from `Auth0Service` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bL61-R81))
  * Modify `Auth0ServiceClass` in `auth0.service.ts` to use cookies and refresh tokens instead of local storage for authentication data and add `isAuthenticated` and `init` methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-3d5774914e8126ba7a274bf40f12b98412ea65760f1bdee43ed85e12b53950ddL1-R4),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-3d5774914e8126ba7a274bf40f12b98412ea65760f1bdee43ed85e12b53950ddL18-R70))
  * Delete `LocalStorage.ts` file as it is no longer used for storing authentication data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1158/files?diff=unified&w=0#diff-c87b20842c3381b71e952d3389064f34f2ec4928df3453f49d6018bf93a08164))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
