### PR TITLE
Cubejs schema updates for preaggregations

### DIFF
--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -97,6 +97,7 @@ cube(`Members`, {
       measures: [Members.count],
       dimensions: [
         Members.score,
+        Members.joinedAt,
         Members.location,
         Members.tenantId,
         Members.isTeamMember,
@@ -141,6 +142,25 @@ cube(`Members`, {
         Members.isOrganization,
         Segments.id,
         Activities.type,
+      ],
+      timeDimension: Activities.date,
+      granularity: `day`,
+      refreshKey: {
+        every: `10 minute`,
+      },
+    },
+
+    MembersByActivityIsContribution: {
+      measures: [Members.count],
+      dimensions: [
+        Members.score,
+        Members.location,
+        Members.tenantId,
+        Members.isTeamMember,
+        Members.isBot,
+        Members.isOrganization,
+        Segments.id,
+        Activities.iscontribution,
       ],
       timeDimension: Activities.date,
       granularity: `day`,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afae894</samp>

This pull request enhances the `Members` schema with new dimensions and cubes to support better analytics of member behavior and engagement. It allows querying members by their join date and contribution type using the `joinedAt` dimension and the `MembersByActivityIsContribution` cube.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at afae894</samp>

> _To analyze members with flair_
> _We added some cubes and a `joinedAt` layer_
> _Now we can see_
> _Who contributes what and when they agree_
> _And how to improve member retention and care_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afae894</samp>

* Add a new dimension to the `Members` cube to track the join date of members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1178/files?diff=unified&w=0#diff-25a3b498daa1b4590f9bc69dfa3b2a15b502df38e12e9350d85d7ccacd9f6a53R100))
* Create a new cube `MembersByActivityIsContribution` to aggregate members by their score, location, tenantId, and activity type ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1178/files?diff=unified&w=0#diff-25a3b498daa1b4590f9bc69dfa3b2a15b502df38e12e9350d85d7ccacd9f6a53R152-R170))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
