### PR TITLE
Cubejs joinedAt dimension with unix timestamp form

### DIFF
--- a/backend/src/cubejs/schema/Members.js
+++ b/backend/src/cubejs/schema/Members.js
@@ -97,7 +97,7 @@ cube(`Members`, {
       measures: [Members.count],
       dimensions: [
         Members.score,
-        Members.joinedAt,
+        Members.joinedAtUnixTs,
         Members.location,
         Members.tenantId,
         Members.isTeamMember,
@@ -312,6 +312,12 @@ cube(`Members`, {
       sql: `${CUBE}."joinedAt"`,
       type: `time`,
     },
+
+    joinedAtUnixTs: {
+      sql: `EXTRACT(EPOCH FROM ${CUBE}."joinedAt")`,
+      type: `number`,
+    },
+
     score: {
       sql: `${CUBE}."score"`,
       type: `number`,

--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -138,14 +138,14 @@ export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
   ],
   filters: [
     {
-      member: 'Members.joinedAt',
+      member: 'Members.joinedAtUnixTs',
       operator: 'beforeDate',
       values: [
         moment()
           .utc()
           .startOf('day')
           .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
+          .unix(),
       ],
     },
     ...getCubeFilters({

--- a/scripts/services/frontend.yaml
+++ b/scripts/services/frontend.yaml
@@ -3,7 +3,7 @@ version: '3.1'
 services:
   frontend:
     build:
-      context: ../frontend
+      context: ../../frontend
       dockerfile: Dockerfile.dev
     env_file:
       - ../../frontend/.env.dist.local
@@ -22,7 +22,7 @@ services:
 
   frontend-dev:
     build:
-      context: ../frontend
+      context: ../../frontend
       dockerfile: Dockerfile.dev
     env_file:
       - ../../frontend/.env.dist.local


### PR DESCRIPTION
Cubejs doesn't support time dimensions as a regular dimensions. 
This PR introduces a UNIX timestamp version of `Members.joinedAt` so that we can also use it in regular dimensions when filtering

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98a5323</samp>

Fixed time zone issues in the `Members` cube and the `TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY` by using Unix epoch values. Changed the schema in `backend/src/cubejs/schema/Members.js` and the filter in `frontend/src/modules/widget/widget-queries.js`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 98a5323</samp>

> _`joinedAt` epoch_
> _a new dimension for time_
> _no more zone issues_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98a5323</samp>

*  Replace `Members.joinedAt` dimension with `Members.joinedAtUnixTs` dimension in `Members` cube to avoid time zone issues ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1180/files?diff=unified&w=0#diff-25a3b498daa1b4590f9bc69dfa3b2a15b502df38e12e9350d85d7ccacd9f6a53L100-R100))
*  Add `Members.joinedAtUnixTs` dimension to `Members` cube using SQL `EXTRACT` function to get Unix epoch number from `joinedAt` column ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1180/files?diff=unified&w=0#diff-25a3b498daa1b4590f9bc69dfa3b2a15b502df38e12e9350d85d7ccacd9f6a53R315-R320))
*  Update `TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY` filter in `widget-queries.js` to use `Members.joinedAtUnixTs` dimension instead of `Members.joinedAt` dimension for consistency and accuracy ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1180/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L141-R141))
*  Change `TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY` filter value in `widget-queries.js` to Unix epoch number using `moment.unix()` method to match `Members.joinedAtUnixTs` dimension type and format ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1180/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L148-R148))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
