### PR TITLE
Fix a bug in Github integration when member has an empty name

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -2013,7 +2013,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           integrationId: context.integration.id,
         },
       } as PlatformIdentities,
-      displayName: memberFromApi.name,
+      displayName: memberFromApi.name.trim() || memberFromApi.login,
       attributes: {
         [MemberAttributeName.IS_HIREABLE]: {
           [PlatformType.GITHUB]: memberFromApi.isHireable || false,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b9596f</samp>

Set `displayName` of members to non-empty name from GitHub API in `githubIntegrationService.ts`. This improves the profile display on crowd.dev.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7b9596f</samp>

> _`displayName` set_
> _from GitHub name or login_
> _no blanks in winter_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b9596f</samp>

*  Set member display name to trimmed name or login from GitHub API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1181/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L2016-R2016))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
