### PR TITLE
Cubejs joinedAtUnixTs now uses number lt filter

### DIFF
--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -139,7 +139,7 @@ export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
   filters: [
     {
       member: 'Members.joinedAtUnixTs',
-      operator: 'beforeDate',
+      operator: 'lt',
       values: [
         moment()
           .utc()


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4f5053</samp>

Fixed a bug in the widget query for active returning members by using the `lt` operator instead of `beforeDate` for the `Members.joinedAtUnixTs` filter. This was part of a pull request to improve the widget queries in `frontend/src/modules/widget/widget-queries.js`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4f5053</samp>

> _`beforeDate` gone_
> _`lt` fixes widget bug_
> _Autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4f5053</samp>

*  Fix bug in active returning members query by using exclusive filter operator ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1182/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L142-R142))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
