### PR TITLE
Cubejs joinedAt filter is stringified before sending to api

### DIFF
--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -145,7 +145,8 @@ export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
           .utc()
           .startOf('day')
           .subtract(period.value, period.granularity)
-          .unix().toString(),
+          .unix()
+          .toString(),
       ],
     },
     ...getCubeFilters({

--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -145,7 +145,7 @@ export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
           .utc()
           .startOf('day')
           .subtract(period.value, period.granularity)
-          .unix(),
+          .unix().toString(),
       ],
     },
     ...getCubeFilters({


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d27ae65</samp>

Fix a bug in the widget query for active returning members. The change ensures the timestamp argument is a string, as required by the GraphQL schema.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d27ae65</samp>

> _`TOTAL_ACTIVE` query_
> _Unix timestamp to string_
> _Winter bug is fixed_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d27ae65</samp>

*  Fix `TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY` bug by converting timestamp to string ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1183/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L148-R148))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
