### PR TITLE
Prevent `falsy` values from being included in member emails

### DIFF
--- a/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
+++ b/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
@@ -80,7 +80,10 @@ const { currentTenant, currentUser } = mapGetters('auth');
 
 const identitiesDrawer = ref(false);
 
-const emails = computed(() => props.member.emails);
+const emails = computed(() => (props.member.emails
+  // Filters out any falsy values (like `null`, `undefined)
+  ? props.member.emails.filter(Boolean)
+  : []));
 
 const socialIdentities = computed(() => {
   const identities = { ...props.member.username };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a9cf06</samp>

Fixed a bug that caused rendering errors when displaying member emails in the identities drawer. Filtered out any falsy values from the `emails` computed property in `frontend/src/modules/member/components/view/_aside/_aside-identities.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a9cf06</samp>

> _`emails` filtered_
> _no more falsy values shown_
> _bug fixed in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a9cf06</samp>

*  Filter out falsy values from member emails to avoid rendering errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1186/files?diff=unified&w=0#diff-8a798a180aeda9f4c67a513073a8f07295701fe7602d572bab6c9a473db1d631L83-R86))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
