### PR TITLE
Fix GitHub undefined name

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts
@@ -2013,7 +2013,7 @@ export class GithubIntegrationService extends IntegrationServiceBase {
           integrationId: context.integration.id,
         },
       } as PlatformIdentities,
-      displayName: memberFromApi.name.trim() || memberFromApi.login,
+      displayName: memberFromApi?.name?.trim() || memberFromApi.login,
       attributes: {
         [MemberAttributeName.IS_HIREABLE]: {
           [PlatformType.GITHUB]: memberFromApi.isHireable || false,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 298da84</samp>

Fixed a bug in `GithubIntegrationService` that caused some GitHub members to be skipped during import. Added optional chaining operators to handle null or undefined names in `backend/src/serverless/integrations/services/integrations/githubIntegrationService.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 298da84</samp>

> _`memberFromApi`?_
> _Name may be null or empty_
> _Fall bug, fixed with `?.`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 298da84</samp>

*  Add optional chaining operators to prevent errors when GitHub member name is null or undefined ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1196/files?diff=unified&w=0#diff-93f2daaa968f5bec5c40cd31fc27ac6422ea3dcbdabecf3ef80f3c16802d1c30L2016-R2016))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
