### PR TITLE
Introduce new cache which is tied up to integrationId

### DIFF
--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -257,6 +257,12 @@ export default class IntegrationStreamService extends LoggerBase {
 
     const globalCache = new RedisCache(`int-global`, this.redisClient, this.log)
 
+    const integrationCache = new RedisCache(
+      `int-${streamInfo.integrationId}`,
+      this.redisClient,
+      this.log,
+    )
+
     const nangoConfig = NANGO_CONFIG()
 
     const context: IProcessWebhookStreamContext = {
@@ -286,6 +292,7 @@ export default class IntegrationStreamService extends LoggerBase {
       log: this.log,
       cache,
       globalCache,
+      integrationCache,
 
       publishData: async (data) => {
         await this.publishData(
@@ -403,6 +410,12 @@ export default class IntegrationStreamService extends LoggerBase {
 
     const globalCache = new RedisCache(`int-global`, this.redisClient, this.log)
 
+    const integrationCache = new RedisCache(
+      `int-${streamInfo.integrationId}`,
+      this.redisClient,
+      this.log,
+    )
+
     const nangoConfig = NANGO_CONFIG()
 
     const context: IProcessStreamContext = {
@@ -433,6 +446,7 @@ export default class IntegrationStreamService extends LoggerBase {
       log: this.log,
       cache,
       globalCache,
+      integrationCache,
 
       publishData: async (data) => {
         await this.publishData(

--- a/services/libs/integrations/src/integrations/github/processStream.ts
+++ b/services/libs/integrations/src/integrations/github/processStream.ts
@@ -64,7 +64,7 @@ function getAuth(ctx: IProcessStreamContext): AuthInterface | undefined {
 
 const getTokenFromCache = async (ctx: IProcessStreamContext) => {
   const key = 'github-token-cache'
-  const cache = ctx.cache
+  const cache = ctx.integrationCache // this cache is tied up with integrationId
 
   const token = await cache.get(key)
 
@@ -77,7 +77,7 @@ const getTokenFromCache = async (ctx: IProcessStreamContext) => {
 
 const setTokenToCache = async (ctx: IProcessStreamContext, token: AppTokenResponse) => {
   const key = 'github-token-cache'
-  const cache = ctx.cache
+  const cache = ctx.integrationCache // this cache is tied up with integrationId
 
   // cache for 5 minutes
   await cache.set(key, JSON.stringify(token), 5 * 60)
@@ -97,7 +97,7 @@ async function getGithubToken(ctx: IProcessStreamContext): Promise<string> {
       appToken = await getAppToken(jwtToken, ctx.integration.identifier)
     }
 
-    setTokenToCache(ctx, appToken)
+    await setTokenToCache(ctx, appToken)
 
     return appToken.token
   }
@@ -115,6 +115,9 @@ async function getMemberEmail(ctx: IProcessStreamContext, login: string): Promis
     return ''
   }
 
+  // here we use cache for tenantId-integrationType
+  // So in LFX case different integration will have access to the same cache
+  // But this is fine
   const cache = ctx.cache
 
   const existing = await cache.get(login)

--- a/services/libs/integrations/src/types.ts
+++ b/services/libs/integrations/src/types.ts
@@ -9,6 +9,9 @@ export interface IIntegrationContext {
   onboarding?: boolean
   integration: IIntegration
   log: Logger
+  /**
+   * Cache that is tied up to the tenantId and integration type
+   */
   cache: ICache
 
   publishStream: <T>(identifier: string, metadata?: T) => Promise<void>
@@ -45,7 +48,15 @@ export interface IProcessStreamContext extends IIntegrationContext {
 
   abortWithError: (message: string, metadata?: unknown, error?: Error) => Promise<void>
 
+  /**
+   * Global cache that is shared between all integrations
+   */
   globalCache: ICache
+
+  /**
+   * Cache that is shared between all streams of the same integration (integrationId)
+   */
+  integrationCache: ICache
 
   getRateLimiter: (maxRequests: number, timeWindowSeconds: number, cacheKey: string) => IRateLimiter
 }
@@ -65,7 +76,15 @@ export interface IProcessWebhookStreamContext {
 
   abortWithError: (message: string, metadata?: unknown, error?: Error) => Promise<void>
 
+  /**
+   * Global cache that is shared between all integrations
+   */
   globalCache: ICache
+
+  /**
+   * Cache that is shared between all streams of the same integration (integrationId)
+   */
+  integrationCache: ICache
 
   getRateLimiter: (maxRequests: number, timeWindowSeconds: number, cacheKey: string) => IRateLimiter
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 844bd71</samp>

This pull request enhances the caching logic for the integration stream and webhook services, using different cache instances for different scopes of data. It also updates the GitHub integration and the integration types to use the new cache instances. This improves the performance, isolation, and consistency of the integration processing.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 844bd71</samp>

> _Heave away, me hearties, heave away with glee_
> _We're caching integration data with `RedisCache` keys_
> _Heave away, me hearties, heave away with pride_
> _We're improving performance and isolation with every tide_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 844bd71</samp>

*  Create and use separate RedisCache instances for each integration stream and webhook service, to avoid sharing the same global cache with other integrations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R260-R265), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R295), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R413-R418), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R449) in `integrationStreamService.ts`)
*  Modify the getTokenFromCache and setTokenToCache functions in `github/processStream.ts` to use the integrationCache instead of the globalCache, to ensure that the GitHub token is cached per integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L67-R67), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L80-R80), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L100-R100))
*  Add the integrationCache property and the corresponding comment to the IProcessStreamContext and IProcessWebhookStreamContext interfaces in `types.ts`, to define the cache that is shared between all streams of the same integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-ab03d52a0b9ccb74ef823f4c1f05a34027f401bc6c2a6183c8baf0056ee8c450L48-R60), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-ab03d52a0b9ccb74ef823f4c1f05a34027f401bc6c2a6183c8baf0056ee8c450L68-R88))
*  Add comments to the IIntegrationContext interface in `types.ts` and the getMemberEmail function in `github/processStream.ts` to explain the purpose and limitations of the globalCache, which is shared between all integrations and can be used for data that is not specific to an integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-ab03d52a0b9ccb74ef823f4c1f05a34027f401bc6c2a6183c8baf0056ee8c450R12-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1200/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2R118-R120))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
