### PR TITLE
Fix path to the docker context for python-worker

### DIFF
--- a/scripts/services/python-worker.yaml
+++ b/scripts/services/python-worker.yaml
@@ -8,7 +8,7 @@ x-env-args: &env-args
 services:
   python-worker:
     build:
-      context: ../backend/src/serverless/microservices/python
+      context: ../../backend/src/serverless/microservices/python
       dockerfile: Dockerfile.kube
     env_file:
       - ../../backend/.env.dist.local
@@ -23,7 +23,7 @@ services:
 
   python-worker-dev:
     build:
-      context: ../backend/src/serverless/microservices/python
+      context: ../../backend/src/serverless/microservices/python
       dockerfile: Dockerfile.kube
     user: '${USER_ID}:${GROUP_ID}'
     env_file:


### PR DESCRIPTION
# Changes proposed ✍️
Minor change to dix the docker context for the `python-worker`.

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c95004b</samp>

Changed the `contextPath` for python-worker services in `scripts/services/python-worker.yaml` to match the new backend layout. This fixes a bug where the services could not run the python scripts.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c95004b</samp>

> _The backend had a new folder design_
> _So the services needed to realign_
> _They changed `contextPath`_
> _To avoid any wrath_
> _From the python scripts they run online_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c95004b</samp>

*  Update context path for python-worker and python-worker-dev services to match new backend location ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1204/files?diff=unified&w=0#diff-f4bb76947c81f91398c7a4496c935f09321520d4a9441c9c09eeb757d58d1a6eL11-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1204/files?diff=unified&w=0#diff-f4bb76947c81f91398c7a4496c935f09321520d4a9441c9c09eeb757d58d1a6eL26-R26))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
