### PR TITLE
Formbricks prevent sending empty data

### DIFF
--- a/frontend/src/modules/auth/store/mutations.js
+++ b/frontend/src/modules/auth/store/mutations.js
@@ -22,10 +22,18 @@ export default {
     state.loading = false;
 
     if (state.currentUser) {
-      formbricks.setEmail(state.currentUser.email);
-      formbricks.setUserId(state.currentUser.id);
-      formbricks.setAttribute('name', state.currentUser.fullName);
-      formbricks.setAttribute('registrationDate', state.currentUser.createdAt);
+      if (state.currentUser.email) {
+        formbricks.setEmail(state.currentUser.email);
+      }
+      if (state.currentUser.id) {
+        formbricks.setUserId(state.currentUser.id);
+      }
+      if (state.currentUser.fullName) {
+        formbricks.setAttribute('name', state.currentUser.fullName);
+      }
+      if (state.currentUser.createdAt) {
+        formbricks.setAttribute('registrationDate', state.currentUser.createdAt);
+      }
       const timestampSignup = new Date(
         state.currentUser.createdAt,
       ).getTime();
@@ -128,10 +136,18 @@ export default {
     state.loadingInit = false;
 
     if (state.currentUser) {
-      formbricks.setEmail(state.currentUser.email);
-      formbricks.setUserId(state.currentUser.id);
-      formbricks.setAttribute('name', state.currentUser.fullName);
-      formbricks.setAttribute('registrationDate', state.currentUser.createdAt);
+      if (state.currentUser.email) {
+        formbricks.setEmail(state.currentUser.email);
+      }
+      if (state.currentUser.id) {
+        formbricks.setUserId(state.currentUser.id);
+      }
+      if (state.currentUser.fullName) {
+        formbricks.setAttribute('name', state.currentUser.fullName);
+      }
+      if (state.currentUser.createdAt) {
+        formbricks.setAttribute('registrationDate', state.currentUser.createdAt);
+      }
       const timestampSignup = new Date(
         state.currentUser.createdAt,
       ).getTime();


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71d87c3</samp>

Improved `formbricks` integration in `auth` store by adding conditional checks. This fixes potential bugs with user attributes for feedback and analytics.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71d87c3</samp>

> _Oh we're the crew of the `auth` store_
> _And we work with `formbricks` galore_
> _We set the user attributes right_
> _On the count of three, heave with all your might_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71d87c3</samp>

*  Add conditional checks before calling `formbricks` methods to set user attributes in `state.currentUser` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1210/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL25-R36), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1210/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL131-R150))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
