### PR TITLE
fix hubspot identity and scale plan limitations

### DIFF
--- a/frontend/src/modules/automation/automation-limit.js
+++ b/frontend/src/modules/automation/automation-limit.js
@@ -3,6 +3,7 @@ import { router } from '@/router';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 
 const workflowMax = {
+  scale: 'unlimited',
   enterprise: 'unlimited',
   growth: 10,
   essential: 2,
@@ -13,6 +14,9 @@ const workflowMax = {
  * @returns maximum number of workflows
  */
 export const getWorkflowMax = (plan) => {
+  if (plan === Plans.values.scale) {
+    return workflowMax.scale;
+  }
   if (plan === Plans.values.enterprise) {
     return workflowMax.enterprise;
   } if (

--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -294,7 +294,7 @@
                     }"
                     class="block"
                   >
-                    <app-member-identities :username="scope.row.username" />
+                    <app-member-identities :username="scope.row.username" :member="scope.row" />
                   </router-link>
                 </template>
               </el-table-column>

--- a/frontend/src/modules/member/components/member-identities.vue
+++ b/frontend/src/modules/member/components/member-identities.vue
@@ -17,6 +17,7 @@
           :tooltip-label="platformContent(platform).tooltipLabel"
           :as-link="platformContent(platform).asLink"
           :show-handles-badge="true"
+          :backup-url="props.member.attributes.url[platform]"
         />
       </div>
     </div>
@@ -32,6 +33,10 @@ import { CrowdIntegrations } from '@/integrations/integrations-config';
 
 const props = defineProps({
   username: {
+    type: Object,
+    default: () => {},
+  },
+  member: {
     type: Object,
     default: () => {},
   },

--- a/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
+++ b/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
@@ -21,6 +21,7 @@
         <app-platform-list
           :username-handles="socialIdentities[platform]"
           :platform="platform"
+          :url="member.attributes.url[platform]"
         />
       </div>
     </div>

--- a/frontend/src/modules/member/member-export-limit.js
+++ b/frontend/src/modules/member/member-export-limit.js
@@ -3,6 +3,7 @@ import { router } from '@/router';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 
 const exportMax = {
+  scale: 'unlimited',
   enterprise: 'unlimited',
   growth: 10,
   essential: 2,
@@ -13,6 +14,9 @@ const exportMax = {
  * @returns maximum number of exports
  */
 export const getExportMax = (plan) => {
+  if (plan === Plans.values.scale) {
+    return exportMax.scale;
+  }
   if (plan === Plans.values.enterprise) {
     return exportMax.enterprise;
   } if (

--- a/frontend/src/modules/organization/components/view/organization-view-members.vue
+++ b/frontend/src/modules/organization/components/view/organization-view-members.vue
@@ -55,6 +55,7 @@
             </div>
             <app-member-identities
               :username="member.username"
+              :member="member"
             />
           </div>
         </div>

--- a/frontend/src/shared/platform/platform-list.vue
+++ b/frontend/src/shared/platform/platform-list.vue
@@ -55,10 +55,17 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  url: {
+    type: String,
+    default: null,
+  },
 });
 
 const asLink = computed(() => CrowdIntegrations.getConfig(props.platform)?.showProfileLink);
-const getPlatformUrl = ({ platform, username }) => CrowdIntegrations.getConfig(platform)?.url(username);
+const getPlatformUrl = ({ platform, username }) => {
+  const url = CrowdIntegrations.getConfig(platform)?.url(username);
+  return url ?? props.url;
+};
 </script>
 
 <script>

--- a/frontend/src/shared/platform/platform.vue
+++ b/frontend/src/shared/platform/platform.vue
@@ -97,6 +97,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  backupUrl: {
+    type: String,
+    default: null,
+  },
 });
 
 const imageProperties = computed(() => CrowdIntegrations.getConfig(props.platform));
@@ -105,7 +109,7 @@ const href = computed(() => {
     return props.href;
   }
 
-  return (props.usernameHandles.length === 1 ? CrowdIntegrations.getConfig(props.platform)?.url(props.usernameHandles[0]) : null);
+  return (props.usernameHandles.length === 1 ? (CrowdIntegrations.getConfig(props.platform)?.url(props.usernameHandles[0]) ?? props.backupUrl) : null);
 });
 
 const trackClick = () => {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c26388</samp>

This pull request adds a new `scale` plan option for automation and member export features, and improves the display of member's social media profiles by using custom URLs. It modifies `automation-limit.js`, `member-export-limit.js`, `_aside-identities.vue`, and `platform-list.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c26388</samp>

> _To show off their social media flair_
> _`AsideIdentities` gets a new prop `url`_
> _`PlatformList` also uses it with care_
> _And `getPlatformUrl` has a fallback to unfurl_
> _The custom links for each member to share_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c26388</samp>

*  Add `scale` plan value and conditional logic for automation and member export limits ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-9865775a22b3d47bb67cf9dc964f5a00af8ef99995174e20197bbda5ce079b58R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-9865775a22b3d47bb67cf9dc964f5a00af8ef99995174e20197bbda5ce079b58R17-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-076ceb7fcaa10b29467c0f55c99382fac4ce62a024527dacbd0f915156fd87c6R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-076ceb7fcaa10b29467c0f55c99382fac4ce62a024527dacbd0f915156fd87c6R17-R19))
* Add `url` prop and fallback logic for displaying member's social media profiles ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-8a798a180aeda9f4c67a513073a8f07295701fe7602d572bab6c9a473db1d631R24), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1213/files?diff=unified&w=0#diff-b441d844c9efdc175733ff046eb4f2b19c27b9e9463fc77b91b0a2b3749ad7b7L58-R68))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
