### PR TITLE
Fix scale plan enrichment limit

### DIFF
--- a/frontend/src/modules/automation/automation-limit.js
+++ b/frontend/src/modules/automation/automation-limit.js
@@ -3,6 +3,7 @@ import { router } from '@/router';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 
 const workflowMax = {
+  scale: 'unlimited',
   enterprise: 'unlimited',
   growth: 10,
   essential: 2,
@@ -13,9 +14,13 @@ const workflowMax = {
  * @returns maximum number of workflows
  */
 export const getWorkflowMax = (plan) => {
+  if (plan === Plans.values.scale) {
+    return workflowMax.scale;
+  }
   if (plan === Plans.values.enterprise) {
     return workflowMax.enterprise;
-  } if (
+  }
+  if (
     plan === Plans.values.growth
   ) {
     return workflowMax.growth;

--- a/frontend/src/modules/member/member-enrichment.js
+++ b/frontend/src/modules/member/member-enrichment.js
@@ -7,6 +7,7 @@ import { formatNumber } from '@/utils/number';
 import Message from '@/shared/message/message';
 import { FeatureFlag, FEATURE_FLAGS } from '@/featureFlag';
 
+const scaleEnrichmentMax = 10000;
 const growthEnrichmentMax = 1000;
 const essentialEnrichmentMax = 5;
 
@@ -15,6 +16,11 @@ const essentialEnrichmentMax = 5;
  * @returns maximum number of enrichments
  */
 export const getEnrichmentMax = (plan) => {
+  if (
+    plan === Plans.values.scale
+  ) {
+    return scaleEnrichmentMax;
+  }
   if (
     plan === Plans.values.growth
     || plan === Plans.values.enterprise

--- a/frontend/src/modules/member/member-export-limit.js
+++ b/frontend/src/modules/member/member-export-limit.js
@@ -3,6 +3,7 @@ import { router } from '@/router';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 
 const exportMax = {
+  scale: 'unlimited',
   enterprise: 'unlimited',
   growth: 10,
   essential: 2,
@@ -13,9 +14,13 @@ const exportMax = {
  * @returns maximum number of exports
  */
 export const getExportMax = (plan) => {
+  if (plan === Plans.values.scale) {
+    return exportMax.scale;
+  }
   if (plan === Plans.values.enterprise) {
     return exportMax.enterprise;
-  } if (
+  }
+  if (
     plan === Plans.values.growth
   ) {
     return exportMax.growth;


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6297116</samp>

Adjust enrichment limit for scale plan in frontend. Use a new constant `scaleEnrichmentMax` in `member-enrichment.js` to determine the maximum number of enrichments allowed for the scale plan.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6297116</samp>

> _`scaleEnrichmentMax`_
> _A new limit for the plan_
> _Autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6297116</samp>

*  Define and use a constant for the maximum enrichments allowed for the scale plan ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1214/files?diff=unified&w=0#diff-44a780e6a3997fcccbdef31f04d51c635d02e2f108718aa6ca6a39f9703143edR10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1214/files?diff=unified&w=0#diff-44a780e6a3997fcccbdef31f04d51c635d02e2f108718aa6ca6a39f9703143edR20-R24)) in `frontend/src/modules/member/member-enrichment.js`
*  Add a condition to the `getEnrichmentMax` function that returns the constant if the plan type is scale ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1214/files?diff=unified&w=0#diff-44a780e6a3997fcccbdef31f04d51c635d02e2f108718aa6ca6a39f9703143edR20-R24))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
