### PR TITLE
fix: Disable submit button in bulk members tags update

### DIFF
--- a/frontend/src/modules/tag/components/tag-popover.vue
+++ b/frontend/src/modules/tag/components/tag-popover.vue
@@ -12,7 +12,7 @@
         <el-button class="btn btn--bordered btn--md mr-3" @click="handleCancel">
           Cancel
         </el-button>
-        <el-button class="btn btn--primary btn--md" @click="handleSubmit">
+        <el-button class="btn btn--primary btn--md" @click="handleSubmit" :disabled="!hasSelectedRole">
           Submit
         </el-button>
       </div>
@@ -74,6 +74,9 @@ export default {
     },
     membersToUpdate() {
       return this.member ? [this.member]: selectedMembers.value;
+    },
+    hasSelectedRole() {
+      return this.editTagsModel.length > 0;
     },
   },
 


### PR DESCRIPTION
# Changes proposed ✍️

Fixes: #1192 

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c8324a</samp>

Update tag popover component to require role selection. This prevents users from creating or editing tags without specifying a role for them in `frontend/src/modules/tag/components/tag-popover.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1c8324a</samp>

> _To edit a tag in the popover_
> _You must pick a role, not just hover_
> _The `hasSelectedRole` prop_
> _And the button's disabled stop_
> _You from saving a tag with no cover_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1c8324a</samp>

*  Disable submit button in tag popover unless a role is selected ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1215/files?diff=unified&w=0#diff-b1ccdd455d3f528eb8a322b0579f5303edc1292b0191399a2f3a073c005d99afL15-R15), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1215/files?diff=unified&w=0#diff-b1ccdd455d3f528eb8a322b0579f5303edc1292b0191399a2f3a073c005d99afR78-R80))
* Remove empty line at the end of script tag in `tag-popover.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1215/files?diff=unified&w=0#diff-b1ccdd455d3f528eb8a322b0579f5303edc1292b0191399a2f3a073c005d99afL139-L138))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.

https://github.com/CrowdDotDev/crowd.dev/assets/125653095/80cc723c-faf1-47a8-87d9-6b6c14255f99

