### PR TITLE
Fix reports timestamps

### DIFF
--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -95,66 +95,82 @@ export const TOTAL_ACTIVE_MEMBERS_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamMembers: selectedHasTeamMembers,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc(),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamMembers: selectedHasTeamMembers,
+    }),
+  };
+};
 
 export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
   period,
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: [
-    {
-      member: 'Members.joinedAtUnixTs',
-      operator: 'lt',
-      values: [
-        moment()
-          .utc()
-          .startOf('day')
-          .subtract(period.value, period.granularity)
-          .unix()
-          .toString(),
-      ],
-    },
-    ...getCubeFilters({
-      platforms: selectedPlatforms,
-      hasTeamMembers: selectedHasTeamMembers,
-    }),
-  ],
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc(),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: [
+      {
+        member: 'Members.joinedAtUnixTs',
+        operator: 'lt',
+        values: [
+          moment()
+            .utc()
+            .startOf('day')
+            .subtract(period.value, period.granularity)
+            .unix()
+            .toString(),
+        ],
+      },
+      ...getCubeFilters({
+        platforms: selectedPlatforms,
+        hasTeamMembers: selectedHasTeamMembers,
+      }),
+    ],
+  };
+};
 
 export const TOTAL_MEMBERS_QUERY = ({
   period,
@@ -163,13 +179,12 @@ export const TOTAL_MEMBERS_QUERY = ({
   selectedHasTeamMembers,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc();
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)
       // we're subtracting one more day, to get the last value of the previous period within the same request
-      .subtract(1, 'day')
-      .format('YYYY-MM-DD');
+      .subtract(1, 'day');
 
     return [start, end];
   };
@@ -257,9 +272,8 @@ export const TOTAL_MONTHLY_ACTIVE_CONTRIBUTORS = ({
           moment()
             .utc()
             .startOf('month')
-            .subtract(period.value, period.granularity)
-            .format('YYYY-MM-DD'),
-          moment().utc().format('YYYY-MM-DD'),
+            .subtract(period.value, period.granularity),
+          moment().utc(),
         ],
       }),
       dimension: 'Activities.date',
@@ -278,82 +292,98 @@ export const ACTIVITIES_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamActivities: selectedHasTeamActivities,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc(),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamActivities: selectedHasTeamActivities,
+    }),
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_TYPES_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  order: {
-    'Activities.count': 'desc',
-  },
-  dimensions: ['Activities.platform', 'Activities.type'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day');
+
+  return {
+    measures: ['Activities.count'],
+    order: {
+      'Activities.count': 'desc',
     },
-  ],
-  filters:
+    dimensions: ['Activities.platform', 'Activities.type'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc(),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_COUNT_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-    },
-  ],
-  filters:
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day');
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc(),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const TOTAL_ACTIVITIES_QUERY = ({
   period,
@@ -362,13 +392,12 @@ export const TOTAL_ACTIVITIES_QUERY = ({
   selectedHasTeamActivities,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc();
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)
       // we're subtracting one more day, to get the last value of the previous period within the same request
-      .subtract(1, 'day')
-      .format('YYYY-MM-DD');
+      .subtract(1, 'day');
 
     return [start, end];
   };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f161ed9</samp>

Refactor and fix `widget-queries.js` to improve date handling and code quality.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f161ed9</samp>

> _The queries for widgets were messy_
> _With logic that made them quite fussy_
> _They used strings and dates_
> _In confusing ways_
> _But now they are cleaner and trusty_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f161ed9</samp>

*  Refactor query functions to use a variable `activityTimestampFrom` for the start date of the date range, align the start date with the granularity unit, and handle week granularity as a special case ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L98-R126), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L124-R174), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L281-R349), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L336-R379))
* Simplify `dateRange` functions by removing unnecessary `.format('YYYY-MM-DD')` calls and letting Cube.js client handle moment objects ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L166-R187), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L260-R276), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L365-R400))
* Add missing `return` statements to `LEADERBOARD_ACTIVITIES_TYPES_QUERY` and `LEADERBOARD_ACTIVITIES_COUNT_QUERY` functions in `frontend/src/modules/widget/widget-queries.js` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L330-R356), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L356-R386))
* Change granularity of `LEADERBOARD_ACTIVITIES_TYPES_QUERY` to be always 'day', since this query is used to display the top activities types by platform, and does not need to be aggregated by other time units ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1222/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L281-R349))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
