### PR TITLE
Fix member undefined attributes

### DIFF
--- a/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
+++ b/frontend/src/modules/member/components/view/_aside/_aside-identities.vue
@@ -21,7 +21,7 @@
         <app-platform-list
           :username-handles="socialIdentities[platform]"
           :platform="platform"
-          :url="member.attributes.url[platform]"
+          :url="member.attributes?.url?.[platform]"
         />
       </div>
     </div>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6d0426</samp>

Fixed a bug in the social identities component of the member view. Used optional chaining operators to safely access the `url` property of `member.attributes` in `frontend/src/modules/member/components/view/_aside/_aside-identities.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c6d0426</samp>

> _`member.attributes`?_
> _Use optional chaining now_
> _Winter bug is fixed_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6d0426</samp>

*  Prevent errors when accessing member url for social identities ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1228/files?diff=unified&w=0#diff-8a798a180aeda9f4c67a513073a8f07295701fe7602d572bab6c9a473db1d631L24-R24))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
