### PR TITLE
Fix reports timestamps

### DIFF
--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -95,66 +95,82 @@ export const TOTAL_ACTIVE_MEMBERS_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamMembers: selectedHasTeamMembers,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DDTHH:mm:ss.SSS'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamMembers: selectedHasTeamMembers,
+    }),
+  };
+};
 
 export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
   period,
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: [
-    {
-      member: 'Members.joinedAtUnixTs',
-      operator: 'lt',
-      values: [
-        moment()
-          .utc()
-          .startOf('day')
-          .subtract(period.value, period.granularity)
-          .unix()
-          .toString(),
-      ],
-    },
-    ...getCubeFilters({
-      platforms: selectedPlatforms,
-      hasTeamMembers: selectedHasTeamMembers,
-    }),
-  ],
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DDTHH:mm:ss.SSS'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: [
+      {
+        member: 'Members.joinedAtUnixTs',
+        operator: 'lt',
+        values: [
+          moment()
+            .utc()
+            .startOf('day')
+            .subtract(period.value, period.granularity)
+            .unix()
+            .toString(),
+        ],
+      },
+      ...getCubeFilters({
+        platforms: selectedPlatforms,
+        hasTeamMembers: selectedHasTeamMembers,
+      }),
+    ],
+  };
+};
 
 export const TOTAL_MEMBERS_QUERY = ({
   period,
@@ -163,13 +179,13 @@ export const TOTAL_MEMBERS_QUERY = ({
   selectedHasTeamMembers,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)
       // we're subtracting one more day, to get the last value of the previous period within the same request
       .subtract(1, 'day')
-      .format('YYYY-MM-DD');
+      .format('YYYY-MM-DDTHH:mm:ss.SSS');
 
     return [start, end];
   };
@@ -258,8 +274,8 @@ export const TOTAL_MONTHLY_ACTIVE_CONTRIBUTORS = ({
             .utc()
             .startOf('month')
             .subtract(period.value, period.granularity)
-            .format('YYYY-MM-DD'),
-          moment().utc().format('YYYY-MM-DD'),
+            .format('YYYY-MM-DDTHH:mm:ss.SSS'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
         ],
       }),
       dimension: 'Activities.date',
@@ -278,82 +294,100 @@ export const ACTIVITIES_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamActivities: selectedHasTeamActivities,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DDTHH:mm:ss.SSS'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamActivities: selectedHasTeamActivities,
+    }),
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_TYPES_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  order: {
-    'Activities.count': 'desc',
-  },
-  dimensions: ['Activities.platform', 'Activities.type'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS');
+
+  return {
+    measures: ['Activities.count'],
+    order: {
+      'Activities.count': 'desc',
     },
-  ],
-  filters:
+    dimensions: ['Activities.platform', 'Activities.type'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_COUNT_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-    },
-  ],
-  filters:
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day')
+    .format('YYYY-MM-DDTHH:mm:ss.SSS');
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const TOTAL_ACTIVITIES_QUERY = ({
   period,
@@ -362,13 +396,13 @@ export const TOTAL_ACTIVITIES_QUERY = ({
   selectedHasTeamActivities,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)
       // we're subtracting one more day, to get the last value of the previous period within the same request
       .subtract(1, 'day')
-      .format('YYYY-MM-DD');
+      .format('YYYY-MM-DDTHH:mm:ss.SSS');
 
     return [start, end];
   };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c899d3f</samp>

This pull request enhances the date range filtering functionality for widget queries. It uses `moment` to standardize the date formats and match them with the query granularity. It also corrects some syntax errors in `widget-queries.js`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c899d3f</samp>

> _The widget queries had a glitch_
> _The date ranges were not a good fit_
> _So they used `moment` to format_
> _And align them with the query stat_
> _And fixed some syntax errors with it_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c899d3f</samp>

*  Align date range with query granularity and Cube.js convention for active and returning members queries ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L98-R126), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L124-R174))
*  Include time component in ISO 8601 format for date range in total members and total activities queries, to avoid timezone and DST issues ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L166-R182), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L172-R188), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L261-R278), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L365-R399), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L371-R405))
*  Use `startOf` and `format` methods of `moment` library to align date range with start of day for activities count and types queries, and extract common variable `activityTimestampFrom` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L281-R352), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L336-R383))
*  Fix syntax errors by adding closing curly braces and semicolons to `LEADERBOARD_ACTIVITIES_TYPES_QUERY` and `LEADERBOARD_ACTIVITIES_COUNT_QUERY` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L330-R359), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1232/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L356-R390))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
