### PR TITLE
Fix endDate reports timestamps

### DIFF
--- a/frontend/src/modules/widget/widget-queries.js
+++ b/frontend/src/modules/widget/widget-queries.js
@@ -95,66 +95,82 @@ export const TOTAL_ACTIVE_MEMBERS_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamMembers: selectedHasTeamMembers,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DD'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamMembers: selectedHasTeamMembers,
+    }),
+  };
+};
 
 export const TOTAL_ACTIVE_RETURNING_MEMBERS_QUERY = ({
   period,
   granularity,
   selectedPlatforms,
   selectedHasTeamMembers,
-}) => ({
-  measures: ['Members.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: [
-    {
-      member: 'Members.joinedAtUnixTs',
-      operator: 'lt',
-      values: [
-        moment()
-          .utc()
-          .startOf('day')
-          .subtract(period.value, period.granularity)
-          .unix()
-          .toString(),
-      ],
-    },
-    ...getCubeFilters({
-      platforms: selectedPlatforms,
-      hasTeamMembers: selectedHasTeamMembers,
-    }),
-  ],
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Members.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DD'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: [
+      {
+        member: 'Members.joinedAtUnixTs',
+        operator: 'lt',
+        values: [
+          moment()
+            .utc()
+            .startOf('day')
+            .subtract(period.value, period.granularity)
+            .unix()
+            .toString(),
+        ],
+      },
+      ...getCubeFilters({
+        platforms: selectedPlatforms,
+        hasTeamMembers: selectedHasTeamMembers,
+      }),
+    ],
+  };
+};
 
 export const TOTAL_MEMBERS_QUERY = ({
   period,
@@ -163,7 +179,7 @@ export const TOTAL_MEMBERS_QUERY = ({
   selectedHasTeamMembers,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)
@@ -259,7 +275,7 @@ export const TOTAL_MONTHLY_ACTIVE_CONTRIBUTORS = ({
             .startOf('month')
             .subtract(period.value, period.granularity)
             .format('YYYY-MM-DD'),
-          moment().utc().format('YYYY-MM-DD'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
         ],
       }),
       dimension: 'Activities.date',
@@ -278,82 +294,100 @@ export const ACTIVITIES_QUERY = ({
   granularity,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-      granularity: granularity.value,
-    },
-  ],
-  filters: getCubeFilters({
-    platforms: selectedPlatforms,
-    hasTeamActivities: selectedHasTeamActivities,
-  }),
-});
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf(granularity.value);
+
+  if (granularity.value === 'week') {
+    activityTimestampFrom.add(1, 'day');
+  }
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom.format('YYYY-MM-DD'),
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+        granularity: granularity.value,
+      },
+    ],
+    filters: getCubeFilters({
+      platforms: selectedPlatforms,
+      hasTeamActivities: selectedHasTeamActivities,
+    }),
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_TYPES_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  order: {
-    'Activities.count': 'desc',
-  },
-  dimensions: ['Activities.platform', 'Activities.type'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day')
+    .format('YYYY-MM-DD');
+
+  return {
+    measures: ['Activities.count'],
+    order: {
+      'Activities.count': 'desc',
     },
-  ],
-  filters:
+    dimensions: ['Activities.platform', 'Activities.type'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const LEADERBOARD_ACTIVITIES_COUNT_QUERY = ({
   period,
   selectedPlatforms,
   selectedHasTeamActivities,
-}) => ({
-  measures: ['Activities.count'],
-  timeDimensions: [
-    {
-      dateRange: [
-        moment()
-          .utc()
-          .subtract(period.value, period.granularity)
-          .format('YYYY-MM-DD'),
-        moment().utc().format('YYYY-MM-DD'),
-      ],
-      dimension: 'Activities.date',
-    },
-  ],
-  filters:
+}) => {
+  const activityTimestampFrom = moment()
+    .utc()
+    .subtract(period.value, period.granularity)
+    .startOf('day')
+    .format('YYYY-MM-DD');
+
+  return {
+    measures: ['Activities.count'],
+    timeDimensions: [
+      {
+        dateRange: [
+          activityTimestampFrom,
+          moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS'),
+        ],
+        dimension: 'Activities.date',
+      },
+    ],
+    filters:
     getCubeFilters({
       platforms: selectedPlatforms,
       hasTeamActivities: selectedHasTeamActivities,
     }),
 
-});
+  };
+};
 
 export const TOTAL_ACTIVITIES_QUERY = ({
   period,
@@ -362,7 +396,7 @@ export const TOTAL_ACTIVITIES_QUERY = ({
   selectedHasTeamActivities,
 }) => {
   const dateRange = (periodValue) => {
-    const end = moment().utc().format('YYYY-MM-DD');
+    const end = moment().utc().format('YYYY-MM-DDTHH:mm:ss.SSS');
     const start = moment()
       .utc()
       .subtract(periodValue.value, periodValue.granularity)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3233fb</samp>

This pull request improves the widget charts functionality by fixing date range and syntax bugs in `widget-queries.js`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c3233fb</samp>

> _The widget charts had some bugs_
> _That made them look like fuzzy rugs_
> _So we tweaked the date range_
> _Based on time and gran's change_
> _And fixed the syntax in some `QUERY` functions_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3233fb</samp>

*  Fix bug where active members, active returning members, and leaderboard charts show incorrect data for weekly and monthly periods by adjusting date range based on granularity and ISO week format ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L98-R126), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L124-R174), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L281-R352), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L336-R383))
*  Fix syntax errors in `LEADERBOARD_ACTIVITIES_TYPES_QUERY` and `LEADERBOARD_ACTIVITIES_COUNT_QUERY` functions by adding missing closing brackets and return statements ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L330-R359), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L356-R390))
*  Make total members, total monthly active contributors, and total activities charts more accurate and consistent by using more precise end date for date range ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L166-R182), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L262-R278), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1234/files?diff=unified&w=0#diff-d6e5e40c658f641768f99d781adc6b63997f3bb576769191dcdf4fd6a2f36321L365-R399))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
