### PR TITLE
Updates hubspot frequency back to 8 hours

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/index.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/index.ts
@@ -9,8 +9,7 @@ import { HUBSPOT_MEMBER_ATTRIBUTES } from './memberAttributes'
 const descriptor: IIntegrationDescriptor = {
   type: 'hubspot',
   memberAttributes: HUBSPOT_MEMBER_ATTRIBUTES,
-  // checkEvery: 8 * 60, // 8 hours
-  checkEvery: 2,
+  checkEvery: 8 * 60, // 8 hours
   generateStreams,
   processStream,
   processData,


### PR DESCRIPTION

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fea661</samp>

Restored the `checkEvery` property of the HubSpot integration to 8 hours. This avoids excessive requests to the HubSpot API and improves performance.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4fea661</samp>

> _`checkEvery` fixed_
> _Eight hours, not two minutes_
> _Testing left a trace_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fea661</samp>

*  Restored the integration check frequency to 8 hours ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1235/files?diff=unified&w=0#diff-3e9d0ff012aef681a4eb3241e93e820f98024b8ea4bbf5410864d5b76f3058baL12-R12))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
