### PR TITLE
Associate organizations activities

### DIFF
--- a/frontend/src/modules/activity/components/activity-header.vue
+++ b/frontend/src/modules/activity/components/activity-header.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <slot>
+      <app-activity-message
+        :activity="activity"
+      />
+    </slot>
+    <div class="whitespace-nowrap flex items-center">
+      <div v-if="activity.organization" class="flex items-center">
+        <span class="mx-1 text-gray-500">·</span>
+        <router-link
+          :to="{
+            name: 'organizationView',
+            params: {
+              id: activity.organization.id,
+            },
+          }"
+          class="group hover:cursor-pointer"
+        >
+          <div class="flex items-center gap-1">
+            <img
+              v-if="activity.organization.logo"
+              class="w-3.5 h-3.5"
+              :src="activity.organization.logo"
+              :alt="`${activity.organization.displayName} logo`"
+            />
+            <span class="text-gray-900 group-hover:text-brand-500 transition">{{ activity.organization.displayName }}</span>
+          </div>
+        </router-link>
+      </div>
+      <span class="mx-1 text-gray-500">·</span>
+      <span class="text-gray-500">{{ timeAgo }}</span>
+    </div>
+    <span
+      v-if="sentiment"
+      class="mx-1"
+    >·</span>
+    <app-activity-sentiment
+      v-if="sentiment"
+      :sentiment="sentiment"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
+import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
+import { formatDateToTimeAgo } from '@/utils/date';
+
+const props = defineProps({
+  activity: {
+    type: Object,
+    default: () => {},
+  },
+});
+
+const timeAgo = computed(() => formatDateToTimeAgo(props.activity.timestamp));
+const sentiment = computed(() => props.activity?.sentiment?.sentiment || 0);
+</script>
+
+<script>
+export default {
+  name: 'AppActivityHeader',
+};
+</script>

--- a/frontend/src/modules/activity/components/activity-item.vue
+++ b/frontend/src/modules/activity/components/activity-item.vue
@@ -50,26 +50,10 @@
                     class="ri-radar-line text-base text-gray-400"
                   />
                 </div>
-                <p
+                <app-activity-header
+                  :activity="activity"
                   class="text-xs leading-4 pl-2 flex flex-wrap"
-                >
-                  <!-- activity message -->
-                  <app-activity-message
-                    :activity="activity"
-                  />
-                  <!-- activity timestamp -->
-                  <span
-                    class="whitespace-nowrap text-gray-500"
-                  ><span class="mx-1">·</span>{{ timeAgo }}</span>
-                  <span
-                    v-if="sentiment"
-                    class="mx-1"
-                  >·</span>
-                  <app-activity-sentiment
-                    v-if="sentiment"
-                    :sentiment="sentiment"
-                  />
-                </p>
+                />
               </div>
             </div>
             <div class="flex items-center">
@@ -138,17 +122,15 @@
 </template>
 
 <script>
-import { formatDateToTimeAgo } from '@/utils/date';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import AppAvatar from '@/shared/avatar/avatar.vue';
 import AppActivityDropdown from '@/modules/activity/components/activity-dropdown.vue';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
-import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import AppActivityLink from '@/modules/activity/components/activity-link.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
 import AppActivityContentFooter from '@/modules/activity/components/activity-content-footer.vue';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 
 export default {
   name: 'AppActivityItem',
@@ -156,12 +138,11 @@ export default {
     AppMemberDisplayName,
     AppActivityLink,
     AppActivityContent,
-    AppActivityMessage,
     AppLoading,
     AppActivityDropdown,
     AppAvatar,
-    AppActivitySentiment,
     AppActivityContentFooter,
+    AppActivityHeader,
   },
   props: {
     activity: {
@@ -186,19 +167,6 @@ export default {
       return CrowdIntegrations.getConfig(
         this.activity.platform,
       );
-    },
-    timeAgo() {
-      return formatDateToTimeAgo(this.activity.timestamp);
-    },
-    sentiment() {
-      if (
-        this.activity
-        && this.activity.sentiment
-        && this.activity.sentiment.sentiment
-      ) {
-        return this.activity.sentiment.sentiment;
-      }
-      return 0;
     },
   },
   methods: {

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -73,16 +73,19 @@
               with-link
               class="bl"
             />
-            <div class="flex items-center mt-0.5">
-              <app-activity-message :activity="activity" />
-              <span class="whitespace-nowrap text-gray-500"><span class="mx-1">·</span>{{ timeAgo(activity) }}</span>
-              <span
-                v-if="activity.sentiment.sentiment"
-                class="mx-1"
-              >·</span>
-              <app-activity-sentiment
-                v-if="activity.sentiment.sentiment"
-                :sentiment="activity.sentiment.sentiment"
+            <div
+              class="flex gap-4 justify-between min-h-9 -mt-1"
+              :class="{
+                'items-center': !isMemberIdentity,
+                'items-start': isMemberIdentity,
+              }"
+            >
+              <app-activity-header
+                :activity="activity"
+                class="flex flex-wrap items-center"
+                :class="{
+                  'mt-1.5': isMemberIdentity,
+                }"
               />
             </div>
             <app-activity-content
@@ -164,17 +167,15 @@ import {
   watch,
 } from 'vue';
 import debounce from 'lodash/debounce';
-import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import { onSelectMouseLeave } from '@/utils/select';
 import authAxios from '@/shared/axios/auth-axios';
-import { formatDateToTimeAgo } from '@/utils/date';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
 import AppActivityLink from '@/modules/activity/components/activity-link.vue';
 import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
 import AppActivityContentFooter from '@/modules/activity/components/activity-content-footer.vue';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 
 const SearchIcon = h(
   'i', // type
@@ -201,6 +202,8 @@ const activeIntegrations = computed(() => {
     label: CrowdIntegrations.getConfig(i).name,
   }));
 });
+
+const isMemberIdentity = computed(() => props.entityType === 'member');
 
 const loading = ref(true);
 const platform = ref(null);
@@ -303,7 +306,6 @@ const fetchActivities = async () => {
 };
 
 const platformDetails = (p) => CrowdIntegrations.getConfig(p);
-const timeAgo = (activity) => formatDateToTimeAgo(activity.timestamp);
 
 const debouncedQueryChange = debounce(async () => {
   await fetchActivities();

--- a/frontend/src/modules/conversation/components/conversation-details.vue
+++ b/frontend/src/modules/conversation/components/conversation-details.vue
@@ -59,25 +59,10 @@
             />
           </el-tooltip>
           <div class="flex-grow leading-none">
-            <p class="text-xs pl-2 inline-flex">
-              <!-- activity message -->
-              <app-activity-message
-                :activity="conversation.conversationStarter"
-              />
-              <!-- activity timestamp -->
-              <span class="whitespace-nowrap text-gray-500"><span class="mx-1">·</span>{{
-                timeAgo(
-                  conversation.conversationStarter
-                    .timestamp,
-                )
-              }}</span>
-              <span v-if="sentiment" class="mx-1">·</span>
-              <!-- conversation starter sentiment -->
-              <app-activity-sentiment
-                v-if="sentiment"
-                :sentiment="sentiment"
-              />
-            </p>
+            <app-activity-header
+              :activity="conversation.conversationStarter"
+              class="text-xs pl-2 inline-flex"
+            />
           </div>
         </div>
       </div>
@@ -170,13 +155,10 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { formatDateToTimeAgo } from '@/utils/date';
 import { toSentenceCase } from '@/utils/string';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
-import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
 import AppConversationReply from '@/modules/conversation/components/conversation-reply.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppAvatar from '@/shared/avatar/avatar.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
@@ -184,19 +166,19 @@ import AppConversationDetailsFooter from '@/modules/conversation/components/conv
 import { ActivityService } from '@/modules/activity/activity-service';
 import Message from '@/shared/message/message';
 import config from '@/config';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 import { ConversationPermissions } from '../conversation-permissions';
 
 export default {
   name: 'AppConversationDetails',
   components: {
     AppMemberDisplayName,
-    AppActivityMessage,
     AppConversationReply,
-    AppActivitySentiment,
     AppActivityContent,
     AppLoading,
     AppAvatar,
     AppConversationDetailsFooter,
+    AppActivityHeader,
   },
   props: {
     conversation: {
@@ -234,10 +216,6 @@ export default {
     },
     member() {
       return this.conversation.conversationStarter.member;
-    },
-    sentiment() {
-      return this.conversation.conversationStarter.sentiment
-        .sentiment;
     },
     url() {
       return this.conversation.url;
@@ -298,9 +276,6 @@ export default {
     },
   },
   methods: {
-    timeAgo(date) {
-      return formatDateToTimeAgo(date);
-    },
     doChangeSort(value) {
       if (value !== 'all') {
         this.loadingActivities = true;

--- a/frontend/src/modules/conversation/components/conversation-item.vue
+++ b/frontend/src/modules/conversation/components/conversation-item.vue
@@ -30,27 +30,10 @@
             />
           </el-tooltip>
           <div class="flex-grow leading-none">
-            <p
+            <app-activity-header
+              :activity="conversation.conversationStarter"
               class="text-xs leading-4 pl-2 flex flex-wrap"
-            >
-              <!-- activity message -->
-              <app-activity-message
-                :activity="conversation.conversationStarter"
-              />
-              <!-- activity timestamp -->
-              <span class="whitespace-nowrap text-gray-500"><span class="mx-1">·</span>{{
-                timeAgo(
-                  conversation.conversationStarter
-                    .timestamp,
-                )
-              }}</span>
-              <span v-if="sentiment" class="mx-1">·</span>
-              <!-- conversation starter sentiment -->
-              <app-activity-sentiment
-                v-if="sentiment"
-                :sentiment="sentiment"
-              />
-            </p>
+            />
           </div>
         </div>
       </div>
@@ -100,29 +83,26 @@
 </template>
 
 <script>
-import { formatDateToTimeAgo } from '@/utils/date';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import AppAvatar from '@/shared/avatar/avatar.vue';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import AppConversationReply from '@/modules/conversation/components/conversation-reply.vue';
-import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppConversationItemFooter from '@/modules/conversation/components/conversation-item-footer.vue';
 import pluralize from 'pluralize';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 
 export default {
   name: 'AppConversationItem',
   components: {
     AppMemberDisplayName,
-    AppActivityMessage,
     AppConversationReply,
     AppActivityContent,
-    AppActivitySentiment,
     AppLoading,
     AppAvatar,
     AppConversationItemFooter,
+    AppActivityHeader,
   },
   props: {
     conversation: {
@@ -146,10 +126,6 @@ export default {
     member() {
       return this.conversation.conversationStarter?.member;
     },
-    sentiment() {
-      return this.conversation.conversationStarter.sentiment
-        .sentiment;
-    },
     url() {
       return this.conversation.url;
     },
@@ -161,9 +137,6 @@ export default {
     },
   },
   methods: {
-    timeAgo(date) {
-      return formatDateToTimeAgo(date);
-    },
     openConversation() {
       this.$emit('details', this.conversation.id);
     },

--- a/frontend/src/modules/dashboard/components/activity/dashboard-activity-item.vue
+++ b/frontend/src/modules/dashboard/components/activity/dashboard-activity-item.vue
@@ -63,18 +63,10 @@
                 v-else
                 class="ri-radar-line text-base text-gray-400"
               />
-              <p class="flex text-2xs leading-4 pl-2">
-                <app-activity-message
-                  :activity="activity"
-                />
-                <span
-                  class="whitespace-nowrap text-gray-500"
-                ><span class="mx-1">·</span>{{ timeAgo }}</span>
-                <span class="mx-1">·</span>
-                <app-activity-sentiment
-                  :sentiment="activity.sentiment.sentiment"
-                />
-              </p>
+              <app-activity-header
+                :activity="activity"
+                class="flex text-2xs leading-4 pl-2"
+              />
             </div>
           </div>
           <div>
@@ -130,28 +122,25 @@
 </template>
 
 <script>
-import { formatDateToTimeAgo } from '@/utils/date';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import AppAvatar from '@/shared/avatar/avatar.vue';
 import AppActivityDropdown from '@/modules/activity/components/activity-dropdown.vue';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
-import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppActivityContentFooter from '@/modules/activity/components/activity-content-footer.vue';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 
 export default {
   name: 'AppDashboardActivityItem',
   components: {
-    AppActivitySentiment,
     AppMemberDisplayName,
-    AppActivityMessage,
     AppActivityContent,
     AppLoading,
     AppActivityDropdown,
     AppAvatar,
     AppActivityContentFooter,
+    AppActivityHeader,
   },
   props: {
     activity: {
@@ -171,9 +160,6 @@ export default {
       return CrowdIntegrations.getConfig(
         this.activity.platform,
       );
-    },
-    timeAgo() {
-      return formatDateToTimeAgo(this.activity.timestamp);
     },
   },
 };

--- a/frontend/src/modules/dashboard/components/conversations/dashboard-conversation-item.vue
+++ b/frontend/src/modules/dashboard/components/conversations/dashboard-conversation-item.vue
@@ -62,34 +62,20 @@
                 />
               </div>
               <div class="flex-grow">
-                <div class="flex items-center">
-                  <!-- channel -->
+                <app-activity-header
+                  :activity="conversation.conversationStarter"
+                  class="flex items-center text-xs"
+                >
                   <p
-                    class="text-red text-xs leading-4"
+                    class="text-red text-xs"
                     @click.stop
                   >
                     <app-activity-message
-                      :activity="
-                        conversation.conversationStarter
-                      "
+                      :activity="conversatoin.conversationStarter"
                       type="channel"
                     />
                   </p>
-                  <span
-                    class="whitespace-nowrap text-xs leading-4 text-gray-500"
-                  >
-                    <span class="mx-1">·</span>
-                    <span>{{
-                      timeAgo(conversation.lastActive)
-                    }}</span>
-                    <span class="mx-1">·</span>
-                  </span>
-                  <!-- sentiment -->
-                  <app-activity-sentiment
-                    v-if="sentiment"
-                    :sentiment="sentiment"
-                  />
-                </div>
+                </app-activity-header>
               </div>
             </div>
           </div>
@@ -149,17 +135,16 @@
 </template>
 
 <script>
-import { formatDateToTimeAgo } from '@/utils/date';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
 import AppAvatar from '@/shared/avatar/avatar.vue';
 import AppConversationDropdown from '@/modules/conversation/components/conversation-dropdown.vue';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppActivityContent from '@/modules/activity/components/activity-content.vue';
 import AppConversationReply from '@/modules/conversation/components/conversation-reply.vue';
-import AppActivitySentiment from '@/modules/activity/components/activity-sentiment.vue';
 import AppMemberDisplayName from '@/modules/member/components/member-display-name.vue';
 import AppActivityMessage from '@/modules/activity/components/activity-message.vue';
 import AppConversationItemFooter from '@/modules/conversation/components/conversation-item-footer.vue';
+import AppActivityHeader from '@/modules/activity/components/activity-header.vue';
 
 export default {
   name: 'AppDashboardConversationItem',
@@ -171,8 +156,8 @@ export default {
     AppLoading,
     AppConversationDropdown,
     AppAvatar,
-    AppActivitySentiment,
     AppConversationItemFooter,
+    AppActivityHeader,
   },
   props: {
     conversation: {
@@ -196,10 +181,6 @@ export default {
     member() {
       return this.conversation.conversationStarter.member;
     },
-    sentiment() {
-      return this.conversation.conversationStarter.sentiment
-        .sentiment;
-    },
     url() {
       return (
         this.conversation.url
@@ -208,9 +189,6 @@ export default {
     },
   },
   methods: {
-    timeAgo(date) {
-      return formatDateToTimeAgo(date);
-    },
     openConversation() {
       this.$emit('details', this.conversation.id);
     },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73f57b7</samp>

This pull request introduces a new component `AppActivityHeader` that handles the common logic and presentation of activity headers across different views. It refactors several existing components that display activity items, conversations and dashboard entries to use the new component and reduce code duplication and improve readability. It also adopts the `script setup` syntax for the new component.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 73f57b7</samp>

> _We rise from the ashes of code duplication_
> _We forge a new component of power and grace_
> _We use the `AppActivityHeader` to rule the views_
> _We refactor the code with fire and fury_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73f57b7</samp>

*  Add a new component `AppActivityHeader` to display the activity message, organization, timestamp and sentiment consistently across different views ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-5f91513b7526d4e6fc2b9901700daf903687446c5514b5efa2207c00db870a1dR1-R66))
*  Replace the inline code for rendering the activity header in various components with the `AppActivityHeader` component, passing the relevant props and slots ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-70ba85a3f4593606a57ff626247925780062d5affc917200140c4d259734db0cL53-R56), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8L76-R88), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fL62-R65), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L33-R36), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-adbcbeff5e69fe3e36389bf5b848d561c0c7d93adac58edf0fffdd3bef7b24c1L66-R69), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L65-R78))
*  Remove the unused imports, components, computed properties and methods related to the activity header from the components that use the `AppActivityHeader` component, such as `formatDateToTimeAgo`, `AppActivitySentiment`, `timeAgo` and `sentiment` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-70ba85a3f4593606a57ff626247925780062d5affc917200140c4d259734db0cL141-R133), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-70ba85a3f4593606a57ff626247925780062d5affc917200140c4d259734db0cL159-R145), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-70ba85a3f4593606a57ff626247925780062d5affc917200140c4d259734db0cL190-L202), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8L167-R172), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8L306), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fL173-R161), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fL193-R181), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fL238-L241), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fL301-L303), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L103), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L110-R94), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L119-R105), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L149-L152), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-b3b2ad178b23631c2c0422da1bf81e7f2c1dd1c51198290e965a39abb52d3423L164-L166), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-adbcbeff5e69fe3e36389bf5b848d561c0c7d93adac58edf0fffdd3bef7b24c1L133), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-adbcbeff5e69fe3e36389bf5b848d561c0c7d93adac58edf0fffdd3bef7b24c1L139-R137), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-adbcbeff5e69fe3e36389bf5b848d561c0c7d93adac58edf0fffdd3bef7b24c1L175-L177), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L152), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L159-R147), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L174-R160), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L199-L202), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L211-L213))
*  Add some conditional classes to the `AppActivityHeader` component in the `AppActivityTimeline` component to adjust the alignment and margin depending on the `entityType` prop ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8L76-R88))
*  Add a computed property `isMemberIdentity` to the `AppActivityTimeline` component to check if the `entityType` prop is equal to 'member' and use it in the template ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8R206-R207))
*  Add the `AppActivityHeader` component to the list of components registered in the `AppActivityTimeline`, `AppConversationDetails` and `AppDashboardActivityItem` components, as they are now using it in the template ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-ac35928641997d2be2d0c43afd02a85bf32a2b169074ac40ddcad8b21477eaf8R178), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-3d4bc3821c6df255a38f54fac2f26e3d1bd58e7cc91c95a54ca59b838086953fR169), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-adbcbeff5e69fe3e36389bf5b848d561c0c7d93adac58edf0fffdd3bef7b24c1R143))
*  Add a slot for the channel name in the `AppActivityHeader` component in the `AppDashboardConversationItem` component, which is rendered by the `AppActivityMessage` component with a custom type prop ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1249/files?diff=unified&w=0#diff-74da5815376d40fd6f0cf89ddee7b59b1cb07c3b2ff2ee97d3d28d0f802fdc16L65-R78))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
