### PR TITLE
Add organizations banner

### DIFF
--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -97,14 +97,25 @@
               class="flex items-center justify-center grow text-sm"
             >
               {{ integrationsNeedReconnectToString }} integration
-                need{{ integrationsInProgress.length > 1 ? '' : 's' }} to be reconnected due to a change in their API.
-                Please reconnect {{ integrationsInProgress.length > 1 ? 'them' : 'it' }} to continue receiving data.
+              need{{ integrationsInProgress.length > 1 ? '' : 's' }} to be reconnected due to a change in their API.
+              Please reconnect {{ integrationsInProgress.length > 1 ? 'them' : 'it' }} to continue receiving data.
               <router-link
                 :to="{ name: 'integration' }"
                 class="btn btn--sm btn--primary ml-4"
               >
                 Go to Integrations
               </router-link>
+            </div>
+          </banner>
+          <banner
+            v-if="showOrganizationsAlertBanner"
+            variant="alert"
+          >
+            <div
+              class="flex items-center justify-center grow text-sm"
+            >
+              We're currently experiencing several issues with Organizations and are sorry for the inconvenience.
+              You can expect major improvements by Tuesday, Aug 15th. 🚧
             </div>
           </banner>
         </div>
@@ -154,6 +165,7 @@ export default {
         'tenant/showIntegrationsInProgressAlert',
       showIntegrationsNeedReconnectAlert:
         'tenant/showIntegrationsNeedReconnectAlert',
+      showOrganizationsAlertBanner: 'tenant/showOrganizationsAlertBanner',
       showBanner: 'tenant/showBanner',
     }),
     integrationsInProgressToString() {

--- a/frontend/src/modules/tenant/store/getters.js
+++ b/frontend/src/modules/tenant/store/getters.js
@@ -1,5 +1,6 @@
 import sharedGetters from '@/shared/store/getters';
 import { router } from '@/router';
+import moment from 'moment';
 
 export default {
   ...sharedGetters(),
@@ -67,11 +68,19 @@ export default {
     );
   },
 
+  showOrganizationsAlertBanner: () => {
+    const today = moment();
+    const limit = moment('2023-08-15').endOf('day');
+
+    return today.isSameOrBefore(limit, 'day');
+  },
+
   showBanner: (_state, getters) => (
     getters.showSampleDataAlert
       || getters.showIntegrationsErrorAlert
       || getters.showIntegrationsNoDataAlert
       || getters.showIntegrationsInProgressAlert
       || getters.showIntegrationsNeedReconnectAlert
+      || getters.showOrganizationsAlertBanner
   ),
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61ebe34</samp>

Added a banner component to the frontend layout to warn users about the organizations feature outage and deprecation. Used `moment` and a new `tenant` getter to control the banner visibility.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 61ebe34</samp>

> _Sing, O Muse, of the banner swift and bright_
> _That the wise coder wrought with skillful hand_
> _To warn the users of the looming plight_
> _Of the organizations feature's end._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61ebe34</samp>

*  Add a new banner component to the layout component to display a message about the issues with Organizations and the expected resolution date ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1315/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bL100-R101), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1315/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR110-R120), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1315/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR168), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1315/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eR84)).

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
