### PR TITLE
Fixed enrichment being removed from the quota when not found

### DIFF
--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -623,7 +623,7 @@ export default class MemberEnrichmentService extends LoggerBase {
       }
       // Make the GET request and extract the profile data from the response
       const response: EnrichmentAPIResponse = (await axios(config)).data
-      if (response.error) {
+      if (response.error || !response.profile) {
         this.log.error(email, `Member not found using email.`)
         throw new Error400(this.options.language, 'enrichment.errors.memberNotFound')
       }

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -587,7 +587,7 @@ export default class MemberEnrichmentService extends LoggerBase {
       // Make the GET request and extract the profile data from the response
       const response: EnrichmentAPIResponse = (await axios(config)).data
 
-      if (response.error || response.profile === undefined) {
+      if (response.error || response.profile === undefined || !response.profile) {
         this.log.error(githubHandle, `Member not found using github handle.`)
         throw new Error400(this.options.language, 'enrichment.errors.memberNotFound')
       }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d25ef9</samp>

Fix bug in `memberEnrichmentService` that could cause error with empty profiles. Add error handling and logging for this case.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d25ef9</samp>

> _No profile, no mercy, the API is a lie_
> _`memberEnrichmentService` will make them cry_
> _We check for falsy values, we don't let them pass_
> _We throw an error_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d25ef9</samp>

*  Prevent errors when Enrichment API returns empty profile object ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1316/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L590-R590), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1316/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L626-R626))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
