### PR TITLE
Update organizations list sorter

### DIFF
--- a/frontend/src/modules/organization/config/saved-views/views/all-organizations.ts
+++ b/frontend/src/modules/organization/config/saved-views/views/all-organizations.ts
@@ -7,7 +7,7 @@ const allOrganizations: SavedView = {
     search: '',
     relation: 'and',
     order: {
-      prop: 'activityCount',
+      prop: 'lastActive',
       order: 'descending',
     },
     settings: {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 751ee6c</samp>

Changed the sorting criteria of the `allOrganizations` view in the frontend module `organization/config/saved-views`. The view now shows the organizations by their last active date instead of their activity count.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 751ee6c</samp>

> _`allOrganizations`_
> _Sorted by last active date_
> _Autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 751ee6c</samp>

*  Sort organizations by last active date instead of activity count in `allOrganizations` view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1320/files?diff=unified&w=0#diff-dd5f51916e2764362dca75be093069994186e0c02a726eccb4237ea5dbd22acbL10-R10))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
