### PR TITLE
Fallback to joinedAt_DESC when orderBy string is empty on querying organizations

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -588,6 +588,10 @@ class OrganizationRepository {
     },
     options: IRepositoryOptions,
   ): Promise<PageData<any>> {
+    if (orderBy.length === 0) {
+      orderBy = 'joinedAt_DESC'
+    }
+
     const tenant = SequelizeRepository.getCurrentTenant(options)
 
     const segmentsEnabled = await isFeatureEnabled(FeatureFlag.SEGMENTS, options)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b46856e</samp>

Add default sorting for `findOrganizations` method in `organizationRepository.ts`. This improves the consistency and usability of the organization list page.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b46856e</samp>

> _`findOrganizations`_
> _now sorts by joined date, too_
> _falling leaves of time_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b46856e</samp>

*  Add default value for `orderBy` parameter in `findOrganizations` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1330/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR591-R594))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
