### PR TITLE
Fix label for no organization

### DIFF
--- a/frontend/src/modules/member/components/member-organizations.vue
+++ b/frontend/src/modules/member/components/member-organizations.vue
@@ -57,7 +57,7 @@
   <div
     v-else-if="
       member.attributes.jobTitle?.default
-        || props.member.organizations?.length
+        || activeOrganization
     "
     class="flex items-start grow mt-2"
   >
@@ -65,7 +65,7 @@
       v-if="member.attributes?.jobTitle?.default"
       class="text-gray-600 text-2xs mr-2 truncate block mt-0.5"
     >{{ member.attributes.jobTitle.default }}
-      {{ member.organizations.length ? 'at' : '' }}</span>
+      {{ activeOrganization ? 'at' : '' }}</span>
     <div
       v-if="activeOrganization"
       class="flex gap-2 flex-wrap max-w-[70%]"


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0ec84b</samp>

Fixed a bug in `member-organizations.vue` that caused the word 'at' to appear incorrectly after the job title. Changed the condition to use the `activeOrganization` computed property instead of the `organizations` array.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f0ec84b</samp>

> _`activeOrganization`_
> _fixes a bug in the UI_
> _word 'at' appears right_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0ec84b</samp>

* Fix bug where 'at' would appear without active organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1332/files?diff=unified&w=0#diff-dc66a022efe1ead61b3877ebec9b442f7c6d12b09e885f876c4c92cb8f37d114L68-R68))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
