### PR TITLE
Improve member's organizations sorting

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3385,20 +3385,41 @@ class MemberRepository {
     organizations.sort((a, b) => {
       a = a.dataValues ? a.get({ plain: true }) : a
       b = b.dataValues ? b.get({ plain: true }) : b
+      const aStart = a.memberOrganizations?.dateStart
+      const bStart = b.memberOrganizations?.dateStart
+      const aEnd = a.memberOrganizations?.dateEnd
+      const bEnd = b.memberOrganizations?.dateEnd
 
-      const aDate = a.memberOrganizations?.dateStart
-      const bDate = b.memberOrganizations?.dateStart
+      // Sorting:
+      // 1. Those without dateEnd, but with dateStart should be at the top, orderd by dateStart
+      // 2. Those with dateEnd and dateStart should be in the middle, ordered by dateEnd
+      // 3. Those without dateEnd and dateStart should be at the bottom, ordered by name
+      if (!aEnd && aStart) {
+        if (!bEnd && bStart) {
+          return aStart > bStart ? -1 : 1
+        }
+        if (bEnd && bStart) {
+          return -1
+        }
+        return -1
+      }
+      if (aEnd && aStart) {
+        if (!bEnd && bStart) {
+          return 1
+        }
+        if (bEnd && bStart) {
+          return aEnd > bEnd ? -1 : 1
+        }
+        return -1
+      }
 
-      if (aDate && bDate) {
-        return bDate.getTime() - aDate.getTime()
-      }
-      if (!aDate && !bDate) {
-        return a.name.localeCompare(b.name)
-      }
-      if (!bDate) {
+      if (!bEnd && bStart) {
         return 1
       }
-      return -1
+      if (bEnd && bStart) {
+        return 1
+      }
+      return a.name > b.name ? 1 : -1
     })
   }
 }


### PR DESCRIPTION
1. Those without dateEnd, but with dateStart should be at the top, orderd by dateStart
2. Those with dateEnd and dateStart should be in the middle, ordered by dateEnd
3. Those without dateEnd and dateStart should be at the bottom, ordered by name

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5918f0a</samp>

Modified the `sortMembers` method in `memberRepository.ts` to use a new sorting logic for members based on their activity status and dates. This change improves the member sorting in the frontend as requested in issue #123.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5918f0a</samp>

> _`sortMembers` changed_
> _New logic for active ones_
> _Fall leaves the old way_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5918f0a</samp>

* Implement new sorting logic for members based on their dateStart and dateEnd properties ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1336/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3388-R3422))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
