### PR TITLE
Opensearch orgs hotfix

### DIFF
--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -43,7 +43,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
             o.attributes,
             o."createdAt",
             o.description,
-            o."displayName",
+            COALESCE(o."displayName", o.name) as "displayName",
             o.emails,
             o."employeeCountByCountry",
             o.employees,

--- a/services/libs/opensearch/src/fieldTranslator.ts
+++ b/services/libs/opensearch/src/fieldTranslator.ts
@@ -1,5 +1,5 @@
 import OpensearchModelBase from './models/base'
-import { OpenSearchIndex } from '@crowd/types'
+import { OpenSearchIndex, OpensearchField, OpensearchFieldType } from '@crowd/types'
 
 export default abstract class FieldTranslator {
   index: OpenSearchIndex
@@ -44,6 +44,13 @@ export default abstract class FieldTranslator {
     return this.model.fieldExists(key)
   }
 
+  convertIfInt(modelField: OpensearchField, value: unknown): unknown {
+    if (modelField.type === OpensearchFieldType.INT) {
+      return parseInt(value as string, 10)
+    }
+    return value
+  }
+
   translateObjectToCrowd(object: unknown): unknown {
     const translated = {}
 
@@ -65,7 +72,10 @@ export default abstract class FieldTranslator {
       if (crowdKey) {
         const modelField = this.model.getField(crowdKey)
         if (!modelField || !modelField.preventNestedFieldTranslation) {
-          translated[crowdKey] = this.translateObjectToCrowd(object[key])
+          translated[crowdKey] = this.convertIfInt(
+            modelField,
+            this.translateObjectToCrowd(object[key]),
+          )
         } else {
           translated[crowdKey] = object[key]
         }

--- a/services/libs/opensearch/src/fieldTranslator.ts
+++ b/services/libs/opensearch/src/fieldTranslator.ts
@@ -45,7 +45,7 @@ export default abstract class FieldTranslator {
   }
 
   convertIfInt(modelField: OpensearchField, value: unknown): unknown {
-    if (modelField.type === OpensearchFieldType.INT) {
+    if (modelField?.type === OpensearchFieldType.INT) {
       return parseInt(value as string, 10)
     }
     return value


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1f036d</samp>

This pull request improves the search functionality for organizations by adding integer field translation and display name fallback logic. It affects the files `fieldTranslator.ts` and `organization.repo.ts` in the `opensearch` and `search_sync_worker` services.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d1f036d</samp>

> _`COALESCE` names_
> _`FieldTranslator` for ints_
> _Autumn of searching_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1f036d</samp>

*  Add and use `convertIfInt` method to handle integer fields in search index ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1341/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0L2-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1341/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0R47-R53), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1341/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0L68-R78))
* Modify query for fetching organizations to use `COALESCE` function for display name ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1341/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L46-R46))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
