### PR TITLE
Affiliations with member-organizations that have no dates

### DIFF
--- a/backend/src/database/migrations/V1692128732__past-activity-affilation-v2.sql
+++ b/backend/src/database/migrations/V1692128732__past-activity-affilation-v2.sql
@@ -1,0 +1,23 @@
+WITH new_activities_organizations AS (
+    SELECT
+        a.id,
+        (ARRAY_REMOVE(ARRAY_AGG(CASE WHEN msa.id IS NULL THEN '00000000-0000-0000-0000-000000000000' ELSE msa."organizationId" END), '00000000-0000-0000-0000-000000000000')
+             || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC), NULL)
+             || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC), NULL)
+            || ARRAY[a."organizationId"])[1] AS new_org
+    FROM activities a
+    LEFT JOIN "memberSegmentAffiliations" msa ON msa."memberId" = a."memberId" AND a."segmentId" = msa."segmentId"
+    LEFT JOIN "memberOrganizations" mo ON mo."memberId" = a."memberId" AND (
+            a.timestamp BETWEEN mo."dateStart" AND mo."dateEnd"
+            OR (a.timestamp >= mo."dateStart" AND mo."dateEnd" IS NULL)
+        )
+    LEFT JOIN "memberOrganizations" mo1 ON mo1."memberId" = a."memberId" AND mo1."createdAt" <= a.timestamp
+    GROUP BY a.id
+)
+UPDATE activities a1
+SET "organizationId" = nao.new_org
+FROM new_activities_organizations nao
+WHERE a1.id = nao.id
+  AND ("organizationId" != nao.new_org
+    OR ("organizationId" IS NULL AND nao.new_org IS NOT NULL)
+    OR ("organizationId" IS NOT NULL AND nao.new_org IS NULL));

--- a/backend/src/database/migrations/V1692128732__past-activity-affilation-v2.sql
+++ b/backend/src/database/migrations/V1692128732__past-activity-affilation-v2.sql
@@ -2,8 +2,8 @@ WITH new_activities_organizations AS (
     SELECT
         a.id,
         (ARRAY_REMOVE(ARRAY_AGG(CASE WHEN msa.id IS NULL THEN '00000000-0000-0000-0000-000000000000' ELSE msa."organizationId" END), '00000000-0000-0000-0000-000000000000')
-             || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC), NULL)
-             || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC), NULL)
+             || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC, mo.id), NULL)
+             || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC, mo1.id), NULL)
             || ARRAY[a."organizationId"])[1] AS new_org
     FROM activities a
     LEFT JOIN "memberSegmentAffiliations" msa ON msa."memberId" = a."memberId" AND a."segmentId" = msa."segmentId"

--- a/backend/src/database/repositories/memberAffiliationRepository.ts
+++ b/backend/src/database/repositories/memberAffiliationRepository.ts
@@ -17,8 +17,8 @@ class MemberAffiliationRepository {
               -- but if there is no manual affiliation, we know this by 'msa.id' being NULL, and then using 000000 as a marker,
               -- which we remove afterwards
               (ARRAY_REMOVE(ARRAY_AGG(CASE WHEN msa.id IS NULL THEN '00000000-0000-0000-0000-000000000000' ELSE msa."organizationId" END), '00000000-0000-0000-0000-000000000000')
-               || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC), NULL)
-               || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC), NULL)
+               || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC, mo.id), NULL)
+               || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC, mo1.id), NULL)
               )[1] AS new_org
           FROM activities a
           LEFT JOIN "memberSegmentAffiliations" msa ON msa."memberId" = a."memberId" AND a."segmentId" = msa."segmentId" AND (

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3410,7 +3410,7 @@ class MemberRepository {
           ("dateStart" <= :timestamp AND "dateEnd" >= :timestamp)
           OR ("dateStart" <= :timestamp AND "dateEnd" IS NULL)
         )
-      ORDER BY "dateStart" DESC
+      ORDER BY "dateStart" DESC, id
       LIMIT 1
     `
 
@@ -3442,7 +3442,7 @@ class MemberRepository {
       SELECT * FROM "memberOrganizations"
       WHERE "memberId" = :memberId
         AND "createdAt" <= :timestamp
-      ORDER BY "createdAt" DESC
+      ORDER BY "createdAt" DESC, id
       LIMIT 1
     `
     const records = await seq.query(query, {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3430,6 +3430,37 @@ class MemberRepository {
     return records[0]
   }
 
+  static async findMostRecentOrganization(
+    memberId: string,
+    timestamp: string,
+    options: IRepositoryOptions,
+  ): Promise<any> {
+    const seq = SequelizeRepository.getSequelize(options)
+    const transaction = SequelizeRepository.getTransaction(options)
+
+    const query = `
+      SELECT * FROM "memberOrganizations"
+      WHERE "memberId" = :memberId
+        AND "createdAt" <= :timestamp
+      ORDER BY "createdAt" DESC
+      LIMIT 1
+    `
+    const records = await seq.query(query, {
+      replacements: {
+        memberId,
+        timestamp,
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    })
+
+    if (records.length === 0) {
+      return null
+    }
+
+    return records[0]
+  }
+
   static sortOrganizations(organizations) {
     organizations.sort((a, b) => {
       a = a.dataValues ? a.get({ plain: true }) : a

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3270,15 +3270,6 @@ class MemberRepository {
     const seq = SequelizeRepository.getSequelize(options)
     const transaction = SequelizeRepository.getTransaction(options)
 
-    let conflictClause
-    if (dateStart && dateEnd) {
-      conflictClause = `("memberId", "organizationId", "dateStart", "dateEnd")`
-    } else if (dateStart) {
-      conflictClause = `("memberId", "organizationId", "dateStart") WHERE "dateEnd" IS NULL`
-    } else {
-      conflictClause = `("memberId", "organizationId") WHERE "dateStart" IS NULL AND "dateEnd" IS NULL`
-    }
-
     if (dateStart) {
       // clean up organizations without dates if we're getting ones with dates
       await seq.query(
@@ -3326,7 +3317,7 @@ class MemberRepository {
       `
         INSERT INTO "memberOrganizations" ("memberId", "organizationId", "createdAt", "updatedAt", "title", "dateStart", "dateEnd")
         VALUES (:memberId, :organizationId, NOW(), NOW(), :title, :dateStart, :dateEnd)
-        ON CONFLICT ${conflictClause} DO NOTHING
+        ON CONFLICT DO NOTHING
       `,
       {
         replacements: {

--- a/backend/src/database/repositories/memberSegmentAffiliationRepository.ts
+++ b/backend/src/database/repositories/memberSegmentAffiliationRepository.ts
@@ -224,7 +224,7 @@ class MemberSegmentAffiliationRepository extends RepositoryBase<
             ("dateStart" <= :timestamp AND "dateEnd" >= :timestamp)
             OR ("dateStart" <= :timestamp AND "dateEnd" IS NULL)
           )
-        ORDER BY "dateStart" DESC
+        ORDER BY "dateStart" DESC, id
         LIMIT 1
       `,
       {

--- a/backend/src/services/memberAffiliationService.ts
+++ b/backend/src/services/memberAffiliationService.ts
@@ -32,6 +32,15 @@ export default class MemberAffiliationService extends LoggerBase {
       return currentEmployment.organizationId
     }
 
+    const mostRecentOrg: any = await MemberRepository.findMostRecentOrganization(
+      memberId,
+      timestamp,
+      this.options,
+    )
+    if (mostRecentOrg) {
+      return mostRecentOrg.organizationId
+    }
+
     return null
   }
 

--- a/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
@@ -56,4 +56,25 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
 
     return result
   }
+
+  public async findMostRecentOrganization(
+    memberId: string,
+    timestamp: string,
+  ): Promise<IWorkExperienceData | null> {
+    const result = await this.db().oneOrNone(
+      `
+        SELECT * FROM "memberOrganizations"
+        WHERE "memberId" = $(memberId)
+          AND "createdAt" <= $(timestamp)
+        ORDER BY "createdAt" DESC
+        LIMIT 1
+      `,
+      {
+        memberId,
+        timestamp,
+      },
+    )
+
+    return result
+  }
 }

--- a/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
@@ -21,7 +21,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
             ("dateStart" <= $(timestamp) AND "dateEnd" >= $(timestamp))
             OR ("dateStart" <= $(timestamp) AND "dateEnd" IS NULL)
           )
-        ORDER BY "dateStart" DESC
+        ORDER BY "dateStart" DESC, id
         LIMIT 1
       `,
       {
@@ -45,7 +45,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
             ("dateStart" <= $(timestamp) AND "dateEnd" >= $(timestamp))
             OR ("dateStart" <= $(timestamp) AND "dateEnd" IS NULL)
           )
-        ORDER BY "dateStart" DESC
+        ORDER BY "dateStart" DESC, id
         LIMIT 1
       `,
       {
@@ -66,7 +66,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
         SELECT * FROM "memberOrganizations"
         WHERE "memberId" = $(memberId)
           AND "createdAt" <= $(timestamp)
-        ORDER BY "createdAt" DESC
+        ORDER BY "createdAt" DESC, id
         LIMIT 1
       `,
       {

--- a/services/apps/data_sink_worker/src/service/memberAffiliation.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAffiliation.service.ts
@@ -26,6 +26,11 @@ export default class MemberAffiliationService extends LoggerBase {
       return currentEmployment.organizationId
     }
 
+    const mostRecentOrg = await this.repo.findMostRecentOrganization(memberId, timestamp)
+    if (mostRecentOrg) {
+      return mostRecentOrg.organizationId
+    }
+
     return null
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f230d7e</samp>

This pull request updates the logic of getting the organizationId of a member based on their most recent work experience. It adds or modifies methods in the `MemberRepository`, `MemberAffiliationRepo`, and `MemberAffiliationService` classes to query and delete work experiences and to find the most recent organization of a member. It also adds a SQL query to a migration file to update the organizationId of past activities based on the most recent affiliation of the member.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f230d7e</samp>

> _`updateOrganizations`_
> _Migrates and deletes old data_
> _Autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f230d7e</samp>

*  Update the organizationId of past activities based on the most recent work experience of the member at the time of the activity ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-0e57df145b50044258d012b86f53b9b8af023362e2ba029f57e5213d8c158dbdR1-R23))
*  Delete the existing work experiences that are not present in the new organizations array when updating the memberOrganizations table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3236-R3255), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3359-R3397))
*  Simplify the ON CONFLICT clause of the INSERT query in the `updateOrganizations` method of the `MemberRepository` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3273-L3281), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3329-R3339))
*  Add methods to fetch and find the most recent work experience of a member from the memberOrganizations table in the `MemberRepository` and `MemberAffiliationRepo` classes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3433-R3463), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-334f732e0c123418e8c236946548b87159b61ec035a2938e7406aa22f21a753dR59-R79))
*  Modify the `getOrganizationId` method of the `MemberAffiliationService` class in the `backend` and `data_sink_worker` services to use the most recent work experience of the member if they do not have a segment affiliation or a current work experience at the given time ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-ceced402a5c460d7120fc97da7a6dbc7a45ec928edc67feab92eeb8cf4abb554R35-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1342/files?diff=unified&w=0#diff-e57521ac45fc1de6968746a4ec5afe58387cccc17975ebd04683273cee070003R29-R33))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
