### PR TITLE
Don't enrich organizations with 0 activities

### DIFF
--- a/backend/src/bin/scripts/enrich-members-and-organizations.ts
+++ b/backend/src/bin/scripts/enrich-members-and-organizations.ts
@@ -138,8 +138,8 @@ if (parameters.help || (!parameters.tenant && (!parameters.organization || !para
             service: 'enrich-organizations',
             tenantId,
             // Since there is no pagination implemented for the organizations enrichment,
-            // we set a limit of 20,000 to ensure all organizations are included when enriched in bulk.
-            maxEnrichLimit: 20000,
+            // we set a limit of 10,000 to ensure all organizations are included when enriched in bulk.
+            maxEnrichLimit: 10000,
           } as NodeWorkerMessageBase
 
           await sendNodeWorkerMessage(tenantId, payload)

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -57,6 +57,7 @@ class OrganizationRepository {
       ,org."crunchbase"
       ,org."github"
       ,org."description"
+      ,activity."orgActivityCount"
       FROM "organizations" as org
       JOIN "organizationCaches" cach ON org."name" = cach."name"
       JOIN orgActivities activity ON activity."organizationId" = org."id"

--- a/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
@@ -76,20 +76,22 @@ export default class OrganizationEnrichmentService extends LoggerBase {
       this.maxOrganizationsLimit,
       this.options,
     )) {
-      const data = await this.getEnrichment(instance)
-      if (data) {
-        const org = this.convertEnrichedDataToOrg(data, instance)
-        enrichedOrganizations.push({ ...org, id: instance.id, tenantId: this.tenantId })
-        enrichedCacheOrganizations.push({ ...org, id: instance.cachId })
-      } else {
-        const lastEnrichedAt = new Date()
-        enrichedOrganizations.push({
-          ...instance,
-          id: instance.id,
-          tenantId: this.tenantId,
-          lastEnrichedAt,
-        })
-        enrichedCacheOrganizations.push({ ...instance, id: instance.cachId, lastEnrichedAt })
+      if (instance.activityCount > 0) {
+        const data = await this.getEnrichment(instance)
+        if (data) {
+          const org = this.convertEnrichedDataToOrg(data, instance)
+          enrichedOrganizations.push({ ...org, id: instance.id, tenantId: this.tenantId })
+          enrichedCacheOrganizations.push({ ...org, id: instance.cachId })
+        } else {
+          const lastEnrichedAt = new Date()
+          enrichedOrganizations.push({
+            ...instance,
+            id: instance.id,
+            tenantId: this.tenantId,
+            lastEnrichedAt,
+          })
+          enrichedCacheOrganizations.push({ ...instance, id: instance.cachId, lastEnrichedAt })
+        }
       }
     }
     const orgs = await this.update(enrichedOrganizations, enrichedCacheOrganizations)

--- a/backend/src/services/premium/enrichment/types/organizationEnrichmentTypes.ts
+++ b/backend/src/services/premium/enrichment/types/organizationEnrichmentTypes.ts
@@ -11,6 +11,7 @@ export interface IOrganization {
   tenantId?: string
   website?: string
   location?: string
+  activityCount?: number
   description?: IEnrichmentResponse['summary']
   employeeCountByCountry?: IEnrichmentResponse['employee_count_by_country']
   type?: IEnrichmentResponse['type']


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ddce8b</samp>

This pull request adds a `activityCount` property to the `IOrganization` interface and the database query that selects organizations. It also modifies the `organizationEnrichmentService` to skip organizations that have no activities from the enrichment process. This improves the performance and accuracy of the enrichment process by avoiding unnecessary API calls and database updates.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ddce8b</samp>

> _Skip `orgs` with none_
> _`activityCount` filters_
> _Winter of data_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ddce8b</samp>

*  Add `activityCount` property to `IOrganization` interface to store the number of activities for each organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1347/files?diff=unified&w=0#diff-174a13e1169ad442dbb819e8f5a416bdf7f12ba9896145fd4bd1b665e95ed8bbR14))
*  Modify query to select organizations from the database to include the `activity."orgActivityCount"` column and populate the `activityCount` property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1347/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR60))
*  Skip organizations with zero `activityCount` from the enrichment process to avoid unnecessary API calls and database updates ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1347/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L79-R94))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
