### PR TITLE
Affiliations for past activities to orgs without dates

### DIFF
--- a/backend/src/database/repositories/memberAffiliationRepository.ts
+++ b/backend/src/database/repositories/memberAffiliationRepository.ts
@@ -19,6 +19,7 @@ class MemberAffiliationRepository {
               (ARRAY_REMOVE(ARRAY_AGG(CASE WHEN msa.id IS NULL THEN '00000000-0000-0000-0000-000000000000' ELSE msa."organizationId" END), '00000000-0000-0000-0000-000000000000')
                || ARRAY_REMOVE(ARRAY_AGG(mo."organizationId" ORDER BY mo."dateStart" DESC, mo.id), NULL)
                || ARRAY_REMOVE(ARRAY_AGG(mo1."organizationId" ORDER BY mo1."createdAt" DESC, mo1.id), NULL)
+               || ARRAY_REMOVE(ARRAY_AGG(mo2."organizationId" ORDER BY mo2."createdAt", mo2.id), NULL)
               )[1] AS new_org
           FROM activities a
           LEFT JOIN "memberSegmentAffiliations" msa ON msa."memberId" = a."memberId" AND a."segmentId" = msa."segmentId" AND (
@@ -30,6 +31,7 @@ class MemberAffiliationRepository {
                   OR (a.timestamp >= mo."dateStart" AND mo."dateEnd" IS NULL)
               )
           LEFT JOIN "memberOrganizations" mo1 ON mo1."memberId" = a."memberId" AND mo1."createdAt" <= a.timestamp
+          LEFT JOIN "memberOrganizations" mo2 ON mo2."memberId" = a."memberId"
           WHERE a."memberId" = :memberId
           GROUP BY a.id
       )

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3461,6 +3461,34 @@ class MemberRepository {
     return records[0]
   }
 
+  static async findMostRecentOrganizationEver(
+    memberId: string,
+    options: IRepositoryOptions,
+  ): Promise<any> {
+    const seq = SequelizeRepository.getSequelize(options)
+    const transaction = SequelizeRepository.getTransaction(options)
+
+    const query = `
+      SELECT * FROM "memberOrganizations"
+      WHERE "memberId" = :memberId
+      ORDER BY "createdAt", id
+      LIMIT 1
+    `
+    const records = await seq.query(query, {
+      replacements: {
+        memberId,
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    })
+
+    if (records.length === 0) {
+      return null
+    }
+
+    return records[0]
+  }
+
   static sortOrganizations(organizations) {
     organizations.sort((a, b) => {
       a = a.dataValues ? a.get({ plain: true }) : a

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -3042,7 +3042,7 @@ describe('ActivityService tests', () => {
         expect(activity.organization.id).toBe(org3.id)
       })
 
-      it('Should affiliate nothing if there is no matching work experience', async () => {
+      it('Should affiliate first created org to past activities', async () => {
         const member = await createMember()
 
         let activity = await createActivity(member.id, {
@@ -3065,7 +3065,7 @@ describe('ActivityService tests', () => {
 
         activity = await findActivity(activity.id)
 
-        expect(activity.organization).toBeNull()
+        expect(activity.organization.id).toBe(org1.id)
       })
 
       it('Should prefer manual affiliation over work experience', async () => {

--- a/backend/src/services/memberAffiliationService.ts
+++ b/backend/src/services/memberAffiliationService.ts
@@ -41,6 +41,14 @@ export default class MemberAffiliationService extends LoggerBase {
       return mostRecentOrg.organizationId
     }
 
+    const mostRecentOrgEver: any = await MemberRepository.findMostRecentOrganizationEver(
+      memberId,
+      this.options,
+    )
+    if (mostRecentOrgEver) {
+      return mostRecentOrgEver.organizationId
+    }
+
     return null
   }
 

--- a/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
@@ -77,4 +77,22 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
 
     return result
   }
+
+  public async findMostRecentOrganizationEver(
+    memberId: string,
+  ): Promise<IWorkExperienceData | null> {
+    const result = await this.db().oneOrNone(
+      `
+        SELECT * FROM "memberOrganizations"
+        WHERE "memberId" = $(memberId)
+        ORDER BY "createdAt", id
+        LIMIT 1
+      `,
+      {
+        memberId,
+      },
+    )
+
+    return result
+  }
 }

--- a/services/apps/data_sink_worker/src/service/memberAffiliation.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAffiliation.service.ts
@@ -31,6 +31,11 @@ export default class MemberAffiliationService extends LoggerBase {
       return mostRecentOrg.organizationId
     }
 
+    const mostRecentOrgEver = await this.repo.findMostRecentOrganizationEver(memberId)
+    if (mostRecentOrgEver) {
+      return mostRecentOrgEver.organizationId
+    }
+
     return null
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfc6d02</samp>

This pull request adds a new feature to get the most recent organization that a member has ever been affiliated with, regardless of whether the affiliation is current or past. It updates the `getAffiliations` and `getMostRecentOrganizationId` methods of the `MemberAffiliationRepository` and `MemberAffiliationService` classes in the backend and the data sink worker. It also adds a new method `findMostRecentOrganizationEver` to the `MemberRepository` and `MemberAffiliationRepo` classes to query the `memberOrganizations` table.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dfc6d02</samp>

> _To find the most recent org ever_
> _We added a method quite clever_
> _It queries the table_
> _And if it is able_
> _Returns the org ID or null, whatever_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dfc6d02</samp>

*  Add logic to get the most recent organization ID of a member, either current or past, in two services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-ceced402a5c460d7120fc97da7a6dbc7a45ec928edc67feab92eeb8cf4abb554R44-R51), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-e57521ac45fc1de6968746a4ec5afe58387cccc17975ebd04683273cee070003R34-R38))
* Add the `findMostRecentOrganizationEver` method to two repositories ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3464-R3491), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-334f732e0c123418e8c236946548b87159b61ec035a2938e7406aa22f21a753dR80-R97))
* Add a condition to remove null values from the array of organization IDs returned by the `getAffiliations` method of the `MemberAffiliationRepository` class in the `backend` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-79b67901acc8bf830c7de52d225a5b98a01b7d05dbd284adc11296cc92259b72R22))
* Add a join to the `getAffiliations` method of the `MemberAffiliationRepository` class in the `backend` to fetch the past affiliations of a member ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1353/files?diff=unified&w=0#diff-79b67901acc8bf830c7de52d225a5b98a01b7d05dbd284adc11296cc92259b72R34))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
