### PR TITLE
fixed organization address indexing

### DIFF
--- a/services/apps/search_sync_worker/src/service/opensearch.service.ts
+++ b/services/apps/search_sync_worker/src/service/opensearch.service.ts
@@ -151,10 +151,15 @@ export class OpenSearchService extends LoggerBase {
         })
       }
 
-      await this.client.bulk({
+      const result = await this.client.bulk({
         body,
         refresh: true,
       })
+
+      if (result.body.errors === true) {
+        this.log.error({ errorItems: result.body.items }, 'Failed to bulk index documents!')
+        throw new Error(`Failed to bulk index documents in index ${index}!`)
+      }
     } catch (err) {
       this.log.error(err, { index }, 'Failed to bulk index documents!')
       throw new Error(`Failed to bulk index documents in index ${index}!`)

--- a/services/apps/search_sync_worker/src/service/organization.sync.service.ts
+++ b/services/apps/search_sync_worker/src/service/organization.sync.service.ts
@@ -428,8 +428,8 @@ export class OrganizationSyncService extends LoggerBase {
     p.uuid_organizationId = data.organizationId
     p.uuid_segmentId = data.segmentId
     p.uuid_tenantId = data.tenantId
-    p.string_address = data.address
-    p.keyword_address = data.address
+    p.obj_address = data.address
+    p.string_address = data.address ? JSON.stringify(data.address) : null
     p.string_attributes = data.attributes ? JSON.stringify(data.attributes) : '{}'
     p.date_createdAt = data.createdAt ? new Date(data.createdAt).toISOString() : null
     p.string_description = data.description

--- a/services/libs/opensearch/src/models/organizations.ts
+++ b/services/libs/opensearch/src/models/organizations.ts
@@ -18,7 +18,7 @@ export class OrganizationsOpensearch extends OpensearchModelBase {
       type: OpensearchFieldType.UUID,
     },
     address: {
-      type: OpensearchFieldType.STRING,
+      type: OpensearchFieldType.OBJECT,
     },
     logo: {
       type: OpensearchFieldType.STRING,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0798836</samp>

This pull request improves the indexing and querying of organization data in OpenSearch by adding error handling to the `bulk` operation, changing the `address` field type to object, and updating the `OrganizationsOpensearch` model accordingly. It affects the files `opensearch.service.ts`, `organization.sync.service.ts`, and `organizations.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0798836</samp>

> _`OpenSearchService`_
> _handles errors, logs, and throws_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0798836</samp>

*  Add error handling to OpenSearch bulk operation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1356/files?diff=unified&w=0#diff-f9964b2ee3e44130d55941c0b2fe7a3b5c0ba9bdb5e22659a73393b0eda3c7adL154-R162))
*  Change address field type from string to object and add string_address field for organization data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1356/files?diff=unified&w=0#diff-6a821d54aeecff44b95ad1e3bb5adb0b5848fc01db7a0f936eeee4d3f611969fL431-R432), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1356/files?diff=unified&w=0#diff-91957f07c0346fbfde9c8806f9f2754eeff2d4c0db103ebc14922be4884a5224L21-R21))
*  Update `OrganizationsOpensearch` model to match the new address field type ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1356/files?diff=unified&w=0#diff-91957f07c0346fbfde9c8806f9f2754eeff2d4c0db103ebc14922be4884a5224L21-R21))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
