### PR TITLE
Add limit 1 when selecting from conversationSettings

### DIFF
--- a/services/libs/conversations/src/repo/conversation.repo.ts
+++ b/services/libs/conversations/src/repo/conversation.repo.ts
@@ -49,7 +49,7 @@ export class ConversationRepository extends RepositoryBase<ConversationRepositor
     const id = generateUUIDv1()
 
     const results = await this.db().oneOrNone(
-      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId) and (enabled is null or enabled = true)`,
+      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId) and (enabled is null or enabled = true) limit 1`,
       {
         tenantId,
       },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e83a567</samp>

Refactor `ConversationRepository` to use `pg-promise` and fix SQL query for `autoPublish` flag.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e83a567</samp>

> _`autoPublish` flag_
> _SQL query refactored_
> _Winter of `pg`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e83a567</samp>

*  Add `limit 1` clause to SQL query for `autoPublish` flag ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1364/files?diff=unified&w=0#diff-1676136fe81dc9e98855135a513fc17da4917c16a5dc71ee382a2dee6bdf1eaeL52-R52))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
