### PR TITLE
Bugfix/data sink worker fixes c 2146

### DIFF
--- a/services/apps/data_sink_worker/src/queue/index.ts
+++ b/services/apps/data_sink_worker/src/queue/index.ts
@@ -23,7 +23,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
-    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog, true)
+    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog)
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {

--- a/services/apps/data_sink_worker/src/queue/index.ts
+++ b/services/apps/data_sink_worker/src/queue/index.ts
@@ -23,7 +23,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
-    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog)
+    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog, true, 5 * 60)
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {

--- a/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
+++ b/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
@@ -198,16 +198,11 @@ export default class IntegrationDataRepository extends RepositoryBase<Integratio
     this.checkUpdateRowCount(result.rowCount, 1)
   }
 
-  public async markDataProcessed(dataId: string): Promise<void> {
+  public async deleteData(dataId: string): Promise<void> {
     const result = await this.db().result(
-      `update integration."apiData"
-       set  state = $(state),
-            "processedAt" = now(),
-            "updatedAt" = now()
-       where id = $(dataId)`,
+      `delete from integration."apiData" where id = $(dataId)`,
       {
         dataId,
-        state: IntegrationStreamDataState.PROCESSED,
       },
     )
 

--- a/services/apps/integration_data_worker/src/service/integrationDataService.ts
+++ b/services/apps/integration_data_worker/src/service/integrationDataService.ts
@@ -181,7 +181,7 @@ export default class IntegrationDataService extends LoggerBase {
     try {
       await integrationService.processData(context)
       this.log.debug('Finished processing data!')
-      await this.repo.markDataProcessed(dataId)
+      await this.repo.deleteData(dataId)
     } catch (err) {
       this.log.error(err, 'Error while processing stream!')
       await this.triggerDataError(

--- a/services/apps/integration_data_worker/src/service/integrationDataService.ts
+++ b/services/apps/integration_data_worker/src/service/integrationDataService.ts
@@ -253,7 +253,12 @@ export default class IntegrationDataService extends LoggerBase {
         type,
         data: entity,
       })
-      await this.dataSinkWorkerEmitter.triggerResultProcessing(tenantId, platform, resultId)
+      await this.dataSinkWorkerEmitter.triggerResultProcessing(
+        tenantId,
+        platform,
+        resultId,
+        resultId,
+      )
     } catch (err) {
       await this.triggerDataError(
         dataId,
@@ -278,7 +283,12 @@ export default class IntegrationDataService extends LoggerBase {
         type: IntegrationResultType.ACTIVITY,
         data: activity,
       })
-      await this.dataSinkWorkerEmitter.triggerResultProcessing(tenantId, platform, resultId)
+      await this.dataSinkWorkerEmitter.triggerResultProcessing(
+        tenantId,
+        platform,
+        resultId,
+        activity.sourceId,
+      )
     } catch (err) {
       await this.triggerDataError(
         dataId,

--- a/services/libs/sqs/src/instances/dataSinkWorker.ts
+++ b/services/libs/sqs/src/instances/dataSinkWorker.ts
@@ -9,7 +9,12 @@ export class DataSinkWorkerEmitter extends SqsQueueEmitter {
     super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
-  public async triggerResultProcessing(tenantId: string, platform: string, resultId: string) {
-    await this.sendMessage(resultId, new ProcessIntegrationResultQueueMessage(resultId), resultId)
+  public async triggerResultProcessing(
+    tenantId: string,
+    platform: string,
+    resultId: string,
+    sourceId: string,
+  ) {
+    await this.sendMessage(sourceId, new ProcessIntegrationResultQueueMessage(resultId), resultId)
   }
 }

--- a/services/libs/sqs/src/instances/integrationRunWorker.ts
+++ b/services/libs/sqs/src/instances/integrationRunWorker.ts
@@ -47,6 +47,6 @@ export class IntegrationRunWorkerEmitter extends SqsQueueEmitter {
   }
 
   public async streamProcessed(tenantId: string, platform: string, runId: string): Promise<void> {
-    await this.sendMessage(runId, new StreamProcessedQueueMessage(runId))
+    await this.sendMessage(runId, new StreamProcessedQueueMessage(runId), runId)
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c455574</samp>

This pull request improves the efficiency and reliability of the data processing and worker queue systems. It deletes data after processing instead of updating its state, and uses message group IDs and deduplication IDs to optimize the SQS queue performance. It affects the files `integrationDataService.ts`, `index.ts`, `integrationData.repo.ts`, `dataSinkWorker.ts`, and `integrationRunWorker.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c455574</samp>

> _Sing, O Muse, of the valiant deeds of the data workers_
> _Who, with skill and cunning, improved their queue performance_
> _By passing `visibilityTimeout` and `sourceId` as parameters_
> _And deleting data swiftly, like Zeus hurling his thunderbolts_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c455574</samp>

*  Add `visibilityTimeout` parameter to `WorkerQueueReceiver` constructor to set message hiding duration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dL26-R26))
*  Replace `markDataProcessed` method with `deleteData` method in `IntegrationDataRepo` to delete data instead of updating state ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-21267776815b1a718da34dc9ad833ea27be064ba2ede0c1535f218f6492ba093L201-R205))
*  Call `deleteData` method instead of `markDataProcessed` method in `IntegrationDataService` after processing data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980L184-R184))
*  Pass `resultId` and `activity.sourceId` as message group IDs to `triggerResultProcessing` method in `IntegrationDataService` to enable ordering and deduplication of messages in `dataSinkWorker.ts` queue ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980L256-R261), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-04ede28c2f3720a1aac02995cb344aa471072c8ab0c506e3069ef1be300d0980L281-R291), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408L12-R18))
*  Pass `runId` as message deduplication ID to `sendMessage` method in `streamProcessed` method of `IntegrationRunWorkerEmitter` to improve `integrationRunWorker.ts` queue performance and reliability ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1370/files?diff=unified&w=0#diff-d7aa0cdffcd058177319fac2aa59ecc8e7597a4959be86cb6ad20c1168430d17L50-R50))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
