### PR TITLE
don't use deduplication id for streamProcessed events

### DIFF
--- a/services/libs/sqs/src/instances/integrationRunWorker.ts
+++ b/services/libs/sqs/src/instances/integrationRunWorker.ts
@@ -47,6 +47,6 @@ export class IntegrationRunWorkerEmitter extends SqsQueueEmitter {
   }
 
   public async streamProcessed(tenantId: string, platform: string, runId: string): Promise<void> {
-    await this.sendMessage(runId, new StreamProcessedQueueMessage(runId), runId)
+    await this.sendMessage(runId, new StreamProcessedQueueMessage(runId))
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fff85c4</samp>

Simplified the `streamProcessed` method of the `IntegrationRunWorkerEmitter` class by removing an unnecessary parameter from the `sendMessage` method. This change affects the file `services/libs/sqs/src/instances/integrationRunWorker.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fff85c4</samp>

> _`streamProcessed` calls_
> _`sendMessage` with two args_
> _simpler code in spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fff85c4</samp>

*  Simplify `sendMessage` method call by removing redundant parameter ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1385/files?diff=unified&w=0#diff-d7aa0cdffcd058177319fac2aa59ecc8e7597a4959be86cb6ad20c1168430d17L50-R50))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
