### PR TITLE
Fix filter operator

### DIFF
--- a/frontend/src/modules/member/config/saved-views/views/slipping-away.ts
+++ b/frontend/src/modules/member/config/saved-views/views/slipping-away.ts
@@ -23,7 +23,7 @@ const slippingAway: SavedView = {
     },
 
     lastActivityDate: {
-      operator: 'gt',
+      operator: 'lt',
       value: moment().subtract(1, 'month').format('YYYY-MM-DD'),
     },
   },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08a2410</samp>

Fixed a bug in the `slippingAway` view that showed the wrong members. The view now correctly filters members who have not been active for more than a month by using the `lt` operator for the `lastActivityDate` filter.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 08a2410</samp>

> _`slippingAway` view_
> _changed filter operator_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08a2410</samp>

* Fix the logic of the `slippingAway` view to filter members who have not been active for more than a month ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1397/files?diff=unified&w=0#diff-c1aac5a82af9d3475f7946eb81fe8c8262724ce78a2304b6bd9198a3e1a44375L26-R26))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
