### PR TITLE
Script to restart x failed results

### DIFF
--- a/services/apps/data_sink_worker/package.json
+++ b/services/apps/data_sink_worker/package.json
@@ -16,6 +16,7 @@
     "tsc-check": "./node_modules/.bin/tsc --noEmit",
     "script:restart-failed-results": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/restart-failed-results.ts",
     "script:restart-all-failed-results": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/restart-all-failed-results.ts",
+    "script:restart-x-failed-results": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/restart-x-failed-results.ts",
     "script:restart-result": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/restart-result.ts"
   },
   "dependencies": {

--- a/services/apps/data_sink_worker/src/bin/restart-x-failed-results.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-x-failed-results.ts
@@ -1,0 +1,57 @@
+import { DB_CONFIG, SQS_CONFIG } from '@/conf'
+import DataSinkRepository from '@/repo/dataSink.repo'
+import { partition } from '@crowd/common'
+import { DbStore, getDbConnection } from '@crowd/database'
+import { getServiceLogger } from '@crowd/logging'
+import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
+
+const MAX_TO_PROCESS = 500
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(2)
+
+if (processArguments.length !== 1) {
+  log.error('Expected 1 argument: numResults')
+  process.exit(1)
+}
+
+let numResults = parseInt(processArguments[0], 10)
+
+numResults = Math.min(numResults, MAX_TO_PROCESS)
+
+setImmediate(async () => {
+  const sqsClient = getSqsClient(SQS_CONFIG())
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
+  await emitter.init()
+
+  const dbConnection = getDbConnection(DB_CONFIG())
+  const store = new DbStore(log, dbConnection)
+
+  const repo = new DataSinkRepository(store, log)
+
+  const results = await repo.getFailedResults(1, numResults)
+
+  if (results.length === 0) {
+    log.info('No results to restart.')
+    process.exit(0)
+  }
+
+  await repo.resetResults(results.map((r) => r.id))
+
+  const messages = results.map((r) => {
+    return {
+      payload: new ProcessIntegrationResultQueueMessage(r.id),
+      groupId: r.id,
+      deduplicationId: r.id,
+    }
+  })
+
+  const batches = partition(messages, 10)
+  for (const batch of batches) {
+    await emitter.sendMessages(batch)
+  }
+
+  log.info(`Restarted total of ${results.length} failed results.`)
+})


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b4f1ba</samp>

Added a script to restart failed results in the data sink worker service. The script uses TypeScript and runs the `restart-x-failed-results.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b4f1ba</samp>

> _`restart-x-failed`_
> _A script to heal the data_
> _Autumn of errors_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b4f1ba</samp>

*  Add a script to restart failed results in the data sink worker service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1400/files?diff=unified&w=0#diff-942c05c53d2abedd67048af9f140025de0cb97b2f0672e0e545ad008bf3d6de5R19)). The script uses `ts-node` to run `restart-x-failed-results.ts` with the TypeScript compiler and `tsconfig-paths`.

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
