### PR TITLE
Move timestamps to ISO strings in lists

### DIFF
--- a/frontend/src/modules/dashboard/components/dashboard-members.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-members.vue
@@ -98,8 +98,8 @@
                   query: filterQueryService().setQuery({
                     ...allMembers.filter,
                     joinedDate: {
-                      value: periodStartDate,
-                      operator: 'gt',
+                      value: periodRange,
+                      operator: 'between',
                     },
                   }),
                 }"
@@ -186,8 +186,8 @@
                   query: filterQueryService().setQuery({
                     ...allMembers.filter,
                     lastActivityDate: {
-                      value: periodStartDate,
-                      operator: 'gt',
+                      value: periodRange,
+                      operator: 'between',
                     },
                   }),
                 }"
@@ -252,11 +252,16 @@ export default {
       'members',
       'period',
     ]),
-    periodStartDate() {
-      return moment()
-        .utc()
-        .subtract(this.period.value, 'day')
-        .format('YYYY-MM-DD');
+    periodRange() {
+      return [
+        moment()
+          .utc()
+          .subtract(this.period.value - 1, 'day')
+          .format('YYYY-MM-DD'),
+        moment()
+          .utc()
+          .format('YYYY-MM-DD'),
+      ];
     },
   },
   methods: {

--- a/frontend/src/modules/dashboard/components/dashboard-organizations.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-organizations.vue
@@ -72,7 +72,7 @@
               No new organizations during this period
             </app-dashboard-empty-state>
             <div
-              v-if="organizations.length >= 5"
+              v-if="recentOrganizations.length >= 5"
               class="pt-3"
             >
               <router-link

--- a/frontend/src/modules/dashboard/components/dashboard-organizations.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-organizations.vue
@@ -81,8 +81,8 @@
                   query: filterQueryService().setQuery({
                     ...allOrganizations.filter,
                     joinedDate: {
-                      value: periodStartDate,
-                      operator: 'gt',
+                      value: periodRange,
+                      operator: 'between',
                     },
                   }),
                 }"
@@ -161,8 +161,8 @@
                   query: filterQueryService().setQuery({
                     ...allOrganizations.filter,
                     lastActivityDate: {
-                      value: periodStartDate,
-                      operator: 'gt',
+                      value: periodRange,
+                      operator: 'between',
                     },
                   }),
                 }"
@@ -224,10 +224,16 @@ export default {
       'organizations',
       'period',
     ]),
-    periodStartDate() {
-      return moment()
-        .subtract(this.period.value, 'day')
-        .format('YYYY-MM-DD');
+    periodRange() {
+      return [
+        moment()
+          .utc()
+          .subtract(this.period.value - 1, 'day')
+          .format('YYYY-MM-DD'),
+        moment()
+          .utc()
+          .format('YYYY-MM-DD'),
+      ];
     },
   },
   methods: {

--- a/frontend/src/shared/modules/filters/config/apiFilterRenderer/date.filter.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/apiFilterRenderer/date.filter.renderer.ts
@@ -12,18 +12,36 @@ export const dateApiFilterRenderer = (property: string, { value, operator }: Dat
     filterOperator = FilterDateOperator.BETWEEN;
   }
 
-  let filter = {
-    [property]: {
-      [filterOperator]: value,
-    },
-  };
-  if ([FilterDateOperator.EQ, FilterDateOperator.NE].includes(operator)) {
+  let filter;
+
+  if ([FilterDateOperator.BETWEEN, FilterDateOperator.NOT_BETWEEN].includes(operator)) {
+    filter = {
+      [property]: {
+        [filterOperator]: [
+          moment.utc(value[0]).startOf('day').toISOString(),
+          moment.utc(value[1]).endOf('day').toISOString(),
+        ],
+      },
+    };
+  } else if ([FilterDateOperator.EQ, FilterDateOperator.NE].includes(operator)) {
     filter = {
       [property]: {
         between: [
           moment.utc(value).startOf('day').toISOString(),
           moment.utc(value).endOf('day').toISOString(),
         ],
+      },
+    };
+  } else {
+    let parsedValue = moment.utc(value).startOf('day').toISOString();
+
+    if ([FilterDateOperator.GT].includes(operator)) {
+      parsedValue = moment.utc(value).endOf('day').toISOString();
+    }
+
+    filter = {
+      [property]: {
+        [filterOperator]: parsedValue,
       },
     };
   }


### PR DESCRIPTION
# Changes proposed ✍️

- Updated requests for "View more" in Members and Organizations dashboard to be between 2 dates. Exactly the same dates we apply on the dashboard's widgets
- Updated `date.filter.renderer.ts` to properly parse values according to the operator. `gt` and `between` operators were using "YYYY-MM-DD" format which was requesting for the wrong periods. Currently we always send in ISO to backend and display in "YYYY-MM-DD" for frontend

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8c17bd</samp>

The pull request updates the dashboard components and the date filter renderer to support more flexible and accurate filtering of data by date ranges. It uses a computed property `periodRange` and a new operator `between` to create and apply date filters for the `allMembers` and `allOrganizations` queries. It also modifies the `dateApiFilterRenderer` function to handle different date operators.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e8c17bd</samp>

> _Sing, O Muse, of the skillful coder who refined the dashboard view_
> _With cunning logic and `periodRange`, he filtered data anew_
> _By `joinedDate` and `lastActivityDate`, he sorted members and organizations_
> _Like Zeus who rules the seasons and the years, he wielded the `between` operator_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8c17bd</samp>

*  Changed the filters for the joinedDate and lastActivityDate properties of the allMembers and allOrganizations queries to use the between operator and the periodRange value instead of the greater than operator and the periodStartDate value. This allows the dashboard to show the members and organizations who joined or were active within the selected period, instead of only those who joined or were active after the start of the period. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L101-R102), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L189-R190), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-89cd853fad6f5e8a06b94fe938a6c3a72c704550ab942d25a42898f84ee00139L84-R85), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-89cd853fad6f5e8a06b94fe938a6c3a72c704550ab942d25a42898f84ee00139L164-R165))
*  Replaced the computed property periodStartDate by the computed property periodRange, which returns an array of two dates: the start and the end of the selected period. This provides the periodRange value for the filters that use the between operator. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L255-R264), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-89cd853fad6f5e8a06b94fe938a6c3a72c704550ab942d25a42898f84ee00139L227-R236))
*  Modified the dateApiFilterRenderer function to handle the between and not between operators for the date filters. The function now creates a filter object with an array of two dates: the start and the end of the day for each value in the input array. This allows the filters to use the between and not between operators for the date properties. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1401/files?diff=unified&w=0#diff-ba4d151c0441929df4ee8dbbef4720c24a5e6ef0d2b8dd778cfe176778a0935dL15-R28))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
