### PR TITLE
Fix `displayName` sorter in members and organizations list

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-table.vue
+++ b/frontend/src/modules/member/components/list/member-list-table.vue
@@ -102,6 +102,7 @@
                 width="250"
                 fixed
                 class="-my-2"
+                sortable="custom"
               >
                 <template #default="scope">
                   <router-link

--- a/frontend/src/modules/organization/components/list/organization-list-table.vue
+++ b/frontend/src/modules/organization/components/list/organization-list-table.vue
@@ -97,6 +97,7 @@
                 prop="displayName"
                 width="260"
                 fixed
+                sortable
               >
                 <template #default="scope">
                   <router-link

--- a/services/libs/opensearch/src/opensearchQueryParser.ts
+++ b/services/libs/opensearch/src/opensearchQueryParser.ts
@@ -18,9 +18,15 @@ export class OpensearchQueryParser {
     // sorting comes with the form `joinedAt_DESC`
     const sorterSplit = criteria.orderBy.split('_')
 
+    let sortField = translator.crowdToOpensearch(sorterSplit[0])
+
+    if (sortField === 'string_displayName') {
+      sortField = 'keyword_displayName'
+    }
+
     const sort = [
       {
-        [translator.crowdToOpensearch(sorterSplit[0])]: sorterSplit[1].toLowerCase(),
+        [sortField]: sorterSplit[1].toLowerCase(),
       },
     ]
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 372d4d8</samp>

This pull request adds or modifies the sorting functionality for the display names and the organization names in the list tables. It uses the `sortable` attribute of the `el-table-column` component and a custom opensearch query parser to achieve case-insensitive sorting for the display names.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 372d4d8</samp>

> _Sorting display names_
> _`keyword` type for winter_
> _Custom or default_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 372d4d8</samp>

*  Enable case-insensitive sorting of display names in member list table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1406/files?diff=unified&w=0#diff-4440397ab723cae9eaefae96077cf8e899c2f9feebd23c4d430d9f5d5d054b18R105), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1406/files?diff=unified&w=0#diff-9e6990074cd1d16fe13ea3ffc9a02e11f101529d10bd847f2c770427085904b9L21-R29))
* Add default sorting functionality to name column in organization list table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1406/files?diff=unified&w=0#diff-99194084f4efcde26d486e359545dd27d3144d0fa43834a7afe08d928753cec0R100))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
