### PR TITLE
Fix handling of nested fields in OpenSearch query

### DIFF
--- a/services/libs/opensearch/src/fieldTranslator.ts
+++ b/services/libs/opensearch/src/fieldTranslator.ts
@@ -51,6 +51,10 @@ export default abstract class FieldTranslator {
     return value
   }
 
+  isNestedField(field: string): boolean {
+    return field.startsWith('nested_')
+  }
+
   translateObjectToCrowd(object: unknown): unknown {
     const translated = {}
 

--- a/services/libs/opensearch/src/opensearchQueryParser.ts
+++ b/services/libs/opensearch/src/opensearchQueryParser.ts
@@ -65,7 +65,18 @@ export class OpensearchQueryParser {
       } else if (translator.fieldExists(key)) {
         const searchKey: string = translator.crowdToOpensearch(key)
 
-        query.bool.must.push(this.parseColumnCondition(filters[key], searchKey))
+        if (translator.isNestedField(searchKey)) {
+          // Extract the path to the nested object
+          const nestedPath = searchKey.split('.')[0]
+          query.bool.must.push({
+            nested: {
+              path: nestedPath,
+              query: this.parseColumnCondition(filters[key], searchKey),
+            },
+          })
+        } else {
+          query.bool.must.push(this.parseColumnCondition(filters[key], searchKey))
+        }
       } else {
         throw new Error(`Unknown field or operator: ${key}!`)
       }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a240668</samp>

Added support for nested field queries in Opensearch. Modified `FieldTranslator` and `OpensearchQueryParser` classes to detect and handle nested fields in the `filters` object.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a240668</samp>

> _`Nested` query added_
> _To filter crowd fields with depth_
> _Autumn leaves nested_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a240668</samp>

*  Add support for nested field queries in Opensearch ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1407/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0R54-R57), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1407/files?diff=unified&w=0#diff-9e6990074cd1d16fe13ea3ffc9a02e11f101529d10bd847f2c770427085904b9L68-R79))
  - Create a new method `isNestedField` in `fieldTranslator.ts` to check if a field name starts with `nested_` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1407/files?diff=unified&w=0#diff-775cc3825ed62dc15b187d37c73ff816b0fb74c6c1e82810a798b703493048e0R54-R57))
  - Modify `parseCrowdFilters` in `opensearchQueryParser.ts` to wrap the query condition for nested fields in a `nested` query with the correct path and query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1407/files?diff=unified&w=0#diff-9e6990074cd1d16fe13ea3ffc9a02e11f101529d10bd847f2c770427085904b9L68-R79))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
