### PR TITLE
Fix some bugs in Discourse integration

### DIFF
--- a/backend/src/serverless/integrations/services/integrations/discourseIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discourseIntegrationService.ts
@@ -130,7 +130,7 @@ export class DiscourseIntegrationService extends IntegrationServiceBase {
     }
 
     const newStreams: IPendingStream[] = []
-    const nextPageStream: IPendingStream | undefined = undefined
+    let nextPageStream: IPendingStream | undefined
     const activities: AddActivitiesSingle[] = []
 
     // another switch statement to handle the different types of results, helps with type safety
@@ -150,20 +150,32 @@ export class DiscourseIntegrationService extends IntegrationServiceBase {
         break
       case DiscourseStreamType.TOPICS_FROM_CATEGORY:
         const data2 = result.data as DiscourseTopicResponse
-        data2.topic_list.topics.forEach((topic) => {
-          newStreams.push({
-            value: DiscourseStreamType.POSTS_FROM_TOPIC,
-            metadata: {
-              topicId: topic.id,
-              topic_slug: topic.slug,
-              page: 0,
-            },
+        if (data2.topic_list.topics.length > 0) {
+          data2.topic_list.topics.forEach((topic) => {
+            newStreams.push({
+              value: DiscourseStreamType.POSTS_FROM_TOPIC,
+              metadata: {
+                topicId: topic.id,
+                topic_slug: topic.slug,
+                page: 0,
+              },
+            })
           })
-        })
+
+          // we aslo need to trigger nextPageStream
+          nextPageStream = {
+            value: DiscourseStreamType.TOPICS_FROM_CATEGORY,
+            metadata: {
+              category_id: stream.metadata.category_id,
+              category_slug: stream.metadata.category_slug,
+              page: stream.metadata.page + 1,
+            },
+          }
+        }
         break
       case DiscourseStreamType.POSTS_FROM_TOPIC:
         const data3 = result.data as DiscoursePostsFromTopicResponse
-        const batchSize = 100
+        const batchSize = 30
         const postBatches: number[][] = []
 
         data3.post_stream.stream.forEach((postId, index) => {

--- a/backend/src/serverless/integrations/services/integrations/discourseIntegrationService.ts
+++ b/backend/src/serverless/integrations/services/integrations/discourseIntegrationService.ts
@@ -150,7 +150,7 @@ export class DiscourseIntegrationService extends IntegrationServiceBase {
         break
       case DiscourseStreamType.TOPICS_FROM_CATEGORY:
         const data2 = result.data as DiscourseTopicResponse
-        if (data2.topic_list.topics.length > 0) {
+        if (data2?.topic_list?.topics?.length > 0) {
           data2.topic_list.topics.forEach((topic) => {
             newStreams.push({
               value: DiscourseStreamType.POSTS_FROM_TOPIC,
@@ -178,7 +178,7 @@ export class DiscourseIntegrationService extends IntegrationServiceBase {
         const batchSize = 30
         const postBatches: number[][] = []
 
-        data3.post_stream.stream.forEach((postId, index) => {
+        data3?.post_stream?.stream?.forEach((postId, index) => {
           if (index % batchSize === 0) {
             postBatches.push([])
           }
@@ -205,7 +205,7 @@ export class DiscourseIntegrationService extends IntegrationServiceBase {
         // just add the activities
         const data4 = result.data as DiscoursePostsByIdsResponse
         const { topicId, lastIdInPreviousBatch } = stream.metadata
-        const posts = data4.post_stream.posts
+        const posts = data4?.post_stream?.posts
         for (const post of posts) {
           if (usernameIsBot(post.username)) {
             /* eslint-disable no-continue */

--- a/backend/src/serverless/integrations/usecases/discourse/getCategories.ts
+++ b/backend/src/serverless/integrations/usecases/discourse/getCategories.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { Logger } from '@crowd/logging'
+import { RateLimitError } from '@crowd/types'
 import type { DiscourseConnectionParams } from '../../types/discourseTypes'
 import { DiscourseCategoryResponse } from '../../types/discourseTypes'
 
@@ -24,6 +25,10 @@ export const getDiscourseCategories = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
+    if (err.response && err.response.status === 429) {
+      // wait 5 mins
+      throw new RateLimitError(5 * 60, 'discourse/getcategories')
+    }
     logger.error({ err, params }, 'Error while getting Discourse categories')
     throw err
   }

--- a/backend/src/serverless/integrations/usecases/discourse/getPostsByIds.ts
+++ b/backend/src/serverless/integrations/usecases/discourse/getPostsByIds.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { Logger } from '@crowd/logging'
+import { RateLimitError } from '@crowd/types'
 import type { DiscourseConnectionParams } from '../../types/discourseTypes'
 import { DiscoursePostsByIdsResponse, DiscoursePostsByIdsInput } from '../../types/discourseTypes'
 
@@ -47,6 +48,10 @@ export const getDiscoursePostsByIds = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
+    if (err.response && err.response.status === 429) {
+      // wait 5 mins
+      throw new RateLimitError(5 * 60, 'discourse/getpostsbyids')
+    }
     logger.error({ err, params, input }, 'Error while getting posts by ids from Discourse ')
     throw err
   }

--- a/backend/src/serverless/integrations/usecases/discourse/getPostsFromTopic.ts
+++ b/backend/src/serverless/integrations/usecases/discourse/getPostsFromTopic.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { Logger } from '@crowd/logging'
+import { RateLimitError } from '@crowd/types'
 import type { DiscourseConnectionParams } from '../../types/discourseTypes'
 import { DiscoursePostsFromTopicResponse, DiscoursePostsInput } from '../../types/discourseTypes'
 
@@ -28,6 +29,10 @@ export const getDiscoursePostsFromTopic = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
+    if (err.response && err.response.status === 429) {
+      // wait 5 mins
+      throw new RateLimitError(5 * 60, 'discourse/getpostsfromtopic')
+    }
     logger.error({ err, params, input }, 'Error while getting posts from topic from Discourse ')
     throw err
   }

--- a/backend/src/serverless/integrations/usecases/discourse/getTopics.ts
+++ b/backend/src/serverless/integrations/usecases/discourse/getTopics.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { Logger } from '@crowd/logging'
+import { RateLimitError } from '@crowd/types'
 import type { DiscourseConnectionParams } from '../../types/discourseTypes'
 import { DiscourseCategoryResponse, DiscourseTopicsInput } from '../../types/discourseTypes'
 
@@ -28,6 +29,10 @@ export const getDiscourseTopics = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
+    if (err.response && err.response.status === 429) {
+      // wait 5 mins
+      throw new RateLimitError(5 * 60, 'discourse/gettopics')
+    }
     logger.error({ err, params }, 'Error while getting Discourse categories')
     throw err
   }

--- a/backend/src/serverless/integrations/usecases/discourse/getUser.ts
+++ b/backend/src/serverless/integrations/usecases/discourse/getUser.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { Logger } from '@crowd/logging'
+import { RateLimitError } from '@crowd/types'
 import type { DiscourseConnectionParams } from '../../types/discourseTypes'
 import { DiscourseUserResponse, DisourseUserByUsernameInput } from '../../types/discourseTypes'
 
@@ -28,6 +29,10 @@ export const getDiscourseUserByUsername = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
+    if (err.response && err.response.status === 429) {
+      // wait 5 mins
+      throw new RateLimitError(5 * 60, 'discourse/getuserbyusername')
+    }
     logger.error({ err, params, input }, 'Error while fetching user by username from Discourse ')
     throw err
   }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 519f09a</samp>

Improved the Discourse integration service by handling the API rate limit errors and fixing the pagination logic. Added the `RateLimitError` class from `@crowd/types` to throw and catch the errors in the use cases. Modified the `discourseIntegrationService.ts` file and the `getCategories.ts`, `getPostsByIds.ts`, `getPostsFromTopic.ts`, `getTopics.ts`, and `getUser.ts` files.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 519f09a</samp>

> _Oh we're the brave Discourse crew and we sail the web so wide_
> _We fetch the posts and topics from the forums far and wide_
> _But when the rate limit hits us and we see the status `429`_
> _We throw the `RateLimitError` and we wait until retry time_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 519f09a</samp>

*  Handle Discourse API rate limit errors by importing and throwing `RateLimitError` class in all Discourse use cases ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-fa86247745bf476444990ff7328ee6e5283b2cecf3e3745c8b436534ec5ddae8R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-e2536df94b7e98422b72b09acdabe90fe0ef44ea374671b18e7168964699f5f8R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-3bd49b91c896bfbf7099da2ce58efb6f00fa54a4a4cec17470a4813a560736f2R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-8eb3b3fbb46b871daab5a3553e8f66770eb458182a0c636bc455ddd595ead0d3R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-48b12a31632d2269f418fbe87f73f9f4cc4a42852edcf59f87fdb183b8827cc5R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-fa86247745bf476444990ff7328ee6e5283b2cecf3e3745c8b436534ec5ddae8R28-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-e2536df94b7e98422b72b09acdabe90fe0ef44ea374671b18e7168964699f5f8R51-R54), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-3bd49b91c896bfbf7099da2ce58efb6f00fa54a4a4cec17470a4813a560736f2R32-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-8eb3b3fbb46b871daab5a3553e8f66770eb458182a0c636bc455ddd595ead0d3R32-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-48b12a31632d2269f418fbe87f73f9f4cc4a42852edcf59f87fdb183b8827cc5R32-R35))
*  Implement pagination logic for Discourse topics from category stream by changing `nextPageStream` variable to `let` and creating a new stream object with the next page metadata ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-895e6815af572b0f428613cb171893e5bdcfd5ae2d2a8f988efd10f4703dc5a4L133-R133), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-895e6815af572b0f428613cb171893e5bdcfd5ae2d2a8f988efd10f4703dc5a4L153-R181))
*  Use optional chaining to access `post_stream.posts` property in `discourseIntegrationService.ts` to prevent errors if response data is undefined or null ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1410/files?diff=unified&w=0#diff-895e6815af572b0f428613cb171893e5bdcfd5ae2d2a8f988efd10f4703dc5a4L196-R208))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
