### PR TITLE
Improvements

### DIFF
--- a/frontend/src/modules/organization/components/view/organization-view-members.vue
+++ b/frontend/src/modules/organization/components/view/organization-view-members.vue
@@ -10,8 +10,7 @@
       <p
         class="text-sm leading-5 text-center italic text-gray-400 pl-6"
       >
-        Members can take up to two minutes to appear in the
-        list
+        No members are currently working in this organization.
       </p>
     </div>
     <div v-else>

--- a/frontend/src/modules/organization/pages/organization-view-page.vue
+++ b/frontend/src/modules/organization/pages/organization-view-page.vue
@@ -25,12 +25,25 @@
         <div class="panel w-full col-span-2">
           <el-tabs v-model="tab">
             <el-tab-pane
-              label="Associated members"
+              label="Current members"
               name="members"
             >
-              <app-organization-view-members
-                :organization-id="props.id"
-              />
+              <template #label>
+                <span class="flex gap-2">
+                  <span>Current members</span>
+                  <el-tooltip
+                    content="Members that are currently a part of this organization."
+                    placement="top"
+                  >
+                    <i class="ri-information-line" />
+                  </el-tooltip>
+                </span>
+              </template>
+              <template #default>
+                <app-organization-view-members
+                  :organization-id="props.id"
+                />
+              </template>
             </el-tab-pane>
             <el-tab-pane
               label="Activities"


### PR DESCRIPTION
# Changes proposed ✍️

Added better UX for members in the organizations' page.
- Tweaked copy and added Tooltip
<img width="748" alt="Screenshot 2023-09-01 at 14 53 05" src="https://github.com/CrowdDotDev/crowd.dev/assets/37874460/79d89b0d-c760-4ae2-ba5d-137ceee4dbb5">

- Changed the empty state
<img width="731" alt="Screenshot 2023-09-01 at 14 53 40" src="https://github.com/CrowdDotDev/crowd.dev/assets/37874460/c1ea44f8-6d82-44e1-890e-c7d8d10a0450">



### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1b3b3b</samp>

This pull request improves the user interface of the organization view page by changing some text and labels to avoid confusion and provide more information. It affects the files `organization-view-members.vue` and `organization-view-page.vue` in the frontend module.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b1b3b3b</samp>

> _`<p>` text updated_
> _No members in the org_
> _Winter of content_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1b3b3b</samp>

*  Clarify the difference between current and past members of an organization in the frontend
  * Change the tab label to "Current members" and add a tooltip in `organization-view-page.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1411/files?diff=unified&w=0#diff-62bbcf91d639b76c71050dcef7dff7db3711b6bc91ea3547770f6fa9a6445702L28-R46))
  * Change the text for the case when there are no members in the organization in `organization-view-members.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1411/files?diff=unified&w=0#diff-7484c004179839db2d389412903d5592a1d6c72b9fa5139dc4607e378eb74c4eL13-R13))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
