### PR TITLE
Increase query timeout to 30 seconds in services

### DIFF
--- a/services/libs/database/src/connection.ts
+++ b/services/libs/database/src/connection.ts
@@ -62,7 +62,7 @@ export const getDbConnection = async (
   dbConnection = dbInstance({
     ...config,
     max: maxPoolSize || 5,
-    query_timeout: 10000,
+    query_timeout: 30000,
   })
 
   await dbConnection.connect()


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a50f10</samp>

Increased the `query_timeout` option for the database connection in `services/libs/database/src/connection.ts` to prevent errors from long-running queries. This was part of a pull request to improve the database service performance and stability.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a50f10</samp>

> _`query_timeout` grows_
> _long-running queries need time_
> _winter patience pays_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a50f10</samp>

* Increase the database connection timeout to 30 seconds ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1415/files?diff=unified&w=0#diff-9e58f25937db0a6e39a8159f110097d74642b6f1f3188104950027074f86f81dL65-R65)) to prevent errors from long-running queries

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
