### PR TITLE
Add last synced information to integrations

### DIFF
--- a/frontend/src/modules/integration/components/integration-list-item.vue
+++ b/frontend/src/modules/integration/components/integration-list-item.vue
@@ -46,7 +46,7 @@
         </div>
         <div class="h-5 leading-5 text-end">
           <el-tooltip
-            v-if="includeTimestamp"
+            v-if="isDone"
             :content="lastSynced.absolute"
             placement="top"
           >
@@ -176,14 +176,9 @@ const isNeedsToBeReconnected = computed(
   () => props.integration.status === 'needs-reconnect',
 );
 
-const includeTimestamp = computed(() => isConnected.value
-|| isDone.value || isError.value
-|| isNoData.value || isWaitingForAction.value
-|| isWaitingApproval.value || isNeedsToBeReconnected.value);
-
 const lastSynced = computed(() => ({
-  absolute: moment.utc(props.integration.updatedAt).format('MMM DD, YYYY HH:mm'),
-  relative: `last synced ${moment.utc(props.integration.updatedAt).fromNow()}`,
+  absolute: moment(props.integration.updatedAt).format('MMM DD, YYYY HH:mm'),
+  relative: `last synced ${moment(props.integration.updatedAt).fromNow()}`,
 }));
 
 const loadingDisconnect = ref(false);


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea09f2c</samp>

Improved the display of integration sync status in the frontend. Used `moment` library to format the last synced timestamp according to the user's locale. Refactored `integration-list-item.vue` component to move the timestamp to a separate line.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea09f2c</samp>

> _Oh, we're the crew of the `integration` ship_
> _And we sail the codebase wide_
> _We moved the `last synced` to a better spot_
> _With `moment` by our side_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea09f2c</samp>

* Move and align integration status badge and last synced timestamp in integration list item component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1416/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6L5-R58))
* Import and use moment library to format and display last synced timestamp in a user-friendly way ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1416/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6L104-R123), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1416/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6R133-R147), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1416/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6R179-R188))
* Add computed properties to determine whether and how to show last synced timestamp in `integration-list-item.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1416/files?diff=unified&w=0#diff-26aca074f8a3c427253e6e5ff198ba6c2b7a9697c76273c6512e028c1e4c6ee6R179-R188))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
