### PR TITLE
Add for update lock when updating members

### DIFF
--- a/services/apps/data_sink_worker/src/repo/member.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/member.repo.ts
@@ -167,6 +167,15 @@ export default class MemberRepository extends RepositoryBase<MemberRepository> {
     )
     const query = this.dbInstance.helpers.update(prepared, dynamicColumnSet)
 
+    // Lock the row to be updated
+    await this.db().oneOrNone(
+      `SELECT * FROM "members" WHERE id = $(id) AND "tenantId" = $(tenantId) FOR UPDATE`,
+      {
+        id,
+        tenantId,
+      },
+    )
+
     const condition = this.format('where id = $(id) and "tenantId" = $(tenantId)', {
       id,
       tenantId,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3bff48</samp>

Added row locking to `updateMemberStatus` method in `member.repo.ts` to avoid concurrent status updates. This method is used by the data sink worker to process member events.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f3bff48</samp>

> _`updateMemberStatus`_
> _Locks the row for a change_
> _Autumn of conflict_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3bff48</samp>

*  Add a query to lock the member row for update in a transaction ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1417/files?diff=unified&w=0#diff-b29056484026f565bb0ebf009aa7f93a9dbf0dc63b4594efb97e7af8f9ecdf45R170-R178))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
