### PR TITLE
Add script to continue integration run

### DIFF
--- a/services/apps/integration_run_worker/package.json
+++ b/services/apps/integration_run_worker/package.json
@@ -16,7 +16,8 @@
     "tsc-check": "./node_modules/.bin/tsc --noEmit",
     "script:onboard-integration": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/onboard-integration.ts",
     "script:process-repo": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/process-repo.ts",
-    "script:trigger-stream-processed": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/trigger-stream-processed.ts"
+    "script:trigger-stream-processed": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/trigger-stream-processed.ts",
+    "script:continue-run": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/continue-run.ts"
   },
   "dependencies": {
     "@crowd/common": "file:../../libs/common",

--- a/services/apps/integration_run_worker/src/bin/continue-run.ts
+++ b/services/apps/integration_run_worker/src/bin/continue-run.ts
@@ -1,0 +1,41 @@
+import { DB_CONFIG, SQS_CONFIG } from '@/conf'
+import { DbStore, getDbConnection } from '@crowd/database'
+import { getServiceLogger } from '@crowd/logging'
+import { IntegrationRunWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import IntegrationRunRepository from '@/repo/integrationRun.repo'
+import { IntegrationRunState } from '@crowd/types'
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(2)
+
+const runId = processArguments[0]
+
+setImmediate(async () => {
+  const sqsClient = getSqsClient(SQS_CONFIG())
+  const emitter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  await emitter.init()
+
+  const dbConnection = await getDbConnection(DB_CONFIG(), 1)
+  const store = new DbStore(log, dbConnection)
+
+  const repo = new IntegrationRunRepository(store, log)
+
+  const run = await repo.findIntegrationRunById(runId)
+
+  if (run) {
+    if (run.state != IntegrationRunState.PENDING) {
+      log.warn(`Integration run is not pending, setting to pending!`)
+
+      await repo.restart(run.id)
+    }
+
+    log.info(`Triggering integration run for ${runId}!`)
+
+    await emitter.triggerIntegrationRun(run.tenantId, run.platform, run.integrationId, true)
+    process.exit(0)
+  } else {
+    log.error({ run }, 'Run not found!')
+    process.exit(1)
+  }
+})


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5e857b</samp>

Added a script and database methods to resume interrupted integration runs. The `continue-run.ts` script uses the `findIntegrationRunById` and `restart` methods from the `integrationRun.repo.ts` file to query and update the integration run table.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c5e857b</samp>

> _`continue-run` script_
> _resumes integration runs_
> _with database help_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5e857b</samp>

*  Add a script command to run `continue-run.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1418/files?diff=unified&w=0#diff-d1ce9411b1493ff8abbf60c134dd2fe51eb93f05bdc6b6303ad7a2c2a21b64a0L19-R20))
*  Implement `findIntegrationRunById` and `restart` methods in `integrationRun.repo.ts` to query and update the integration runs table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1418/files?diff=unified&w=0#diff-0b5d417572e8526e91c2ced57ccbe0a06750f1cd69319b75e37c88962ec5ca2fR374-R415))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
