### PR TITLE
Better member affiliation, which doesn't override UI changes

### DIFF
--- a/backend/src/database/migrations/U1693388845__better-affiliations-source.sql
+++ b/backend/src/database/migrations/U1693388845__better-affiliations-source.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "memberOrganizations" DROP COLUMN source;
+ALTER TABLE "memberOrganizations" DROP COLUMN "deletedAt";

--- a/backend/src/database/migrations/V1693388845__better-affiliations-source.sql
+++ b/backend/src/database/migrations/V1693388845__better-affiliations-source.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "memberOrganizations" ADD source VARCHAR(255) NULL DEFAULT NULL;
+ALTER TABLE "memberOrganizations" ADD "deletedAt" TIMESTAMP NULL DEFAULT NULL;

--- a/backend/src/database/repositories/__tests__/memberRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/memberRepository.test.ts
@@ -3749,6 +3749,7 @@ describe('MemberRepository tests', () => {
         {
           memberId,
           organizationId: orgId,
+          source: 'test',
           ...data,
         },
         options,

--- a/backend/src/database/repositories/memberAffiliationRepository.ts
+++ b/backend/src/database/repositories/memberAffiliationRepository.ts
@@ -26,12 +26,17 @@ class MemberAffiliationRepository {
                  a.timestamp BETWEEN msa."dateStart" AND msa."dateEnd"
                  OR (a.timestamp >= msa."dateStart" AND msa."dateEnd" IS NULL)
              )
-          LEFT JOIN "memberOrganizations" mo ON mo."memberId" = a."memberId" AND (
+          LEFT JOIN "memberOrganizations" mo ON mo."memberId" = a."memberId"
+              AND (
                   a.timestamp BETWEEN mo."dateStart" AND mo."dateEnd"
                   OR (a.timestamp >= mo."dateStart" AND mo."dateEnd" IS NULL)
               )
-          LEFT JOIN "memberOrganizations" mo1 ON mo1."memberId" = a."memberId" AND mo1."createdAt" <= a.timestamp
+              AND mo."deletedAt" IS NULL
+          LEFT JOIN "memberOrganizations" mo1 ON mo1."memberId" = a."memberId"
+              AND mo1."createdAt" <= a.timestamp
+              AND mo1."deletedAt" IS NULL
           LEFT JOIN "memberOrganizations" mo2 ON mo2."memberId" = a."memberId"
+              AND mo2."deletedAt" IS NULL
           WHERE a."memberId" = :memberId
           GROUP BY a.id
       )

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3330,7 +3330,8 @@ class MemberRepository {
       // clean up organizations without dates if we're getting ones with dates
       await seq.query(
         `
-          DELETE FROM "memberOrganizations"
+          UPDATE "memberOrganizations"
+          SET "deletedAt" = NOW()
           WHERE "memberId" = :memberId
           AND "organizationId" = :organizationId
           AND "dateStart" IS NULL
@@ -3341,7 +3342,7 @@ class MemberRepository {
             memberId,
             organizationId,
           },
-          type: QueryTypes.DELETE,
+          type: QueryTypes.UPDATE,
           transaction,
         },
       )
@@ -3399,14 +3400,15 @@ class MemberRepository {
 
     await seq.query(
       `
-        DELETE FROM "memberOrganizations"
+        UPDATE "memberOrganizations"
+        SET "deletedAt" = NOW()
         WHERE "id" = :id
       `,
       {
         replacements: {
           id,
         },
-        type: QueryTypes.DELETE,
+        type: QueryTypes.UPDATE,
         transaction,
       },
     )

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3320,6 +3320,7 @@ class MemberRepository {
     {
       memberId,
       organizationId,
+      source,
       title = null,
       dateStart = null,
       dateEnd = null,
@@ -3377,8 +3378,8 @@ class MemberRepository {
 
     await seq.query(
       `
-        INSERT INTO "memberOrganizations" ("memberId", "organizationId", "createdAt", "updatedAt", "title", "dateStart", "dateEnd")
-        VALUES (:memberId, :organizationId, NOW(), NOW(), :title, :dateStart, :dateEnd)
+        INSERT INTO "memberOrganizations" ("memberId", "organizationId", "createdAt", "updatedAt", "title", "dateStart", "dateEnd", "source")
+        VALUES (:memberId, :organizationId, NOW(), NOW(), :title, :dateStart, :dateEnd, :source)
         ON CONFLICT DO NOTHING
       `,
       {
@@ -3388,6 +3389,7 @@ class MemberRepository {
           title: title || null,
           dateStart: dateStart || null,
           dateEnd: dateEnd || null,
+          source: source || null,
         },
         type: QueryTypes.INSERT,
         transaction,

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -400,6 +400,7 @@ class OrganizationRepository {
       from "memberOrganizations" as mo
       where mo."memberId" = m.id
       and mo."organizationId" = :organizationId
+      and mo."deletedAt" is null
       and m."tenantId" = :tenantId;
    `,
       {
@@ -464,7 +465,9 @@ class OrganizationRepository {
               member_counts AS (
                   SELECT "organizationId", COUNT(DISTINCT "memberId") AS "memberCount"
                   FROM "memberOrganizations"
-                  WHERE "organizationId" = :id and "dateEnd" is null
+                  WHERE "organizationId" = :id
+                    AND "deletedAt" IS NULL
+                    AND "dateEnd" IS NULL
                   GROUP BY "organizationId"
               ),
               active_on AS (
@@ -478,6 +481,7 @@ class OrganizationRepository {
                   FROM "memberOrganizations" mo
                   JOIN "memberIdentities" mi ON mi."memberId" = mo."memberId"
                   WHERE mo."organizationId" = :id
+                    AND mo."deletedAt" IS NULL
                   GROUP BY "organizationId"
               ),
               last_active AS (
@@ -485,6 +489,7 @@ class OrganizationRepository {
                   FROM "memberOrganizations" mo
                   JOIN activities a ON a."memberId" = mo."memberId"
                   WHERE mo."organizationId" = :id
+                    AND mo."deletedAt" IS NULL
                   GROUP BY mo."organizationId"
               ),
               segments AS (
@@ -807,6 +812,9 @@ class OrganizationRepository {
         attributes: [],
         through: {
           attributes: [],
+          where: {
+            deletedAt: null,
+          },
         },
         include: [
           {

--- a/backend/src/serverless/microservices/nodejs/analytics/workers/weeklyAnalyticsEmailsWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/analytics/workers/weeklyAnalyticsEmailsWorker.ts
@@ -355,7 +355,9 @@ async function getAnalyticsData(tenantId: string) {
          o.name as name,
          o.logo as "avatarUrl"
       from organizations o
-        inner join "memberOrganizations" mo on o.id = mo."organizationId"
+        inner join "memberOrganizations" mo
+          on o.id = mo."organizationId"
+          and mo."deletedAt" is null
         inner join members m on mo."memberId" = m.id
         inner join activities a on m.id = a."memberId"
       where m."tenantId" = :tenantId

--- a/backend/src/services/__tests__/activityService.test.ts
+++ b/backend/src/services/__tests__/activityService.test.ts
@@ -2807,6 +2807,7 @@ describe('ActivityService tests', () => {
           memberId,
           organizationId: orgId,
           updateAffiliation: false,
+          source: 'test',
           ...data,
         },
         options,

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -11,6 +11,7 @@ import {
   MemberEnrichmentAttributes,
   PlatformType,
   IOrganization,
+  OrganizationSource,
 } from '@crowd/types'
 import { ENRICHMENT_CONFIG, REDIS_CONFIG } from '../../../conf'
 import { AttributeData } from '../../../database/attributes/attribute'
@@ -321,6 +322,7 @@ export default class MemberEnrichmentService extends LoggerBase {
             title: workExperience.title,
             dateStart: workExperience.startDate,
             dateEnd,
+            source: OrganizationSource.ENRICHMENT,
           }
           await MemberRepository.createOrUpdateWorkExperience(data, options)
           await OrganizationRepository.includeOrganizationToSegments(org.id, options)

--- a/frontend/src/modules/member/components/form/member-form-organizations-drawer.vue
+++ b/frontend/src/modules/member/components/form/member-form-organizations-drawer.vue
@@ -117,6 +117,7 @@ const save = () => {
           ...o.memberOrganizations?.dateEnd && {
             endDate: o.memberOrganizations?.dateEnd,
           },
+          source: 'ui',
         }),
       ),
     },

--- a/frontend/src/modules/member/pages/member-form-page.vue
+++ b/frontend/src/modules/member/pages/member-form-page.vue
@@ -365,6 +365,7 @@ async function onSubmit() {
           ...o.memberOrganizations?.dateEnd && {
             endDate: o.memberOrganizations?.dateEnd,
           },
+          source: 'ui',
         }),
       ).filter(
         (o) => !!o.id,

--- a/scripts/cli
+++ b/scripts/cli
@@ -34,11 +34,11 @@ function prepare_dev_env() {
 
     set +eo pipefail
 
-    which $_DC >> /dev/null 2>&1
+    $_DC >> /dev/null 2>&1
 
     if [[ ! $? -eq 0 ]]; then
         _DC="docker-compose"
-        which $_DC >> /dev/null 2>&1
+        $_DC >> /dev/null 2>&1
 
         if [[ ! $? -eq 0 ]]; then
             error "Docker compose not detected!"

--- a/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/memberAffiliation.repo.ts
@@ -45,6 +45,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
             ("dateStart" <= $(timestamp) AND "dateEnd" >= $(timestamp))
             OR ("dateStart" <= $(timestamp) AND "dateEnd" IS NULL)
           )
+          AND "deletedAt" IS NULL
         ORDER BY "dateStart" DESC, id
         LIMIT 1
       `,
@@ -66,6 +67,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
         SELECT * FROM "memberOrganizations"
         WHERE "memberId" = $(memberId)
           AND "createdAt" <= $(timestamp)
+          AND "deletedAt" IS NULL
         ORDER BY "createdAt" DESC, id
         LIMIT 1
       `,
@@ -85,6 +87,7 @@ export default class MemberAffiliationRepository extends RepositoryBase<MemberAf
       `
         SELECT * FROM "memberOrganizations"
         WHERE "memberId" = $(memberId)
+          AND "deletedAt" IS NULL
         ORDER BY "createdAt", id
         LIMIT 1
       `,

--- a/services/apps/data_sink_worker/src/service/member.data.ts
+++ b/services/apps/data_sink_worker/src/service/member.data.ts
@@ -1,4 +1,4 @@
-import { IMemberIdentity, IOrganization } from '@crowd/types'
+import { IMemberIdentity, IOrganization, OrganizationSource } from '@crowd/types'
 
 export interface IMemberUpdateData {
   attributes?: Record<string, unknown>
@@ -8,6 +8,7 @@ export interface IMemberUpdateData {
   identities: IMemberIdentity[]
   organizations?: IOrganization[]
   displayName?: string
+  source?: OrganizationSource
 }
 
 export interface IMemberCreateData {

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -3,7 +3,13 @@ import MemberRepository from '@/repo/member.repo'
 import { areArraysEqual, isObjectEmpty, singleOrDefault } from '@crowd/common'
 import { DbStore } from '@crowd/database'
 import { Logger, LoggerBase, getChildLogger } from '@crowd/logging'
-import { IMemberData, IMemberIdentity, PlatformType } from '@crowd/types'
+import {
+  IMemberData,
+  IMemberIdentity,
+  PlatformType,
+  IOrganization,
+  OrganizationSource,
+} from '@crowd/types'
 import mergeWith from 'lodash.mergewith'
 import isEqual from 'lodash.isequal'
 import { IMemberCreateData, IMemberUpdateData } from './member.data'
@@ -36,7 +42,7 @@ export default class MemberService extends LoggerBase {
         throw new Error('Member must have at least one identity!')
       }
 
-      const { id, organizationIds } = await this.store.transactionally(async (txStore) => {
+      const { id, organizations } = await this.store.transactionally(async (txStore) => {
         const txRepo = new MemberRepository(txStore, this.log)
         const txMemberAttributeService = new MemberAttributeService(txStore, this.log)
 
@@ -66,33 +72,32 @@ export default class MemberService extends LoggerBase {
 
         await txRepo.insertIdentities(id, tenantId, integrationId, data.identities)
 
-        const organizationIds = []
+        const organizations = []
+        const orgService = new OrganizationService(txStore, this.log)
         if (data.organizations) {
-          const orgService = new OrganizationService(txStore, this.log)
           for (const org of data.organizations) {
             const id = await orgService.findOrCreate(tenantId, segmentId, org)
-            organizationIds.push(id)
-          }
-
-          if (organizationIds.length > 0) {
-            await orgService.addToMember(tenantId, segmentId, id, organizationIds)
+            organizations.push({
+              id,
+              source: org.source,
+            })
           }
         }
 
         if (data.emails) {
-          const orgIds = await this.assignOrganizationByEmailDomain(
-            tenantId,
-            segmentId,
-            data.emails,
-          )
-          if (orgIds.length > 0) {
-            organizationIds.push(...orgIds)
+          const orgs = await this.assignOrganizationByEmailDomain(tenantId, segmentId, data.emails)
+          if (orgs.length > 0) {
+            organizations.push(...orgs)
           }
+        }
+
+        if (organizations.length > 0) {
+          await orgService.addToMember(tenantId, segmentId, id, organizations)
         }
 
         return {
           id,
-          organizationIds,
+          organizations,
         }
       })
 
@@ -102,10 +107,14 @@ export default class MemberService extends LoggerBase {
         await this.searchSyncWorkerEmitter.triggerMemberSync(tenantId, id)
       }
 
-      if (organizationIds.length > 0) {
-        await this.nodejsWorkerEmitter.enrichMemberOrganizations(tenantId, id, organizationIds)
-        for (const orgId of organizationIds) {
-          await this.searchSyncWorkerEmitter.triggerOrganizationSync(tenantId, orgId)
+      if (organizations.length > 0) {
+        await this.nodejsWorkerEmitter.enrichMemberOrganizations(
+          tenantId,
+          id,
+          organizations.map((org) => org.id),
+        )
+        for (const org of organizations) {
+          await this.searchSyncWorkerEmitter.triggerOrganizationSync(tenantId, org.id)
         }
       }
 
@@ -126,7 +135,7 @@ export default class MemberService extends LoggerBase {
     fireSync = true,
   ): Promise<void> {
     try {
-      const { updated, organizationIds } = await this.store.transactionally(async (txStore) => {
+      const { updated, organizations } = await this.store.transactionally(async (txStore) => {
         const txRepo = new MemberRepository(txStore, this.log)
         const txMemberAttributeService = new MemberAttributeService(txStore, this.log)
         const dbIdentities = await txRepo.getIdentities(id, tenantId)
@@ -180,42 +189,45 @@ export default class MemberService extends LoggerBase {
           updated = true
         }
 
-        const organizationIds = []
+        const organizations = []
+        const orgService = new OrganizationService(txStore, this.log)
         if (data.organizations) {
-          const orgService = new OrganizationService(txStore, this.log)
           for (const org of data.organizations) {
             const id = await orgService.findOrCreate(tenantId, segmentId, org)
-            organizationIds.push(id)
-          }
-
-          if (organizationIds.length > 0) {
-            await orgService.addToMember(tenantId, segmentId, id, organizationIds)
-            updated = true
+            organizations.push({
+              id,
+              source: data.source,
+            })
           }
         }
 
         if (data.emails) {
-          const orgIds = await this.assignOrganizationByEmailDomain(
-            tenantId,
-            segmentId,
-            data.emails,
-          )
-          if (orgIds.length > 0) {
-            organizationIds.push(...orgIds)
+          const orgs = await this.assignOrganizationByEmailDomain(tenantId, segmentId, data.emails)
+          if (orgs.length > 0) {
+            organizations.push(...orgs)
           }
         }
 
-        return { updated, organizationIds }
+        if (organizations.length > 0) {
+          await orgService.addToMember(tenantId, segmentId, id, organizations)
+          updated = true
+        }
+
+        return { updated, organizations }
       })
 
       if (updated && fireSync) {
         await this.searchSyncWorkerEmitter.triggerMemberSync(tenantId, id)
       }
 
-      if (organizationIds.length > 0) {
-        await this.nodejsWorkerEmitter.enrichMemberOrganizations(tenantId, id, organizationIds)
-        for (const orgId of organizationIds) {
-          await this.searchSyncWorkerEmitter.triggerOrganizationSync(tenantId, orgId)
+      if (organizations.length > 0) {
+        await this.nodejsWorkerEmitter.enrichMemberOrganizations(
+          tenantId,
+          id,
+          organizations.map((org) => org.id),
+        )
+        for (const org of organizations) {
+          await this.searchSyncWorkerEmitter.triggerOrganizationSync(tenantId, org.id)
         }
       }
     } catch (err) {
@@ -228,9 +240,9 @@ export default class MemberService extends LoggerBase {
     tenantId: string,
     segmentId: string,
     emails: string[],
-  ): Promise<string[]> {
+  ): Promise<IOrganization[]> {
     const orgService = new OrganizationService(this.store, this.log)
-    const organizationIds: string[] = []
+    const organizations: IOrganization[] = []
     const emailDomains = new Set<string>()
 
     // Collect unique domains
@@ -243,11 +255,14 @@ export default class MemberService extends LoggerBase {
     for (const domain of emailDomains) {
       const org = await orgService.findByDomain(tenantId, segmentId, domain as string)
       if (org) {
-        organizationIds.push(org.id)
+        organizations.push({
+          ...org,
+          source: OrganizationSource.EMAIL_DOMAIN,
+        })
       }
     }
 
-    return organizationIds
+    return organizations
   }
 
   public async processMemberEnrich(

--- a/services/apps/data_sink_worker/src/service/organization.service.ts
+++ b/services/apps/data_sink_worker/src/service/organization.service.ts
@@ -189,10 +189,14 @@ export class OrganizationService extends LoggerBase {
     tenantId: string,
     segmentId: string,
     memberId: string,
-    orgIds: string[],
+    orgs: IOrganization[],
   ): Promise<void> {
-    await this.repo.addToSegments(tenantId, segmentId, orgIds)
-    await this.repo.addToMember(memberId, orgIds)
+    await this.repo.addToSegments(
+      tenantId,
+      segmentId,
+      orgs.map((org) => org.id),
+    )
+    await this.repo.addToMember(memberId, orgs)
   }
 
   public async findByDomain(

--- a/services/apps/integration_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/member.repo.ts
@@ -202,6 +202,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
       `select distinct "memberId"
         from "memberOrganizations"
         where "organizationId" = $(organizationId)
+          and "deletedAt" is null
         order by "memberId"
         limit $(limit) offset $(offset)`,
       {
@@ -258,6 +259,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
                                               inner join "organizationSegments" os on o.id = os."organizationId"
                                       where mo."memberId" = $(id)
                                         and o."deletedAt" is null
+                                        and mo."deletedAt" is null
                                       group by mo."memberId", os."segmentId"),
             identities as (select mi."memberId",
                                   json_agg(

--- a/services/apps/integration_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/organization.repo.ts
@@ -89,12 +89,14 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
           FROM "memberOrganizations" mo
           LEFT JOIN activities a ON a."memberId" = mo."memberId"
           WHERE mo."organizationId" = $(organizationId)
+            AND mo."deletedAt" IS NULL
           GROUP BY mo."organizationId"
       ),
       member_counts AS (
           SELECT "organizationId", COUNT(DISTINCT "memberId") AS "memberCount"
           FROM "memberOrganizations"
           WHERE "organizationId" = $(organizationId)
+            AND "deletedAt" IS NULL
           GROUP BY "organizationId"
       ),
       active_on AS (
@@ -102,6 +104,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
           FROM "memberOrganizations" mo
           JOIN activities a ON a."memberId" = mo."memberId"
           WHERE mo."organizationId" = $(organizationId)
+            AND mo."deletedAt" IS NULL
           GROUP BY mo."organizationId"
       ),
       identities AS (
@@ -109,6 +112,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
           FROM "memberOrganizations" mo
           JOIN "memberIdentities" mi ON mi."memberId" = mo."memberId"
           WHERE mo."organizationId" = $(organizationId)
+            AND mo."deletedAt" IS NULL
           GROUP BY "organizationId"
       ),
       last_active AS (
@@ -116,6 +120,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
           FROM "memberOrganizations" mo
           JOIN activities a ON a."memberId" = mo."memberId"
           WHERE mo."organizationId" = $(organizationId)
+            AND mo."deletedAt" IS NULL
           GROUP BY mo."organizationId"
       ),
       segments AS (
@@ -186,7 +191,9 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
             count(actAgg.id)            as "memberCount",
             SUM(actAgg."activityCount") as "activityCount"
         from "memberActivityAggregatesMVs" actAgg
-              inner join "memberOrganizations" memOrgs on actAgg."id" = memOrgs."memberId"
+              inner join "memberOrganizations" memOrgs
+                 on actAgg."id" = memOrgs."memberId"
+                 and memOrgs."deletedAt" is null
         group by memOrgs."organizationId")
         select org.*,
         oa."activityCount",

--- a/services/apps/search_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/member.repo.ts
@@ -167,6 +167,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
                                               inner join organizations o on mo."organizationId" = o.id
                                               inner join "organizationSegments" os on o.id = os."organizationId"
                                       where mo."memberId" in ($(ids:csv))
+                                        and mo."deletedAt" is null
                                         and o."deletedAt" is null
                                         and exists (select 1
                                           from activities a

--- a/services/apps/search_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/member.repo.ts
@@ -98,7 +98,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
     const results = await this.db().any(
       `
       select id from members m
-      where m"tenantId" = $(tenantId) and m"deletedAt" is null
+      where m."tenantId" = $(tenantId) and m."deletedAt" is null
        and (
         m."searchSyncedAt" is null or
         m."searchSyncedAt" < $(cutoffDate)

--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -31,7 +31,9 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
                                                 a."segmentId" = os."segmentId" and a."deletedAt" is null
                                     left join members m on a."memberId" = m.id and m."deletedAt" is null
                                     left join "memberOrganizations" mo
-                                              on m.id = mo."memberId" and a."organizationId" = mo."organizationId"
+                                              on m.id = mo."memberId"
+                                              and a."organizationId" = mo."organizationId"
+                                              and mo."deletedAt" is null
                                     left join "memberIdentities" mi on m.id = mi."memberId"
                           group by os."segmentId", os."organizationId")
       select o.id                              as "organizationId",

--- a/services/libs/integrations/src/integrations/github/processData.ts
+++ b/services/libs/integrations/src/integrations/github/processData.ts
@@ -20,6 +20,7 @@ import {
   PlatformType,
   MemberAttributeName,
   IActivityScoringGrid,
+  OrganizationSource,
 } from '@crowd/types'
 import { GITHUB_GRID } from './grid'
 import { generateSourceIdHash } from '../../helpers'
@@ -73,7 +74,7 @@ const parseMember = (memberData: GithubPrepareMemberOutput): IMemberData => {
 
   if (memberFromApi.company) {
     if (IS_TEST_ENV) {
-      member.organizations = [{ name: 'crowd.dev' }]
+      member.organizations = [{ name: 'crowd.dev', source: OrganizationSource.GITHUB }]
     } else {
       const company = memberFromApi.company.replace('@', '').trim()
 
@@ -88,10 +89,11 @@ const parseMember = (memberData: GithubPrepareMemberOutput): IMemberData => {
             github: orgs.url ? orgs.url.replace('https://github.com/', '') : null,
             twitter: orgs.twitterUsername ? orgs.twitterUsername : null,
             website: orgs.websiteUrl ?? null,
+            source: OrganizationSource.GITHUB,
           },
         ]
       } else {
-        member.organizations = [{ name: company }]
+        member.organizations = [{ name: company, source: OrganizationSource.GITHUB }]
       }
     }
   }

--- a/services/libs/integrations/src/integrations/premium/hubspot/field-mapper/memberFieldMapper.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/field-mapper/memberFieldMapper.ts
@@ -7,6 +7,7 @@ import {
   MemberAttributeType,
   PlatformType,
   ITagOpensearch,
+  OrganizationSource,
 } from '@crowd/types'
 import { HubspotPropertyType, IFieldProperty, IHubspotContact } from '../types'
 import { HubspotFieldMapper } from './hubspotFieldMapper'
@@ -206,6 +207,7 @@ export class HubspotMemberFieldMapper extends HubspotFieldMapper {
             member.organizations = [
               {
                 name: contactProperties[hubspotPropertyName],
+                source: OrganizationSource.HUBSPOT,
               },
             ]
           } else {

--- a/services/libs/integrations/src/integrations/premium/hubspot/field-mapper/organizationFieldMapper.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/field-mapper/organizationFieldMapper.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { IOrganization, OrganizationAttributeName, PlatformType } from '@crowd/types'
+import {
+  IOrganization,
+  OrganizationAttributeName,
+  PlatformType,
+  OrganizationSource,
+} from '@crowd/types'
 import { HubspotPropertyType, IFieldProperty, IHubspotObject } from '../types'
 import { HubspotFieldMapper } from './hubspotFieldMapper'
 import { serializeArray } from './utils/serialization'
@@ -242,6 +247,7 @@ export class HubspotOrganizationFieldMapper extends HubspotFieldMapper {
           [PlatformType.HUBSPOT]: organizationProperties.domain,
         },
       },
+      source: OrganizationSource.HUBSPOT,
     }
 
     // loop through organization properties

--- a/services/libs/types/src/enums/organizations.ts
+++ b/services/libs/types/src/enums/organizations.ts
@@ -10,4 +10,5 @@ export enum OrganizationSource {
   ENRICHMENT = 'enrichment',
   HUBSPOT = 'hubspot',
   GITHUB = 'github',
+  UI = 'ui',
 }

--- a/services/libs/types/src/enums/organizations.ts
+++ b/services/libs/types/src/enums/organizations.ts
@@ -4,3 +4,10 @@ export enum OrganizationAttributeName {
   SYNC_REMOTE = 'syncRemote',
   DOMAIN = 'domain',
 }
+
+export enum OrganizationSource {
+  EMAIL_DOMAIN = 'email-domain',
+  ENRICHMENT = 'enrichment',
+  HUBSPOT = 'hubspot',
+  GITHUB = 'github',
+}

--- a/services/libs/types/src/organizations.ts
+++ b/services/libs/types/src/organizations.ts
@@ -1,4 +1,5 @@
 import { IAttributes } from './attributes'
+import { OrganizationSource } from './enums/organizations'
 
 export interface IOrganization {
   id?: string
@@ -39,6 +40,7 @@ export interface IOrganization {
   gicsSector?: string
   grossAdditionsByMonth?: Record<string, number>
   grossDeparturesByMonth?: Record<string, number>
+  source?: OrganizationSource
 }
 
 export interface IExecutiveChange {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1fcd97</samp>

This pull request adds soft deletion and source tracking features to the member-organization affiliations in the `memberOrganizations` table. It also updates various repositories, services, workers, and components to filter out the deleted affiliations and store the source of the affiliations. This improves the accuracy and consistency of the member and organization data, queries, responses, analytics, and search synchronization. Additionally, it fixes some bugs and simplifies a script.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b1fcd97</samp>

> _`memberOrganizations`_
> _Soft deletion, source tracking_
> _Autumn migration_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b1fcd97</samp>

*  Drop and add `source` and `deletedAt` columns to `memberOrganizations` table with different constraints and defaults, to support soft deletion and tracking the source of the member-organization affiliation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-6b230120a11e60be00d39b1cea558880e6182704bb1fdb321c02330c1e5d782bR1-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a0b4dd0ba8cb4cac644b2c46f3d5c8ca06732431da85aaa49b56b22f8e8d6d78R1-R2))
*  Filter out the deleted member-organization affiliations in various queries and associations, to ensure that the data only includes the current and active organizations of the member or the organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-987f06572bad79c47ef62d518a7a4e419dda775d942d365da55dc5509acf5291R647-R651), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-79b67901acc8bf830c7de52d225a5b98a01b7d05dbd284adc11296cc92259b72L29-R39), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR574), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR1424), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR1600), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR1792), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3202-R3207), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3365), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3415-R3441), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3448-R3449), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3478), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3511), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3541), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR403), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL467-R470), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR484), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR492), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR815-R817), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-697ea4871953442b989256533e0a23185da4aa8cfb0ae3296326383d8e772477L358-R360), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-334f732e0c123418e8c236946548b87159b61ec035a2938e7406aa22f21a753dR48), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-334f732e0c123418e8c236946548b87159b61ec035a2938e7406aa22f21a753dR70), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-334f732e0c123418e8c236946548b87159b61ec035a2938e7406aa22f21a753dR90), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6R205), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6R262), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R92), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R99), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R107), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R123), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045L189-R196), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-58e3a08705154d31681cf22d4f5eabd037994a686415ca44cf502451c11594a7R170), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L34-R36))
*  Store and pass the source of the member-organization affiliation in various methods and queries, to track where the affiliation came from, such as the UI, the enrichment service, or the email domain ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL964-R969), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3273-R3281), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3309), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3327), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3333-R3343), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3344-R3354), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3372-R3400), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3409), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3402-R3428), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3409-R3435), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3478), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807R325), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-7746ffea2d74a6b5e460af0f332d58c176ecb384747a842ac5e5676aa0e05602R120), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768R368), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L15-R15), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L301-R301), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L307-R311), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L316-R317), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-f919f31d661073cc057f491ebbba2b9ba4c984bbc27b10248ede6ca16648487eL1-R1), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-f919f31d661073cc057f491ebbba2b9ba4c984bbc27b10248ede6ca16648487eR11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L6-R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L39-R45), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L69-R100), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L105-R117), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L129-R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L183-R216), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L215-R230), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L231-R245), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L246-R265), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-c4775fb9079e4d3766f7b65b1d34e302fdf4b798a53e206c4cd85c683a4885d1L192-R199))
*  Implement soft deletion of the member-organization affiliation, by setting the `deletedAt` column to the current timestamp, instead of removing the row from the table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3333-R3343), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3344-R3354), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3402-R3428), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3409-R3435))
*  Update the existing UI source affiliation with the new values, and set the `deletedAt` column to null, when inserting a new UI source affiliation with the same member and organization ids ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3372-R3400))
*  Simplify the check for the existence of the `$_DC` variable in the `scripts/cli` file, by using the variable directly instead of the `which` command ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-5e2da9ab3fa1cd8081cbd3848fb84fbe0fd7ce37b42a726520e9d10398a40ef2L37-R41))
*  Fix a typo in the `WHERE` clause of the `members` table in the `MemberRepository` of the `search_sync_worker`, by adding a dot between `m` and `"tenantId"` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1419/files?diff=unified&w=0#diff-58e3a08705154d31681cf22d4f5eabd037994a686415ca44cf502451c11594a7L101-R101))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
