### PR TITLE
fixed member filtering by organization ids

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1987,7 +1987,7 @@ class MemberRepository {
 
     if (filter.organizations && filter.organizations.length > 0) {
       parsed.query.bool.must = parsed.query.bool.must.filter(
-        (d) => d.term['nested_organizations.uuid_id'] === undefined,
+        (d) => d.nested?.query?.term?.['nested_organizations.uuid_id'] === undefined,
       )
 
       // add organizations filter manually for now


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88815e3</samp>

Fixed a bug in the member search feature by handling nested queries for organizations in the `filter` function of the `MemberRepository` class in `backend/src/database/repositories/memberRepository.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 88815e3</samp>

> _`filter` function_
> _handles nested queries well_
> _no more search errors_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88815e3</samp>

*  Fix member search bug by handling nested queries for organizations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1425/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL1990-R1990))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
