### PR TITLE
Set github alert modal

### DIFF
--- a/frontend/src/integrations/github/components/github-connect.vue
+++ b/frontend/src/integrations/github/components/github-connect.vue
@@ -37,7 +37,7 @@ const connect = () => {
     vertical: true,
     distinguishCancelAndClose: true,
     autofocus: false,
-    messageClass: 'text-xs !leading-5 !mt-1',
+    messageClass: 'text-xs !leading-5 !mt-1 text-gray-600',
   }).then(() => {
     window.open(githubConnectUrl.value, '_self');
   }).catch((action) => {

--- a/frontend/src/integrations/github/components/github-connect.vue
+++ b/frontend/src/integrations/github/components/github-connect.vue
@@ -3,8 +3,10 @@
 </template>
 
 <script setup>
-import { defineProps, computed } from 'vue';
+import { computed } from 'vue';
 import config from '@/config';
+import ConfirmDialog from '@/shared/dialog/confirm-dialog';
+import { useRouter } from 'vue-router';
 
 defineProps({
   integration: {
@@ -13,11 +15,38 @@ defineProps({
   },
 });
 
+const router = useRouter();
+
 // We have 3 GitHub apps: test, test-local and prod
 // Getting the proper URL from config file
 const githubConnectUrl = computed(() => config.gitHubInstallationUrl);
 const connect = () => {
-  window.open(githubConnectUrl.value, '_self');
+  ConfirmDialog({
+    type: 'notification',
+    title:
+      'Are you the admin of your GitHub organization?',
+    titleClass: 'text-lg pt-2',
+    message:
+      `Only GitHub users with admin permissions are able to connect crowd.dev's GitHub integration.
+      If you are an organization member, you will need an approval from the GitHub workspace admin. <a href="https://docs.crowd.dev/docs/github-integration" target="_blank">Read more</a>`,
+    icon: 'ri-information-line',
+    confirmButtonText: 'I\'m the GitHub organization admin',
+    cancelButtonText: 'Invite organization admin to this workspace',
+    verticalCancelButtonClass: 'btn btn--md btn--primary w-full',
+    verticalConfirmButtonClass: 'btn btn--md btn--bordered w-full !mb-2',
+    vertical: true,
+    distinguishCancelAndClose: true,
+    autofocus: false,
+    messageClass: 'text-xs !leading-5 !mt-1',
+  }).then(() => {
+    window.open(githubConnectUrl.value, '_self');
+  }).catch((action) => {
+    if (action === 'cancel') {
+      router.push({
+        name: 'settings',
+      });
+    }
+  });
 };
 
 </script>

--- a/frontend/src/shared/dialog/confirm-dialog.js
+++ b/frontend/src/shared/dialog/confirm-dialog.js
@@ -17,6 +17,12 @@ export default ({
   confirmButtonText = 'Discard',
   confirmButtonClass = 'btn btn--md btn--primary',
   icon = 'ri-error-warning-line',
+  distinguishCancelAndClose = false,
+  autofocus = true,
+  titleClass,
+  messageClass,
+  verticalCancelButtonClass,
+  verticalConfirmButtonClass,
 }) => {
   let iconColorClass = 'text-yellow-600';
   let iconBgColorClass = 'bg-yellow-100';
@@ -59,7 +65,7 @@ export default ({
       h('div', [
         h('p', {
           innerHTML: message,
-          class: 'text-gray-500 text-sm',
+          class: `text-gray-500 text-sm ${messageClass}`,
         }),
         highlightedInfo
           ? h(
@@ -133,7 +139,7 @@ export default ({
         ),
         h('h6', {
           innerHTML: title,
-          class: 'text-black mb-3',
+          class: `text-black mb-3 ${titleClass}`,
         }),
         badgeContent
           ? h('div', {
@@ -144,7 +150,7 @@ export default ({
           : undefined,
         h('p', {
           innerHTML: message,
-          class: 'text-gray-500 text-sm',
+          class: `text-gray-500 text-sm ${messageClass}`,
         }),
         highlightedInfo
           ? h(
@@ -181,9 +187,11 @@ export default ({
       showCancelButton,
       customClass: overrideCustomClass,
       confirmButtonText,
-      confirmButtonClass: overrideConfirmButtonClass,
+      confirmButtonClass: verticalConfirmButtonClass || overrideConfirmButtonClass,
       cancelButtonText,
-      cancelButtonClass: overrideCancelButtonClass,
+      cancelButtonClass: verticalCancelButtonClass || overrideCancelButtonClass,
+      distinguishCancelAndClose,
+      autofocus,
     });
   }
 
@@ -197,5 +205,7 @@ export default ({
     cancelButtonClass,
     confirmButtonText,
     confirmButtonClass,
+    distinguishCancelAndClose,
+    autofocus,
   });
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16fd0d8</samp>

Added a confirmation step for GitHub integration to verify the user's organization admin status. Modified the `ConfirmDialog` component to support customizations for different use cases.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 16fd0d8</samp>

> _To connect with GitHub, you must state_
> _If you're an admin of your org, mate_
> _Use `ConfirmDialog` to show_
> _A customized message, you know_
> _With `MessageBox` parameters to create_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 16fd0d8</samp>

*  Show a confirmation dialog before opening the GitHub installation URL in the `connect` function of `github-connect.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-f05cbe01e75107ec8e37db917346ee0b77e52d6e39a2745f8fe1e01222387837L6-R9),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-f05cbe01e75107ec8e37db917346ee0b77e52d6e39a2745f8fe1e01222387837L16-R49))
*  Add parameters to customize the appearance and behavior of the `ConfirmDialog` function in `confirm-dialog.js` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51R20-R25),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51L62-R68),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51L136-R142),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51L147-R153),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51L184-R194),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1434/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51R208-R209))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
