### PR TITLE
Adjust locking time and randomize lock acquire time

### DIFF
--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -18,6 +18,11 @@ import MemberAffiliationService from './memberAffiliation.service'
 import { acquireLock, releaseLock } from '@crowd/redis'
 import { RedisClient } from '@crowd/redis'
 
+const DEFAULT_EXPIRE_AFTER = 15 * 60 // 15 minutes
+const DEFAULT_TIMEOUT_AFTER = DEFAULT_EXPIRE_AFTER // 10 minutes
+const MEMBER_LOCK_EXPIRE_AFTER = 5 * 60 // 10 minutes
+const MEMBER_LOCK_TIMEOUT_AFTER = 3 * 60 // 5 minutes
+
 export default class ActivityService extends LoggerBase {
   private readonly conversationService: ConversationService
 
@@ -395,8 +400,8 @@ export default class ActivityService extends LoggerBase {
           this.redisClient,
           `activity:processing:${tenantId}:${segmentId}:${activity.sourceId}`,
           'check-activity',
-          10 * 60,
-          3 * 60,
+          DEFAULT_EXPIRE_AFTER,
+          DEFAULT_TIMEOUT_AFTER,
         )
 
         // find existing activity
@@ -413,8 +418,8 @@ export default class ActivityService extends LoggerBase {
             this.redisClient,
             `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
             'check-member-inside-activity-exists',
-            10 * 60,
-            3 * 60,
+            MEMBER_LOCK_EXPIRE_AFTER,
+            MEMBER_LOCK_TIMEOUT_AFTER,
           )
 
           let dbMember = await txMemberRepo.findMember(tenantId, segmentId, platform, username)
@@ -517,8 +522,8 @@ export default class ActivityService extends LoggerBase {
               this.redisClient,
               `member:processing:${tenantId}:${segmentId}:${platform}:${objectMemberUsername}`,
               'check-object-member-inside-activity-exists',
-              10 * 60,
-              3 * 60,
+              MEMBER_LOCK_EXPIRE_AFTER,
+              MEMBER_LOCK_TIMEOUT_AFTER,
             )
 
             if (dbActivity.objectMemberId) {
@@ -676,8 +681,8 @@ export default class ActivityService extends LoggerBase {
             this.redisClient,
             `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
             'check-member-inside-activity-does-not-exist',
-            10 * 60,
-            3 * 60,
+            MEMBER_LOCK_EXPIRE_AFTER,
+            MEMBER_LOCK_TIMEOUT_AFTER,
           )
 
           // we don't have the activity yet in the database
@@ -736,8 +741,8 @@ export default class ActivityService extends LoggerBase {
               this.redisClient,
               `member:processing:${tenantId}:${segmentId}:${platform}:${objectMemberUsername}`,
               'check-object-member-inside-activity-does-not-exist',
-              10 * 60,
-              3 * 60,
+              MEMBER_LOCK_EXPIRE_AFTER,
+              MEMBER_LOCK_TIMEOUT_AFTER,
             )
 
             const dbObjectMember = await txMemberRepo.findMember(

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -20,8 +20,8 @@ import { RedisClient } from '@crowd/redis'
 
 const DEFAULT_EXPIRE_AFTER = 15 * 60 // 15 minutes
 const DEFAULT_TIMEOUT_AFTER = DEFAULT_EXPIRE_AFTER // 10 minutes
-const MEMBER_LOCK_EXPIRE_AFTER = 5 * 60 // 10 minutes
-const MEMBER_LOCK_TIMEOUT_AFTER = 3 * 60 // 5 minutes
+const MEMBER_LOCK_EXPIRE_AFTER = 10 * 60 // 10 minutes
+const MEMBER_LOCK_TIMEOUT_AFTER = 5 * 60 // 5 minutes
 
 export default class ActivityService extends LoggerBase {
   private readonly conversationService: ConversationService

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -467,6 +467,13 @@ export default class ActivityService extends LoggerBase {
               false,
             )
 
+            // release lock for member inside activity exists right after we update the member
+            await releaseLock(
+              this.redisClient,
+              `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
+              'check-member-inside-activity-exists',
+            )
+
             if (!createActivity) {
               // and use it's member id for the new activity
               dbActivity.memberId = dbMember.id
@@ -502,6 +509,13 @@ export default class ActivityService extends LoggerBase {
               },
               dbMember,
               false,
+            )
+
+            // release lock for member inside activity exists right after we update the member
+            await releaseLock(
+              this.redisClient,
+              `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
+              'check-member-inside-activity-exists',
             )
 
             memberId = dbActivity.memberId
@@ -666,7 +680,7 @@ export default class ActivityService extends LoggerBase {
             activityId = dbActivity.id
           }
 
-          // release lock for member inside activity exists
+          // release lock for member inside activity exists - this migth be redundant, but just in case
           await releaseLock(
             this.redisClient,
             `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
@@ -709,6 +723,13 @@ export default class ActivityService extends LoggerBase {
               false,
             )
             memberId = dbMember.id
+
+            // release lock for member inside activity does not exist right after we update the member
+            await releaseLock(
+              this.redisClient,
+              `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
+              'check-member-inside-activity-does-not-exist',
+            )
           } else {
             this.log.trace(
               'We did not find a member for the identity provided! Creating a new one.',
@@ -729,6 +750,13 @@ export default class ActivityService extends LoggerBase {
                 organizations: member.organizations,
               },
               false,
+            )
+
+            // release lock for member inside activity does not exist right after we create the member
+            await releaseLock(
+              this.redisClient,
+              `member:processing:${tenantId}:${segmentId}:${platform}:${username}`,
+              'check-member-inside-activity-does-not-exist',
             )
           }
 

--- a/services/libs/redis/src/mutex.ts
+++ b/services/libs/redis/src/mutex.ts
@@ -22,7 +22,9 @@ export const acquireLock = async (
       throw new TimeoutError(diff / 1000, 's')
     }
 
-    await timeout(200)
+    // Randomize timeout between 100ms and 300ms
+    const randomTimeout = Math.floor(Math.random() * (300 - 100 + 1)) + 100
+    await timeout(randomTimeout)
     result = await client.set(key, value, {
       EX: expireAfterSeconds,
       NX: true,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0fdb63</samp>

This pull request improves the Redis lock logic in `activity.service.ts` by using constants and a random timeout. This aims to enhance the code quality and reduce the lock contention among workers.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0fdb63</samp>

> _Oh we are the workers of the `activity.service.ts`_
> _We use the `redis` library to lock and unlock with zest_
> _But sometimes we face a problem of contention and collision_
> _So we change the `acquireLock` to use a random timeout decision_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0fdb63</samp>

*  Introduce constants for Redis lock expiration and timeout values in `activity.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR21-R25))
*  Replace hard-coded values for Redis lock expiration and timeout with constants in `activity.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL398-R404), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL416-R422), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL520-R526), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL679-R685), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL739-R745))
*  Use random timeout between 100ms and 300ms for acquiring Redis locks in `redis` library ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1442/files?diff=unified&w=0#diff-cdb64095aef574d92d01eed510891f8830bbc97cb9324d1efb819ad881be8ac4L25-R27))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
