### PR TITLE
Fix creation of parent and grandparent segment documents for members/orgs

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -479,7 +479,7 @@ class OrganizationRepository {
                             segment_level as (select case
                                         when "parentSlug" is not null and "grandparentSlug" is not null
                                             then 'child'
-                                        when "parentSlug" is null and "grandparentSlug" is not null
+                                        when "parentSlug" is not null and "grandparentSlug" is null
                                             then 'parent'
                                         when "parentSlug" is null and "grandparentSlug" is null
                                             then 'grandparent'
@@ -495,7 +495,7 @@ class OrganizationRepository {
                             segment_level sl
                             on
                             (sl.level = 'child' and s.id = sl.id) or
-                            (sl.level = 'parent' and s."parentSlug" = sl.slug) or
+                            (sl.level = 'parent' and s."parentSlug" = sl.slug and s."grandparentSlug" is not null) or
                             (sl.level = 'grandparent' and s."grandparentSlug" = sl.slug)`
     }
 

--- a/services/apps/search_sync_worker/src/service/member.sync.service.ts
+++ b/services/apps/search_sync_worker/src/service/member.sync.service.ts
@@ -300,38 +300,38 @@ export class MemberSyncService extends LoggerBase {
               id: `${memberId}-${member.segmentId}`,
               body: prepared,
             })
-          }
 
-          const relevantSegmentInfos = segmentInfos.filter((s) => s.id === memberDocs[0].segmentId)
+            const relevantSegmentInfos = segmentInfos.filter((s) => s.id === member.segmentId)
 
-          // and for each parent and grandparent
-          const parentIds = distinct(relevantSegmentInfos.map((s) => s.parentId))
-          for (const parentId of parentIds) {
-            const aggregated = MemberSyncService.aggregateData(
-              memberDocs,
-              relevantSegmentInfos,
-              parentId,
-            )
-            const prepared = MemberSyncService.prefixData(aggregated, attributes)
-            forSync.push({
-              id: `${memberId}-${parentId}`,
-              body: prepared,
-            })
-          }
+            // and for each parent and grandparent
+            const parentIds = distinct(relevantSegmentInfos.map((s) => s.parentId))
+            for (const parentId of parentIds) {
+              const aggregated = MemberSyncService.aggregateData(
+                memberDocs,
+                relevantSegmentInfos,
+                parentId,
+              )
+              const prepared = MemberSyncService.prefixData(aggregated, attributes)
+              forSync.push({
+                id: `${memberId}-${parentId}`,
+                body: prepared,
+              })
+            }
 
-          const grandParentIds = distinct(relevantSegmentInfos.map((s) => s.grandParentId))
-          for (const grandParentId of grandParentIds) {
-            const aggregated = MemberSyncService.aggregateData(
-              memberDocs,
-              relevantSegmentInfos,
-              undefined,
-              grandParentId,
-            )
-            const prepared = MemberSyncService.prefixData(aggregated, attributes)
-            forSync.push({
-              id: `${memberId}-${grandParentId}`,
-              body: prepared,
-            })
+            const grandParentIds = distinct(relevantSegmentInfos.map((s) => s.grandParentId))
+            for (const grandParentId of grandParentIds) {
+              const aggregated = MemberSyncService.aggregateData(
+                memberDocs,
+                relevantSegmentInfos,
+                undefined,
+                grandParentId,
+              )
+              const prepared = MemberSyncService.prefixData(aggregated, attributes)
+              forSync.push({
+                id: `${memberId}-${grandParentId}`,
+                body: prepared,
+              })
+            }
           }
         } else {
           if (memberDocs.length > 1) {

--- a/services/apps/search_sync_worker/src/service/organization.sync.service.ts
+++ b/services/apps/search_sync_worker/src/service/organization.sync.service.ts
@@ -269,47 +269,45 @@ export class OrganizationSyncService extends LoggerBase {
       for (const organizationId of organizationIds) {
         const organizationDocs = grouped.get(organizationId)
         if (isMultiSegment) {
-          // index each of them individually
           for (const organization of organizationDocs) {
+            // index each of them individually because it's per leaf segment
             const prepared = OrganizationSyncService.prefixData(organization)
             forSync.push({
               id: `${organizationId}-${organization.segmentId}`,
               body: prepared,
             })
-          }
 
-          const relevantSegmentInfos = segmentInfos.filter(
-            (s) => s.id === organizationDocs[0].segmentId,
-          )
+            const relevantSegmentInfos = segmentInfos.filter((s) => s.id === organization.segmentId)
 
-          // and for each parent and grandparent
-          const parentIds = distinct(relevantSegmentInfos.map((s) => s.parentId))
-          for (const parentId of parentIds) {
-            const aggregated = OrganizationSyncService.aggregateData(
-              organizationDocs,
-              relevantSegmentInfos,
-              parentId,
-            )
-            const prepared = OrganizationSyncService.prefixData(aggregated)
-            forSync.push({
-              id: `${organizationId}-${parentId}`,
-              body: prepared,
-            })
-          }
+            // and for each parent and grandparent
+            const parentIds = distinct(relevantSegmentInfos.map((s) => s.parentId))
+            for (const parentId of parentIds) {
+              const aggregated = OrganizationSyncService.aggregateData(
+                organizationDocs,
+                relevantSegmentInfos,
+                parentId,
+              )
+              const prepared = OrganizationSyncService.prefixData(aggregated)
+              forSync.push({
+                id: `${organizationId}-${parentId}`,
+                body: prepared,
+              })
+            }
 
-          const grandParentIds = distinct(relevantSegmentInfos.map((s) => s.grandParentId))
-          for (const grandParentId of grandParentIds) {
-            const aggregated = OrganizationSyncService.aggregateData(
-              organizationDocs,
-              relevantSegmentInfos,
-              undefined,
-              grandParentId,
-            )
-            const prepared = OrganizationSyncService.prefixData(aggregated)
-            forSync.push({
-              id: `${organizationId}-${grandParentId}`,
-              body: prepared,
-            })
+            const grandParentIds = distinct(relevantSegmentInfos.map((s) => s.grandParentId))
+            for (const grandParentId of grandParentIds) {
+              const aggregated = OrganizationSyncService.aggregateData(
+                organizationDocs,
+                relevantSegmentInfos,
+                undefined,
+                grandParentId,
+              )
+              const prepared = OrganizationSyncService.prefixData(aggregated)
+              forSync.push({
+                id: `${organizationId}-${grandParentId}`,
+                body: prepared,
+              })
+            }
           }
         } else {
           if (organizationDocs.length > 1) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2d9d7a</samp>

This pull request fixes bugs and improves code quality in the files that handle the organization and member data for the search index. It enhances the SQL queries in `organizationRepository.ts` to classify and match organizations correctly. It also simplifies the indexing logic and reduces redundancy in `organization.sync.service.ts` and `member.sync.service.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b2d9d7a</samp>

> _`sync` code refactored_
> _bugs fixed in `organization`_
> _autumn of cleaning_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2d9d7a</samp>

*  Fix bugs in SQL queries for organization level and segment level in `organizationRepository.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1443/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL482-R482), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1443/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL498-R498))
*  Refactor code for aggregating and prefixing member and organization data for search index in `member.sync.service.ts` and `organization.sync.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1443/files?diff=unified&w=0#diff-e3ad346a8bf0daa4b0251547c29fd9d2b3adc3faf13c1c44cea000df528a3291L303-R334), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1443/files?diff=unified&w=0#diff-6a821d54aeecff44b95ad1e3bb5adb0b5848fc01db7a0f936eeee4d3f611969fL279-R310))
*  Add comment to explain indexing logic for organization data in `organization.sync.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1443/files?diff=unified&w=0#diff-6a821d54aeecff44b95ad1e3bb5adb0b5848fc01db7a0f936eeee4d3f611969fL272-R273))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
