### PR TITLE
Search for just any `conversationSettings` row

### DIFF
--- a/services/libs/conversations/src/repo/conversation.repo.ts
+++ b/services/libs/conversations/src/repo/conversation.repo.ts
@@ -49,7 +49,7 @@ export class ConversationRepository extends RepositoryBase<ConversationRepositor
     const id = generateUUIDv1()
 
     const results = await this.db().oneOrNone(
-      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId) and (enabled is null or enabled = true) limit 1`,
+      `select "autoPublish" from "conversationSettings" where "tenantId" = $(tenantId) limit 1`,
       {
         tenantId,
       },


### PR DESCRIPTION
Otherwise it'll duplicate them inifinitely. Plus, this functionality doesn't matter anyway

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7f5854</samp>

Simplified query for `autoPublish` setting in `conversation.repo.ts`. Removed unused `enabled` column from `conversationSettings` table as part of a refactor.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f7f5854</samp>

> _`autoPublish` query_
> _simplified by removing_
> _`enabled` column_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7f5854</samp>

*  Simplify query for `autoPublish` setting by removing unused `enabled` column condition ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1455/files?diff=unified&w=0#diff-1676136fe81dc9e98855135a513fc17da4917c16a5dc71ee382a2dee6bdf1eaeL52-R52))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
