### PR TITLE
Fix GitHub unstar events

### DIFF
--- a/services/apps/webhook_api/src/routes/github.ts
+++ b/services/apps/webhook_api/src/routes/github.ts
@@ -43,6 +43,7 @@ export const installGithubRoutes = async (app: express.Express) => {
             signature,
             event,
             data,
+            date: new Date().toISOString(),
           },
         )
 

--- a/services/libs/integrations/src/integrations/github/processData.ts
+++ b/services/libs/integrations/src/integrations/github/processData.ts
@@ -940,7 +940,7 @@ const parseWebhookStar = async (ctx: IProcessDataContext) => {
       sourceId: generateSourceIdHash(
         payload.sender.login,
         type,
-        Math.floor(new Date(payload.starred_at).getTime() / 1000).toString(),
+        Math.floor(new Date(starredAt).getTime() / 1000).toString(),
         PlatformType.GITHUB,
       ),
       sourceParentId: null,

--- a/services/libs/integrations/src/integrations/github/processData.ts
+++ b/services/libs/integrations/src/integrations/github/processData.ts
@@ -931,7 +931,7 @@ const parseWebhookStar = async (ctx: IProcessDataContext) => {
     const starredAt =
       type === GithubActivityType.STAR
         ? new Date(payload.starred_at).toISOString()
-        : new Date().toISOString()
+        : data.date ?? new Date().toISOString()
 
     const activity: IActivityData = {
       member,

--- a/services/libs/integrations/src/integrations/github/processWebhookStream.ts
+++ b/services/libs/integrations/src/integrations/github/processWebhookStream.ts
@@ -245,7 +245,7 @@ const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext)
   if (payload.action === 'created' || payload.action === 'deleted') {
     const member = await prepareWebhookMember(payload?.sender?.login, ctx)
 
-    if (member && payload.starred_at !== null) {
+    if (member) {
       await ctx.publishData<GithubWebhookData>({
         webhookType: GithubWehookEvent.STAR,
         data: payload,

--- a/services/libs/integrations/src/integrations/github/processWebhookStream.ts
+++ b/services/libs/integrations/src/integrations/github/processWebhookStream.ts
@@ -241,7 +241,7 @@ const parseWebhookPullRequestReview = async (
   }
 }
 
-const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext) => {
+const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext, date?: string) => {
   if (payload.action === 'created' || payload.action === 'deleted') {
     const member = await prepareWebhookMember(payload?.sender?.login, ctx)
 
@@ -250,6 +250,7 @@ const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext)
         webhookType: GithubWehookEvent.STAR,
         data: payload,
         member,
+        ...(date ? { date } : {}),
       })
     }
   }
@@ -352,7 +353,7 @@ const handler: ProcessWebhookStreamHandler = async (ctx) => {
     await processPullCommitsStream(ctx as IProcessStreamContext)
   } else {
     // this is for normal weqbook events
-    const { signature, event, data } = ctx.stream.data as GithubWebhookPayload
+    const { signature, event, data, date } = ctx.stream.data as GithubWebhookPayload
 
     await verifyWebhookSignature(signature, data, ctx)
 

--- a/services/libs/integrations/src/integrations/github/processWebhookStream.ts
+++ b/services/libs/integrations/src/integrations/github/processWebhookStream.ts
@@ -371,7 +371,7 @@ const handler: ProcessWebhookStreamHandler = async (ctx) => {
         await parseWebhookPullRequestReview(data, ctx)
         break
       case GithubWehookEvent.STAR:
-        await parseWebhookStar(data, ctx)
+        await parseWebhookStar(data, ctx, date)
         break
       case GithubWehookEvent.FORK:
         await parseWebhookFork(data, ctx)

--- a/services/libs/integrations/src/integrations/github/types.ts
+++ b/services/libs/integrations/src/integrations/github/types.ts
@@ -67,6 +67,7 @@ export interface GithubWebhookPayload {
   signature: string
   event: any
   data: any
+  date?: string
 }
 
 export enum GithubActivitySubType {
@@ -137,6 +138,7 @@ export interface GithubWebhookData {
   member: GithubPrepareMemberOutput
   objectMember?: GithubPrepareMemberOutput
   sourceParentId?: string
+  date?: string
 }
 
 export interface GithubRootStream {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a7b8bf6</samp>

Fixed a bug in the GitHub integration where some webhook events without the `starred_at` property were not processed correctly. Added a `date` parameter and property to the `parseWebhookStar` function and the relevant interfaces and routes to handle such events.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a7b8bf6</samp>

> _No starred_at, no glory_
> _We need the date to tell our story_
> _We parse the webhook with our might_
> _We fix the bug and shine our light_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a7b8bf6</samp>

*  Add `date` property to webhook payload and data types ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-a116a239a02eb969a5ce2b6439d23b1ee7cc5a595d7f16451bdceae0d2555ba7R70), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-a116a239a02eb969a5ce2b6439d23b1ee7cc5a595d7f16451bdceae0d2555ba7R141))
*  Pass `date` value from webhook route to stream handler ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-f56d61a87b6d429d4e7fcd9d9364c336efa2a7c7d348866c2ceaca56ac32a4ffR46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL244-R253))
*  Extract `date` value from stream data and pass to star parser ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL355-R356))
*  Use `date` value as fallback for starred_at property in star parser ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-1fef046692d1b07b29d9c634f0a743fc6122b9ed5a22e7820d3ff3a7cd9d0c49L934-R934), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-1fef046692d1b07b29d9c634f0a743fc6122b9ed5a22e7820d3ff3a7cd9d0c49L943-R943))
*  Use consistent and unique activity id based on starred_at or date value in star parser ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1456/files?diff=unified&w=0#diff-1fef046692d1b07b29d9c634f0a743fc6122b9ed5a22e7820d3ff3a7cd9d0c49L943-R943))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
