### PR TITLE
Fix GitHub unstars

### DIFF
--- a/services/apps/integration_stream_worker/src/repo/incomingWebhook.data.ts
+++ b/services/apps/integration_stream_worker/src/repo/incomingWebhook.data.ts
@@ -7,6 +7,7 @@ export interface IWebhookData {
   state: WebhookState
   type: WebhookType
   platform: string
+  createdAt: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   payload: any
 }

--- a/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
@@ -19,6 +19,7 @@ export default class IncomingWebhookRepository extends RepositoryBase<IncomingWe
             iw.state,
             iw.type,
             iw.payload,
+            iw."createdAt" as "createdAt",
             i.platform as "platform"
         from 
             "incomingWebhooks" iw

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -287,6 +287,7 @@ export default class IntegrationStreamService extends LoggerBase {
         identifier: streamInfo.identifier,
         type: streamInfo.parentId ? IntegrationStreamType.CHILD : IntegrationStreamType.ROOT,
         data: streamInfo.data,
+        webhookCreatedAt: webhookInfo.createdAt,
       },
 
       log: this.log,

--- a/services/libs/integrations/src/integrations/github/processData.ts
+++ b/services/libs/integrations/src/integrations/github/processData.ts
@@ -929,9 +929,7 @@ const parseWebhookStar = async (ctx: IProcessDataContext) => {
       (type === GithubActivityType.STAR && payload.starred_at !== null))
   ) {
     const starredAt =
-      type === GithubActivityType.STAR
-        ? new Date(payload.starred_at).toISOString()
-        : data.date ?? new Date().toISOString()
+      type === GithubActivityType.STAR ? new Date(payload.starred_at).toISOString() : data.date
 
     const activity: IActivityData = {
       member,

--- a/services/libs/integrations/src/integrations/github/processWebhookStream.ts
+++ b/services/libs/integrations/src/integrations/github/processWebhookStream.ts
@@ -241,7 +241,7 @@ const parseWebhookPullRequestReview = async (
   }
 }
 
-const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext, date?: string) => {
+const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext, date: string) => {
   if (payload.action === 'created' || payload.action === 'deleted') {
     const member = await prepareWebhookMember(payload?.sender?.login, ctx)
 
@@ -250,7 +250,7 @@ const parseWebhookStar = async (payload: any, ctx: IProcessWebhookStreamContext,
         webhookType: GithubWehookEvent.STAR,
         data: payload,
         member,
-        ...(date ? { date } : {}),
+        date,
       })
     }
   }
@@ -345,6 +345,7 @@ const parseWebhookPullRequestReviewComment = async (
 
 const handler: ProcessWebhookStreamHandler = async (ctx) => {
   const identifier = ctx.stream.identifier
+  const webhookCreatedAt = ctx.stream.webhookCreatedAt
 
   // this is for pull request commits which are published during runtime
   if (identifier.startsWith(GithubStreamType.PULL_COMMITS)) {
@@ -353,7 +354,7 @@ const handler: ProcessWebhookStreamHandler = async (ctx) => {
     await processPullCommitsStream(ctx as IProcessStreamContext)
   } else {
     // this is for normal weqbook events
-    const { signature, event, data, date } = ctx.stream.data as GithubWebhookPayload
+    const { signature, event, data } = ctx.stream.data as GithubWebhookPayload
 
     await verifyWebhookSignature(signature, data, ctx)
 
@@ -371,7 +372,7 @@ const handler: ProcessWebhookStreamHandler = async (ctx) => {
         await parseWebhookPullRequestReview(data, ctx)
         break
       case GithubWehookEvent.STAR:
-        await parseWebhookStar(data, ctx, date)
+        await parseWebhookStar(data, ctx, webhookCreatedAt)
         break
       case GithubWehookEvent.FORK:
         await parseWebhookFork(data, ctx)

--- a/services/libs/types/src/integrations.ts
+++ b/services/libs/types/src/integrations.ts
@@ -8,6 +8,7 @@ export interface IIntegrationStream {
   identifier: string
   type: IntegrationStreamType
   data?: unknown
+  webhookCreatedAt?: string
 }
 
 export interface IIntegrationResult {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d348a6a</samp>

This pull request improves the accuracy of the date of starring a repository on GitHub by using the `webhookCreatedAt` property from the webhook event data. It adds this property to the `IWebhookData` and `IIntegrationStream` interfaces, and modifies the data parsing and processing functions accordingly.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d348a6a</samp>

> _To process GitHub stars with precision_
> _We added a new date decision_
> _We use `webhookCreatedAt`_
> _As the `starredAt` stat_
> _And removed the fallback condition_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d348a6a</samp>

*  Add `createdAt` property to `IWebhookData` interface to store webhook event timestamp ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-6f368a0a3dc861324c0b4e22c7c7d73d95eab34b00c64605d4d27c6e7ffdde64R10))
*  Add `iw."createdAt"` column to SQL query to select webhook data from `integration_webhook` table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-ba9fb67671acb0571a2e9fec5e2c17c75235b9f85448b0847d13079010a37921R22))
*  Add `webhookCreatedAt` property to object passed to `processWebhookStream` function to handle different webhook types ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R290))
*  Use `webhookCreatedAt` value as `starredAt` value for GitHub star webhook events, instead of current date or optional `date` value ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-1fef046692d1b07b29d9c634f0a743fc6122b9ed5a22e7820d3ff3a7cd9d0c49L932-R932), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL244-R244), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL253-R253), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL374-R375))
*  Make `date` parameter mandatory for `parseWebhookStar` function, and simplify object passed to `parseWebhookData` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL244-R244), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL253-R253))
*  Assign `webhookCreatedAt` value to variable in `handler` function, and remove `date` property from `ctx.stream.data` object ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eR348), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-8e0c19460db4e01b5f50795e82e42b545e6d65a449ffa4b380ed1357a127f15eL356-R357))
*  Add optional `webhookCreatedAt` property to `IIntegrationStream` interface to store webhook event timestamp for integration streams ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1464/files?diff=unified&w=0#diff-709b696c721c7c0bcf4b258a1e2dad053b40e41eb01db2b31c5b098495973288R11))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
