### PR TITLE
Detect stream type and process accordingly

### DIFF
--- a/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
@@ -109,10 +109,10 @@ export default class IncomingWebhookRepository extends RepositoryBase<IncomingWe
     tenantId: string,
     integrationId: string,
     type: string,
-    //  eslint-disable-next-line @typescript-eslint/no-explicit-any
-    payload: any,
-  ): Promise<string | null> {
-    const result = await this.db().oneOrNone(
+    payload: unknown,
+  ): Promise<string> {
+    const id = generateUUIDv1()
+    const result = await this.db().result(
       `
         insert into "incomingWebhooks" (
           id,
@@ -132,7 +132,7 @@ export default class IncomingWebhookRepository extends RepositoryBase<IncomingWe
         returning id
       `,
       {
-        id: generateUUIDv1(),
+        id,
         tenantId,
         integrationId,
         type,
@@ -141,7 +141,9 @@ export default class IncomingWebhookRepository extends RepositoryBase<IncomingWe
       },
     )
 
-    return result?.id ?? null
+    this.checkUpdateRowCount(result.rowCount, 1)
+
+    return id
   }
 
   public async getFailedWebhooks(limit: number): Promise<

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -210,10 +210,7 @@ export default class IntegrationStreamService extends LoggerBase {
     }
 
     if (streamInfo.runId) {
-      this.log.warn(
-        { webhookId, streamId },
-        'Webhook stream is not a webhook stream! Processing as a regular stream!',
-      )
+      this.log.warn({ webhookId, streamId }, 'Stream is not a webhook stream! Processing as such!')
       await this.processStream(streamId)
       return
     }
@@ -374,7 +371,7 @@ export default class IntegrationStreamService extends LoggerBase {
     }
 
     if (streamInfo.webhookId) {
-      this.log.warn({ streamId }, 'Stream is a webhook stream! Processing as a webhook stream!')
+      this.log.warn({ streamId }, 'Stream is a webhook stream! Processing as such!')
       await this.processWebhookStream(streamInfo.webhookId)
       return
     }

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -210,7 +210,7 @@ export default class IntegrationStreamService extends LoggerBase {
     }
 
     if (streamInfo.runId) {
-      this.log.warn({ webhookId, streamId }, 'Stream is not a webhook stream! Processing as such!')
+      this.log.warn({ streamId }, 'Stream is a regular stream! Processing as such!')
       await this.processStream(streamId)
       return
     }

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -209,6 +209,15 @@ export default class IntegrationStreamService extends LoggerBase {
       return
     }
 
+    if (streamInfo.runId) {
+      this.log.warn(
+        { webhookId, streamId },
+        'Webhook stream is not a webhook stream! Processing as a regular stream!',
+      )
+      await this.processStream(streamId)
+      return
+    }
+
     this.log = getChildLogger('webhook-stream-processor', this.log, {
       webhookId: streamInfo.webhookId,
       integrationId: streamInfo.integrationId,
@@ -361,6 +370,12 @@ export default class IntegrationStreamService extends LoggerBase {
 
     if (!streamInfo) {
       this.log.error({ streamId }, 'Stream not found!')
+      return
+    }
+
+    if (streamInfo.webhookId) {
+      this.log.warn({ streamId }, 'Stream is a webhook stream! Processing as a webhook stream!')
+      await this.processWebhookStream(streamInfo.webhookId)
       return
     }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08504e0</samp>

Refactored `saveIncomingWebhook` method in `incomingWebhook.repo.ts` to improve code quality and return webhook UUID. Added support for mixed streams in `IntegrationStreamService` by checking stream type and delegating to specific methods.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 08504e0</samp>

> _Sing, O Muse, of the skillful coder who refactored_
> _The `saveIncomingWebhook` method, and made it safer_
> _To store the UUIDs of the webhooks, those swift messengers_
> _That bring the news of distant events to the eager listeners._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08504e0</samp>

*  Add type safety and UUID generation to `saveIncomingWebhook` method in `IncomingWebhookRepo` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1465/files?diff=unified&w=0#diff-ba9fb67671acb0571a2e9fec5e2c17c75235b9f85448b0847d13079010a37921L112-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1465/files?diff=unified&w=0#diff-ba9fb67671acb0571a2e9fec5e2c17c75235b9f85448b0847d13079010a37921L135-R135), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1465/files?diff=unified&w=0#diff-ba9fb67671acb0571a2e9fec5e2c17c75235b9f85448b0847d13079010a37921L144-R146))
*  Add logic to handle mixed streams in `processWebhookStream` and `processStream` methods in `IntegrationStreamService` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1465/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R212-R220), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1465/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R376-R381))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
