### PR TITLE
Force typescript for org enrich config

### DIFF
--- a/frontend/src/modules/organization/config/enrichment/affiliatedProfiles.ts
+++ b/frontend/src/modules/organization/config/enrichment/affiliatedProfiles.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const affiliatedProfiles: OrganizationEnrichmentConfig = {
   name: 'affiliatedProfiles',
   label: 'Affilliated Profiles',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
 };
+
+export default affiliatedProfiles;

--- a/frontend/src/modules/organization/config/enrichment/allSubsidiaries.ts
+++ b/frontend/src/modules/organization/config/enrichment/allSubsidiaries.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const allSubsidiaries: OrganizationEnrichmentConfig = {
   name: 'allSubsidiaries',
   label: 'All subsidiaries',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
 };
+
+export default allSubsidiaries;

--- a/frontend/src/modules/organization/config/enrichment/alternativeDomains.ts
+++ b/frontend/src/modules/organization/config/enrichment/alternativeDomains.ts
@@ -1,12 +1,15 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const alternativeDomains: OrganizationEnrichmentConfig = {
   name: 'alternativeDomains',
   label: 'Alternative Domains',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
   isLink: true,
 };
+
+export default alternativeDomains;

--- a/frontend/src/modules/organization/config/enrichment/alternativeNames.ts
+++ b/frontend/src/modules/organization/config/enrichment/alternativeNames.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const alternativeNames: OrganizationEnrichmentConfig = {
   name: 'alternativeNames',
   label: 'Alternative Names',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
 };
+
+export default alternativeNames;

--- a/frontend/src/modules/organization/config/enrichment/averageEmployeeTenure.ts
+++ b/frontend/src/modules/organization/config/enrichment/averageEmployeeTenure.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { formatFloatToYears } from '@/utils/number';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const averageEmployeeTenure: OrganizationEnrichmentConfig = {
   name: 'averageEmployeeTenure',
   label: 'Average Employee Tenure',
-  type: attributesTypes.number,
+  type: AttributeType.NUMBER,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => formatFloatToYears(value),
 };
+
+export default averageEmployeeTenure;

--- a/frontend/src/modules/organization/config/enrichment/averageTenureByLevel.ts
+++ b/frontend/src/modules/organization/config/enrichment/averageTenureByLevel.ts
@@ -1,20 +1,23 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatFloatToYears } from '@/utils/number';
 import { snakeToSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-const AverageTenureByLevel = {
+const AverageTenureByLevel: Record<string, string> = {
   vp: 'VP',
   cxo: 'CXO',
 };
 
-export default {
+const averageTenureByLevel: OrganizationEnrichmentConfig = {
   name: 'averageTenureByLevel',
   label: 'Average Tenure by Level',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => AverageTenureByLevel[key] || snakeToSentenceCase(key),
   valueParser: (value) => formatFloatToYears(value),
 };
+
+export default averageTenureByLevel;

--- a/frontend/src/modules/organization/config/enrichment/averageTenureByRole.ts
+++ b/frontend/src/modules/organization/config/enrichment/averageTenureByRole.ts
@@ -1,15 +1,18 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatFloatToYears } from '@/utils/number';
 import { snakeToSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const averageTenureByRole: OrganizationEnrichmentConfig = {
   name: 'averageTenureByRole',
   label: 'Average Tenure by Role',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => snakeToSentenceCase(key),
   valueParser: (value) => formatFloatToYears(value),
 };
+
+export default averageTenureByRole;

--- a/frontend/src/modules/organization/config/enrichment/directSubsidiaries.ts
+++ b/frontend/src/modules/organization/config/enrichment/directSubsidiaries.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const directSubsidiaries: OrganizationEnrichmentConfig = {
   name: 'directSubsidiaries',
   label: 'Direct Subsidiaries',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
 };
+
+export default directSubsidiaries;

--- a/frontend/src/modules/organization/config/enrichment/employeeChurnRate.ts
+++ b/frontend/src/modules/organization/config/enrichment/employeeChurnRate.ts
@@ -1,12 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatFloatToPercentage } from '@/utils/number';
 import { snakeToSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const employeeChurnRate: OrganizationEnrichmentConfig = {
   name: 'employeeChurnRate',
   label: 'Employee Churn Rate',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
@@ -14,3 +15,5 @@ export default {
   keyParser: (key) => `${snakeToSentenceCase(key)}s`,
   filterValue: (value) => ({ '12_month': value['12_month'] }),
 };
+
+export default employeeChurnRate;

--- a/frontend/src/modules/organization/config/enrichment/employeeCount.ts
+++ b/frontend/src/modules/organization/config/enrichment/employeeCount.ts
@@ -1,10 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const employeeCount: OrganizationEnrichmentConfig = {
   name: 'employeeCount',
   label: 'Employee Count',
-  type: attributesTypes.number,
+  type: AttributeType.NUMBER,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => value,
 };
+
+export default employeeCount;

--- a/frontend/src/modules/organization/config/enrichment/employeeCountByCountry.ts
+++ b/frontend/src/modules/organization/config/enrichment/employeeCountByCountry.ts
@@ -1,13 +1,16 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { toSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const employeeCountByCountry: OrganizationEnrichmentConfig = {
   name: 'employeeCountByCountry',
   label: 'Employee Count by Country',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => toSentenceCase(key),
 };
+
+export default employeeCountByCountry;

--- a/frontend/src/modules/organization/config/enrichment/employeeCountByMonth.ts
+++ b/frontend/src/modules/organization/config/enrichment/employeeCountByMonth.ts
@@ -1,16 +1,19 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatDate } from '@/utils/date';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const employeeCountByMonth: OrganizationEnrichmentConfig = {
   name: 'employeeCountByMonth',
   label: 'Employee Count by Month',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => formatDate({
     timestamp: key,
     format: 'MMMM YYYY',
-  }),
+  } as any),
 };
+
+export default employeeCountByMonth;

--- a/frontend/src/modules/organization/config/enrichment/employeeGrowthRate.ts
+++ b/frontend/src/modules/organization/config/enrichment/employeeGrowthRate.ts
@@ -1,12 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatFloatToPercentage } from '@/utils/number';
 import { snakeToSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const employeeGrowthRate: OrganizationEnrichmentConfig = {
   name: 'employeeGrowthRate',
   label: 'Employee Growth Rate',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
@@ -14,3 +15,5 @@ export default {
   keyParser: (key) => `${snakeToSentenceCase(key)}s`,
   filterValue: (value) => ({ '12_month': value['12_month'] }),
 };
+
+export default employeeGrowthRate;

--- a/frontend/src/modules/organization/config/enrichment/founded.ts
+++ b/frontend/src/modules/organization/config/enrichment/founded.ts
@@ -1,10 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const founded: OrganizationEnrichmentConfig = {
   name: 'founded',
   label: 'Founded',
-  type: attributesTypes.number,
+  type: AttributeType.NUMBER,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => value,
 };
+
+export default founded;

--- a/frontend/src/modules/organization/config/enrichment/gicsSector.ts
+++ b/frontend/src/modules/organization/config/enrichment/gicsSector.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { toSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const gicsSector: OrganizationEnrichmentConfig = {
   name: 'gicsSector',
   label: 'GICS Sector',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => toSentenceCase(value),
 };
+
+export default gicsSector;

--- a/frontend/src/modules/organization/config/enrichment/grossAdditionsByMonth.ts
+++ b/frontend/src/modules/organization/config/enrichment/grossAdditionsByMonth.ts
@@ -1,16 +1,19 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatDate } from '@/utils/date';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const grossAdditionsByMonth: OrganizationEnrichmentConfig = {
   name: 'grossAdditionsByMonth',
   label: 'Gross Additions by Month',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => formatDate({
     timestamp: key,
     format: 'MMMM YYYY',
-  }),
+  } as any),
 };
+
+export default grossAdditionsByMonth;

--- a/frontend/src/modules/organization/config/enrichment/grossDeparturesByMonth.ts
+++ b/frontend/src/modules/organization/config/enrichment/grossDeparturesByMonth.ts
@@ -1,16 +1,19 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesJSONRenderer from '@/modules/organization/components/organization-attributes-json-renderer.vue';
 import { formatDate } from '@/utils/date';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const grossDeparturesByMonth: OrganizationEnrichmentConfig = {
   name: 'grossDeparturesByMonth',
   label: 'Gross Departures by Month',
-  type: attributesTypes.json,
+  type: AttributeType.JSON,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesJSONRenderer,
   keyParser: (key) => formatDate({
     timestamp: key,
     format: 'MMMM YYYY',
-  }),
+  } as any),
 };
+
+export default grossDeparturesByMonth;

--- a/frontend/src/modules/organization/config/enrichment/headcount.ts
+++ b/frontend/src/modules/organization/config/enrichment/headcount.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { toSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const size: OrganizationEnrichmentConfig = {
   name: 'size',
   label: 'Headcount',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: false,
   displayValue: (value) => toSentenceCase(value),
 };
+
+export default size;

--- a/frontend/src/modules/organization/config/enrichment/immediateParent.ts
+++ b/frontend/src/modules/organization/config/enrichment/immediateParent.ts
@@ -1,10 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const immediateParent: OrganizationEnrichmentConfig = {
   name: 'immediateParent',
   label: 'Immediate Parent',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => value,
 };
+
+export default immediateParent;

--- a/frontend/src/modules/organization/config/enrichment/index.ts
+++ b/frontend/src/modules/organization/config/enrichment/index.ts
@@ -26,17 +26,17 @@ import immediateParent from './immediateParent';
 import ultimateParent from './ultimateParent';
 
 export interface OrganizationEnrichmentConfig {
-  name: string;
-  label: string;
-  type: AttributeType;
-  showInForm: boolean;
-  showInAttributes: boolean;
-  displayValue?: (value: any) => string;
-  component?: any;
-  isLink?: boolean;
-  keyParser?: (key: string) => string;
-  valueParser?: (value: any) => string;
-  filterValue?: (value: any) => any;
+  name: string; // id of the enrichment attribute
+  label: string; // name of the enrichment property
+  type: AttributeType; // Type of the attribute
+  showInForm: boolean; // Display in Organization Form
+  showInAttributes: boolean; // Display in Organization Profile
+  isLink?: boolean; // If attribute is a url
+  component?: any; // Component that will render attribute in organization profile
+  displayValue?: (value: any) => string; // Formatter for displaying attribute value
+  keyParser?: (key: string) => string; // Formatter for keys of jsons if attribute is json
+  valueParser?: (value: any) => string; // Formatter for values of jsons if attribute is json
+  filterValue?: (value: any) => any; // Filter attributes values
 }
 
 const enrichmentConfig: OrganizationEnrichmentConfig[] = [

--- a/frontend/src/modules/organization/config/enrichment/index.ts
+++ b/frontend/src/modules/organization/config/enrichment/index.ts
@@ -1,3 +1,4 @@
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import affiliatedProfiles from './affiliatedProfiles';
 import allSubsidiaries from './allSubsidiaries';
 import alternativeDomains from './alternativeDomains';
@@ -24,7 +25,21 @@ import typeAttribute from './type';
 import immediateParent from './immediateParent';
 import ultimateParent from './ultimateParent';
 
-export default [
+export interface OrganizationEnrichmentConfig {
+  name: string;
+  label: string;
+  type: AttributeType;
+  showInForm: boolean;
+  showInAttributes: boolean;
+  displayValue?: (value: any) => string;
+  component?: any;
+  isLink?: boolean;
+  keyParser?: (key: string) => string;
+  valueParser?: (value: any) => string;
+  filterValue?: (value: any) => any;
+}
+
+const enrichmentConfig: OrganizationEnrichmentConfig[] = [
   lastEnrichedAt,
   industry,
   headcount,
@@ -51,3 +66,5 @@ export default [
   tags,
   ultimateParent,
 ];
+
+export default enrichmentConfig;

--- a/frontend/src/modules/organization/config/enrichment/industry.ts
+++ b/frontend/src/modules/organization/config/enrichment/industry.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { toSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const industry: OrganizationEnrichmentConfig = {
   name: 'industry',
   label: 'Industry',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => toSentenceCase(value),
 };
+
+export default industry;

--- a/frontend/src/modules/organization/config/enrichment/lastEnrichedAt.ts
+++ b/frontend/src/modules/organization/config/enrichment/lastEnrichedAt.ts
@@ -1,16 +1,19 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { formatDate } from '@/utils/date';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const lastEnrichedAt: OrganizationEnrichmentConfig = {
   name: 'lastEnrichedAt',
   label: 'Last enrichment',
-  type: attributesTypes.date,
+  type: AttributeType.DATE,
   showInForm: false,
   showInAttributes: true,
-  displayValue: (value) => formatDate({
+  displayValue: (value) => (formatDate({
     timestamp: value,
     subtractDays: null,
     subtractMonths: null,
     format: 'D MMMM, YYYY',
-  }),
+  } as any)),
 };
+
+export default lastEnrichedAt;

--- a/frontend/src/modules/organization/config/enrichment/revenueRange.ts
+++ b/frontend/src/modules/organization/config/enrichment/revenueRange.ts
@@ -1,6 +1,7 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-const getValue = (value) => {
+const getValue = (value?: number) => {
   if (value === undefined || value === null) {
     return '';
   }
@@ -8,7 +9,7 @@ const getValue = (value) => {
   return `$${value >= 1000 ? value / 1000 : value}${value >= 1000 ? 'B' : 'M'}`;
 };
 
-const getMiddle = (min, max) => {
+const getMiddle = (min: string, max: string) => {
   if (min && max) {
     return '-';
   }
@@ -20,10 +21,10 @@ const getMiddle = (min, max) => {
   return '';
 };
 
-export default {
+const revenueRange: OrganizationEnrichmentConfig = {
   name: 'revenueRange',
   label: 'Annual Revenue',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: false,
   showInAttributes: false,
   displayValue: (value) => {
@@ -37,3 +38,5 @@ export default {
     return `${min}${getMiddle(min, max)}${max}`;
   },
 };
+
+export default revenueRange;

--- a/frontend/src/modules/organization/config/enrichment/revenueRange.ts
+++ b/frontend/src/modules/organization/config/enrichment/revenueRange.ts
@@ -1,7 +1,7 @@
 import { AttributeType } from '@/modules/organization/types/Attributes';
 import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-const getValue = (value?: number) => {
+const getValue = (value?: number | null): string => {
   if (value === undefined || value === null) {
     return '';
   }
@@ -9,7 +9,7 @@ const getValue = (value?: number) => {
   return `$${value >= 1000 ? value / 1000 : value}${value >= 1000 ? 'B' : 'M'}`;
 };
 
-const getMiddle = (min: string, max: string) => {
+const getMiddle = (min: string, max: string): string => {
   if (min && max) {
     return '-';
   }

--- a/frontend/src/modules/organization/config/enrichment/tags.ts
+++ b/frontend/src/modules/organization/config/enrichment/tags.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import OrganizationAttributesArrayRenderer from '@/modules/organization/components/organization-attributes-array-renderer.vue';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const tags: OrganizationEnrichmentConfig = {
   name: 'tags',
   label: 'Tags',
-  type: attributesTypes.array,
+  type: AttributeType.ARRAY,
   showInForm: true,
   showInAttributes: true,
   component: OrganizationAttributesArrayRenderer,
 };
+
+export default tags;

--- a/frontend/src/modules/organization/config/enrichment/type.ts
+++ b/frontend/src/modules/organization/config/enrichment/type.ts
@@ -1,11 +1,14 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
 import { toSentenceCase } from '@/utils/string';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const type: OrganizationEnrichmentConfig = {
   name: 'type',
   label: 'Type',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: true,
   displayValue: (value) => toSentenceCase(value),
 };
+
+export default type;

--- a/frontend/src/modules/organization/config/enrichment/ultimateParent.ts
+++ b/frontend/src/modules/organization/config/enrichment/ultimateParent.ts
@@ -1,10 +1,13 @@
-import { attributesTypes } from '@/modules/organization/types/Attributes';
+import { AttributeType } from '@/modules/organization/types/Attributes';
+import { OrganizationEnrichmentConfig } from '@/modules/organization/config/enrichment/index';
 
-export default {
+const ultimateParent: OrganizationEnrichmentConfig = {
   name: 'ultimateParent',
   label: 'Ultimate Parent',
-  type: attributesTypes.string,
+  type: AttributeType.STRING,
   showInForm: true,
   showInAttributes: true,
-  displayValue: (value) => value,
+  displayValue: (value: string) => value,
 };
+
+export default ultimateParent;

--- a/frontend/src/modules/organization/types/Attributes.ts
+++ b/frontend/src/modules/organization/types/Attributes.ts
@@ -1,10 +1,10 @@
-export const attributesTypes = {
-  string: 'Text',
-  number: 'Number',
-  email: 'E-mail',
-  url: 'URL',
-  date: 'Date',
-  boolean: 'Boolean',
-  array: 'List',
-  json: 'Data',
-};
+export enum AttributeType {
+  STRING = 'Text',
+  NUMBER = 'Number',
+  EMAIL = 'E-mail',
+  URL = 'URL',
+  DATE = 'Date',
+  BOOLEAN = 'Boolean',
+  ARRAY = 'List',
+  JSON = 'Data',
+}


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71a3c29</samp>

This pull request adds default exports and improves type safety for the frontend enrichment modules for organizations. It also introduces a new `getEnrichmentConfig` function and an `EnrichmentConfig` type to simplify and standardize the enrichment configuration objects. Additionally, it replaces the `attributesTypes` object with the `AttributeType` enum for consistency. These changes affect the files in the `frontend/src/modules/organization/config/enrichment` directory.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71a3c29</samp>

> _`AttributeType` enum_
> _simplifies enrichment code_
> _refactor in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71a3c29</samp>

*  Replace the import of `attributesTypes` with `AttributeType` enum in all enrichment files ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-8094655ce6220e048937bcd2fa79af8187895a5e900ec9fe166efb1da7e96ca5L1-R14)-[link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-c409478ea3bfef0ff4a3dc0fef18a9b5d3b112ab2eb72dd9c0f01791747edcaaL1-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0a15712949a5eb1c4e8627398048562e1851caaf9ed3b351f081d781b37e297dR1))
*  Add default exports of the enrichment objects to the end of the files that were missing them ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-10cfc3ee4a8dff3ea4a960b60fb3ea74f3822d5db4eb1a3ebb8d2ede7f4ce112R14-R15), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-6e28a0255d6d7679b6378b72f22c896adae3f1f372955bcf0535272b5e382ffdR22-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-22481c10aeccbc2748ada455e767011a0d0b9f0e2245ceaaa7dd14583f96703eR17-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-3ac24442bcaa9ae3849dffcc28d8aa570a0250ddf15dc55ea131cd181423de4fR18-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-a3c1fd4780f6a855a098b74eba658f0ddeb03febf5b61dfafe7dc84275592d8dR15-R16), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-9a2e8a3f5a011a1639509bc1dc6fada22721702764f099c645929a9102e2b207L15-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-286a7ee727c99a8d7e6cb2c2c5208226f45fc16e7212b5635a73ba7c04026746R18-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0ae70ba2937f15cef635634c5f011ee8d752154025a3a21214bb15c178992067L15-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-f4860f5e9683f0a4b62ae2f2808be64396fa594592001ab1b5d6e652432fe59dL15-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0a15712949a5eb1c4e8627398048562e1851caaf9ed3b351f081d781b37e297dR69-R70))
*  Type the `AverageTenureByLevel` object as `Record<string, string>` in `averageTenureByLevel.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-6e28a0255d6d7679b6378b72f22c896adae3f1f372955bcf0535272b5e382ffdL1-R15))
*  Add `as any` cast to avoid TypeScript error in `employeeCountByMonth.ts` and `grossAdditionsByMonth.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-9a2e8a3f5a011a1639509bc1dc6fada22721702764f099c645929a9102e2b207L15-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0ae70ba2937f15cef635634c5f011ee8d752154025a3a21214bb15c178992067L15-R19))
*  Create `enrichmentConfig` array and `OrganizationEnrichmentConfig` interface in `index.ts` to store and export the enrichment objects ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0a15712949a5eb1c4e8627398048562e1851caaf9ed3b351f081d781b37e297dL27-R42), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1467/files?diff=unified&w=0#diff-0a15712949a5eb1c4e8627398048562e1851caaf9ed3b351f081d781b37e297dR69-R70))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
