### PR TITLE
When webhook processing results in error mark that incomingWebhooks row

### DIFF
--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -350,6 +350,11 @@ export default class IntegrationStreamService extends LoggerBase {
       await this.webhookRepo.markWebhookProcessed(webhookId)
     } catch (err) {
       this.log.error(err, 'Error while processing webhook stream!')
+      await this.webhookRepo.markWebhookError(webhookId, {
+        errorMessage: err?.message,
+        errorStack: err?.stack,
+        errorString: err ? JSON.stringify(err) : undefined,
+      })
       await this.triggerStreamError(
         streamInfo,
         'webhook-stream-process',


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dc4263</samp>

Improved error handling for webhook execution in `integrationStreamService`. Added a database update to mark webhooks with error information.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3dc4263</samp>

> _`processWebhook` fails_
> _Error info stored in `webhookRepo`_
> _Winter of debugging_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3dc4263</samp>

*  Add error handling logic for webhook execution ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1468/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R353-R357))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
