### PR TITLE
Don't throw errors when Discord channel is not found

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/getMessage.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMessage.ts
@@ -20,7 +20,20 @@ export const getMessage = async (
     const response = await axios(config)
     return response.data
   } catch (err) {
-    const newErr = handleDiscordError(err, config, { channelId, messageId }, ctx)
-    throw newErr
+    if (
+      err.response &&
+      err.response.data &&
+      err.response.data.message === 'Unknown Channel' &&
+      err.response.data.code === 10003
+    ) {
+      ctx.log.warn(
+        { channelId, messageId },
+        'Discord API returned Unknown Channel error when fetching message during webhook processing, skipping message.',
+      )
+      return null
+    } else {
+      const newErr = handleDiscordError(err, config, { channelId, messageId }, ctx)
+      throw newErr
+    }
   }
 }

--- a/services/libs/integrations/src/integrations/discord/processWebhookStream.ts
+++ b/services/libs/integrations/src/integrations/discord/processWebhookStream.ts
@@ -26,6 +26,11 @@ const parseWebhookMessage = async (payload: any, ctx: IProcessWebhookStreamConte
     ctx as IProcessStreamContext,
   )
 
+  if (!record) {
+    // skipping 404 errors, they are most likely due to the message / channel being deleted
+    return
+  }
+
   let parent: string | undefined
   let parentChannel: string | undefined
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5554438</samp>

This pull request fixes a bug in the Discord integration that caused errors when fetching deleted or inaccessible messages during webhook processing. It adds error handling and null checks to `getMessage.ts` and `processWebhookStream.ts` to gracefully skip such messages.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5554438</samp>

> _`Unknown Channel` error_
> _Discord message may be null_
> _Skip it in the fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5554438</samp>

*  Handle Unknown Channel error when fetching Discord messages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1470/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aL23-R37))
*  Skip parsing null messages in webhook processing ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1470/files?diff=unified&w=0#diff-422669bc13f64aab41114357cb0edf995b94f1099d2c7304678255845a224d23R29-R33))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
