### PR TITLE
intersecting roles fix on org merge

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -901,10 +901,10 @@ class OrganizationRepository {
         addRoles.push({
           dateStart: new Date(Math.min.apply(null, startDates)).toISOString(),
           dateEnd: new Date(Math.max.apply(null, endDates)).toISOString(),
-          memberId: foundIntersectingRoles[0].memberId,
-          organizationId: foundIntersectingRoles[0].organizationId,
-          title: foundIntersectingRoles[0].title,
-          source: foundIntersectingRoles[0].source,
+          memberId: memberOrganization.memberId,
+          organizationId: toOrganizationId,
+          title: foundIntersectingRoles.length > 0 ? foundIntersectingRoles[0].title : memberOrganization.title,
+          source: foundIntersectingRoles.length > 0 ? foundIntersectingRoles[0].source : memberOrganization.source,
         })
 
         // we'll delete all roles that intersect with incoming org member roles and create a merged role


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a48cee2</samp>

Fixed a bug in `mergeOrganizations` that caused incorrect or missing member roles in the merged organization. The fix ensures that the merged organization has the most relevant role information for each member from the source and target organizations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a48cee2</samp>

> _`mergeOrganizations`_
> _Fixes roles for each member_
> _A bug in autumn_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a48cee2</samp>

* Fix bug in `mergeOrganizations` method of `OrganizationRepository` class that caused incorrect or missing member roles in merged organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1472/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL904-R907))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
