### PR TITLE
Refresh token when getting organization

### DIFF
--- a/services/libs/integrations/src/integrations/github/processStream.ts
+++ b/services/libs/integrations/src/integrations/github/processStream.ts
@@ -169,7 +169,8 @@ export const prepareMember = async (
       orgs = [{ name: 'crowd.dev' }]
     } else {
       const company = memberFromApi.company.replace('@', '').trim()
-      const fromAPI = await getOrganization(company, ctx.integration.token)
+      const token = await getGithubToken(ctx)
+      const fromAPI = await getOrganization(company, token)
 
       orgs = fromAPI
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fca9d30</samp>

Refactored GitHub integration token handling to use a new service. Updated `prepareMember` function in `processStream.ts` to use `getGithubToken` instead of integration token.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fca9d30</samp>

> _`getGithubToken`_
> _A new way to access code_
> _Winter of refactor_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fca9d30</samp>

*  Refactor GitHub token management to use a centralized service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1473/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L172-R173),                             

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
