### PR TITLE
Handle needs-reconnect integrations

### DIFF
--- a/backend/src/database/repositories/incomingWebhookRepository.ts
+++ b/backend/src/database/repositories/incomingWebhookRepository.ts
@@ -5,7 +5,6 @@ import {
   ErrorWebhook,
   IncomingWebhookData,
   PendingWebhook,
-  WebhookError,
   WebhookState,
   WebhookType,
 } from '../../types/webhooks'
@@ -155,7 +154,7 @@ export default class IncomingWebhookRepository extends RepositoryBase<
     )
   }
 
-  async markError(id: string, error: WebhookError): Promise<void> {
+  async markError(id: string, error: any): Promise<void> {
     const transaction = this.transaction
 
     const [, rowCount] = await this.seq.query(
@@ -172,10 +171,9 @@ export default class IncomingWebhookRepository extends RepositoryBase<
           id,
           state: WebhookState.ERROR,
           error: JSON.stringify({
-            message: error.message,
-            originalError: JSON.stringify(error.originalError),
-            originalMessage: error.originalError.message,
-            stack: error.stack,
+            errorMessage: error.message,
+            errorString: JSON.stringify(error.originalError),
+            errorStack: error.stack,
           }),
         },
         type: QueryTypes.UPDATE,

--- a/backend/src/serverless/integrations/services/webhookProcessor.ts
+++ b/backend/src/serverless/integrations/services/webhookProcessor.ts
@@ -9,7 +9,7 @@ import getUserContext from '../../../database/utils/getUserContext'
 import { IServiceOptions } from '../../../services/IServiceOptions'
 import { IStepContext } from '../../../types/integration/stepResult'
 import { NodeWorkerProcessWebhookMessage } from '../../../types/mq/nodeWorkerProcessWebhookMessage'
-import { WebhookError, WebhookState } from '../../../types/webhooks'
+import { WebhookState } from '../../../types/webhooks'
 import bulkOperations from '../../dbOperations/operationsWorker'
 import { sendNodeWorkerMessage } from '../../utils/nodeWorkerSQS'
 import { IntegrationServiceBase } from './integrationServiceBase'
@@ -121,10 +121,7 @@ export class WebhookProcessor extends LoggerBase {
         )
       } else {
         logger.error(err, 'Error processing webhook!')
-        await repo.markError(
-          webhook.id,
-          new WebhookError(webhook.id, 'Error processing webhook!', err),
-        )
+        await repo.markError(webhook.id, err)
       }
     } finally {
       await SequelizeRepository.commitTransaction(whContext.transaction)

--- a/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/incomingWebhook.repo.ts
@@ -52,6 +52,14 @@ export default class IncomingWebhookRepository extends RepositoryBase<IncomingWe
     )
   }
 
+  public async deleteWebhook(id: string): Promise<void> {
+    const result = await this.db().result(`delete from "incomingWebhooks" where id = $(id)`, {
+      id,
+    })
+
+    this.checkUpdateRowCount(result.rowCount, 1)
+  }
+
   public async markWebhookPending(id: string): Promise<void> {
     await this.db().none(
       `

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -14,6 +14,7 @@ import {
 } from '@crowd/sqs'
 import {
   IntegrationRunState,
+  IntegrationState,
   IntegrationStreamType,
   RateLimitError,
   WebhookType,
@@ -146,6 +147,14 @@ export default class IntegrationStreamService extends LoggerBase {
       return
     }
 
+    if (stream.webhookId) {
+      await this.webhookRepo.markWebhookError(stream.webhookId, {
+        errorMessage: err?.message,
+        errorStack: err?.stack,
+        errorString: err ? JSON.stringify(err) : undefined,
+      })
+    }
+
     // stop run because of stream error
     if (stream.runId) {
       this.log.warn('Reached maximum retries for stream! Stopping the run!')
@@ -212,6 +221,13 @@ export default class IntegrationStreamService extends LoggerBase {
     if (streamInfo.runId) {
       this.log.warn({ streamId }, 'Stream is a regular stream! Processing as such!')
       await this.processStream(streamId)
+      return
+    }
+
+    if (streamInfo.integrationState === IntegrationState.NEEDS_RECONNECT) {
+      this.log.warn('Integration is not correctly connected! Deleting the stream and webhook!')
+      await this.repo.deleteStream(streamId)
+      await this.webhookRepo.deleteWebhook(webhookId)
       return
     }
 
@@ -350,11 +366,6 @@ export default class IntegrationStreamService extends LoggerBase {
       await this.webhookRepo.markWebhookProcessed(webhookId)
     } catch (err) {
       this.log.error(err, 'Error while processing webhook stream!')
-      await this.webhookRepo.markWebhookError(webhookId, {
-        errorMessage: err?.message,
-        errorStack: err?.stack,
-        errorString: err ? JSON.stringify(err) : undefined,
-      })
       await this.triggerStreamError(
         streamInfo,
         'webhook-stream-process',
@@ -387,7 +398,14 @@ export default class IntegrationStreamService extends LoggerBase {
     }
 
     if (streamInfo.runState === IntegrationRunState.INTEGRATION_DELETED) {
-      this.log.warn('Integration was deleted! Skipping stream processing!')
+      this.log.warn('Integration was deleted! Skipping stream processing! Deleting the stream!')
+      await this.repo.deleteStream(streamId)
+      return
+    }
+
+    if (streamInfo.integrationState === IntegrationState.NEEDS_RECONNECT) {
+      this.log.warn('Integration is not correctly connected! Deleting the stream!')
+      await this.repo.deleteStream(streamId)
       return
     }
 

--- a/services/libs/integrations/src/integrations/github/api/graphql/baseQuery.ts
+++ b/services/libs/integrations/src/integrations/github/api/graphql/baseQuery.ts
@@ -125,10 +125,9 @@ class BaseQuery {
 
   static processGraphQLError(err: any): any {
     if (
-      (err.status &&
-        err.status === 403 &&
+      (err.status === 403 &&
         err.message &&
-        (err.message as string).includes('secondary rate limit')) ||
+        (err.message as string).toLowerCase().includes('secondary rate limit')) ||
       (err.errors && err.errors[0].type === 'RATE_LIMITED')
     ) {
       if (err.headers && err.headers['x-ratelimit-reset']) {

--- a/services/libs/integrations/src/integrations/github/api/graphql/baseQuery.ts
+++ b/services/libs/integrations/src/integrations/github/api/graphql/baseQuery.ts
@@ -124,7 +124,13 @@ class BaseQuery {
   }
 
   static processGraphQLError(err: any): any {
-    if (err.errors && err.errors[0].type === 'RATE_LIMITED') {
+    if (
+      (err.status &&
+        err.status === 403 &&
+        err.message &&
+        (err.message as string).includes('secondary rate limit')) ||
+      (err.errors && err.errors[0].type === 'RATE_LIMITED')
+    ) {
       if (err.headers && err.headers['x-ratelimit-reset']) {
         const query =
           err.request && err.request.query ? err.request.query : 'Unknown GraphQL query!'

--- a/services/libs/types/src/enums/integrations.ts
+++ b/services/libs/types/src/enums/integrations.ts
@@ -4,6 +4,7 @@ export enum IntegrationState {
   ERROR = 'error',
   INACTIVE = 'inactive',
   WAITING_APPROVAL = 'waiting-approval',
+  NEEDS_RECONNECT = 'needs-reconnect',
 }
 
 export enum IntegrationRunState {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea49cf2</samp>

This pull request enhances the error handling and cleanup logic for the integration stream service, which handles data from webhook providers like GitHub. It adds a new method to delete webhooks from the database, a new condition to handle GitHub's secondary rate limit, and a new enum value to indicate integrations that need to be reconnected.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea49cf2</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A way to handle errors from the GitHub API,_
> _And to delete the `webhooks` that had expired_
> _Or lost their connection with the `integration stream`._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea49cf2</samp>

*  Add `needs-reconnect` value to `IntegrationState` enum to handle integrations that require reconnection ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-bee69c14664dadfdb3ce6a56d01c020ac1eecc04a65670cfc2ef01e242c3fcd3R7))
*  Delete webhooks and streams from database when they are no longer valid or needed ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-ba9fb67671acb0571a2e9fec5e2c17c75235b9f85448b0847d13079010a37921R55-R62), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R227-R233), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278L390-R411))
*  Mark webhooks as having errors when stream processing fails due to webhook provider issues ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R150-R157))
*  Skip stream processing when integration state is `needs-reconnect` or `integration-deleted` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R227-R233), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278L390-R411))
*  Handle secondary rate limit errors from GitHub API in `BaseQuery` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-dc492961084cfb77107b2a52549f32dae0f7986d130e88b786a6ac5ea4300f30L127-R133))
*  Remove redundant code that marks webhooks as having errors in `processWebhook` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278L353-L357))
*  Import `IntegrationState` enum from `types` library to `IntegrationStreamService` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1474/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R17))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
