### PR TITLE
Fix Discord 404s

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/getMessage.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMessage.ts
@@ -22,6 +22,7 @@ export const getMessage = async (
   } catch (err) {
     if (
       err.response &&
+      err.response.status === 404 &&
       err.response.data &&
       err.response.data.message === 'Unknown Channel' &&
       err.response.data.code === 10003
@@ -29,6 +30,18 @@ export const getMessage = async (
       ctx.log.warn(
         { channelId, messageId },
         'Discord API returned Unknown Channel error when fetching message during webhook processing, skipping message.',
+      )
+      return null
+    } else if (
+      err.response &&
+      err.response.status === 404 &&
+      err.response.data &&
+      err.response.data.message === 'Unknown Message' &&
+      err.response.data.code === 10008
+    ) {
+      ctx.log.warn(
+        { channelId, messageId },
+        'Discord API returned Unknown Message error when fetching message during webhook processing, skipping message.',
       )
       return null
     } else {

--- a/services/libs/integrations/src/integrations/discord/api/getMessage.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMessage.ts
@@ -44,6 +44,12 @@ export const getMessage = async (
         'Discord API returned Unknown Message error when fetching message during webhook processing, skipping message.',
       )
       return null
+    } else if (err.response && err.response.status === 404) {
+      ctx.log.warn(
+        { channelId, messageId },
+        'Discord API returned 404 error when fetching message during webhook processing, skipping message.',
+      )
+      return null
     } else {
       const newErr = handleDiscordError(err, config, { channelId, messageId }, ctx)
       throw newErr


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e72a5f</samp>

Improved error handling for Discord integration. Added logic to `getMessage` function to handle missing or forbidden messages and return null instead of throwing an error.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e72a5f</samp>

> _Oh we're the coders of the sea, and we work with APIs_
> _We handle errors gracefully, and we test our code with ease_
> _When we call `getMessage`, we don't want to see a crash_
> _So we check for 404s, and return null for the trash_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e72a5f</samp>

*  Add error handling for 404 status code from Discord API when fetching messages ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1475/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1475/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR35-R52))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
