### PR TITLE
Fix rendering of custom platforms in org list

### DIFF
--- a/frontend/src/modules/organization/components/organization-identities.vue
+++ b/frontend/src/modules/organization/components/organization-identities.vue
@@ -12,11 +12,12 @@
           :platform="platform"
           :username-handles="getHandlesByPlatform(platform)"
           :links="getUrlsByPlatform(platform)"
-          :track-event-name="getPlatformDetails(platform).trackEventName"
-          :track-event-channel="getPlatformDetails(platform).trackEventChannel"
-          :tooltip-label="getPlatformDetails(platform).tooltipLabel"
+          :track-event-name="getPlatformDetails(platform)?.trackEventName"
+          :track-event-channel="getPlatformDetails(platform)?.trackEventChannel"
+          :tooltip-label="getPlatformDetails(platform)?.tooltipLabel"
           :show-handles-badge="true"
           :as-link="true"
+          custom-platform-icon-class="ri-community-fill"
         />
       </div>
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 840d6d2</samp>

Added optional chaining to `getPlatformDetails` calls and custom icon class prop to `PlatformIcon` component. This improves error handling and UI for community platforms as identity sources.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 840d6d2</samp>

> _`getPlatformDetails`?_
> _No error if not found now_
> _Autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 840d6d2</samp>

*  Add optional chaining operator to prevent errors when platform is not found and allow custom icon class for community platform ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1482/files?diff=unified&w=0#diff-e36f36cc416768d80e53470b86c944651decc2e2b0de4496003b8dcb0de60e08L15-R20))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
