### PR TITLE
Performance fixes

### DIFF
--- a/backend/src/bin/jobs/refreshMaterializedViewsForCube.ts
+++ b/backend/src/bin/jobs/refreshMaterializedViewsForCube.ts
@@ -25,7 +25,9 @@ const job: CrowdJob = {
     for (const view of materializedViews) {
       await logExecutionTimeV2(
         () =>
-          dbOptions.database.sequelize.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`),
+          dbOptions.database.sequelize.query(`REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`, {
+            useMaster: true,
+          }),
         log,
         `Refresh Materialized View ${view}`,
       )

--- a/backend/src/database/models/index.ts
+++ b/backend/src/database/models/index.ts
@@ -56,6 +56,9 @@ function models() {
     credentials.password,
     {
       dialect: DB_CONFIG.dialect,
+      dialectOptions: {
+        application_name: SERVICE,
+      },
       port: DB_CONFIG.port,
       replication: {
         read: [

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -903,8 +903,14 @@ class OrganizationRepository {
           dateEnd: new Date(Math.max.apply(null, endDates)).toISOString(),
           memberId: memberOrganization.memberId,
           organizationId: toOrganizationId,
-          title: foundIntersectingRoles.length > 0 ? foundIntersectingRoles[0].title : memberOrganization.title,
-          source: foundIntersectingRoles.length > 0 ? foundIntersectingRoles[0].source : memberOrganization.source,
+          title:
+            foundIntersectingRoles.length > 0
+              ? foundIntersectingRoles[0].title
+              : memberOrganization.title,
+          source:
+            foundIntersectingRoles.length > 0
+              ? foundIntersectingRoles[0].source
+              : memberOrganization.source,
         })
 
         // we'll delete all roles that intersect with incoming org member roles and create a merged role

--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -216,15 +216,12 @@ class SegmentRepository extends RepositoryBase<
     if (data.activityChannels && typeof data.activityChannels === 'object') {
       if (Object.keys(data.activityChannels).length > 0) {
         const replacements = {}
-        let valuePlaceholders = ''
+        const valuePlaceholders = []
         Object.keys(data.activityChannels).forEach((platform) => {
           data.activityChannels[platform].forEach((channel, i) => {
-            valuePlaceholders += data.activityChannels[platform]
-              .map(
-                () =>
-                  `(:tenantId_${platform}_${i}, :segmentId_${platform}_${i}, :platform_${platform}_${i}, :channel_${platform}_${i})`,
-              )
-              .join(', ')
+            valuePlaceholders.push(
+              `(:tenantId_${platform}_${i}, :segmentId_${platform}_${i}, :platform_${platform}_${i}, :channel_${platform}_${i})`,
+            )
 
             replacements[`tenantId_${platform}_${i}`] = this.options.currentTenant.id
             replacements[`segmentId_${platform}_${i}`] = id
@@ -236,7 +233,7 @@ class SegmentRepository extends RepositoryBase<
         await this.options.database.sequelize.query(
           `
           INSERT INTO "segmentActivityChannels" ("tenantId", "segmentId", "platform", "channel")
-          VALUES ${valuePlaceholders}
+          VALUES ${valuePlaceholders.join(', ')}
           ON CONFLICT DO NOTHING;
         `,
           {

--- a/services/libs/database/src/connection.ts
+++ b/services/libs/database/src/connection.ts
@@ -63,6 +63,7 @@ export const getDbConnection = async (
     ...config,
     max: maxPoolSize || 5,
     query_timeout: 30000,
+    application_name: process.env.SERVICE || 'unknown-app',
   })
 
   await dbConnection.connect()


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5359728</samp>

This pull request improves the database queries and data processing for segments and activity channels in the `SegmentRepository`. It also adds the `application_name` option to the database connection configuration in both the `models` and the `connection` modules, using the `SERVICE` environment variable to identify the source of the queries.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5359728</samp>

> _We are the masters of the database_
> _We set the `application_name` to trace our fate_
> _We optimize the queries with `jsonb_merge_agg`_
> _We unleash the power of the `SegmentRepository`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5359728</samp>

*  Add `application_name` option to database configuration and connection to identify query source ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-9ce5e52d0b259da42e2d77e9dbc11a9bbd7b38df687b9b50abe436fe15d5d734R59-R61), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-9e58f25937db0a6e39a8159f110097d74642b6f1f3188104950027074f86f81dR66))
*  Refactor bulk insert query of `segmentActivityChannels` table to improve performance and readability ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL219-R224), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL239-R236))
*  Use `jsonb_merge_agg` function to aggregate activity channels by segment and platform in queries of `SegmentRepository` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL333-R347), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL383-R402), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL634-R651))
*  Add `segmentId` column and `DISTINCT` modifier to join and aggregate activity channels correctly in queries of `SegmentRepository` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL333-R347), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL383-R402), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL634-R651))
*  Check for null or undefined `activityChannels` property before using spread operator in `SegmentRepository` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL360-R362), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL414-R421))
*  Remove redundant assignment of `activityChannels` property in `SegmentRepository` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1485/files?diff=unified&w=0#diff-34bafcbdf18c61c493d0b410145c4e8deec31824f45aa98816f45d51ada4839eL668))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
