### PR TITLE
removed processing state for integration.streams

### DIFF
--- a/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
@@ -40,25 +40,47 @@ export default class IntegrationStreamRepository extends RepositoryBase<Integrat
 
   public async getPendingStreams(
     runId: string,
-    page: number,
-    perPage: number,
+    limit: number,
+    lastId?: string,
   ): Promise<IProcessableStream[]> {
-    const results = await this.db().any(
-      `
-        select s.id,
-               s."tenantId",
-               i.platform as "integrationType"
-        from integration.streams s
-        inner join integrations i on i.id = s."integrationId"
-        where s."runId" = $(runId) and s.state = $(state)
-        order by s."createdAt" asc
-        limit ${perPage} offset ${(page - 1) * perPage}
-      `,
-      {
-        runId,
-        state: IntegrationStreamState.PENDING,
-      },
-    )
+    let results: IProcessableStream[]
+
+    if (lastId) {
+      results = await this.db().any(
+        `
+          select s.id,
+                 s."tenantId",
+                 i.platform as "integrationType"
+          from integration.streams s
+          inner join integrations i on i.id = s."integrationId"
+          where s."runId" = $(runId) and s.state = $(state) and s.id > $(lastId)
+          order by s.id
+          limit ${limit}
+        `,
+        {
+          runId,
+          lastId,
+          state: IntegrationStreamState.PENDING,
+        },
+      )
+    } else {
+      results = await this.db().any(
+        `
+          select s.id,
+                 s."tenantId",
+                 i.platform as "integrationType"
+          from integration.streams s
+          inner join integrations i on i.id = s."integrationId"
+          where s."runId" = $(runId) and s.state = $(state)
+          order by s.id
+          limit ${limit}
+        `,
+        {
+          runId,
+          state: IntegrationStreamState.PENDING,
+        },
+      )
+    }
 
     return results
   }
@@ -126,21 +148,6 @@ export default class IntegrationStreamRepository extends RepositoryBase<Integrat
       {
         streamId,
         state: IntegrationStreamState.PENDING,
-      },
-    )
-
-    this.checkUpdateRowCount(result.rowCount, 1)
-  }
-
-  public async markStreamInProgress(streamId: string): Promise<void> {
-    const result = await this.db().result(
-      `update integration.streams
-       set  state = $(state),
-            "updatedAt" = now()
-       where id = $(streamId)`,
-      {
-        streamId,
-        state: IntegrationStreamState.PROCESSING,
       },
     )
 

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -74,11 +74,10 @@ export default class IntegrationStreamService extends LoggerBase {
   public async continueProcessingRunStreams(runId: string): Promise<void> {
     this.log.info('Continuing processing run streams!')
 
-    let streams = await this.repo.getPendingStreams(runId, 1, 20)
+    let streams = await this.repo.getPendingStreams(runId, 20)
     while (streams.length > 0) {
       for (const stream of streams) {
         this.log.info({ streamId: stream.id }, 'Triggering stream processing!')
-        await this.repo.markStreamInProgress(stream.id)
         this.streamWorkerEmitter.triggerStreamProcessing(
           stream.tenantId,
           stream.integrationType,
@@ -86,7 +85,7 @@ export default class IntegrationStreamService extends LoggerBase {
         )
       }
 
-      streams = await this.repo.getPendingStreams(runId, 1, 20)
+      streams = await this.repo.getPendingStreams(runId, 20, streams[streams.length - 1].id)
     }
   }
 

--- a/services/libs/types/src/enums/integrations.ts
+++ b/services/libs/types/src/enums/integrations.ts
@@ -19,7 +19,6 @@ export enum IntegrationRunState {
 export enum IntegrationStreamState {
   DELAYED = 'delayed',
   PENDING = 'pending',
-  PROCESSING = 'processing',
   PROCESSED = 'processed',
   ERROR = 'error',
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84bea03</samp>

This pull request refactors the logic for fetching and processing integration streams in the `IntegrationStreamWorker` service. It uses cursor-based pagination to improve performance and avoid inconsistencies. It also simplifies the stream state management by removing the `PROCESSING` value from the `IntegrationStreamState` enum.
​
copilot:poem

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84bea03</samp>

*  Replace offset-based pagination with cursor-based pagination for fetching pending streams from the database ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1488/files?diff=unified&w=0#diff-16c03d797c0332dc5d6e23ed733c69ae397708314cf7cd861ae71a125cf288e6L43-R84), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1488/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278L77-R80), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1488/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278L89-R88))
* Remove unused `PROCESSING` value from `IntegrationStreamState` enum in `integrations.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1488/files?diff=unified&w=0#diff-bee69c14664dadfdb3ce6a56d01c020ac1eecc04a65670cfc2ef01e242c3fcd3L22))
* Remove unused `markStreamInProgress` method of `IntegrationStreamRepo` class in `integrationStream.repo.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1488/files?diff=unified&w=0#diff-16c03d797c0332dc5d6e23ed733c69ae397708314cf7cd861ae71a125cf288e6L135-L149))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
