### PR TITLE
Add segments to organization merge endpoints

### DIFF
--- a/frontend/src/modules/organization/components/organization-dropdown.vue
+++ b/frontend/src/modules/organization/components/organization-dropdown.vue
@@ -226,6 +226,7 @@ const doDestroyWithConfirm = async (id) => {
 };
 
 const handleCommand = (command) => {
+  const segments = route.query.segmentId ? [route.query.segmentId] : [route.query.projectGroup];
   if (command.action === 'organizationDelete') {
     return doDestroyWithConfirm(command.organization.id);
   } if (command.action === 'organizationEdit') {
@@ -254,7 +255,7 @@ const handleCommand = (command) => {
             reload: true,
           });
         } else {
-          fetchOrganization(command.organization.id);
+          fetchOrganization(command.organization.id, segments);
         }
         if (sync) {
           Message.success('Organization is now syncing with HubSpot');
@@ -278,7 +279,7 @@ const handleCommand = (command) => {
           reload: true,
         });
       } else {
-        fetchOrganization(command.organization.id);
+        fetchOrganization(command.organization.id, segments);
       }
     });
   }

--- a/frontend/src/modules/organization/components/organization-merge-dialog.vue
+++ b/frontend/src/modules/organization/components/organization-merge-dialog.vue
@@ -125,7 +125,9 @@ const mergeSuggestion = () => {
 
       if (route.name === 'organizationView') {
         const keepId = originalOrganizationPrimary.value ? props.modelValue?.id : organizationToMerge.value?.id;
-        fetchOrganization(keepId);
+        const segments = route.query.segmentId ? [route.query.segmentId] : [route.query.projectGroup];
+
+        fetchOrganization(keepId, segments);
         router.push({
           name: 'organizationView',
           params: {

--- a/frontend/src/modules/organization/components/organization-selection-dropdown.vue
+++ b/frontend/src/modules/organization/components/organization-selection-dropdown.vue
@@ -43,7 +43,7 @@ import {
   computed,
   ref,
   defineProps,
-  defineEmits,
+  defineEmits, onMounted,
 } from 'vue';
 import AppAutocompleteOneInput from '@/shared/form/autocomplete-one-input.vue';
 import AppAvatar from '@/shared/avatar/avatar.vue';
@@ -60,6 +60,10 @@ const props = defineProps({
     required: true,
   },
 });
+
+const route = useRoute();
+
+const segments = ref([]);
 const loadingOrganizationToMerge = ref();
 const computedOrganizationToMerge = computed({
   get() {
@@ -68,7 +72,7 @@ const computedOrganizationToMerge = computed({
   async set(value) {
     loadingOrganizationToMerge.value = true;
 
-    const response = await OrganizationService.find(value.id);
+    const response = await OrganizationService.find(value.id, segments.value);
 
     emit('update:modelValue', response);
     loadingOrganizationToMerge.value = false;
@@ -79,6 +83,7 @@ const fetchFn = async (query, limit) => {
   const options = await OrganizationService.listAutocomplete(
     query,
     limit,
+    segments.value,
   );
 
   // Remove primary organization from organizations that can be merged with
@@ -88,10 +93,14 @@ const fetchFn = async (query, limit) => {
   if (options.length !== filteredOptions.length) {
     filteredOptions.push({});
   }
-  console.log(filteredOptions);
 
   return filteredOptions;
 };
+
+onMounted(() => {
+  segments.value = route.query.segmentId ? [route.query.segmentId] : [route.query.projectGroup];
+});
+
 </script>
 
 <script>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 124e5fa</samp>

This pull request adds segment filtering to the organization dropdown and selection components, and updates the organization merge dialog to show the correct segments. It uses the `segments` variable to pass the segmentId or projectGroup from the route query to the organization service functions. It affects the files `organization-dropdown.vue`, `organization-selection-dropdown.vue`, and `organization-merge-dialog.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 124e5fa</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever way to filter organizations by segments_
> _And passed the variable to the function that retrieves_
> _The merged ones, showing their true and glorious aspects._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 124e5fa</samp>

*  Add `segments` variable to filter organizations by their segments in the organization dropdown and selection components ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-e7a5bc247d89df5dea81c882fff900b99c338a07567aa55dd811ea1c42cc67b1R229), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-e7a5bc247d89df5dea81c882fff900b99c338a07567aa55dd811ea1c42cc67b1L257-R258), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-e7a5bc247d89df5dea81c882fff900b99c338a07567aa55dd811ea1c42cc67b1L281-R282), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dL128-R130), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L46-R46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64R63-R66), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L71-R75), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64R86), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L91-R103))
* Import `onMounted` function from Vue in `organization-selection-dropdown.vue` to run logic after the component is mounted ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L46-R46))
* Remove console.log statement in `organization-selection-dropdown.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1501/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L91-R103))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
