### PR TITLE
Hubspot integration sync errors & better error handling

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -299,8 +299,8 @@ export default class MemberService extends LoggerBase {
         (!member.identities || member.identities.length === 0)
       ) {
         const errorMessage = `Member can't be enriched. It is missing both emails and identities fields.`
-        this.log.error(errorMessage)
-        throw new Error(errorMessage)
+        this.log.warn(errorMessage)
+        return
       }
 
       await this.store.transactionally(async (txStore) => {
@@ -317,7 +317,10 @@ export default class MemberService extends LoggerBase {
         const segmentId = dbIntegration.segmentId
 
         // first try finding the member using the identity
-        const identity = singleOrDefault(member.identities, (i) => i.platform === platform)
+        const identity = singleOrDefault(
+          member.identities,
+          (i) => i.platform === platform && i.sourceId !== null,
+        )
         let dbMember = await txRepo.findMember(tenantId, segmentId, platform, identity.username)
 
         if (!dbMember && member.emails && member.emails.length > 0) {

--- a/services/apps/data_sink_worker/src/service/organization.service.ts
+++ b/services/apps/data_sink_worker/src/service/organization.service.ts
@@ -341,6 +341,8 @@ export class OrganizationService extends LoggerBase {
         const txRepo = new OrganizationRepository(txStore, this.log)
         const txIntegrationRepo = new IntegrationRepository(txStore, this.log)
 
+        const txService = new OrganizationService(txStore, this.log)
+
         const dbIntegration = await txIntegrationRepo.findById(integrationId)
         const segmentId = dbIntegration.segmentId
 
@@ -381,7 +383,7 @@ export class OrganizationService extends LoggerBase {
             organization.identities.unshift(...existingIdentities)
           }
 
-          await this.findOrCreate(tenantId, segmentId, integrationId, organization)
+          await txService.findOrCreate(tenantId, segmentId, integrationId, organization)
         } else {
           this.log.debug(
             'No organization found for enriching. This organization enrich process had no affect.',

--- a/services/apps/integration_sync_worker/src/errors.ts
+++ b/services/apps/integration_sync_worker/src/errors.ts
@@ -1,0 +1,5 @@
+export const integrationNotFound = (integrationId: string): string =>
+  `Integration ${integrationId} not found!`
+
+export const automationNotFound = (automationId: string): string =>
+  `Automation ${automationId} not found!`

--- a/services/apps/integration_sync_worker/src/service/organization.sync.service.ts
+++ b/services/apps/integration_sync_worker/src/service/organization.sync.service.ts
@@ -46,6 +46,13 @@ export class OrganizationSyncService extends LoggerBase {
     const organizationsToUpdate = []
 
     if (syncRemote.sourceId) {
+      organization.attributes = {
+        ...organization.attributes,
+        sourceId: {
+          ...(organization.attributes.sourceId || {}),
+          [integration.platform]: syncRemote.sourceId,
+        },
+      }
       organizationsToUpdate.push(organization)
     } else {
       oranizationsToCreate.push(organization)
@@ -121,6 +128,7 @@ export class OrganizationSyncService extends LoggerBase {
           organization.attributes = {
             ...organization.attributes,
             sourceId: {
+              ...(organization.attributes.sourceId || {}),
               [integration.platform]: organizationToSync.sourceId,
             },
           }
@@ -235,6 +243,7 @@ export class OrganizationSyncService extends LoggerBase {
             organization.attributes = {
               ...organization.attributes,
               sourceId: {
+                ...(organization.attributes.sourceId || {}),
                 [integration.platform]: syncRemote.sourceId,
               },
             }

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
@@ -26,33 +26,35 @@ export const batchUpdateOrganizations = async (
     const hubspotCompanies = []
 
     for (const organization of organizations) {
-      const hubspotSourceId = organization.attributes?.sourceId?.hubspot
+      if (organization) {
+        const hubspotSourceId = organization.attributes?.sourceId?.hubspot
 
-      if (!hubspotSourceId) {
-        ctx.log.warn(
-          `Organization ${organization.id} can't be updated in hubspot! Organization doesn't have a hubspot sourceId.`,
-        )
-      } else {
-        const hubspotCompany = {
-          id: hubspotSourceId,
-          properties: {},
-        } as any
+        if (!hubspotSourceId) {
+          ctx.log.warn(
+            `Organization ${organization.id} can't be updated in hubspot! Organization doesn't have a hubspot sourceId.`,
+          )
+        } else {
+          const hubspotCompany = {
+            id: hubspotSourceId,
+            properties: {},
+          } as any
 
-        const fields = organizationMapper.getAllCrowdFields()
+          const fields = organizationMapper.getAllCrowdFields()
 
-        for (const crowdField of fields) {
-          const hubspotField = organizationMapper.getHubspotFieldName(crowdField)
+          for (const crowdField of fields) {
+            const hubspotField = organizationMapper.getHubspotFieldName(crowdField)
 
-          if (hubspotField && organization[crowdField] !== undefined) {
-            hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
-              organization,
-              crowdField,
-            )
+            if (hubspotField && organization[crowdField] !== undefined) {
+              hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
+                organization,
+                crowdField,
+              )
+            }
           }
-        }
 
-        if (Object.keys(hubspotCompany.properties).length > 0) {
-          hubspotCompanies.push(hubspotCompany)
+          if (Object.keys(hubspotCompany.properties).length > 0) {
+            hubspotCompanies.push(hubspotCompany)
+          }
         }
       }
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d134449</samp>

This pull request improves the error handling, data consistency, and synchronization logic of the data sink and integration sync workers. It also adds support for syncing organizations with HubSpot and other external platforms. The main changes are in the `member.service.ts`, `organization.service.ts`, `member.sync.service.ts`, `organization.sync.service.ts`, and `errors.ts` files in the `services/apps` folder, and the `batchUpdateMembers.ts` and `batchUpdateOrganizations.ts` files in the `services/libs/integrations` folder.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d134449</samp>

> _We are the sync masters, we control the data flow_
> _We handle the errors, we make the integrations glow_
> _We use the `sourceId`, we find the `organization`_
> _We update the `member`, we rule the automation_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d134449</samp>

*  Prevent data sink worker from crashing when encountering invalid members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L302-R303), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L320-R323))
*  Ensure organization service methods are executed within the same transaction context ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-c4775fb9079e4d3766f7b65b1d34e302fdf4b798a53e206c4cd85c683a4885d1R344-R345), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-c4775fb9079e4d3766f7b65b1d34e302fdf4b798a53e206c4cd85c683a4885d1L384-R386))
*  Add error message functions for missing integrations and automations in `errors.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-858a3413cd5a48acf588057381b819cab8dc2675a60d793c534b03a7f46eda4bR1-R5))
*  Use error message functions and skip processing of sync requests when integration, automation or member are null in `member.sync.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L48-R61), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R119-R124), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L231-R271), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L456-R509))
*  Add `sourceId` property to member objects for syncing with external platforms in `member.sync.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R68-R75), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R202), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R404), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266R550))
*  Add `sourceId` property to organization objects for syncing with external platforms in `organization.sync.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2R49-R55), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2R131), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2R246))
*  Skip processing of null members or organizations for updating in HubSpot in `batchUpdateMembers.ts` and `batchUpdateOrganizations.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-f4cea7cfc5f2e3edcbffe72465cb6ad8ea4ac44483363e737b4f2e1d277b7b36L29-R73), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1503/files?diff=unified&w=0#diff-cd835b0eb2f6b6e9410179b1a26e7339d6f7887aa2144f57a0f40a50bae608f9L29-R57))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
