### PR TITLE
Checking primary key maps in while creating/updating in hubspot

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateOrganizations.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateOrganizations.ts
@@ -47,12 +47,15 @@ export const batchCreateOrganizations = async (
 
         for (const crowdField of fields) {
           const hubspotField = organizationMapper.getHubspotFieldName(crowdField)
-
-          if (hubspotField && organization[crowdField] !== undefined) {
-            hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
-              organization,
-              crowdField,
-            )
+          // if hubspot domain field is mapped to a crowd field, we should ignore it
+          // because we handle this manually above
+          if (hubspotField && hubspotField !== 'domain') {
+            if (organization[crowdField] !== undefined) {
+              hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
+                organization,
+                crowdField,
+              )
+            }
           }
         }
 

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateMembers.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateMembers.ts
@@ -43,28 +43,32 @@ export const batchUpdateMembers = async (
 
           for (const crowdField of fields) {
             const hubspotField = memberMapper.getHubspotFieldName(crowdField)
-            if (crowdField.startsWith('attributes')) {
-              const attributeName = crowdField.split('.')[1] || null
+            // if hubspot e-mail field is mapped to a crowd field, we should ignore it because
+            // we handle this manually above
+            if (hubspotField && hubspotField !== 'email') {
+              if (crowdField.startsWith('attributes')) {
+                const attributeName = crowdField.split('.')[1] || null
 
-              if (
-                attributeName &&
-                hubspotField &&
-                member.attributes[attributeName]?.default !== undefined
-              ) {
-                hsMember.properties[hubspotField] = member.attributes[attributeName].default
+                if (
+                  attributeName &&
+                  hubspotField &&
+                  member.attributes[attributeName]?.default !== undefined
+                ) {
+                  hsMember.properties[hubspotField] = member.attributes[attributeName].default
+                }
+              } else if (crowdField.startsWith('identities')) {
+                const identityPlatform = crowdField.split('.')[1] || null
+
+                const identityFound = member.identities.find((i) => i.platform === identityPlatform)
+
+                if (identityPlatform && hubspotField && identityFound) {
+                  hsMember.properties[hubspotField] = identityFound.username
+                }
+              } else if (crowdField === 'organizationName') {
+                // send latest org of member as value
+              } else if (hubspotField && member[crowdField] !== undefined) {
+                hsMember.properties[hubspotField] = memberMapper.getHubspotValue(member, crowdField)
               }
-            } else if (crowdField.startsWith('identities')) {
-              const identityPlatform = crowdField.split('.')[1] || null
-
-              const identityFound = member.identities.find((i) => i.platform === identityPlatform)
-
-              if (identityPlatform && hubspotField && identityFound) {
-                hsMember.properties[hubspotField] = identityFound.username
-              }
-            } else if (crowdField === 'organizationName') {
-              // send latest org of member as value
-            } else if (hubspotField && member[crowdField] !== undefined) {
-              hsMember.properties[hubspotField] = memberMapper.getHubspotValue(member, crowdField)
             }
           }
 

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
@@ -43,12 +43,15 @@ export const batchUpdateOrganizations = async (
 
           for (const crowdField of fields) {
             const hubspotField = organizationMapper.getHubspotFieldName(crowdField)
-
-            if (hubspotField && organization[crowdField] !== undefined) {
-              hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
-                organization,
-                crowdField,
-              )
+            // if hubspot domain field is mapped to a crowd field, we should ignore it
+            // because we handle this manually above
+            if (hubspotField && hubspotField !== 'domain') {
+              if (organization[crowdField] !== undefined) {
+                hubspotCompany.properties[hubspotField] = organizationMapper.getHubspotValue(
+                  organization,
+                  crowdField,
+                )
+              }
             }
           }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd4b3f1</samp>

This pull request fixes a bug in the hubspot integration that could overwrite the email and domain fields of hubspot members and companies. It adds conditions to check if the hubspot field is not equal to `email` or `domain` before mapping the crowd field to the hubspot property. It applies this fix to both the batch create and batch update functions for members and organizations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cd4b3f1</samp>

> _`hubspot` mapping_
> _avoid overwriting fields_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd4b3f1</samp>

*  Prevent overwriting email and domain fields in hubspot integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1512/files?diff=unified&w=0#diff-22374b0f86ca346b0adce9a6c0d37bc295dec7cebef18dc74752ec600f239bc5L49-R74), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1512/files?diff=unified&w=0#diff-1f6bca915001acdcf36a41b56874074be374abb6bf867fe861054c7acaa54610L50-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1512/files?diff=unified&w=0#diff-f4cea7cfc5f2e3edcbffe72465cb6ad8ea4ac44483363e737b4f2e1d277b7b36L46-R71), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1512/files?diff=unified&w=0#diff-cd835b0eb2f6b6e9410179b1a26e7339d6f7887aa2144f57a0f40a50bae608f9L46-R54))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
