### PR TITLE
Fix member error if no suggestions

### DIFF
--- a/frontend/src/modules/member/pages/member-merge-suggestions-page.vue
+++ b/frontend/src/modules/member/pages/member-merge-suggestions-page.vue
@@ -202,8 +202,8 @@ const fetch = (page) => {
       [membersToMerge.value] = res.rows;
       const { members } = membersToMerge.value;
       // Set member with maximum identities and activities as primary
-      if ((members[0].identities.length < members[1].identities.length)
-        || (members[0].activityCount < members[1].activityCount)) {
+      if (members.length > 2 && ((members[0].identities.length < members[1].identities.length)
+        || (members[0].activityCount < members[1].activityCount))) {
         primary.value = 1;
       }
     })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e71cd7</samp>

Fixed a bug in `member-merge-suggestions-page.vue` that caused an error when the members array had only one element. Added a condition to check the array length before comparing the members.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2e71cd7</samp>

> _`members` array_
> _check length before compare_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e71cd7</samp>

*  Add a condition to prevent index out of bounds error when comparing members to be merged ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1526/files?diff=unified&w=0#diff-028321f33abc948ebdace8fc713d5f2c264c9eaa01ab3af2b60865b94c64b60aL205-R206))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
