### PR TITLE
Discard organizations without name when getting contact associations

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/api/contacts.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/contacts.ts
@@ -70,7 +70,9 @@ export const getContacts = async (
             throttler,
           )
 
-          element.organization = company
+          if ((company?.properties as any)?.name) {
+            element.organization = company
+          }
         }
       }
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 989291b</samp>

Added a validation for company name property when mapping HubSpot contacts to Crowd.dev users. This improves the reliability and accuracy of the `services/libs/integrations` module.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 989291b</samp>

> _`company name` checked_
> _HubSpot contacts join crowd.dev_
> _a winter feature_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 989291b</samp>

*  Add a condition to check company name property before assigning it to organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1531/files?diff=unified&w=0#diff-e99851f5900fff59bfd149999df94e2cc85ab1545343c9c8a1fdc626c9a014e7L73-R75))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
