### PR TITLE
Stricter throttler options for hubspot

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
@@ -15,7 +15,7 @@ import { getAllCompanies } from './api/companies'
 import { RequestThrottler } from '@crowd/common'
 
 const processRootStream: ProcessStreamHandler = async (ctx) => {
-  const throttler = new RequestThrottler(100, 10000, ctx.log)
+  const throttler = new RequestThrottler(10, 10000, ctx.log)
 
   const settings = ctx.integration.settings as IHubspotIntegrationSettings
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97c3f74</samp>

Reduced the concurrency limit of the `RequestThrottler` for the Hubspot integration to avoid API rate limit errors. This improves the reliability and performance of the data synchronization between Crowd and Hubspot.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 97c3f74</samp>

> _`RequestThrottler`_
> _Slows down to sync with Hubspot_
> _Autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97c3f74</samp>

*  Lowered the concurrent request limit for Hubspot API calls to avoid rate limit errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1532/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L18-R18))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
