### PR TITLE
Hubspot throttler optimization: 9 requests every 5 seconds max

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
@@ -15,7 +15,7 @@ import { getAllCompanies } from './api/companies'
 import { RequestThrottler } from '@crowd/common'
 
 const processRootStream: ProcessStreamHandler = async (ctx) => {
-  const throttler = new RequestThrottler(10, 10000, ctx.log)
+  const throttler = new RequestThrottler(9, 5000, ctx.log)
 
   const settings = ctx.integration.settings as IHubspotIntegrationSettings
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e89e3e</samp>

Reduced the request rate and concurrency of the `RequestThrottler` for the Hubspot integration. This improves the integration performance and avoids rate limit errors.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5e89e3e</samp>

> _`RequestThrottler`_
> _Slows down Hubspot requests -_
> _Winter of refactoring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e89e3e</samp>

* Reduce the request concurrency and interval to the Hubspot API to avoid rate limits and improve performance (`[link](https://github.com/CrowdDotDev/crowd.dev/pull/1533/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L18-R18)`)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
