### PR TITLE
Fix organization dropdown for affilation form

### DIFF
--- a/frontend/src/modules/lf/member/components/form/lf-member-form-affiliations.vue
+++ b/frontend/src/modules/lf/member/components/form/lf-member-form-affiliations.vue
@@ -60,7 +60,7 @@
                       <el-option
                         v-for="organization in availableOrganizations"
                         :key="organization.id"
-                        :label="organization.name"
+                        :label="organization.displayName || organization.name"
                         :value="organization.id"
                         class="!px-3"
                       >
@@ -71,7 +71,7 @@
                             :alt="`${organization.name} Logo`"
                             class="w-5 h-5"
                           />
-                          <div>{{ organization.name }}</div>
+                          <div>{{ organization.displayName || organization.name }}</div>
                         </div>
                       </el-option>
                     </el-select>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b40561</samp>

Use organization `displayName` for affiliation selection in `lf-member-form-affiliations.vue`. This enhances the UI and aligns with the backend data model.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4b40561</samp>

> _Oh, we're the crew of the Vue ship, and we sail the web so fine_
> _We update our components with the latest code design_
> _We use `displayName` for the label, or `name` if not there_
> _And we heave away on the pull request, with a hearty yo-ho-ho!_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b40561</samp>

* Display organization's displayName or name in affiliation select label and options ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1537/files?diff=unified&w=0#diff-80be2287522db5944a2dec71963095bf13e8c623911e13aeb4482e0c8a5bfcebL63-R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1537/files?diff=unified&w=0#diff-80be2287522db5944a2dec71963095bf13e8c623911e13aeb4482e0c8a5bfcebL74-R74))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
