### PR TITLE
Synchronous stream processing in hubspot

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/api/contacts.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/contacts.ts
@@ -70,6 +70,7 @@ export const getContacts = async (
             throttler,
           )
 
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           if ((company?.properties as any)?.name) {
             element.organization = company
           }

--- a/services/libs/integrations/src/integrations/premium/hubspot/generateStreams.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/generateStreams.ts
@@ -1,8 +1,8 @@
 import { GenerateStreamsHandler } from '../../../types'
 import {
   HubspotEntity,
+  HubspotStream,
   IHubspotAttributeMap,
-  IHubspotBaseStream,
   IHubspotIntegrationSettings,
 } from './types'
 
@@ -15,6 +15,8 @@ const handler: GenerateStreamsHandler = async (ctx) => {
     await ctx.abortRunWithError('Integration is not enabled for members or organizations!')
     return
   }
+
+  const streams: HubspotStream[] = []
 
   if (settings.enabledFor.includes(HubspotEntity.MEMBERS)) {
     const fieldMap: IHubspotAttributeMap = settings.attributesMapping?.members
@@ -40,7 +42,7 @@ const handler: GenerateStreamsHandler = async (ctx) => {
       return
     }
 
-    await ctx.publishStream<IHubspotBaseStream>(`${HubspotEntity.MEMBERS}`, {})
+    streams.push(HubspotStream.MEMBERS)
   }
 
   if (settings.enabledFor.includes(HubspotEntity.ORGANIZATIONS)) {
@@ -53,7 +55,11 @@ const handler: GenerateStreamsHandler = async (ctx) => {
       return
     }
 
-    await ctx.publishStream<IHubspotBaseStream>(`${HubspotEntity.ORGANIZATIONS}`, {})
+    streams.push(HubspotStream.ORGANIZATIONS)
+  }
+
+  if (streams.length > 0) {
+    await ctx.publishStream<HubspotStream[]>(HubspotStream.ROOT, streams)
   }
 }
 

--- a/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/processStream.ts
@@ -19,7 +19,9 @@ const processRootStream: ProcessStreamHandler = async (ctx) => {
 
   const settings = ctx.integration.settings as IHubspotIntegrationSettings
 
-  if (ctx.stream.identifier === HubspotStream.MEMBERS) {
+  const streams = ctx.stream.data as HubspotStream[]
+
+  if (streams.includes(HubspotStream.MEMBERS)) {
     const memberMapper = HubspotFieldMapperFactory.getFieldMapper(
       HubspotEntity.MEMBERS,
       settings.hubspotId,
@@ -66,7 +68,9 @@ const processRootStream: ProcessStreamHandler = async (ctx) => {
 
       contactsPage = await contactsGenerator.next()
     }
-  } else if (ctx.stream.identifier === HubspotStream.ORGANIZATIONS) {
+  }
+
+  if (streams.includes(HubspotStream.ORGANIZATIONS)) {
     const organizationMapper = HubspotFieldMapperFactory.getFieldMapper(
       HubspotEntity.ORGANIZATIONS,
       settings.hubspotId,
@@ -96,8 +100,6 @@ const processRootStream: ProcessStreamHandler = async (ctx) => {
 
       companyPage = await companyGenerator.next()
     }
-  } else {
-    await ctx.abortWithError(`Unknown root stream identifier: ${ctx.stream.identifier}`)
   }
 }
 

--- a/services/libs/integrations/src/integrations/premium/hubspot/types.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/types.ts
@@ -30,6 +30,7 @@ export enum HubspotEntity {
 export enum HubspotStream {
   MEMBERS = 'members',
   ORGANIZATIONS = 'organizations',
+  ROOT = 'root',
 }
 
 export enum HubspotAssociationType {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64cfd71</samp>

Refactored the Hubspot integration to use an enum type for the streams and handle multiple streams in the root stream data. This improves the code quality and enables mapping Hubspot entities to Crowd.dev entities.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64cfd71</samp>

> _`HubspotStream.ROOT`_
> _Refactored with enum type_
> _Spring cleaning the code_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64cfd71</samp>

*  Add `HubspotStream.ROOT` to `HubspotStream` enum to identify the root stream ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-26db7490264508d3370eaa777ce6a377b888a4f7c4b5f001290dbe2c54aff555R33))
*  Initialize an empty array of type `HubspotStream[]` to store the streams to be generated based on the settings and the entities in `generateStreams.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-eb4841c5723fd44b3831763a082978d6d9d71a743269cc8cdbf1bb290dbe8083R19-R20))
*  Push `HubspotStream.MEMBERS` and `HubspotStream.ORGANIZATIONS` to the streams array instead of publishing them directly in `generateStreams.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-eb4841c5723fd44b3831763a082978d6d9d71a743269cc8cdbf1bb290dbe8083L43-R45), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-eb4841c5723fd44b3831763a082978d6d9d71a743269cc8cdbf1bb290dbe8083L56-R63))
*  Publish the root stream with the streams array as its data if the array is not empty in `generateStreams.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-eb4841c5723fd44b3831763a082978d6d9d71a743269cc8cdbf1bb290dbe8083L56-R63))
*  Modify `processRootStream` function in `processStream.ts` to use the streams array as the data of the root stream ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L22-R24))
*  Check if the streams array includes `HubspotStream.MEMBERS` or `HubspotStream.ORGANIZATIONS` and proceed with the corresponding mapping logic in `processStream.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L22-R24), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L69-R73))
*  Remove the else branch that aborted the process for unknown root stream identifiers in `processStream.ts`, as the streams array should only contain valid values from the `HubspotStream` enum ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1538/files?diff=unified&w=0#diff-9f1e520577b76cc5d6a43ee5a18bb292de586ed1bcaa63270bad90caf79268c6L99-L100))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
