### PR TITLE
Not sanitizing URLs that doesn't start with http when getting organization domain

### DIFF
--- a/services/libs/integrations/src/integrations/premium/hubspot/api/utils/getOrganizationDomain.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/utils/getOrganizationDomain.ts
@@ -1,6 +1,9 @@
 export const getOrganizationDomain = (website: string): string => {
   try {
-    return new URL(website).host
+    if (website.startsWith('http')) {
+      return new URL(website).host
+    }
+    return website
   } catch (e) {
     return null
   }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d96c302</samp>

Improved the `getOrganizationDomain` function to handle HubSpot contacts with non-URL website fields. This prevents errors when importing contacts from HubSpot to Crowd.dev.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d96c302</samp>

> _`getOrganizationDomain`_
> _handles bad websites better_
> _fall leaves no errors_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d96c302</samp>

*  Handle invalid or missing website fields when importing HubSpot contacts ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1540/files?diff=unified&w=0#diff-46ae8933582d4d8684b5e351e85c649c797414629a49820e778ffe6a09fdfb3fL3-R6))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
