### PR TITLE
Auto merge member on identity conflict during enrichment

### DIFF
--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -241,7 +241,6 @@ export default class MemberEnrichmentService extends LoggerBase {
       // Create an instance of the MemberService and use it to look up the member
       const memberService = new MemberService(options)
       const member = await memberService.findById(memberId, false, false)
-      console.log('member username one', member.username)
 
       // If the member's GitHub handle or email address is not available, throw an error
       if (!member.username[PlatformType.GITHUB] && member.emails.length === 0) {

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -241,6 +241,7 @@ export default class MemberEnrichmentService extends LoggerBase {
       // Create an instance of the MemberService and use it to look up the member
       const memberService = new MemberService(options)
       const member = await memberService.findById(memberId, false, false)
+      console.log('member username one', member.username)
 
       // If the member's GitHub handle or email address is not available, throw an error
       if (!member.username[PlatformType.GITHUB] && member.emails.length === 0) {
@@ -266,10 +267,34 @@ export default class MemberEnrichmentService extends LoggerBase {
         return null
       }
 
+      // To preserve the original member object, creating a deep copy
+      const memberCopy = JSON.parse(JSON.stringify(member))
+      const normalized = await this.normalize(memberCopy, enrichmentData)
+
+      if (normalized.username) {
+        const filteredUsername = Object.keys(normalized.username).reduce((obj, key) => {
+          if (!member.username[key]) {
+            obj[key] = normalized.username[key]
+          }
+          return obj
+        }, {})
+
+        for (const [platform, usernames] of Object.entries(filteredUsername)) {
+          const usernameArray = Array.isArray(usernames) ? usernames : [usernames]
+
+          for (const username of usernameArray) {
+            // Check if a member with this username already exists
+            const existingMember = await memberService.memberExists(username, platform)
+
+            if (existingMember) {
+              await memberService.merge(memberId, existingMember.id)
+            }
+          }
+        }
+      }
+
       // save raw data to cache
       await MemberEnrichmentCacheRepository.upsert(memberId, enrichmentData, options)
-
-      const normalized = await this.normalize(member, enrichmentData)
 
       // We are updating the displayName only if the existing one has one word only
       // And we are using an update here instead of the upsert because


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0abdd55</samp>

This pull request adds a feature to merge members with the same username across different platforms. It modifies the `enrich` method in the `memberEnrichmentService` and adds a console log statement for debugging.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0abdd55</samp>

> _In the shadows of the platforms, they lurk with different names_
> _But we have the power to reveal their hidden games_
> _We `enrich` the `members` with our logic and our skill_
> _We `console.log` their doom as we merge them with our will_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0abdd55</samp>

*  Add and modify logic to merge members with the same username across platforms ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1542/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807R244), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1542/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L269-R298))
  - In `memberEnrichmentService.ts`, log the member username for debugging ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1542/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807R244))
  - In the same file, update the `enrich` method to check and merge existing members with the same username as the normalized data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1542/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L269-R298))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
