### PR TITLE
Postgres replication identity fixes

### DIFF
--- a/backend/src/database/migrations/V1695667633__entitySegmentsReplicationIdentitiesFix.sql
+++ b/backend/src/database/migrations/V1695667633__entitySegmentsReplicationIdentitiesFix.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "organizationSegments" REPLICA IDENTITY USING INDEX 'organizationSegments_organizationId_segmentId_tenantId_key';
-ALTER TABLE "memberSegments" REPLICA IDENTITY USING INDEX 'memberSegments_memberId_segmentId_tenantId_key';
+ALTER TABLE "organizationSegments" REPLICA IDENTITY USING INDEX "organizationSegments_organizationId_segmentId_tenantId_key";
+ALTER TABLE "memberSegments" REPLICA IDENTITY USING INDEX "memberSegments_memberId_segmentId_tenantId_key";

--- a/backend/src/database/migrations/V1695667633__entitySegmentsReplicationIdentitiesFix.sql
+++ b/backend/src/database/migrations/V1695667633__entitySegmentsReplicationIdentitiesFix.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "organizationSegments" REPLICA IDENTITY USING INDEX 'organizationSegments_organizationId_segmentId_tenantId_key';
+ALTER TABLE "memberSegments" REPLICA IDENTITY USING INDEX 'memberSegments_memberId_segmentId_tenantId_key';


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dad120</samp>

This file modifies the database schema to use unique indexes as replication identities for two tables related to entity segments. This prevents replication conflicts and supports logical replication across tenants and regions.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1dad120</samp>

> _`Replication` fix_
> _Alter identity columns_
> _Winter bug no more_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1dad120</samp>

* Alter replication identity of `organizationSegments` and `memberSegments` tables to use unique indexes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1552/files?diff=unified&w=0#diff-89dcd2fb90c821e5ffa16c0a75786f9c4742911be536f6817f7570bb344e6aa1L1-R1))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
