### PR TITLE
Bugfix/removing awaits

### DIFF
--- a/frontend/src/modules/member/pages/member-form-page.vue
+++ b/frontend/src/modules/member/pages/member-form-page.vue
@@ -342,9 +342,6 @@ onBeforeRouteLeave((to) => {
 });
 
 onMounted(() => {
-  // Fetch custom attributes on mount
-  getMemberCustomAttributes();
-
   if (isEditPage.value) {
     const { id } = route.params;
 
@@ -357,6 +354,9 @@ onMounted(() => {
   } else {
     isPageLoading.value = false;
   }
+
+  // Fetch custom attributes on mount
+  getMemberCustomAttributes();
 });
 
 // Prevent window reload when form has changes
@@ -474,13 +474,13 @@ async function onSubmit() {
     manuallyCreated: true,
   };
 
-  let isRequestSuccessful = false;
+  let request;
 
   // Edit member
   if (isEditPage.value) {
     isFormSubmitting.value = true;
 
-    isRequestSuccessful = await store.dispatch(
+    request = store.dispatch(
       'member/doUpdate',
       {
         id: record.value.id,
@@ -491,7 +491,7 @@ async function onSubmit() {
   } else {
     // Create new member
     isFormSubmitting.value = true;
-    isRequestSuccessful = await store.dispatch(
+    request = store.dispatch(
       'member/doCreate',
       {
         data,
@@ -502,8 +502,10 @@ async function onSubmit() {
 
   isFormSubmitting.value = false;
 
-  if (isRequestSuccessful) {
-    wasFormSubmittedSuccessfuly.value = true;
+  if (request) {
+    request.then(() => {
+      wasFormSubmittedSuccessfuly.value = true;
+    });
   }
 }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc92ca7</samp>

The pull request simplifies and improves the code for managing custom attributes of members in the `member-form-page.vue` and `member-form-global-attributes.vue` components. It reduces the number of requests and state variables, and uses a single `request` variable to handle the response and feedback.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cc92ca7</samp>

> _To simplify code and enhance feedback_
> _They removed `hasErrorOccurred` from the stack_
> _They refactored the fetching_
> _And the updating of setting_
> _The custom attributes with a single `request` hack_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc92ca7</samp>

*  Removed `hasErrorOccurred` variable and simplified error handling logic in `member-form-global-attributes.vue` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-5a1f673c58a4f28a9329c093cd6b954251de901b883c7f0734530e718c18f0efL175), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-5a1f673c58a4f28a9329c093cd6b954251de901b883c7f0734530e718c18f0efL195-R194), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-5a1f673c58a4f28a9329c093cd6b954251de901b883c7f0734530e718c18f0efL222-R240))
*  Improved performance and concurrency of requests to create or update custom attributes by using `Promise.all` and `requests` array in `member-form-global-attributes.vue` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-5a1f673c58a4f28a9329c093cd6b954251de901b883c7f0734530e718c18f0efL202-R212), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-5a1f673c58a4f28a9329c093cd6b954251de901b883c7f0734530e718c18f0efL222-R240))
*  Moved responsibility of fetching custom attributes from `member-form-page.vue` to `member-form-global-attributes.vue` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L345-L347), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768R357-R359))
*  Removed `isRequestSuccessful` variable and simplified success handling logic in `member-form-page.vue` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L477-R477), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L483-R483), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L494-R494), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1556/files?diff=unified&w=0#diff-cdca8fd519246834c10f9137b64e69c56feb2f4809c420449fdfeb20b8877768L505-R508))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
