### PR TITLE
Single quote sanitization when finding organization identities

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1069,7 +1069,10 @@ class OrganizationRepository {
     }
 
     const identityParams = identities
-      .map((identity) => `('${identity.platform.replace(/'/g, "''")}', '${identity.name.replace(/'/g, "''")}')`)
+      .map(
+        (identity) =>
+          `('${identity.platform.replace(/'/g, "''")}', '${identity.name.replace(/'/g, "''")}')`,
+      )
       .join(', ')
 
     const results = (await sequelize.query(

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1069,7 +1069,7 @@ class OrganizationRepository {
     }
 
     const identityParams = identities
-      .map((identity) => `('${identity.platform}', '${identity.name}')`)
+      .map((identity) => `('${identity.platform.replace(/'/g, "''")}', '${identity.name.replace(/'/g, "''")}')`)
       .join(', ')
 
     const results = (await sequelize.query(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4b0a3c</samp>

Escape single quotes in identity fields to prevent SQL injection. This is a security fix for the `organizationRepository.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c4b0a3c</samp>

> _`'` becomes `''`_
> _Security fix for repo_
> _Autumn leaves no trace_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4b0a3c</samp>

*  Escape single quotes in identity platform and name fields to prevent SQL injection attacks ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1559/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1072-R1072))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
