### PR TITLE
Move certain platform identities to buttons in slack notifications

### DIFF
--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
@@ -5,9 +5,6 @@ import { API_CONFIG } from '../../../../../../conf'
 const defaultAvatarUrl =
   'https://uploads-ssl.webflow.com/635150609746eee5c60c4aac/6502afc9d75946873c1efa93_image%20(292).png'
 
-// Which platform identities are displayed as buttons and which ones go to menu
-const buttonPlatforms = ['github', 'twitter', 'linkedin']
-
 const computeEngagementLevel = (score) => {
   if (score <= 1) {
     return 'Silent'
@@ -53,6 +50,9 @@ const truncateText = (text: string, characters: number = 60): string => {
 }
 
 export const newActivityBlocks = (activity) => {
+  // Which platform identities are displayed as buttons and which ones go to menu
+  let buttonPlatforms = ['github', 'twitter', 'linkedin']
+
   const display = htmlToMrkdwn(replaceHeadline(activity.display.default))
   const reach = activity.member.reach?.[activity.platform] || activity.member.reach?.total
 
@@ -100,6 +100,10 @@ export const newActivityBlocks = (activity) => {
       }
     })
     .filter((p) => !!p.url)
+
+  if (!buttonPlatforms.includes(activity.platform)) {
+    buttonPlatforms = [activity.platform, ...buttonPlatforms]
+  }
 
   const buttonProfiles = buttonPlatforms
     .map((platform) => profiles.find((profile) => profile.platform === platform))

--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
@@ -5,6 +5,9 @@ import { API_CONFIG } from '../../../../../../conf'
 const defaultAvatarUrl =
   'https://uploads-ssl.webflow.com/635150609746eee5c60c4aac/6502afc9d75946873c1efa93_image%20(292).png'
 
+// Which platform identities are displayed as buttons and which ones go to menu
+const buttonPlatforms = ['github', 'twitter', 'linkedin']
+
 const computeEngagementLevel = (score) => {
   if (score <= 1) {
     return 'Silent'
@@ -98,6 +101,12 @@ export const newActivityBlocks = (activity) => {
     })
     .filter((p) => !!p.url)
 
+  const buttonProfiles = buttonPlatforms
+    .map((platform) => profiles.find((profile) => profile.platform === platform))
+    .filter((profiles) => !!profiles)
+
+  const menuProfiles = profiles.filter((profile) => !buttonPlatforms.includes(profile.platform))
+
   return {
     blocks: [
       {
@@ -173,11 +182,22 @@ export const newActivityBlocks = (activity) => {
             },
             url: `${API_CONFIG.frontendUrl}/members/${member.id}`,
           },
-          ...(profiles.length > 0
+          ...(buttonProfiles || [])
+            .map(({ platform, url }) => ({
+              type: 'button',
+              text: {
+                type: 'plain_text',
+                text: `${integrationLabel[platform] ?? platform} profile`,
+                emoji: true,
+              },
+              url,
+            }))
+            .filter((action) => !!action.url),
+          ...(menuProfiles.length > 0
             ? [
                 {
                   type: 'overflow',
-                  options: profiles.map(({ platform, url }) => ({
+                  options: menuProfiles.map(({ platform, url }) => ({
                     text: {
                       type: 'plain_text',
                       text: `${integrationLabel[platform] ?? platform} profile`,

--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
@@ -4,6 +4,8 @@ import { API_CONFIG } from '../../../../../../conf'
 const defaultAvatarUrl =
   'https://uploads-ssl.webflow.com/635150609746eee5c60c4aac/6502afc9d75946873c1efa93_image%20(292).png'
 
+// Which platform identities are displayed as buttons and which ones go to menu
+const buttonPlatforms = ['github', 'twitter', 'linkedin']
 export const newMemberBlocks = (member) => {
   const platforms = member.activeOn
   const reach =
@@ -30,7 +32,6 @@ export const newMemberBlocks = (member) => {
     details.push(`*✉️ Email:* <mailto:${email}|${email}>`)
   }
   const profiles = Object.keys(member.username)
-    .filter((p) => !platforms.includes(p))
     .map((p) => {
       const username = (member.username?.[p] || []).length > 0 ? member.username[p][0] : null
       const url =
@@ -41,6 +42,12 @@ export const newMemberBlocks = (member) => {
       }
     })
     .filter((p) => !!p.url)
+
+  const buttonProfiles = buttonPlatforms
+    .map((platform) => profiles.find((profile) => profile.platform === platform))
+    .filter((profiles) => !!profiles)
+
+  const menuProfiles = profiles.filter((profile) => !buttonPlatforms.includes(profile.platform))
 
   return {
     blocks: [
@@ -101,22 +108,22 @@ export const newMemberBlocks = (member) => {
             },
             url: `${API_CONFIG.frontendUrl}/members/${member.id}`,
           },
-          ...(platforms || [])
-            .map((platform) => ({
+          ...(buttonProfiles || [])
+            .map(({ platform, url }) => ({
               type: 'button',
               text: {
                 type: 'plain_text',
                 text: `${integrationLabel[platform] ?? platform} profile`,
                 emoji: true,
               },
-              url: member.attributes?.url?.[platform],
+              url,
             }))
             .filter((action) => !!action.url),
-          ...(profiles.length > 0
+          ...(menuProfiles.length > 0
             ? [
                 {
                   type: 'overflow',
-                  options: profiles.map(({ platform, url }) => ({
+                  options: menuProfiles.map(({ platform, url }) => ({
                     text: {
                       type: 'plain_text',
                       text: `${integrationLabel[platform] ?? platform} profile`,

--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
@@ -4,9 +4,10 @@ import { API_CONFIG } from '../../../../../../conf'
 const defaultAvatarUrl =
   'https://uploads-ssl.webflow.com/635150609746eee5c60c4aac/6502afc9d75946873c1efa93_image%20(292).png'
 
-// Which platform identities are displayed as buttons and which ones go to menu
-const buttonPlatforms = ['github', 'twitter', 'linkedin']
 export const newMemberBlocks = (member) => {
+  // Which platform identities are displayed as buttons and which ones go to menu
+  let buttonPlatforms = ['github', 'twitter', 'linkedin']
+
   const platforms = member.activeOn
   const reach =
     platforms && platforms.length > 0 ? member.reach?.[platforms[0]] : member.reach?.total
@@ -42,6 +43,10 @@ export const newMemberBlocks = (member) => {
       }
     })
     .filter((p) => !!p.url)
+
+  if (platforms.length > 0 && !buttonPlatforms.includes(platforms[0])) {
+    buttonPlatforms = [platforms[0], ...buttonPlatforms]
+  }
 
   const buttonProfiles = buttonPlatforms
     .map((platform) => profiles.find((profile) => profile.platform === platform))


### PR DESCRIPTION
(cherry picked from commit ff8cc350954e2a16ad8cc19a07625c9d2ade575d)

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07e6d4d</samp>

This pull request refactors the code for generating Slack message blocks for new activities and new members in the `backend/src/serverless/microservices/nodejs/automation/workers/slack` directory. It introduces a constant array of `buttonPlatforms` and uses subarrays of `buttonProfiles` and `menuProfiles` to display the platform profiles of the users. This makes the code more readable, consistent, and bug-free.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 07e6d4d</samp>

> _To generate blocks for Slack_
> _We refactored some code in our stack_
> _We used `buttonPlatforms`_
> _And some subarrays of profiles_
> _To make the code more compact_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 07e6d4d</samp>

*  Define a constant array of platform names that are displayed as buttons in the Slack message blocks for new activities and new members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-90329126cb3eb37452bf181071d5b6aed739d8e2144a51c82ab694d1bf04449dR8-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baR7-R8))
*  Filter the profiles array into two subarrays: one for the platforms that are shown as buttons and one for the platforms that are shown as menu options, using the constant array in both `newActivityBlocks.ts` and `newMemberBlocks.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-90329126cb3eb37452bf181071d5b6aed739d8e2144a51c82ab694d1bf04449dR104-R109), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baR46-R51))
*  Modify the Slack message blocks for new activities and new members to use the subarrays instead of the original profiles array, and fix a bug where the platforms array was used instead of the profiles array to generate the buttons, in both `newActivityBlocks.ts` and `newMemberBlocks.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-90329126cb3eb37452bf181071d5b6aed739d8e2144a51c82ab694d1bf04449dL176-R200), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baL104-R112), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baL112-R126))
*  Remove an unnecessary filtering condition from the platforms array in `newMemberBlocks.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1564/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baL33))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
