### PR TITLE
Add segments to Twitter authenticate request

### DIFF
--- a/frontend/src/integrations/twitter/components/twitter-connect-2.vue
+++ b/frontend/src/integrations/twitter/components/twitter-connect-2.vue
@@ -55,7 +55,7 @@ const connectUrl = computed(() => {
   const redirectUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}?success=true`;
 
   return `${config.backendUrl}/twitter/${store.getters['auth/currentTenant'].id
-  }/connect?redirectUrl=${redirectUrl}&crowdToken=${AuthToken.get()}`;
+  }/connect?redirectUrl=${redirectUrl}&crowdToken=${AuthToken.get()}&segments[]=${route.params.id}`;
 });
 
 const connect = () => {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a069fd8</samp>

Added segment filtering to Twitter integration. The frontend now sends the segment ID as a query parameter to the backend when connecting to the Twitter API.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a069fd8</samp>

> _`segments[]` added_
> _to filter tweets by criteria_
> _autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a069fd8</samp>

*  Add `segments[]` query parameter to Twitter API URL with segment ID from route params ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1565/files?diff=unified&w=0#diff-be820f145e6bfa5b0bcb3f350b027b369cb98823de8a99d94afcbfcb5640780eL58-R58))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
