### PR TITLE
Saving lastSyncedPayload to syncRemote tables for easier debugging

### DIFF
--- a/backend/src/database/migrations/V1695885001__lastSyncedPayloadForSyncRemoteTables.sql
+++ b/backend/src/database/migrations/V1695885001__lastSyncedPayloadForSyncRemoteTables.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public."membersSyncRemote" ADD COLUMN "lastSyncedPayload" jsonb;
+ALTER TABLE public."organizationsSyncRemote" ADD COLUMN "lastSyncedPayload" jsonb;

--- a/services/apps/integration_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/member.repo.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { generateUUIDv1 as uuid } from '@crowd/common'
 
@@ -87,7 +85,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
 
   public async setLastSyncedAtBySyncRemoteId(
     syncRemoteId: string,
-    lastSyncedPayload: any,
+    lastSyncedPayload: unknown,
   ): Promise<void> {
     this.log.debug(`Setting lastSyncedAt for id ${syncRemoteId}.`)
 
@@ -104,7 +102,7 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
   public async setLastSyncedAt(
     memberId: string,
     integrationId: string,
-    lastSyncedPayload: any,
+    lastSyncedPayload: unknown,
   ): Promise<void> {
     this.log.debug(
       `Setting lastSyncedAt for member ${memberId} and integration ${integrationId} to now!`,

--- a/services/apps/integration_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/member.repo.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { generateUUIDv1 as uuid } from '@crowd/common'
 
@@ -83,28 +85,37 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
     )
   }
 
-  public async setLastSyncedAtBySyncRemoteId(syncRemoteId: string): Promise<void> {
+  public async setLastSyncedAtBySyncRemoteId(
+    syncRemoteId: string,
+    lastSyncedPayload: any,
+  ): Promise<void> {
     this.log.debug(`Setting lastSyncedAt for id ${syncRemoteId}.`)
 
     await this.db().none(
-      `update "membersSyncRemote" set "lastSyncedAt" = now(), "status" = $(status) where id = $(syncRemoteId)`,
+      `update "membersSyncRemote" set "lastSyncedAt" = now(), "status" = $(status), "lastSyncedPayload" = $(lastSyncedPayload) where id = $(syncRemoteId)`,
       {
         syncRemoteId,
+        lastSyncedPayload: JSON.stringify(lastSyncedPayload),
         status: SyncStatus.ACTIVE,
       },
     )
   }
 
-  public async setLastSyncedAt(memberId: string, integrationId: string): Promise<void> {
+  public async setLastSyncedAt(
+    memberId: string,
+    integrationId: string,
+    lastSyncedPayload: any,
+  ): Promise<void> {
     this.log.debug(
       `Setting lastSyncedAt for member ${memberId} and integration ${integrationId} to now!`,
     )
 
     await this.db().none(
-      `update "membersSyncRemote" set "lastSyncedAt" = now(), "status" = $(status) where "memberId" = $(memberId) and "integrationId" = $(integrationId) and status <> $(neverStatus)`,
+      `update "membersSyncRemote" set "lastSyncedAt" = now(), "status" = $(status), "lastSyncedPayload" = $(lastSyncedPayload) where "memberId" = $(memberId) and "integrationId" = $(integrationId) and status <> $(neverStatus)`,
       {
         memberId,
         integrationId,
+        lastSyncedPayload: JSON.stringify(lastSyncedPayload),
         status: SyncStatus.ACTIVE,
         neverStatus: SyncStatus.NEVER,
       },

--- a/services/apps/integration_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/organization.repo.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
 import { generateUUIDv1 as uuid } from '@crowd/common'
@@ -158,12 +160,10 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
     tenantId: string,
     segmentIds: string[],
     platform: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     filter: any,
     limit: number,
     offset: number,
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const params: any = {
       tenantId,
       segmentIds,
@@ -234,28 +234,37 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
     )
   }
 
-  public async setLastSyncedAtBySyncRemoteId(syncRemoteId: string): Promise<void> {
+  public async setLastSyncedAtBySyncRemoteId(
+    syncRemoteId: string,
+    lastSyncedPayload: any,
+  ): Promise<void> {
     this.log.debug(`Setting lastSyncedAt for id ${syncRemoteId}.`)
 
     await this.db().none(
-      `update "organizationsSyncRemote" set "lastSyncedAt" = now(), "status" = $(status) where id = $(syncRemoteId)`,
+      `update "organizationsSyncRemote" set "lastSyncedAt" = now(), "status" = $(status), "lastSyncedPayload" = $(lastSyncedPayload) where id = $(syncRemoteId)`,
       {
         syncRemoteId,
+        lastSyncedPayload: JSON.stringify(lastSyncedPayload),
         status: SyncStatus.ACTIVE,
       },
     )
   }
 
-  public async setLastSyncedAt(organizationId: string, integrationId: string): Promise<void> {
+  public async setLastSyncedAt(
+    organizationId: string,
+    integrationId: string,
+    lastSyncedPayload: any,
+  ): Promise<void> {
     this.log.debug(
       `Setting lastSyncedAt for organization ${organizationId} and integration ${integrationId} to now!`,
     )
 
     await this.db().none(
-      `update "organizationsSyncRemote" set "lastSyncedAt" = now(), "status" = $(status) where "organizationId" = $(organizationId) and "integrationId" = $(integrationId) and status <> $(neverStatus)`,
+      `update "organizationsSyncRemote" set "lastSyncedAt" = now(), "status" = $(status), "lastSyncedPayload" = $(lastSyncedPayload) where "organizationId" = $(organizationId) and "integrationId" = $(integrationId) and status <> $(neverStatus)`,
       {
         organizationId,
         integrationId,
+        lastSyncedPayload: JSON.stringify(lastSyncedPayload),
         status: SyncStatus.ACTIVE,
         neverStatus: SyncStatus.NEVER,
       },

--- a/services/apps/integration_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/integration_sync_worker/src/repo/organization.repo.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
 import { generateUUIDv1 as uuid } from '@crowd/common'
@@ -160,11 +158,11 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
     tenantId: string,
     segmentIds: string[],
     platform: string,
-    filter: any,
+    filter: unknown,
     limit: number,
     offset: number,
   ) {
-    const params: any = {
+    const params: unknown = {
       tenantId,
       segmentIds,
       limit,
@@ -236,7 +234,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
 
   public async setLastSyncedAtBySyncRemoteId(
     syncRemoteId: string,
-    lastSyncedPayload: any,
+    lastSyncedPayload: unknown,
   ): Promise<void> {
     this.log.debug(`Setting lastSyncedAt for id ${syncRemoteId}.`)
 
@@ -253,7 +251,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
   public async setLastSyncedAt(
     organizationId: string,
     integrationId: string,
-    lastSyncedPayload: any,
+    lastSyncedPayload: unknown,
   ): Promise<void> {
     this.log.debug(
       `Setting lastSyncedAt for organization ${organizationId} and integration ${integrationId} to now!`,

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateMembers.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateMembers.ts
@@ -5,7 +5,7 @@ import { getNangoToken } from './../../../nango'
 import { IMember, PlatformType } from '@crowd/types'
 import { RequestThrottler } from '@crowd/common'
 import { HubspotMemberFieldMapper } from '../field-mapper/memberFieldMapper'
-import { IBatchCreateMemberResult } from './types'
+import { IBatchCreateMembersResult } from './types'
 import { batchUpdateMembers } from './batchUpdateMembers'
 import { getContactById } from './contactById'
 
@@ -15,7 +15,7 @@ export const batchCreateMembers = async (
   memberMapper: HubspotMemberFieldMapper,
   ctx: IProcessStreamContext | IGenerateStreamsContext,
   throttler: RequestThrottler,
-): Promise<IBatchCreateMemberResult[]> => {
+): Promise<IBatchCreateMembersResult[]> => {
   const config: AxiosRequestConfig<unknown> = {
     method: 'post',
     url: `https://api.hubapi.com/crm/v3/objects/contacts/batch/create`,
@@ -100,9 +100,15 @@ export const batchCreateMembers = async (
         (crowdMember) =>
           crowdMember.emails.length > 0 && crowdMember.emails[0] === m.properties.email,
       )
+
+      const hubspotPayload = hubspotMembers.find(
+        (hubspotMember) => hubspotMember.properties.email === m.properties.email,
+      )
+
       acc.push({
         memberId: member.id,
         sourceId: m.id,
+        lastSyncedPayload: hubspotPayload,
       })
       return acc
     }, [])

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateOrganizations.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchCreateOrganizations.ts
@@ -88,10 +88,17 @@ export const batchCreateOrganizations = async (
           crowdOrganization.website &&
           getOrganizationDomain(crowdOrganization.website) === o.properties.domain,
       )
+
+      const hubspotPayload = hubspotCompanies.find(
+        (hubspotCompany) => hubspotCompany.properties.domain === o.properties.domain,
+      )
+
       acc.push({
         organizationId: organization.id,
         sourceId: o.id,
+        lastSyncedPayload: hubspotPayload,
       })
+
       return acc
     }, [])
   } catch (err) {

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateMembers.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateMembers.ts
@@ -5,6 +5,7 @@ import { getNangoToken } from './../../../nango'
 import { IMember, PlatformType } from '@crowd/types'
 import { RequestThrottler } from '@crowd/common'
 import { HubspotMemberFieldMapper } from '../field-mapper/memberFieldMapper'
+import { IBatchUpdateMembersResult } from './types'
 
 export const batchUpdateMembers = async (
   nangoId: string,
@@ -12,7 +13,7 @@ export const batchUpdateMembers = async (
   memberMapper: HubspotMemberFieldMapper,
   ctx: IProcessStreamContext | IGenerateStreamsContext,
   throttler: RequestThrottler,
-): Promise<any> => {
+): Promise<IBatchUpdateMembersResult[]> => {
   const config: AxiosRequestConfig<unknown> = {
     method: 'post',
     url: `https://api.hubapi.com/crm/v3/objects/contacts/batch/update`,
@@ -92,7 +93,20 @@ export const batchUpdateMembers = async (
 
     const result = await throttler.throttle(() => axios(config))
 
-    return result.data?.results || []
+    return result.data.results.reduce((acc, m) => {
+      const member = members.find(
+        (crowdMember) => crowdMember.attributes?.sourceId?.hubspot === m.id,
+      )
+
+      const hubspotPayload = hubspotMembers.find((hubspotMember) => hubspotMember.id === m.id)
+
+      acc.push({
+        memberId: member.id,
+        sourceId: m.id,
+        lastSyncedPayload: hubspotPayload,
+      })
+      return acc
+    }, [])
   } catch (err) {
     ctx.log.error({ err }, 'Error while batch update contacts to HubSpot')
     throw err

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/batchUpdateOrganizations.ts
@@ -5,6 +5,7 @@ import { getNangoToken } from './../../../nango'
 import { IOrganization, PlatformType } from '@crowd/types'
 import { RequestThrottler } from '@crowd/common'
 import { HubspotOrganizationFieldMapper } from '../field-mapper/organizationFieldMapper'
+import { IBatchUpdateOrganizationsResult } from './types'
 
 export const batchUpdateOrganizations = async (
   nangoId: string,
@@ -12,7 +13,7 @@ export const batchUpdateOrganizations = async (
   organizationMapper: HubspotOrganizationFieldMapper,
   ctx: IProcessStreamContext | IGenerateStreamsContext,
   throttler: RequestThrottler,
-): Promise<any> => {
+): Promise<IBatchUpdateOrganizationsResult[]> => {
   const config: AxiosRequestConfig<unknown> = {
     method: 'post',
     url: `https://api.hubapi.com/crm/v3/objects/companies/batch/update`,
@@ -75,7 +76,21 @@ export const batchUpdateOrganizations = async (
 
     const result = await throttler.throttle(() => axios(config))
 
-    return result.data?.results || []
+    return result.data.results.reduce((acc, o) => {
+      const organization = organizations.find(
+        (crowdOrganization) => crowdOrganization.attributes?.sourceId?.hubspot === o.id,
+      )
+
+      const hubspotPayload = hubspotCompanies.find((hubspotCompany) => hubspotCompany.id === o.id)
+
+      acc.push({
+        organizationId: organization.id,
+        sourceId: o.id,
+        lastSyncedPayload: hubspotPayload,
+      })
+
+      return acc
+    }, [])
   } catch (err) {
     ctx.log.error({ err }, 'Error while batch update companies in HubSpot')
     throw err

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 export interface IPaginatedResponse<T> {
   elements: T[]
   after?: string
@@ -8,7 +6,7 @@ export interface IPaginatedResponse<T> {
 export interface IBatchCreateOrganizationsResult {
   organizationId: string
   sourceId: string
-  lastSyncedPayload: any
+  lastSyncedPayload: unknown
 }
 
 export type IBatchUpdateOrganizationsResult = IBatchCreateOrganizationsResult
@@ -16,7 +14,7 @@ export type IBatchUpdateOrganizationsResult = IBatchCreateOrganizationsResult
 export interface IBatchCreateMembersResult {
   memberId: string
   sourceId: string
-  lastSyncedPayload: any
+  lastSyncedPayload: unknown
 }
 
 export type IBatchUpdateMembersResult = IBatchCreateMembersResult

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export interface IPaginatedResponse<T> {
   elements: T[]
   after?: string

--- a/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/api/types.ts
@@ -6,11 +6,20 @@ export interface IPaginatedResponse<T> {
 export interface IBatchCreateOrganizationsResult {
   organizationId: string
   sourceId: string
+  lastSyncedPayload: any
 }
 
-export interface IBatchCreateMemberResult {
+export type IBatchUpdateOrganizationsResult = IBatchCreateOrganizationsResult
+
+export interface IBatchCreateMembersResult {
   memberId: string
   sourceId: string
+  lastSyncedPayload: any
 }
 
-export type IBatchOperationResult = IBatchCreateMemberResult[] | IBatchCreateOrganizationsResult[]
+export type IBatchUpdateMembersResult = IBatchCreateMembersResult
+
+export interface IBatchOperationResult {
+  created: IBatchCreateMembersResult[] | IBatchCreateOrganizationsResult[]
+  updated: IBatchCreateMembersResult[] | IBatchCreateOrganizationsResult[]
+}

--- a/services/libs/integrations/src/integrations/premium/hubspot/processSyncRemote.ts
+++ b/services/libs/integrations/src/integrations/premium/hubspot/processSyncRemote.ts
@@ -40,6 +40,7 @@ const handler: ProcessIntegrationSyncHandler = async <T>(
   switch (entity) {
     case Entity.MEMBERS: {
       let membersCreatedInHubspot = []
+      let membersUpdatedInHubspot = []
 
       const memberMapper = HubspotFieldMapperFactory.getFieldMapper(
         HubspotEntity.MEMBERS,
@@ -63,7 +64,7 @@ const handler: ProcessIntegrationSyncHandler = async <T>(
       }
 
       if (toUpdate.length > 0) {
-        await batchUpdateMembers(
+        membersUpdatedInHubspot = await batchUpdateMembers(
           nangoId,
           toUpdate as IMember[],
           memberMapper,
@@ -91,10 +92,11 @@ const handler: ProcessIntegrationSyncHandler = async <T>(
         )
       }
 
-      return membersCreatedInHubspot || []
+      return { created: membersCreatedInHubspot, updated: membersUpdatedInHubspot }
     }
     case Entity.ORGANIZATIONS: {
-      let companiesCreatedInHubspot
+      let companiesCreatedInHubspot = []
+      let companiesUpdatedInHubspot = []
 
       const organizationMapper = HubspotFieldMapperFactory.getFieldMapper(
         HubspotEntity.ORGANIZATIONS,
@@ -116,7 +118,7 @@ const handler: ProcessIntegrationSyncHandler = async <T>(
       }
 
       if (toUpdate.length > 0) {
-        await batchUpdateOrganizations(
+        companiesUpdatedInHubspot = await batchUpdateOrganizations(
           nangoId,
           toUpdate as IOrganization[],
           organizationMapper,
@@ -125,7 +127,7 @@ const handler: ProcessIntegrationSyncHandler = async <T>(
         )
       }
 
-      return companiesCreatedInHubspot || []
+      return { created: companiesCreatedInHubspot, updated: companiesUpdatedInHubspot }
     }
     default: {
       const message = `Unsupported entity ${entity} while processing HubSpot sync remote!`


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 354da7e</samp>

This pull request adds the functionality to store and return the last payload received from the remote integration source for each member and organization that is synced by the integration sync worker. It updates the types, methods, and database tables related to the hubspot integration service and the integration sync worker service to include the lastSyncedPayload property. It also refactors some code to improve readability and consistency.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 354da7e</samp>

> _To sync with the remote integration_
> _We store the last payload's rendition_
> _In `lastSyncedPayload`_
> _For each member and org detail_
> _And use new types for better precision_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 354da7e</samp>

*  Add `lastSyncedPayload` columns to `membersSyncRemote` and `organizationsSyncRemote` tables to store the last payload received from the remote integration source for each member or organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-65a8a24c61574ede497fe0c49ae1c766daffd94a6363a310bbefffd9efd96bbcL1-R1))
*  Modify `MemberRepository` and `OrganizationRepository` classes to accept and store `lastSyncedPayload` parameter of type `any` in `setLastSyncedAtBySyncRemoteId` and `setLastSyncedAt` methods, and disable eslint rule for `no-explicit-any` in `member.repo.ts` and `organization.repo.ts` files ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6R1-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6L86-R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6L98-R108), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-9747551162f0df1ee46055b33351b122a484c1338cd6eb8a26baabe814ee69e6L104-R118), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045R1-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045L161-R166), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045L237-R247), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045L249-R257), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cf9bd965b6c06ac3c6d752416c546a6ead25a0019d5c10ca8bad67137cbc0045L255-R267))
*  Modify `MemberSyncService` and `OrganizationSyncService` classes to destructure and store the result of `processSyncRemote` method of the integration service, which is an object with two properties named `created` and `updated`, which are arrays of the last payloads received from the remote integration source for each member or organization, and pass them to the repository methods in `syncRemoteMember`, `syncMembers`, `syncMembersBySegmentIds`, `syncMembersByFilter`, `syncRemoteOrganization`, `syncOrganizations`, and `syncOrganizationsBySegmentIds` methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L13-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L97-R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L104-R120), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L228-R240), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L235-R247), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L241-R265), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L434-R454), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L441-R461), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L448-R480), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L576-R604), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L583-R611), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-bb7cc52b1f0f72e50f9cedd8c770edfc5f9ef777c9194e9bf7e136534efde266L589-R629), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L8-R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L77-R77), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L84-R99), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L157-R168), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L164-R175), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L174-R194), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L275-R291), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L282-R298), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-25114714bdd06a53ea7e24ce741180a60be9d0799d7053a92b24fb0c6993f4f2L292-R317))
*  Modify `batchCreateMembers`, `batchCreateOrganizations`, `batchUpdateMembers`, and `batchUpdateOrganizations` functions in the hubspot API files to include the `hubspotPayload` in the result array along with the `memberId`, `organizationId`, and `sourceId`, and use the new types that include the `lastSyncedPayload` property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-22374b0f86ca346b0adce9a6c0d37bc295dec7cebef18dc74752ec600f239bc5L8-R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-22374b0f86ca346b0adce9a6c0d37bc295dec7cebef18dc74752ec600f239bc5L18-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-22374b0f86ca346b0adce9a6c0d37bc295dec7cebef18dc74752ec600f239bc5L103-R111), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-1f6bca915001acdcf36a41b56874074be374abb6bf867fe861054c7acaa54610L91-R101), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-f4cea7cfc5f2e3edcbffe72465cb6ad8ea4ac44483363e737b4f2e1d277b7b36R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-f4cea7cfc5f2e3edcbffe72465cb6ad8ea4ac44483363e737b4f2e1d277b7b36L15-R16), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-f4cea7cfc5f2e3edcbffe72465cb6ad8ea4ac44483363e737b4f2e1d277b7b36L95-R109), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cd835b0eb2f6b6e9410179b1a26e7339d6f7887aa2144f57a0f40a50bae608f9R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cd835b0eb2f6b6e9410179b1a26e7339d6f7887aa2144f57a0f40a50bae608f9L15-R16), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-cd835b0eb2f6b6e9410179b1a26e7339d6f7887aa2144f57a0f40a50bae608f9L78-R93))
*  Modify `types.ts` file in the hubspot API folder to include the `lastSyncedPayload` property in the `IBatchCreateOrganizationsResult` and `IBatchCreateMembersResult` interfaces, and create new types named `IBatchUpdateOrganizationsResult` and `IBatchUpdateMembersResult` that are aliases of the previous types, and modify the `IBatchOperationResult` type to be an object with two properties named `created` and `updated`, which are arrays of the previous types ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-6d4c2eb19ed3293c56fc260ae00d7aab837f95601c8d2d7bd545518ee72f11f6L9-R25))
*  Modify `processSyncRemote` function in the `processSyncRemote.ts` file to store and return the result of the `batchUpdateMembers` and `batchUpdateOrganizations` function calls, which are arrays of the last payloads received from the remote integration source for each updated member or organization, and return an object with two properties named `created` and `updated`, which are arrays of the last payloads received from the remote integration source for each member or organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-5acb979c8b8ba2f643ed89c587e5f022b83575f4251551deb85d1b21c5e92da0R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-5acb979c8b8ba2f643ed89c587e5f022b83575f4251551deb85d1b21c5e92da0L66-R67), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-5acb979c8b8ba2f643ed89c587e5f022b83575f4251551deb85d1b21c5e92da0L94-R99), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-5acb979c8b8ba2f643ed89c587e5f022b83575f4251551deb85d1b21c5e92da0L119-R121), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1569/files?diff=unified&w=0#diff-5acb979c8b8ba2f643ed89c587e5f022b83575f4251551deb85d1b21c5e92da0L128-R130))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
