### PR TITLE
Fix bugs in groups.io stream names

### DIFF
--- a/services/libs/integrations/src/integrations/groupsio/processStream.ts
+++ b/services/libs/integrations/src/integrations/groupsio/processStream.ts
@@ -57,7 +57,7 @@ const processGroupStream: ProcessStreamHandler = async (ctx) => {
   // processing next page stream
   if (response?.next_page_token) {
     await ctx.publishStream<GroupsioGroupStreamMetadata>(
-      `${GroupsioStreamType.GROUP}-${data.group}-${response.next_page_token}`,
+      `${GroupsioStreamType.GROUP}:${data.group}-${response.next_page_token}`,
       {
         group: data.group,
         page: response.next_page_token.toString(),
@@ -92,7 +92,7 @@ const processTopicStream: ProcessStreamHandler = async (ctx) => {
   // processing next page stream
   if (response?.next_page_token) {
     await ctx.publishStream<GroupsioTopicStreamMetadata>(
-      `${GroupsioStreamType.TOPIC}-${data.topic.id}-${response.next_page_token}`,
+      `${GroupsioStreamType.TOPIC}:${data.topic.id}-${response.next_page_token}`,
       {
         group: data.group,
         topic: data.topic,
@@ -157,7 +157,7 @@ const processGroupMembersStream: ProcessStreamHandler = async (ctx) => {
   // processing next page stream
   if (response?.next_page_token) {
     await ctx.publishStream<GroupsioGroupMembersStreamMetadata>(
-      `${GroupsioStreamType.GROUP_MEMBERS}-${data.group}-${response.next_page_token}`,
+      `${GroupsioStreamType.GROUP_MEMBERS}:${data.group}-${response.next_page_token}`,
       {
         group: data.group,
         page: response.next_page_token.toString(),


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d5a7c3</samp>

Updated stream name format for Groups.io integration. Replaced dashes with colons in `group`, `topic`, and `group members` stream names in `processStream.ts` to match other integrations and prevent name clashes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3d5a7c3</samp>

> _Sing, O Muse, of the skillful coder who changed the stream names_
> _In `processStream.ts`, where the data flows like rivers_
> _He made them use colons, not dashes, as separators_
> _To avoid confusion and conflict, like wise Athena_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d5a7c3</samp>

*  Standardize stream name separators to use colons instead of dashes for group, topic, and group members streams ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1570/files?diff=unified&w=0#diff-b184044e63b504962cb246ba4f04f0b2259c997175e0a989ef7cd688e0d3b7b1L60-R60), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1570/files?diff=unified&w=0#diff-b184044e63b504962cb246ba4f04f0b2259c997175e0a989ef7cd688e0d3b7b1L95-R95), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1570/files?diff=unified&w=0#diff-b184044e63b504962cb246ba4f04f0b2259c997175e0a989ef7cd688e0d3b7b1L160-R160)) in `processStream.ts`

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
