### PR TITLE
Process old streams/data/results

### DIFF
--- a/services/apps/data_sink_worker/src/jobs/processOldResults.ts
+++ b/services/apps/data_sink_worker/src/jobs/processOldResults.ts
@@ -1,0 +1,45 @@
+import DataSinkRepository from '@/repo/dataSink.repo'
+import DataSinkService from '@/service/dataSink.service'
+import { DbConnection, DbStore } from '@crowd/database'
+import { Logger } from '@crowd/logging'
+import { RedisClient, processWithLock } from '@crowd/redis'
+import { NodejsWorkerEmitter, SearchSyncWorkerEmitter } from '@crowd/sqs'
+
+export const processOldResultsJob = async (
+  dbConn: DbConnection,
+  redis: RedisClient,
+  nodejsWorkerEmitter: NodejsWorkerEmitter,
+  searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
+  log: Logger,
+): Promise<void> => {
+  const store = new DbStore(log, dbConn)
+  const repo = new DataSinkRepository(store, log)
+  const service = new DataSinkService(
+    store,
+    nodejsWorkerEmitter,
+    searchSyncWorkerEmitter,
+    redis,
+    log,
+  )
+
+  const loadNextBatch = async (): Promise<string[]> => {
+    return await processWithLock(redis, 'process-old-results', 5 * 60, 3 * 60, async () => {
+      const resultIds = await repo.getOldResultsToProcess(5)
+      await repo.touchUpdatedAt(resultIds)
+      return resultIds
+    })
+  }
+
+  // load 5 oldest results and try process them
+  let resultsToProcess = await loadNextBatch()
+
+  while (resultsToProcess.length > 0) {
+    log.info(`Detected ${resultsToProcess.length} old results rows to process!`)
+
+    for (const resultId of resultsToProcess) {
+      await service.processResult(resultId)
+    }
+
+    resultsToProcess = await loadNextBatch()
+  }
+}

--- a/services/apps/data_sink_worker/src/jobs/processOldResults.ts
+++ b/services/apps/data_sink_worker/src/jobs/processOldResults.ts
@@ -33,12 +33,27 @@ export const processOldResultsJob = async (
   // load 5 oldest results and try process them
   let resultsToProcess = await loadNextBatch()
 
+  let successCount = 0
+  let errorCount = 0
+
   while (resultsToProcess.length > 0) {
     log.info(`Detected ${resultsToProcess.length} old results rows to process!`)
 
     for (const resultId of resultsToProcess) {
-      await service.processResult(resultId)
+      try {
+        const result = await service.processResult(resultId)
+        if (result) {
+          successCount++
+        } else {
+          errorCount++
+        }
+      } catch (err) {
+        log.error(err, 'Failed to process result!')
+        errorCount++
+      }
     }
+
+    log.info(`Processed ${successCount} old results successfully and ${errorCount} with errors.`)
 
     resultsToProcess = await loadNextBatch()
   }

--- a/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
@@ -56,37 +56,51 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
   }
 
   public async getOldResultsToProcess(limit: number): Promise<string[]> {
-    const results = await this.db().any(
-      `
-      select id
-      from integration.results
-      where state in ($(pendingState), $(processingState))
-        and "updatedAt" < now() - interval '1 hour'
-      order by case when "webhookId" is not null then 0 else 1 end, -- Prioritize non-null webhookId
-              "webhookId" asc,                                     -- Order non-null webhookId in ascending order
-              "updatedAt" desc
-      limit ${limit};
-      `,
-      {
-        pendingState: IntegrationResultState.PENDING,
-        processingState: IntegrationResultState.PROCESSING,
-        maxRetries: 5,
-      },
-    )
+    try {
+      const results = await this.db().any(
+        `
+        select id
+        from integration.results
+        where state in ($(pendingState), $(processingState))
+          and "updatedAt" < now() - interval '1 hour'
+        order by case when "webhookId" is not null then 0 else 1 end,
+                "webhookId" asc,
+                "updatedAt" desc
+        limit ${limit};
+        `,
+        {
+          pendingState: IntegrationResultState.PENDING,
+          processingState: IntegrationResultState.PROCESSING,
+          maxRetries: 5,
+        },
+      )
 
-    return results.map((s) => s.id)
+      return results.map((s) => s.id)
+    } catch (err) {
+      this.log.error(err, 'Failed to get old results to process!')
+      throw err
+    }
   }
 
   public async touchUpdatedAt(resultIds: string[]): Promise<void> {
-    await this.db().none(
-      `
-      update integration.results set "updatedAt" = now()
-      where id in ($(resultIds:csv))
-    `,
-      {
-        resultIds,
-      },
-    )
+    if (resultIds.length === 0) {
+      return
+    }
+
+    try {
+      await this.db().none(
+        `
+        update integration.results set "updatedAt" = now()
+        where id in ($(resultIds:csv))
+      `,
+        {
+          resultIds,
+        },
+      )
+    } catch (err) {
+      this.log.error(err, 'Failed to touch updatedAt for results!')
+      throw err
+    }
   }
 
   public async markResultInProgress(resultId: string): Promise<void> {

--- a/services/apps/data_sink_worker/src/service/dataSink.service.ts
+++ b/services/apps/data_sink_worker/src/service/dataSink.service.ts
@@ -66,14 +66,14 @@ export default class DataSinkService extends LoggerBase {
     await this.processResult(resultId)
   }
 
-  public async processResult(resultId: string): Promise<void> {
+  public async processResult(resultId: string): Promise<boolean> {
     this.log.debug({ resultId }, 'Processing result.')
 
     const resultInfo = await this.repo.getResultInfo(resultId)
 
     if (!resultInfo) {
       this.log.error({ resultId }, 'Result not found.')
-      return
+      return false
     }
 
     this.log = getChildLogger('result-processor', this.log, {
@@ -90,11 +90,11 @@ export default class DataSinkService extends LoggerBase {
       this.log.warn({ actualState: resultInfo.state }, 'Result is not pending.')
       if (resultInfo.state === IntegrationResultState.PROCESSED) {
         this.log.warn('Result has already been processed. Skipping...')
-        return
+        return false
       }
 
       await this.repo.resetResults([resultId])
-      return
+      return false
     }
 
     // this.log.debug('Marking result as in progress.')
@@ -161,36 +161,43 @@ export default class DataSinkService extends LoggerBase {
         }
       }
       await this.repo.deleteResult(resultId)
+      return true
     } catch (err) {
       this.log.error(err, 'Error processing result.')
-      await this.triggerResultError(
-        resultId,
-        'process-result',
-        'Error processing result.',
-        undefined,
-        err,
-      )
+      try {
+        await this.triggerResultError(
+          resultId,
+          'process-result',
+          'Error processing result.',
+          undefined,
+          err,
+        )
 
-      await sendSlackAlert({
-        slackURL: SLACK_ALERTING_CONFIG().url,
-        alertType: SlackAlertTypes.SINK_WORKER_ERROR,
-        integration: {
-          id: resultInfo.integrationId,
-          platform: resultInfo.platform,
-          tenantId: resultInfo.tenantId,
-          resultId: resultInfo.id,
-          apiDataId: resultInfo.apiDataId,
-        },
-        userContext: {
-          currentTenant: {
-            name: resultInfo.name,
-            plan: resultInfo.plan,
-            isTrial: resultInfo.isTrialPlan,
+        await sendSlackAlert({
+          slackURL: SLACK_ALERTING_CONFIG().url,
+          alertType: SlackAlertTypes.SINK_WORKER_ERROR,
+          integration: {
+            id: resultInfo.integrationId,
+            platform: resultInfo.platform,
+            tenantId: resultInfo.tenantId,
+            resultId: resultInfo.id,
+            apiDataId: resultInfo.apiDataId,
           },
-        },
-        log: this.log,
-        frameworkVersion: 'new',
-      })
+          userContext: {
+            currentTenant: {
+              name: resultInfo.name,
+              plan: resultInfo.plan,
+              isTrial: resultInfo.isTrialPlan,
+            },
+          },
+          log: this.log,
+          frameworkVersion: 'new',
+        })
+      } catch (err2) {
+        this.log.error(err2, 'Error sending slack alert.')
+      }
+
+      return false
     }
   }
 }

--- a/services/apps/integration_data_worker/src/jobs/processOldData.ts
+++ b/services/apps/integration_data_worker/src/jobs/processOldData.ts
@@ -33,16 +33,25 @@ export const processOldDataJob = async (
   // load 5 oldest apiData and try process them
   let dataToProcess = await loadNextBatch()
 
-  while (dataToProcess.length > 0) {
-    log.info(`Detected ${dataToProcess.length} old data rows to process!`)
+  let successCount = 0
+  let errorCount = 0
 
+  while (dataToProcess.length > 0) {
     for (const dataId of dataToProcess) {
       try {
-        await service.processData(dataId)
+        const result = await service.processData(dataId)
+        if (result) {
+          successCount++
+        } else {
+          errorCount++
+        }
       } catch (err) {
         log.error(err, 'Failed to process data!')
+        errorCount++
       }
     }
+
+    log.info(`Processed ${successCount} old data successfully and ${errorCount} with errors.`)
 
     dataToProcess = await loadNextBatch()
   }

--- a/services/apps/integration_data_worker/src/jobs/processOldData.ts
+++ b/services/apps/integration_data_worker/src/jobs/processOldData.ts
@@ -1,0 +1,47 @@
+import IntegrationDataRepository from '@/repo/integrationData.repo'
+import IntegrationDataService from '@/service/integrationDataService'
+import { DbConnection, DbStore } from '@crowd/database'
+import { Logger } from '@crowd/logging'
+import { RedisClient, processWithLock } from '@crowd/redis'
+import { IntegrationStreamWorkerEmitter, DataSinkWorkerEmitter } from '@crowd/sqs'
+
+export const processOldDataJob = async (
+  dbConn: DbConnection,
+  redis: RedisClient,
+  streamWorkerEmitter: IntegrationStreamWorkerEmitter,
+  dataSinkWorkerEmitter: DataSinkWorkerEmitter,
+  log: Logger,
+): Promise<void> => {
+  const store = new DbStore(log, dbConn)
+  const repo = new IntegrationDataRepository(store, log)
+
+  // load 5 oldest streams and try process them
+  const dataToProcess = await processWithLock(
+    redis,
+    'process-old-data',
+    5 * 60,
+    3 * 60,
+    async () => {
+      const dataIds = await repo.getOldDataToProcess(5)
+      await repo.touchUpdatedAt(dataIds)
+      return dataIds
+    },
+  )
+
+  if (dataToProcess.length > 0) {
+    log.info(`Detected ${dataToProcess.length} old data rows to process!`)
+    const service = new IntegrationDataService(
+      redis,
+      streamWorkerEmitter,
+      dataSinkWorkerEmitter,
+      store,
+      log,
+    )
+
+    for (const dataId of dataToProcess) {
+      await service.processData(dataId)
+    }
+  } else {
+    log.info('No old streams to process!')
+  }
+}

--- a/services/apps/integration_data_worker/src/main.ts
+++ b/services/apps/integration_data_worker/src/main.ts
@@ -4,10 +4,12 @@ import { getRedisClient } from '@crowd/redis'
 import { getDbConnection } from '@crowd/database'
 import { DataSinkWorkerEmitter, IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { WorkerQueueReceiver } from './queue'
+import { processOldDataJob } from './jobs/processOldData'
 
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
+const PROCESSING_INTERVAL_MINUTES = 5
 
 setImmediate(async () => {
   log.info('Starting integration data worker...')
@@ -33,6 +35,26 @@ setImmediate(async () => {
   try {
     await streamWorkerEmitter.init()
     await dataSinkWorkerEmitter.init()
+
+    let processing = false
+    setInterval(async () => {
+      try {
+        if (!processing) {
+          processing = true
+          await processOldDataJob(
+            dbConnection,
+            redisClient,
+            streamWorkerEmitter,
+            dataSinkWorkerEmitter,
+            log,
+          )
+        }
+      } catch (err) {
+        log.error(err, 'Failed to process old data!')
+      } finally {
+        processing = false
+      }
+    }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
     await queue.start()
   } catch (err) {
     log.error({ err }, 'Failed to start queues!')

--- a/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
+++ b/services/apps/integration_data_worker/src/repo/integrationData.repo.ts
@@ -60,44 +60,58 @@ export default class IntegrationDataRepository extends RepositoryBase<Integratio
   }
 
   public async getOldDataToProcess(limit: number): Promise<string[]> {
-    const results = await this.db().any(
-      `
-      select id
-      from integration."apiData"
-      where (
-              (state = $(errorState) and retries <= $(maxRetries))
-              or
-              (state = $(pendingState))
-              or
-              (state = $(delayedState) and "delayedUntil" < now())
-          )
-        and "updatedAt" < now() - interval '1 hour'
-      order by case when "webhookId" is not null then 0 else 1 end, -- Prioritize non-null webhookId
-              "webhookId" asc,                                     -- Order non-null webhookId in ascending order
-              "updatedAt" desc
-      limit ${limit};
-      `,
-      {
-        errorState: IntegrationStreamDataState.ERROR,
-        pendingState: IntegrationStreamDataState.PENDING,
-        delayedState: IntegrationStreamDataState.DELAYED,
-        maxRetries: 5,
-      },
-    )
+    try {
+      const results = await this.db().any(
+        `
+        select id
+        from integration."apiData"
+        where (
+                (state = $(errorState) and retries <= $(maxRetries))
+                or
+                (state = $(pendingState))
+                or
+                (state = $(delayedState) and "delayedUntil" < now())
+            )
+          and "updatedAt" < now() - interval '1 hour'
+        order by case when "webhookId" is not null then 0 else 1 end,
+                "webhookId" asc,
+                "updatedAt" desc
+        limit ${limit};
+        `,
+        {
+          errorState: IntegrationStreamDataState.ERROR,
+          pendingState: IntegrationStreamDataState.PENDING,
+          delayedState: IntegrationStreamDataState.DELAYED,
+          maxRetries: 5,
+        },
+      )
 
-    return results.map((s) => s.id)
+      return results.map((s) => s.id)
+    } catch (err) {
+      this.log.error(err, 'Error getting old data to process')
+      throw err
+    }
   }
 
   public async touchUpdatedAt(dataIds: string[]): Promise<void> {
-    await this.db().none(
-      `
-      update integration."apiData" set "updatedAt" = now()
-      where id in ($(dataIds:csv))
-    `,
-      {
-        dataIds,
-      },
-    )
+    if (dataIds.length === 0) {
+      return
+    }
+
+    try {
+      await this.db().none(
+        `
+        update integration."apiData" set "updatedAt" = now()
+        where id in ($(dataIds:csv))
+      `,
+        {
+          dataIds,
+        },
+      )
+    } catch (err) {
+      this.log.error(err, 'Failed to touch updatedAt for data!')
+      throw err
+    }
   }
 
   public async markRunError(runId: string, error: unknown): Promise<void> {

--- a/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
+++ b/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
@@ -39,15 +39,26 @@ export const processOldStreamsJob = async (
   // load 5 oldest streams and try process them
   let streamsToProcess = await loadNextBatch()
 
+  let successCount = 0
+  let errorCount = 0
+
   while (streamsToProcess.length > 0) {
-    log.info(`Detected ${streamsToProcess.length} old streams to process!`)
     for (const streamId of streamsToProcess) {
       try {
-        await service.processStream(streamId)
+        const result = await service.processStream(streamId)
+
+        if (result) {
+          successCount++
+        } else {
+          errorCount++
+        }
       } catch (err) {
         log.error(err, 'Failed to process stream!')
+        errorCount++
       }
     }
+
+    log.info(`Processed ${successCount} old streams successfully and ${errorCount} with errors.`)
 
     streamsToProcess = await loadNextBatch()
   }

--- a/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
+++ b/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
@@ -18,36 +18,37 @@ export const processOldStreamsJob = async (
   log: Logger,
 ): Promise<void> => {
   const store = new DbStore(log, dbConn)
+  const service = new IntegrationStreamService(
+    redis,
+    runWorkerEmitter,
+    dataWorkerEmitter,
+    streamWorkerEmitter,
+    store,
+    log,
+  )
   const repo = new IntegrationStreamRepository(store, log)
 
-  // load 5 oldest streams and try process them
-  const streamsToProcess = await processWithLock(
-    redis,
-    'process-old-streams',
-    5 * 60,
-    3 * 60,
-    async () => {
+  const loadNextBatch = async (): Promise<string[]> => {
+    return await processWithLock(redis, 'process-old-streams', 5 * 60, 3 * 60, async () => {
       const streams = await repo.getOldStreamsToProcess(5)
       await repo.touchUpdatedAt(streams)
       return streams
-    },
-  )
+    })
+  }
 
-  if (streamsToProcess.length > 0) {
+  // load 5 oldest streams and try process them
+  let streamsToProcess = await loadNextBatch()
+
+  while (streamsToProcess.length > 0) {
     log.info(`Detected ${streamsToProcess.length} old streams to process!`)
-    const service = new IntegrationStreamService(
-      redis,
-      runWorkerEmitter,
-      dataWorkerEmitter,
-      streamWorkerEmitter,
-      store,
-      log,
-    )
-
     for (const streamId of streamsToProcess) {
-      await service.processStream(streamId)
+      try {
+        await service.processStream(streamId)
+      } catch (err) {
+        log.error(err, 'Failed to process stream!')
+      }
     }
-  } else {
-    log.info('No old streams to process!')
+
+    streamsToProcess = await loadNextBatch()
   }
 }

--- a/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
+++ b/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
@@ -28,7 +28,7 @@ export const processOldStreamsJob = async (
     3 * 60,
     async () => {
       const streams = await repo.getOldStreamsToProcess(5)
-      await repo.touchUpdatedAt(streams.map((s) => s.id))
+      await repo.touchUpdatedAt(streams)
       return streams
     },
   )
@@ -44,8 +44,8 @@ export const processOldStreamsJob = async (
       log,
     )
 
-    for (const stream of streamsToProcess) {
-      await service.processStream(stream.id)
+    for (const streamId of streamsToProcess) {
+      await service.processStream(streamId)
     }
   } else {
     log.info('No old streams to process!')

--- a/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
+++ b/services/apps/integration_stream_worker/src/jobs/processOldStreams.ts
@@ -1,0 +1,53 @@
+import IntegrationStreamRepository from '@/repo/integrationStream.repo'
+import IntegrationStreamService from '@/service/integrationStreamService'
+import { DbConnection, DbStore } from '@crowd/database'
+import { Logger } from '@crowd/logging'
+import { RedisClient, processWithLock } from '@crowd/redis'
+import {
+  IntegrationRunWorkerEmitter,
+  IntegrationDataWorkerEmitter,
+  IntegrationStreamWorkerEmitter,
+} from '@crowd/sqs'
+
+export const processOldStreamsJob = async (
+  dbConn: DbConnection,
+  redis: RedisClient,
+  runWorkerEmitter: IntegrationRunWorkerEmitter,
+  dataWorkerEmitter: IntegrationDataWorkerEmitter,
+  streamWorkerEmitter: IntegrationStreamWorkerEmitter,
+  log: Logger,
+): Promise<void> => {
+  const store = new DbStore(log, dbConn)
+  const repo = new IntegrationStreamRepository(store, log)
+
+  // load 5 oldest streams and try process them
+  const streamsToProcess = await processWithLock(
+    redis,
+    'process-old-streams',
+    5 * 60,
+    3 * 60,
+    async () => {
+      const streams = await repo.getOldStreamsToProcess(5)
+      await repo.touchUpdatedAt(streams.map((s) => s.id))
+      return streams
+    },
+  )
+
+  if (streamsToProcess.length > 0) {
+    log.info(`Detected ${streamsToProcess.length} old streams to process!`)
+    const service = new IntegrationStreamService(
+      redis,
+      runWorkerEmitter,
+      dataWorkerEmitter,
+      streamWorkerEmitter,
+      store,
+      log,
+    )
+
+    for (const stream of streamsToProcess) {
+      await service.processStream(stream.id)
+    }
+  } else {
+    log.info('No old streams to process!')
+  }
+}

--- a/services/apps/integration_stream_worker/src/main.ts
+++ b/services/apps/integration_stream_worker/src/main.ts
@@ -9,10 +9,12 @@ import {
   getSqsClient,
 } from '@crowd/sqs'
 import { WorkerQueueReceiver } from './queue'
+import { processOldStreamsJob } from './jobs/processOldStreams'
 
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
+const PROCESSING_INTERVAL_MINUTES = 5
 
 setImmediate(async () => {
   log.info('Starting integration stream worker...')
@@ -41,6 +43,28 @@ setImmediate(async () => {
     await runWorkerEmiiter.init()
     await dataWorkerEmitter.init()
     await streamWorkerEmitter.init()
+
+    let processing = false
+    setInterval(async () => {
+      try {
+        if (!processing) {
+          processing = true
+          await processOldStreamsJob(
+            dbConnection,
+            redisClient,
+            runWorkerEmiiter,
+            dataWorkerEmitter,
+            streamWorkerEmitter,
+            log,
+          )
+        }
+      } catch (err) {
+        log.error(err, 'Failed to process old streams/webhooks!')
+      } finally {
+        processing = false
+      }
+    }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
+
     await queue.start()
   } catch (err) {
     log.error({ err }, 'Failed to start queues!')

--- a/services/apps/integration_stream_worker/src/repo/integrationStream.data.ts
+++ b/services/apps/integration_stream_worker/src/repo/integrationStream.data.ts
@@ -1,3 +1,4 @@
+import { DbColumnSet, DbInstance } from '@crowd/database'
 import { IntegrationRunState, IntegrationState, IntegrationStreamState } from '@crowd/types'
 
 export interface IStreamData {
@@ -27,4 +28,29 @@ export interface IProcessableStream {
   integrationType: string
   runId: string | null
   webhookId: string | null
+}
+
+export interface IInsertableWebhookStream {
+  identifier: string
+  webhookId: string
+  data: unknown
+  integrationId: string
+  tenantId: string
+}
+
+let insertWebhookStreamColumnSet: DbColumnSet
+export function getInsertWebhookStreamColumnSet(instance: DbInstance): DbColumnSet {
+  if (insertWebhookStreamColumnSet) return insertWebhookStreamColumnSet
+
+  insertWebhookStreamColumnSet = new instance.helpers.ColumnSet(
+    ['webhookId', 'state', 'identifier', 'data', 'tenantId', 'integrationId'],
+    {
+      table: {
+        table: 'streams',
+        schema: 'integration',
+      },
+    },
+  )
+
+  return insertWebhookStreamColumnSet
 }

--- a/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
@@ -14,44 +14,58 @@ export default class IntegrationStreamRepository extends RepositoryBase<Integrat
   }
 
   public async getOldStreamsToProcess(limit: number): Promise<string[]> {
-    const results = await this.db().any(
-      `
-      select id
-      from integration.streams s
-      where (
-              (state = $(errorState) and retries <= $(maxRetries))
-              or
-              (state = $(pendingState))
-              or
-              (state = $(delayedState) and "delayedUntil" < now())
-          )
-        and "updatedAt" < now() - interval '1 hour'
-      order by case when "webhookId" is not null then 0 else 1 end, -- Prioritize non-null webhookId
-               "webhookId" asc,                                     -- Order non-null webhookId in ascending order
-               "updatedAt" desc
-      limit ${limit};
-      `,
-      {
-        errorState: IntegrationStreamState.ERROR,
-        pendingState: IntegrationStreamState.PENDING,
-        delayedState: IntegrationStreamState.DELAYED,
-        maxRetries: 5,
-      },
-    )
+    try {
+      const results = await this.db().any(
+        `
+        select id
+        from integration.streams s
+        where (
+                (state = $(errorState) and retries <= $(maxRetries))
+                or
+                (state = $(pendingState))
+                or
+                (state = $(delayedState) and "delayedUntil" < now())
+            )
+          and "updatedAt" < now() - interval '1 hour'
+        order by case when "webhookId" is not null then 0 else 1 end,
+                 "webhookId" asc,
+                 "updatedAt" desc
+        limit ${limit};
+        `,
+        {
+          errorState: IntegrationStreamState.ERROR,
+          pendingState: IntegrationStreamState.PENDING,
+          delayedState: IntegrationStreamState.DELAYED,
+          maxRetries: 5,
+        },
+      )
 
-    return results.map((s) => s.id)
+      return results.map((s) => s.id)
+    } catch (err) {
+      this.log.error(err, 'Error getting old streams to process')
+      throw err
+    }
   }
 
   public async touchUpdatedAt(streamIds: string[]): Promise<void> {
-    await this.db().none(
-      `
-      update integration.streams set "updatedAt" = now()
-      where id in ($(streamIds:csv))
-    `,
-      {
-        streamIds,
-      },
-    )
+    if (streamIds.length === 0) {
+      return
+    }
+
+    try {
+      await this.db().none(
+        `
+        update integration.streams set "updatedAt" = now()
+        where id in ($(streamIds:csv))
+      `,
+        {
+          streamIds,
+        },
+      )
+    } catch (err) {
+      this.log.error(err, 'Failed to touch updatedAt for streams!')
+      throw err
+    }
   }
 
   public async getPendingDelayedStreams(

--- a/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
+++ b/services/apps/integration_stream_worker/src/repo/integrationStream.repo.ts
@@ -1,16 +1,62 @@
 import { generateUUIDv1 } from '@crowd/common'
-import { DbStore, RepositoryBase } from '@crowd/database'
+import { DbColumnSet, DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
-import { IProcessableStream, IStreamData } from './integrationStream.data'
 import {
   IntegrationRunState,
   IntegrationStreamDataState,
   IntegrationStreamState,
+  WebhookState,
+  WebhookType,
 } from '@crowd/types'
+import {
+  IInsertableWebhookStream,
+  IProcessableStream,
+  IStreamData,
+  getInsertWebhookStreamColumnSet,
+} from './integrationStream.data'
+import { IWebhookData } from './incomingWebhook.data'
 
 export default class IntegrationStreamRepository extends RepositoryBase<IntegrationStreamRepository> {
+  private readonly insertWebhookStreamColumnSet: DbColumnSet
+
   constructor(dbStore: DbStore, parentLog: Logger) {
     super(dbStore, parentLog)
+
+    this.insertWebhookStreamColumnSet = getInsertWebhookStreamColumnSet(this.dbInstance)
+  }
+
+  public async getOldWebhooksToProcess(limit: number): Promise<IWebhookData[]> {
+    try {
+      const results = await this.db().any(
+        `
+        select  iw.id,
+                iw."tenantId",
+                iw."integrationId",
+                iw.state,
+                iw.type,
+                iw.payload,
+                iw."createdAt" as "createdAt",
+                i.platform as "platform"
+        from "incomingWebhooks" iw
+                 inner join integrations i on iw."integrationId" = i.id
+                 left join integration.streams s on iw.id = s."webhookId"
+        where s.id is null
+          and iw.type <> $(discourseType)
+          and iw.state = $(pendingState)
+          and iw."createdAt" < now() - interval '1 hour'
+        limit ${limit};
+        `,
+        {
+          discourseType: WebhookType.DISCOURSE,
+          pendingState: WebhookState.PENDING,
+        },
+      )
+
+      return results
+    } catch (err) {
+      this.log.error(err, 'Error getting old webhooks to process')
+      throw err
+    }
   }
 
   public async getOldStreamsToProcess(limit: number): Promise<string[]> {
@@ -376,17 +422,35 @@ export default class IntegrationStreamRepository extends RepositoryBase<Integrat
     return null
   }
 
+  public async publishWebhookStreams(records: IInsertableWebhookStream[]): Promise<void> {
+    const preparedObjects = RepositoryBase.prepareBatch(
+      records.map((w) => {
+        return {
+          identifier: w.identifier,
+          webhookId: w.webhookId,
+          data: w.data ? JSON.stringify(w.data) : null,
+          integrationId: w.integrationId,
+          tenantId: w.tenantId,
+          state: IntegrationStreamState.PENDING,
+        }
+      }),
+      this.insertWebhookStreamColumnSet,
+    )
+    const query = this.dbInstance.helpers.insert(preparedObjects, this.insertWebhookStreamColumnSet)
+    await this.db().any(query)
+  }
+
   public async publishWebhookStream(
     identifier: string,
     webhookId: string,
     data: unknown,
     integrationId: string,
     tenantId: string,
-  ): Promise<string | null> {
-    const result = await this.db().oneOrNone(
+  ): Promise<string> {
+    const result = await this.db().one(
       `
-    insert into integration.streams("parentId", "runId", "webhookId", state, identifier, data, "tenantId", "integrationId", "microserviceId")
-    values (null, null, $(webhookId)::uuid, $(state), $(identifier), $(data)::json, $(tenantId), $(integrationId), null)
+    insert into integration.streams("webhookId", state, identifier, data, "tenantId", "integrationId")
+    values ($(webhookId)::uuid, $(state), $(identifier), $(data)::json, $(tenantId), $(integrationId))
     returning id;
     `,
       {
@@ -399,11 +463,7 @@ export default class IntegrationStreamRepository extends RepositoryBase<Integrat
       },
     )
 
-    if (result) {
-      return result.id
-    }
-
-    return null
+    return result.id
   }
 
   public async getStreamIdByWebhookId(webhookId: string): Promise<string | undefined> {

--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -199,11 +199,6 @@ export default class IntegrationStreamService extends LoggerBase {
         webhookInfo.tenantId,
       )
 
-      if (!streamId) {
-        this.log.error({ webhookId }, 'Could not create webhook stream!')
-        return false
-      }
-
       this.log.debug({ webhookId, streamId }, 'Webhook stream created!')
     } else {
       this.log.debug({ webhookId, streamId }, 'Found existing webhook stream, using it!')

--- a/services/libs/redis/src/mutex.ts
+++ b/services/libs/redis/src/mutex.ts
@@ -50,13 +50,13 @@ export const releaseLock = async (
   })
 }
 
-export const processWithLock = async <T = void>(
+export const processWithLock = async <T>(
   client: RedisClient,
   key: string,
   expireAfterSeconds: number,
   timeoutAfterSeconds: number,
   process: () => Promise<T>,
-): Promise<T | void> => {
+): Promise<T> => {
   const value = generateUUIDv4()
 
   await acquireLock(client, key, value, expireAfterSeconds, timeoutAfterSeconds)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f248020</samp>

This pull request adds new background jobs to the `data_sink_worker`, `integration_data_worker`, and `integration_stream_worker` services that process old data, results, and streams from the database. These jobs are defined in new files and imported and executed in the `main.ts` files of each service. The pull request also adds new methods to the repository classes to support the query and update of the old data, results, and streams. Additionally, the pull request refactors the `processWithLock` function in the `mutex.ts` file to improve type safety and consistency. The purpose of these changes is to clean up stale data and prevent them from blocking the queues of the services.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f248020</samp>

> _Oh, we are the workers of the data queue_
> _We process the old results, data, and streams too_
> _With a Redis lock and a `touchUpdatedAt` call_
> _We heave away and clear the backlog, one and all_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f248020</samp>

*  Implement periodic jobs to process old integration data, results, and streams that are in stale states ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922R1-R45), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-f34edd66f16dbb823d342d962ceb64585f8ff14d17123186f16e8d7dc28c8d6fR1-R49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-a444938c4371f3140d290fc0809fcc5035e31820d5f375ce1d30bc64f08957a6R1-R54))
  - Add new files `processOldResults.ts`, `processOldData.ts`, and `processOldStreams.ts` that export functions to process batches of old records using Redis locks and service methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922R1-R45), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-f34edd66f16dbb823d342d962ceb64585f8ff14d17123186f16e8d7dc28c8d6fR1-R49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-a444938c4371f3140d290fc0809fcc5035e31820d5f375ce1d30bc64f08957a6R1-R54))
  - Add new methods to `DataSinkRepository`, `IntegrationDataRepository`, and `IntegrationStreamRepository` to query and update the old records by their `updatedAt` and `webhookId` columns ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2R58-R91), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-21267776815b1a718da34dc9ad833ea27be064ba2ede0c1535f218f6492ba093R62-R102), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-16c03d797c0332dc5d6e23ed733c69ae397708314cf7cd861ae71a125cf288e6R16-R56))
  - Import the new functions and set intervals to call them every `PROCESSING_INTERVAL_MINUTES` minutes in the `main.ts` files of the `data_sink_worker`, `integration_data_worker`, and `integration_stream_worker` services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7L8-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R44-R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-2d0080400851bce55f8de1729a0b4fc3434b86ac6fd60d5b7bd402a26810a4b1L7-R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-2d0080400851bce55f8de1729a0b4fc3434b86ac6fd60d5b7bd402a26810a4b1R38-R57), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-c4dc28fd932febd3c9126c03b6e52569a15ccecf469161c7673574b0a1e063baL12-R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-c4dc28fd932febd3c9126c03b6e52569a15ccecf469161c7673574b0a1e063baR46-R67))
* Improve the type-safety of the `processWithLock` function in the `mutex.ts` file by removing the default and optional types for the generic parameter and the return type ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-cdb64095aef574d92d01eed510891f8830bbc97cb9324d1efb819ad881be8ac4L53-R53), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-cdb64095aef574d92d01eed510891f8830bbc97cb9324d1efb819ad881be8ac4L59-R59))
* Reorder the imports in the `dataSink.repo.ts` file to group them by module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1576/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L3-R4))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation]~(https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
