### PR TITLE
Improve concurrent request limiter

### DIFF
--- a/services/libs/redis/src/rateLimiter.ts
+++ b/services/libs/redis/src/rateLimiter.ts
@@ -33,15 +33,19 @@ export class RateLimiter implements IRateLimiter {
 export class ConcurrentRequestLimiter implements IConcurrentRequestLimiter {
   constructor(
     private readonly cache: ICache,
+    // max concurrent requests per integrationId
     private readonly maxConcurrentRequests: number,
     private readonly requestKey: string,
+    // cache key will be deleted after this time since last increment / decrement
+    private readonly maxLockTimeSeconds = 30,
   ) {
     this.cache = cache
     this.maxConcurrentRequests = maxConcurrentRequests
     this.requestKey = requestKey
+    this.maxLockTimeSeconds = maxLockTimeSeconds
   }
 
-  public async checkConcurrentRequestLimit(integrationId: string, retries = 5, sleepTimeMs = 1000) {
+  public async checkConcurrentRequestLimit(integrationId: string, retries = 200, sleepTimeMs = 50) {
     const key = this.getRequestKey(integrationId)
     const value = await this.cache.get(key)
     const currentRequests = value === null ? 0 : parseInt(value)
@@ -60,12 +64,12 @@ export class ConcurrentRequestLimiter implements IConcurrentRequestLimiter {
 
   public async incrementConcurrentRequest(integrationId: string) {
     const key = this.getRequestKey(integrationId)
-    await this.cache.increment(key, 1)
+    await this.cache.increment(key, 1, this.maxLockTimeSeconds)
   }
 
   public async decrementConcurrentRequest(integrationId: string) {
     const key = this.getRequestKey(integrationId)
-    await this.cache.decrement(key, 1)
+    await this.cache.decrement(key, 1, this.maxLockTimeSeconds)
   }
 
   public async processWithLimit<T>(integrationId: string, func: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64ca2a8</samp>

Added a new parameter to `ConcurrentRequestLimiter` to limit the cache key lifetime in Redis. This improves the performance and reliability of the rate limiting feature in `services/libs/redis`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 64ca2a8</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A new parameter for the `ConcurrentRequestLimiter`,_
> _The swift and skillful class that guards the Redis cache_
> _From the onslaught of concurrent requests that strain its power._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64ca2a8</samp>

*  Add `maxLockTimeSeconds` parameter to `ConcurrentRequestLimiter` constructor and methods to prevent stale cache keys from blocking concurrent requests ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1607/files?diff=unified&w=0#diff-e54ee1725503853d1505ffaa63c0553049b33099546c3e8baf8d90a4692c1800L36-R48), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1607/files?diff=unified&w=0#diff-e54ee1725503853d1505ffaa63c0553049b33099546c3e8baf8d90a4692c1800L63-R72))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
