### PR TITLE
Mimic browser user agent in DEV integration

### DIFF
--- a/services/libs/integrations/src/integrations/devto/api/articles.ts
+++ b/services/libs/integrations/src/integrations/devto/api/articles.ts
@@ -20,6 +20,12 @@ export const getArticle = async (id: number): Promise<IDevToArticle> => {
   try {
     const result = await axios.get(
       `https://dev.to/api/articles/${encodeURIComponent(id.toString())}`,
+      {
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+        },
+      },
     )
 
     return result.data
@@ -52,6 +58,10 @@ export const getOrganizationArticles = async (
         params: {
           page,
           per_page: perPage,
+        },
+        headers: {
+          'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
         },
       },
     )
@@ -87,6 +97,10 @@ export const getUserArticles = async (
         username,
         page,
         per_page: perPage,
+      },
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
       },
     })
     return result.data

--- a/services/libs/integrations/src/integrations/devto/api/comments.ts
+++ b/services/libs/integrations/src/integrations/devto/api/comments.ts
@@ -28,6 +28,10 @@ export const getArticleComments = async (articleId: number): Promise<IDevToComme
       params: {
         a_id: articleId,
       },
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+      },
     })
     return result.data
   } catch (err) {

--- a/services/libs/integrations/src/integrations/devto/api/user.ts
+++ b/services/libs/integrations/src/integrations/devto/api/user.ts
@@ -16,7 +16,12 @@ export interface IDevToUser {
 
 export const getUser = async (userId: number): Promise<IDevToUser | null> => {
   try {
-    const result = await axios.get(`https://dev.to/api/users/${userId}`)
+    const result = await axios.get(`https://dev.to/api/users/${userId}`, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+      },
+    })
     return result.data
   } catch (err) {
     // rate limit?


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4048436</samp>

Added a custom `User-Agent` header to axios requests in various functions that interact with the dev.to API. This fixes a bug where the API would block requests without a valid header.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4048436</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A subtle header for his axios requests, and thus_
> _Avoided the wrath of the dev.to API, which guards_
> _Its precious data with a keen and jealous eye._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4048436</samp>

*  Add custom User-Agent header to axios requests in dev.to API functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1619/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65R23-R28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1619/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65R62-R65), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1619/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65R101-R104), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1619/files?diff=unified&w=0#diff-cec2f799a6222eae2efc080d9436cca3ff4a217343d01ab1f1d13ea44072cd3aR31-R34), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1619/files?diff=unified&w=0#diff-438e0bf6f7a1496db1c20faafa24334b4fb9b765f262ccb657d25c2568dbe130L19-R24))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
