### PR TITLE
Try another user agent for DEV api requests

### DIFF
--- a/services/libs/integrations/src/integrations/devto/api/articles.ts
+++ b/services/libs/integrations/src/integrations/devto/api/articles.ts
@@ -22,8 +22,7 @@ export const getArticle = async (id: number): Promise<IDevToArticle> => {
       `https://dev.to/api/articles/${encodeURIComponent(id.toString())}`,
       {
         headers: {
-          'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+          'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)',
         },
       },
     )
@@ -60,8 +59,7 @@ export const getOrganizationArticles = async (
           per_page: perPage,
         },
         headers: {
-          'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+          'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)',
         },
       },
     )
@@ -99,8 +97,7 @@ export const getUserArticles = async (
         per_page: perPage,
       },
       headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+        'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)',
       },
     })
     return result.data

--- a/services/libs/integrations/src/integrations/devto/api/comments.ts
+++ b/services/libs/integrations/src/integrations/devto/api/comments.ts
@@ -29,8 +29,7 @@ export const getArticleComments = async (articleId: number): Promise<IDevToComme
         a_id: articleId,
       },
       headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+        'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)',
       },
     })
     return result.data

--- a/services/libs/integrations/src/integrations/devto/api/user.ts
+++ b/services/libs/integrations/src/integrations/devto/api/user.ts
@@ -18,8 +18,7 @@ export const getUser = async (userId: number): Promise<IDevToUser | null> => {
   try {
     const result = await axios.get(`https://dev.to/api/users/${userId}`, {
       headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+        'User-Agent': 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)',
       },
     })
     return result.data


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3dfd4b</samp>

Changed the user agent header for axios requests in `integrations/devto/api` files to experiment with the dev.to API behavior. This is part of a larger effort to improve the dev.to integration.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e3dfd4b</samp>

> _Sing, O Muse, of the valiant code review_
> _That sought to tame the fickle dev.to API_
> _With cunning changes to the user agent header_
> _In `articles`, `comments`, and `user` files alike._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3dfd4b</samp>

*  Modify user agent header for axios requests in dev.to API functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1620/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65L25-R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1620/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65L63-R62), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1620/files?diff=unified&w=0#diff-2aee25821bb6e9319849612f39c23268f11cd2aca486287f2062255c13796c65L102-R100), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1620/files?diff=unified&w=0#diff-cec2f799a6222eae2efc080d9436cca3ff4a217343d01ab1f1d13ea44072cd3aL32-R32), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1620/files?diff=unified&w=0#diff-438e0bf6f7a1496db1c20faafa24334b4fb9b765f262ccb657d25c2568dbe130L21-R21))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
