### PR TITLE
Add function to fetch active organizations in the last year

### DIFF
--- a/backend/src/bin/scripts/enrich-organizations-synchronous.ts
+++ b/backend/src/bin/scripts/enrich-organizations-synchronous.ts
@@ -57,7 +57,7 @@ if (parameters.help || !parameters.tenant || !parameters.limit) {
     const limit = parameters.limit
 
     for (const tenantId of tenantIds) {
-      await BulkorganizationEnrichmentWorker(tenantId, limit, true)
+      await BulkorganizationEnrichmentWorker(tenantId, limit, true, true)
       log.info(`Done for tenant ${tenantId}`)
     }
 

--- a/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkOrganizationEnrichmentWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/bulk-enrichment/bulkOrganizationEnrichmentWorker.ts
@@ -10,6 +10,7 @@ export async function BulkorganizationEnrichmentWorker(
   tenantId: string,
   maxEnrichLimit: number = 0,
   verbose: boolean = false,
+  includeOrgsActiveLastYear: boolean = false,
 ) {
   const userContext = await getUserContext(tenantId)
   const redis = await getRedisClient(REDIS_CONFIG, true)
@@ -39,7 +40,10 @@ export async function BulkorganizationEnrichmentWorker(
       tenantId,
       limit: remainderEnrichmentLimit,
     })
-    enrichedOrgs = await enrichmentService.enrichOrganizationsAndSignalDone(verbose)
+    enrichedOrgs = await enrichmentService.enrichOrganizationsAndSignalDone(
+      includeOrgsActiveLastYear,
+      verbose,
+    )
   }
 
   if (!skipCredits) {

--- a/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
@@ -80,7 +80,12 @@ export default class OrganizationEnrichmentService extends LoggerBase {
     const enrichedOrganizations: IOrganization[] = []
     const enrichedCacheOrganizations: IOrganizationCache[] = []
     let count = 0
-    for (const instance of await OrganizationRepository.filterByPayingTenant(
+
+    const organizationFilterMethod = verbose
+      ? OrganizationRepository.filterByActiveLastYear
+      : OrganizationRepository.filterByPayingTenant
+
+    for (const instance of await organizationFilterMethod(
       this.tenantId,
       this.maxOrganizationsLimit,
       this.options,

--- a/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
@@ -70,6 +70,7 @@ export default class OrganizationEnrichmentService extends LoggerBase {
   }
 
   public async enrichOrganizationsAndSignalDone(
+    includeOrgsActiveLastYear: boolean = false,
     verbose: boolean = false,
   ): Promise<IOrganization[]> {
     const enrichmentPlatformPriority = [
@@ -81,7 +82,7 @@ export default class OrganizationEnrichmentService extends LoggerBase {
     const enrichedCacheOrganizations: IOrganizationCache[] = []
     let count = 0
 
-    const organizationFilterMethod = verbose
+    const organizationFilterMethod = includeOrgsActiveLastYear
       ? OrganizationRepository.filterByActiveLastYear
       : OrganizationRepository.filterByPayingTenant
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01d182f</samp>

This pull request adds a new method to `organizationRepository.ts` to query active organizations and updates `organizationEnrichmentService.ts` to use it as an optional filter. The purpose is to improve the efficiency and accuracy of the organization enrichment process by prioritizing the most relevant organizations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 01d182f</samp>

> _`OrganizationRepository`_
> _Queries active ones_
> _Enrichment service adapts_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 01d182f</samp>

*  Add a new method to filter organizations by activity in the last year ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1630/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR134-R216))
*  Use a conditional variable to switch between filtering methods based on verbosity level ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1630/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L83-R88))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
