### PR TITLE
Repo-layer fix

### DIFF
--- a/services/apps/data_sink_worker/src/repo/githubRepos.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/githubRepos.repo.ts
@@ -7,7 +7,7 @@ export default class GithubReposRepository extends RepositoryBase<GithubReposRep
   }
 
   public async findSegmentForRepo(tenantId: string, url: string): Promise<string | null> {
-    const results = await this.db().one(
+    const results = await this.db().oneOrNone(
       `
         SELECT "segmentId"
         FROM "githubRepos"

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -398,9 +398,13 @@ export default class ActivityService extends LoggerBase {
           segmentId = providedSegmentId
           if (!segmentId) {
             const dbIntegration = await txIntegrationRepo.findById(integrationId)
+            const repoSegmentId = await txGithubReposRepo.findSegmentForRepo(
+              tenantId,
+              activity.channel,
+            )
             segmentId =
-              platform === PlatformType.GITHUB
-                ? await txGithubReposRepo.findSegmentForRepo(tenantId, activity.channel)
+              platform === PlatformType.GITHUB && repoSegmentId
+                ? repoSegmentId
                 : dbIntegration.segmentId
           }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e96316b</samp>

Fixed a bug that caused incorrect segmentId assignment for GitHub activities. Modified `findSegmentForRepo` to return null instead of throwing an error for unmapped repos, and updated `activity.service.ts` to handle null values.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e96316b</samp>

> _`findSegmentForRepo`_
> _Returns null if no match found_
> _Winter of bug fix_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e96316b</samp>

*  Fix bug for handling GitHub activities with unmapped repos ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1631/files?diff=unified&w=0#diff-f7da06cbadf6168339c43286f20eaa565a9a83c2822d57b9fd57ed1cb3ee3654L10-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1631/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL401-R407))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
