### PR TITLE
Check email domain is not undefined when assigning orgs

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -271,8 +271,11 @@ export default class MemberService extends LoggerBase {
     for (const email of emails) {
       if (email) {
         const domain = email.split('@')[1]
-        if (!isDomainExcluded(domain)) {
-          emailDomains.add(domain)
+        // domain can be undefined if email is invalid
+        if (domain) {
+          if (!isDomainExcluded(domain)) {
+            emailDomains.add(domain)
+          }
         }
       }
     }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43876a2</samp>

Fixed a bug in `member.service.ts` that could cause an error when processing invalid emails. Improved the email domain analysis logic for the data sink worker service.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43876a2</samp>

> _`isDomainExcluded`_
> _Check before calling, avoid_
> _Error in winter_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43876a2</samp>

* Fix potential error when email is invalid or does not contain a domain ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1637/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L274-R278))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
