### PR TITLE
Fix members links

### DIFF
--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newActivityBlocks.ts
@@ -117,7 +117,7 @@ export const newActivityBlocks = (activity) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*<${API_CONFIG.frontendUrl}/members/${activity.member.id}|${activity.member.displayName}>* *${display.text}*`,
+          text: `*<${API_CONFIG.frontendUrl}/contacts/${activity.member.id}|${activity.member.displayName}>* *${display.text}*`,
         },
         ...(activity.url
           ? {
@@ -184,7 +184,7 @@ export const newActivityBlocks = (activity) => {
               text: 'View in crowd.dev',
               emoji: true,
             },
-            url: `${API_CONFIG.frontendUrl}/members/${member.id}`,
+            url: `${API_CONFIG.frontendUrl}/contacts/${member.id}`,
           },
           ...(buttonProfiles || [])
             .map(({ platform, url }) => ({

--- a/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/slack/newMemberBlocks.ts
@@ -111,7 +111,7 @@ export const newMemberBlocks = (member) => {
               text: 'View in crowd.dev',
               emoji: true,
             },
-            url: `${API_CONFIG.frontendUrl}/members/${member.id}`,
+            url: `${API_CONFIG.frontendUrl}/contacts/${member.id}`,
           },
           ...(buttonProfiles || [])
             .map(({ platform, url }) => ({

--- a/backend/src/services/quickstartGuideService.ts
+++ b/backend/src/services/quickstartGuideService.ts
@@ -111,7 +111,7 @@ export default class QuickstartGuideService extends LoggerBase {
       if (enrichableMembers.count > 0) {
         guides[
           QuickstartGuideType.ENRICH_MEMBER
-        ].buttonLink = `/members/${enrichableMembers.rows[0].id}`
+        ].buttonLink = `/contacts/${enrichableMembers.rows[0].id}`
       }
     }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74e0bf1</samp>

This pull request updates the links to member profiles in various places to point to the new contacts page. This is part of the frontend refactor that renames `members` to `contacts` throughout the app.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 74e0bf1</samp>

> _`members` to `contacts`_
> _frontend refactor complete_
> _autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74e0bf1</samp>

*  Update links to member profiles in Slack messages and quickstart guide to point to contacts page instead of members page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1638/files?diff=unified&w=0#diff-90329126cb3eb37452bf181071d5b6aed739d8e2144a51c82ab694d1bf04449dL120-R120), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1638/files?diff=unified&w=0#diff-90329126cb3eb37452bf181071d5b6aed739d8e2144a51c82ab694d1bf04449dL187-R187), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1638/files?diff=unified&w=0#diff-3cec4fee5da40dacb7da50427e92935d2bd87099f869ff7a88edc0dc45c984baL114-R114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1638/files?diff=unified&w=0#diff-dad7e11e29fe49a25a6c9f92f56720aa2ac86085638dab5b486e32480dad68a5L114-R114))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
