### PR TITLE
Support redirect

### DIFF
--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -115,11 +115,11 @@
 
 <script setup>
 
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref } from 'vue';
 import { MemberPermissions } from '@/modules/member/member-permissions';
 import { useMemberStore } from '@/modules/member/store/pinia';
 import { storeToRefs } from 'pinia';
-import { mapActions, mapGetters } from '@/shared/vuex/vuex.helpers';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 import { MemberService } from '@/modules/member/member-service';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import Message from '@/shared/message/message';
@@ -136,7 +136,6 @@ import AppTagPopover from '@/modules/tag/components/tag-popover.vue';
 import AppSvg from '@/shared/svg/svg.vue';
 
 const { currentUser, currentTenant } = mapGetters('auth');
-const { doRefreshCurrentUser } = mapActions('auth');
 const memberStore = useMemberStore();
 const { selectedMembers, filters } = storeToRefs(memberStore);
 const { fetchMembers, getMemberCustomAttributes } = memberStore;
@@ -233,10 +232,6 @@ const handleMergeMembers = () => {
       Message.error('Error merging contacts');
     });
 };
-
-onMounted(() => {
-  doRefreshCurrentUser({});
-});
 
 const doDestroyAllWithConfirm = () => ConfirmDialog({
   type: 'danger',

--- a/frontend/src/modules/member/components/member-dropdown.vue
+++ b/frontend/src/modules/member/components/member-dropdown.vue
@@ -292,15 +292,11 @@ export default {
       return !this.isHubspotConnected || this.isHubspotDisabledForMember || !this.isHubspotFeatureEnabled;
     },
   },
-  created() {
-    this.doRefreshCurrentUser({});
-  },
   methods: {
     ...mapActions({
       doFind: 'member/doFind',
       doDestroy: 'member/doDestroy',
       doEnrich: 'member/doEnrich',
-      doRefreshCurrentUser: 'auth/doRefreshCurrentUser',
     }),
     ...piniaMapActions(useMemberStore, ['fetchMembers']),
     async doDestroyWithConfirm(id) {

--- a/frontend/src/modules/member/member-routes.js
+++ b/frontend/src/modules/member/member-routes.js
@@ -74,11 +74,17 @@ export default [
       },
       {
         path: '/members',
-        redirect: '/contacts',
+        redirect: (to) => ({
+          path: '/contacts',
+          query: to.query,
+        }),
       },
       {
         path: '/members/new',
-        redirect: '/contacts/new',
+        redirect: (to) => ({
+          path: '/contacts/new',
+          query: to.query,
+        }),
       },
       {
         path: '/members/:id/edit',
@@ -89,7 +95,10 @@ export default [
       },
       {
         path: '/members/merge-suggestions',
-        redirect: '/contacts/merge-suggestions',
+        redirect: (to) => ({
+          path: '/contacts/merge-suggestions',
+          query: to.query,
+        }),
       },
       {
         path: '/members/:id',

--- a/frontend/src/modules/member/member-routes.js
+++ b/frontend/src/modules/member/member-routes.js
@@ -72,6 +72,39 @@ export default [
         },
         props: true,
       },
+      {
+        path: '/members',
+        redirect: '/contacts',
+      },
+      {
+        path: '/members/new',
+        redirect: '/contacts/new',
+      },
+      {
+        path: '/members/:id/edit',
+        redirect: (to) => ({
+          path: `/contacts/${to.params.id}/edit`,
+          query: to.query,
+        }),
+      },
+      {
+        path: '/members/merge-suggestions',
+        redirect: '/contacts/merge-suggestions',
+      },
+      {
+        path: '/members/:id',
+        redirect: (to) => ({
+          path: `/contacts/${to.params.id}`,
+          query: to.query,
+        }),
+      },
+      {
+        path: '/members/:id/merge',
+        redirect: (to) => ({
+          path: `/contacts/${to.params.id}/merge`,
+          query: to.query,
+        }),
+      },
     ],
   },
 ];

--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -88,7 +88,7 @@ import {
 } from 'vue';
 import { MemberService } from '@/modules/member/member-service';
 import { MemberPermissions } from '@/modules/member/member-permissions';
-import { mapGetters } from '@/shared/vuex/vuex.helpers';
+import { mapGetters, mapActions } from '@/shared/vuex/vuex.helpers';
 import { FilterQuery } from '@/shared/modules/filters/types/FilterQuery';
 import CrSavedViews from '@/shared/modules/saved-views/components/SavedViews.vue';
 import AppMemberListTable from '@/modules/member/components/list/member-list-table.vue';
@@ -104,6 +104,7 @@ const membersToMergeCount = ref(0);
 
 const { listByPlatform } = mapGetters('integration');
 const { currentUser, currentTenant } = mapGetters('auth');
+const { doRefreshCurrentUser } = mapActions('auth');
 
 const memberFilter = ref<CrFilter | null>(null);
 
@@ -193,6 +194,7 @@ const onPaginationChange = ({
 };
 
 onMounted(() => {
+  doRefreshCurrentUser({});
   fetchMembersToMergeCount();
   doGetMembersCount();
   getMemberCustomAttributes();

--- a/frontend/src/modules/organization/components/organization-dropdown.vue
+++ b/frontend/src/modules/organization/components/organization-dropdown.vue
@@ -142,11 +142,10 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue';
+import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import {
   mapGetters,
-  mapActions,
 } from '@/shared/vuex/vuex.helpers';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import Message from '@/shared/message/message';
@@ -177,7 +176,6 @@ const emit = defineEmits([
 const store = useStore();
 
 const { currentUser, currentTenant } = mapGetters('auth');
-const { doRefreshCurrentUser } = mapActions('auth');
 
 const organizationStore = useOrganizationStore();
 const { fetchOrganizations, fetchOrganization } = organizationStore;
@@ -207,10 +205,6 @@ const isHubspotEnabled = computed(() => FeatureFlag.isFlagEnabled(
 ));
 
 const isSyncingWithHubspot = (organization) => organization.attributes?.syncRemote?.hubspot || false;
-
-onMounted(() => {
-  doRefreshCurrentUser({});
-});
 
 const isHubspotConnected = computed(() => {
   const hubspot = CrowdIntegrations.getMappedConfig('hubspot', store);

--- a/frontend/src/modules/organization/pages/organization-list-page.vue
+++ b/frontend/src/modules/organization/pages/organization-list-page.vue
@@ -78,6 +78,7 @@ import AppPageWrapper from '@/shared/layout/page-wrapper.vue';
 import AppOrganizationListTable from '@/modules/organization/components/list/organization-list-table.vue';
 import {
   mapGetters,
+  mapActions,
 } from '@/shared/vuex/vuex.helpers';
 import CrSavedViews from '@/shared/modules/saved-views/components/SavedViews.vue';
 import CrFilter from '@/shared/modules/filters/components/Filter.vue';
@@ -90,6 +91,7 @@ import { OrganizationService } from '@/modules/organization/organization-service
 import { OrganizationPermissions } from '../organization-permissions';
 
 const { currentUser, currentTenant } = mapGetters('auth');
+const { doRefreshCurrentUser } = mapActions('auth');
 
 const organizationStore = useOrganizationStore();
 const { filters, totalOrganizations, savedFilterBody } = storeToRefs(organizationStore);
@@ -189,6 +191,7 @@ const fetchOrganizationsToMergeCount = () => {
 };
 
 onMounted(async () => {
+  doRefreshCurrentUser({});
   fetchOrganizationsToMergeCount();
   doGetOrganizationCount();
   (window as any).analytics.page('Organization');


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12ec555</samp>

The code adds redirect routes for the `members` module to the `contacts` module, as part of a renaming refactoring. This preserves the functionality and usability of the existing links and bookmarks to the `members` module.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 12ec555</samp>

> _`/members` is gone_
> _redirect to `/contacts`_
> _autumn of old paths_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 12ec555</samp>

*  Add redirect routes for members module to contacts module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1640/files?diff=unified&w=0#diff-75e0f3c8c2f87a3470ac0ebab18c8be5412aa211ee553b5cc8d8ffecd7a40d9eR75-R107))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
