### PR TITLE
Fix invitation signin checking

### DIFF
--- a/frontend/src/modules/auth/pages/invitation-page.vue
+++ b/frontend/src/modules/auth/pages/invitation-page.vue
@@ -63,57 +63,61 @@ export default {
     },
   },
 
-  created() {
+  mounted() {
     this.doAcceptFromAuth(this.token);
   },
 
   methods: {
-    ...mapActions('auth', ['doSignout', 'doSelectTenant']),
+    ...mapActions('auth', ['doSignout', 'doSelectTenant', 'doWaitUntilInit']),
 
     doAcceptWithWrongEmail() {
       this.doAcceptFromAuth(this.token, true);
     },
-    doAcceptFromAuth(token, forceAcceptOtherEmail = false) {
+    async doAcceptFromAuth(token, forceAcceptOtherEmail = false) {
       if (this.loading) {
         return;
       }
+      try {
+        await this.doWaitUntilInit();
+        if (!this.signedIn) {
+          AuthInvitationToken.set(token);
+          router.push('/auth/signup');
+          return;
+        }
 
-      if (!this.signedIn) {
-        AuthInvitationToken.set(token);
-        router.push('/auth/signup');
-        return;
-      }
+        this.warningMessage = null;
+        this.loading = true;
 
-      this.warningMessage = null;
-      this.loading = true;
+        TenantService.acceptInvitation(
+          token,
+          forceAcceptOtherEmail,
+        )
+          .then((tenant) => this.doSelectTenant({ tenant }))
+          .then(() => {
+            this.warningMessage = null;
+            this.loading = false;
+          })
+          .catch((error) => {
+            if (Errors.errorCode(error) === 404) {
+              this.loading = false;
+              router.push('/');
+              return;
+            }
 
-      TenantService.acceptInvitation(
-        token,
-        forceAcceptOtherEmail,
-      )
-        .then((tenant) => this.doSelectTenant({ tenant }))
-        .then(() => {
-          this.warningMessage = null;
-          this.loading = false;
-        })
-        .catch((error) => {
-          if (Errors.errorCode(error) === 404) {
+            if (Errors.errorCode(error) === 400) {
+              this.warningMessage = Errors.selectMessage(error);
+              this.loading = false;
+              return;
+            }
+
+            Errors.handle(error);
+            this.warningMessage = null;
             this.loading = false;
             router.push('/');
-            return;
-          }
-
-          if (Errors.errorCode(error) === 400) {
-            this.warningMessage = Errors.selectMessage(error);
-            this.loading = false;
-            return;
-          }
-
-          Errors.handle(error);
-          this.warningMessage = null;
-          this.loading = false;
-          router.push('/');
-        });
+          });
+      } catch (_) {
+        router.push('/auth/signup');
+      }
     },
   },
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 691b2d9</samp>

Fixed a bug in the invitation page that caused invitation tokens to be ignored or lost when the user was already signed in. Changed the component lifecycle hook and added a wait action to ensure the authentication state is ready before accepting the invitation.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 691b2d9</samp>

> _`mounted` hook used_
> _to fix invitation bug_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 691b2d9</samp>

*  Fix invitation acceptance bug when user is already signed in ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1644/files?diff=unified&w=0#diff-a92e3342755721e38e23478d3f3c43bb4e8d1f22a66a64756f85f7393b79c222L66-R120))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
