### PR TITLE
Fix Groups-io webhooks

### DIFF
--- a/services/apps/webhook_api/src/main.ts
+++ b/services/apps/webhook_api/src/main.ts
@@ -21,6 +21,16 @@ setImmediate(async () => {
 
   const dbConnection = await getDbConnection(DB_CONFIG(), 3)
 
+  app.use((req, res, next) => {
+    // Groups.io doesn't send a content-type header,
+    // so request body parsing is just skipped
+    // But we fix it
+    if (!req.headers['content-type']) {
+      req.headers['content-type'] = 'application/json'
+    }
+    next()
+  })
+
   app.use(cors({ origin: true }))
   app.use(express.json({ limit: '5mb' }))
   app.use(express.urlencoded({ extended: true, limit: '5mb' }))

--- a/services/apps/webhook_api/src/routes/groupsio.ts
+++ b/services/apps/webhook_api/src/routes/groupsio.ts
@@ -15,14 +15,15 @@ export const installGroupsIoRoutes = async (app: express.Express) => {
       const data = req.body
 
       // TODO: Validate signature - need to get secret from groups io for Linux
+      const groupName = data?.group?.name
 
-      if (!data?.group?.name) {
+      if (!groupName) {
         throw new Error400BadRequest('Missing group name!')
       }
 
       const repo = new WebhooksRepository(req.dbStore, req.log)
 
-      const integration = await repo.findGroupsIoIntegrationByGroupName(data.group.name)
+      const integration = await repo.findGroupsIoIntegrationByGroupName(groupName)
 
       if (integration) {
         req.log.info({ integrationId: integration.id }, 'Incoming Groups.io Webhook!')
@@ -47,7 +48,7 @@ export const installGroupsIoRoutes = async (app: express.Express) => {
 
         res.sendStatus(204)
       } else {
-        req.log.error({ event }, 'No integration found for incoming Groups.io Webhook!')
+        req.log.error({ event, groupName }, 'No integration found for incoming Groups.io Webhook!')
         res.status(200).send({
           message: 'No integration found for incoming Groups.io Webhook!',
         })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e7d41e</samp>

This pull request improves the webhook handling for Groups.io in the `webhook_api` app. It refactors the code in `groupsio.ts` to use a variable for the group name and adds it to the error log, and it adds a middleware function in `main.ts` to set the content-type header to application/json if it is missing.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8e7d41e</samp>

> _To handle webhooks from Groups.io_
> _We need a middleware to go_
> _And set the content-type_
> _To JSON, that's right_
> _Or else the parsing will blow_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8e7d41e</samp>

*  Add middleware to set content-type header for JSON requests ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1645/files?diff=unified&w=0#diff-4d0bb96426ff483c76835f5019710944e1d79f47d64dd8c49a2ecc3fb4af8228R24-R33))
*  Refactor group name access and use variable in logic and error handling ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1645/files?diff=unified&w=0#diff-b3a1f3ab0e7e1a6dd7b8ab5588b76e846a4134830f02f2ec84530b1c9580f9e2L18-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1645/files?diff=unified&w=0#diff-b3a1f3ab0e7e1a6dd7b8ab5588b76e846a4134830f02f2ec84530b1c9580f9e2L25-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1645/files?diff=unified&w=0#diff-b3a1f3ab0e7e1a6dd7b8ab5588b76e846a4134830f02f2ec84530b1c9580f9e2L50-R51))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
