### PR TITLE
Fix widget number icon

### DIFF
--- a/frontend/src/modules/widget/components/widget-number.vue
+++ b/frontend/src/modules/widget/components/widget-number.vue
@@ -127,7 +127,7 @@ export default {
           'ri-radar-line bg-brand-50 text-brand-500 ',
         'avg-time-to-first-interaction':
           'ri-timer-flash-line bg-yellow-50 text-yellow-500 ',
-        members: 'ri-contacts-line bg-gray-900 text-white ',
+        contacts: 'ri-contacts-line bg-gray-900 text-white ',
         activities:
           'ri-radar-line bg-brand-50 text-brand-500 ',
       };


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 695431e</samp>

Renamed `members` to `contacts` in widget-number component. This aligns the frontend code with the backend API and the UI labels.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 695431e</samp>

> _`members` no more_
> _`contacts` match API and UI_
> _widget-number adapts_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 695431e</samp>

*  Rename `members` to `contacts` in widget-number component and related tests ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1650/files?diff=unified&w=0#diff-15fbcc18f69eca7ccc8f699db628b292c5bd3573ddb8907b83d7e1ae8e7cc1f7L130-R130),                             F

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
