### PR TITLE
Reload tenants on tenant create

### DIFF
--- a/frontend/src/modules/tenant/components/tenant-new-form.vue
+++ b/frontend/src/modules/tenant/components/tenant-new-form.vue
@@ -44,7 +44,7 @@ import { useStore } from 'vuex';
 const props = defineProps<{
   modelValue: boolean,
 }>();
-const emit = defineEmits<{(e: 'update:modelValue', value: boolean): void, (e: 'createdTenant', value: boolean): void}>();
+const emit = defineEmits<{(e: 'update:modelValue', value: boolean): void, (e: 'createdTenant', value: boolean): void }>();
 
 const store = useStore();
 
@@ -87,6 +87,7 @@ const onBtnClick = () => {
         emit('createdTenant', true);
 
         // Select tenant in app
+        store.dispatch('tenant/doFetch', {});
         store.dispatch('auth/doSelectTenant', { tenant });
         return Promise.resolve();
       }))


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8086cd</samp>

This pull request adds a feature to create and display new tenants in the frontend. It modifies the `tenant-new-form.vue` component and fixes a type definition.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c8086cd</samp>

> _From the ashes of the old, a new tenant rises_
> _With a form of power, they claim their domain_
> _The list of rivals, updated and refreshed_
> _They `emit` their fury, no one can restrain_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8086cd</samp>

* Dispatch `tenant/doFetch` action to refresh tenant list after creating a new tenant ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1651/files?diff=unified&w=0#diff-cb3253a2a3e653296d094502636eff3497d772806bd818c77347d6d159107c36R90))
* Add space before closing curly brace of `emit` type definition for readability ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1651/files?diff=unified&w=0#diff-cb3253a2a3e653296d094502636eff3497d772806bd818c77347d6d159107c36L47-R47))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
