### PR TITLE
No merge array existence check before parsing the suggestion query

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1237,7 +1237,10 @@ class OrganizationRepository {
             }
           }
 
-          if (organization._source.uuid_arr_noMergeIds && organization._source.uuid_arr_noMergeIds.length > 0) {
+          if (
+            organization._source.uuid_arr_noMergeIds &&
+            organization._source.uuid_arr_noMergeIds.length > 0
+          ) {
             for (const noMergeId of organization._source.uuid_arr_noMergeIds) {
               identitiesPartialQuery.must_not.push({
                 term: {

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1237,12 +1237,14 @@ class OrganizationRepository {
             }
           }
 
-          for (const noMergeId of organization._source.uuid_arr_noMergeIds) {
-            identitiesPartialQuery.must_not.push({
-              term: {
-                uuid_organizationId: noMergeId,
-              },
-            })
+          if (organization._source.uuid_arr_noMergeIds && organization._source.uuid_arr_noMergeIds.length > 0) {
+            for (const noMergeId of organization._source.uuid_arr_noMergeIds) {
+              identitiesPartialQuery.must_not.push({
+                term: {
+                  uuid_organizationId: noMergeId,
+                },
+              })
+            }
           }
 
           const sameOrganizationsQueryBody = {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f00145</samp>

Fixed a bug in `organizationRepository.ts` that caused the identities query to fail when the organization had no merge ids. Added a condition to check the existence and length of the `uuid_arr_noMergeIds` field before using it.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f00145</samp>

> _`uuid_arr_noMergeIds`_
> _Check before looping over_
> _A bug fix for fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f00145</samp>

*  Fix a bug that caused the identities query to fail when the organization had no merge ids ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1655/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1240-R1247))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
