### PR TITLE
Pass the existing transaction to merge organizations on enrichment

### DIFF
--- a/backend/src/services/IServiceOptions.ts
+++ b/backend/src/services/IServiceOptions.ts
@@ -10,4 +10,5 @@ export interface IServiceOptions {
   currentSegments: SegmentData[]
   database: any
   redis: RedisClient
+  transaction?: any
 }

--- a/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/organizationEnrichmentService.ts
@@ -168,7 +168,7 @@ export default class OrganizationEnrichmentService extends LoggerBase {
 
         // Check for an organization with the same website exists
         const existingOrg = await OrganizationRepository.findByDomain(org.website, this.options)
-        const orgService = new OrganizationService(this.options)
+        const orgService = new OrganizationService({ ...this.options, transaction })
 
         if (existingOrg && existingOrg.id !== org.id) {
           await orgService.merge(existingOrg.id, org.id)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d911abf</samp>

Refactored `organizationEnrichmentService` and `orgService` to use database transactions for data consistency and error handling. Updated `backend/src/services/premium/enrichment/organizationEnrichmentService.ts` to pass the `transaction` option to `orgService`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d911abf</samp>

> _`orgService` changed_
> _To use same transaction_
> _Data stays intact_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d911abf</samp>

*  Pass `transaction` option to `orgService` constructor to use same database transaction as `organizationEnrichmentService` methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1661/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L171-R171))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
