### PR TITLE
Organizations merge on conflict during enrichment hotfix

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1782,6 +1782,7 @@ class OrganizationRepository {
           join activities a
                     on a."segmentId" = ls.id and a."organizationId" = :id and
                       a."deletedAt" is null
+          join "organizationSegments" os on a."segmentId" = os."segmentId" and os."organizationId" = :id
           join members m on a."memberId" = m.id and m."deletedAt" is null
           join "memberOrganizations" mo on m.id = mo."memberId" and mo."organizationId" = :id and mo."dateEnd" is null
     group by a."organizationId"),


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 110d257</samp>

Improved organization enrichment service by removing duplicate organizations and fixing variable declaration. Modified `backend/src/services/premium/enrichment/organizationEnrichmentService.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 110d257</samp>

> _`unmergedOrgs` now_
> _let, no duplicates by site_
> _enrichment in spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 110d257</samp>

*  Remove duplicate organizations based on website in organization enrichment service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1664/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L152-R152), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1664/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L185-R201))
  - Change `unmergedOrgs` from `const` to `let` to allow reassignment ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1664/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L152-R152))
  - Add code to iterate over `unmergedOrgs` and collect and filter out duplicates ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1664/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L185-R201))
  - Log the removed duplicate organizations for debugging purposes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1664/files?diff=unified&w=0#diff-b8b65cf54228d58772f94e34b19582d291f4fb99d8299147f110d78e7aacca71L185-R201))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
