### PR TITLE
No org merge suggestion button

### DIFF
--- a/frontend/src/modules/organization/organization-service.js
+++ b/frontend/src/modules/organization/organization-service.js
@@ -150,14 +150,13 @@ export class OrganizationService {
     return response.data;
   }
 
-  static async fetchMergeSuggestions(limit, offset, segments) {
+  static async fetchMergeSuggestions(limit, offset) {
     const sampleTenant = AuthCurrentTenant.getSampleTenantData();
     const tenantId = sampleTenant?.id || AuthCurrentTenant.get();
 
     const params = {
       limit,
       offset,
-      segments,
     };
 
     return authAxios.get(

--- a/frontend/src/modules/organization/organization-service.js
+++ b/frontend/src/modules/organization/organization-service.js
@@ -150,13 +150,14 @@ export class OrganizationService {
     return response.data;
   }
 
-  static async fetchMergeSuggestions(limit, offset) {
+  static async fetchMergeSuggestions(limit, offset, segments) {
     const sampleTenant = AuthCurrentTenant.getSampleTenantData();
     const tenantId = sampleTenant?.id || AuthCurrentTenant.get();
 
     const params = {
       limit,
       offset,
+      segments,
     };
 
     return authAxios.get(

--- a/frontend/src/modules/organization/pages/organization-list-page.vue
+++ b/frontend/src/modules/organization/pages/organization-list-page.vue
@@ -18,7 +18,7 @@
                 },
               }"
             >
-              <button type="button" class="btn btn--bordered btn--md flex items-center">
+              <button :disabled="isEditLockedForSampleData" type="button" class="btn btn--secondary btn--md flex items-center">
                 <span class="ri-shuffle-line text-base mr-2 text-gray-900" />
                 <span class="text-gray-900">Merge suggestions</span>
                 <span
@@ -198,7 +198,7 @@ const onPaginationChange = ({
 
 const organizationsToMergeCount = ref(0);
 const fetchOrganizationsToMergeCount = () => {
-  OrganizationService.fetchMergeSuggestions(1, 0, segments)
+  OrganizationService.fetchMergeSuggestions(1, 0)
     .then(({ count }: any) => {
       organizationsToMergeCount.value = count;
     });

--- a/frontend/src/modules/organization/pages/organization-list-page.vue
+++ b/frontend/src/modules/organization/pages/organization-list-page.vue
@@ -8,6 +8,25 @@
             <h4>Organizations</h4>
           </div>
           <div class="flex items-center">
+            <router-link
+              class=" mr-4 "
+              :class="{ 'pointer-events-none': isEditLockedForSampleData }"
+              :to="{
+                name: 'organizationMergeSuggestions',
+                query: {
+                  projectGroup: selectedProjectGroup?.id,
+                },
+              }"
+            >
+              <button type="button" class="btn btn--bordered btn--md flex items-center">
+                <span class="ri-shuffle-line text-base mr-2 text-gray-900" />
+                <span class="text-gray-900">Merge suggestions</span>
+                <span
+                  v-if="organizationsToMergeCount > 0"
+                  class="ml-2 bg-brand-100 text-brand-500 py-px px-1.5 leading-5 rounded-full font-semibold"
+                >{{ Math.ceil(organizationsToMergeCount) }}</span>
+              </button>
+            </router-link>
             <el-button
               v-if="hasPermissionToCreate"
               class="btn btn--primary btn--md"
@@ -78,6 +97,7 @@ import { organizationFilters, organizationSearchFilter } from '@/modules/organiz
 import { organizationSavedViews, organizationViews } from '@/modules/organization/config/saved-views/main';
 import { FilterQuery } from '@/shared/modules/filters/types/FilterQuery';
 import { OrganizationService } from '@/modules/organization/organization-service';
+import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { OrganizationPermissions } from '../organization-permissions';
 
 const router = useRouter();
@@ -93,6 +113,9 @@ const organizationCount = ref(0);
 const isSubProjectSelectionOpen = ref(false);
 
 const organizationFilter = ref<CrFilter | null>(null);
+const lsSegmentsStore = useLfSegmentsStore();
+
+const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
 
 const hasPermissionToCreate = computed(
   () => new OrganizationPermissions(
@@ -105,6 +128,13 @@ const isCreateLockedForSampleData = computed(
     currentTenant.value,
     currentUser.value,
   ).createLockedForSampleData,
+);
+
+const isEditLockedForSampleData = computed(
+  () => new OrganizationPermissions(
+    currentTenant.value,
+    currentUser.value,
+  ).editLockedForSampleData,
 );
 
 const pagination = ref({
@@ -166,8 +196,17 @@ const onPaginationChange = ({
   });
 };
 
+const organizationsToMergeCount = ref(0);
+const fetchOrganizationsToMergeCount = () => {
+  OrganizationService.fetchMergeSuggestions(1, 0, segments)
+    .then(({ count }: any) => {
+      organizationsToMergeCount.value = count;
+    });
+};
+
 onMounted(async () => {
   doGetOrganizationCount();
+  fetchOrganizationsToMergeCount();
   (window as any).analytics.page('Organization');
 });
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9760d6f</samp>

Added a feature to `organization-list-page.vue` to access organization merge suggestions. The feature shows the number of suggestions for the chosen project group and checks the user's permission to edit the sample data.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9760d6f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A feature for the list of organizations, where he placed_
> _A link to merge suggestions, showing how many lie_
> _In wait for those who edit samples and segments trace_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9760d6f</samp>

*  Add a button to navigate to the organization merge suggestions page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdR11-R29))
*  Import and use the useLfSegmentsStore hook to access the project group selection state ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdR100), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdL96-R119))
*  Check the user's permission to edit the sample data and disable the button accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdR133-R139), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdR11-R29))
*  Fetch and display the number of merge suggestions for the selected project group ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdL169-R209), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdR11-R29))
*  Call the `OrganizationService.fetchMergeSuggestions` method on mounted hook to get the initial count ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1667/files?diff=unified&w=0#diff-6d4c5ade1be7c99be770af5fbed6c2b896106ec501176d57948ac236e3be4bcdL169-R209))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
