### PR TITLE
added back process.exit otherwise services don't die

### DIFF
--- a/services/libs/tracing/src/tracer.ts
+++ b/services/libs/tracing/src/tracer.ts
@@ -72,6 +72,7 @@ async function gracefulShutdown() {
   try {
     await sdk.shutdown()
     console.log('Tracing successfully finished')
+    process.exit(0)
   } catch (err) {
     console.log('Error terminating tracing', err)
   }

--- a/services/libs/tracing/src/tracer.ts
+++ b/services/libs/tracing/src/tracer.ts
@@ -72,8 +72,9 @@ async function gracefulShutdown() {
   try {
     await sdk.shutdown()
     console.log('Tracing successfully finished')
-    process.exit(0)
   } catch (err) {
     console.log('Error terminating tracing', err)
+  } finally {
+    process.exit(0)
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0881869</samp>

Added a statement to exit the tracer process after flushing traces in `tracer.ts`. This fixes a bug that caused the process to hang when the main process ended.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0881869</samp>

> _`gracefulShutdown`_
> _flushes traces, then exits_
> _no more hanging `process`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0881869</samp>

* Ensure tracer process exits gracefully after flushing traces ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1671/files?diff=unified&w=0#diff-4947eaf91d0c076e0d3bfc4c28bec695614f2907be564b95e589c4bca62f6071R75))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
