### PR TITLE
fixes and improvements for transaction handling in member and org merge

### DIFF
--- a/backend/src/database/repositories/activityRepository.ts
+++ b/backend/src/database/repositories/activityRepository.ts
@@ -290,6 +290,8 @@ class ActivityRepository {
 
     const currentTenant = SequelizeRepository.getCurrentTenant(options)
 
+    const transaction = SequelizeRepository.getTransaction(options)
+
     const where = {
       id: {
         [Op.in]: ids,
@@ -300,6 +302,7 @@ class ActivityRepository {
     const records = await options.database.activity.findAll({
       attributes: ['id'],
       where,
+      transaction,
     })
 
     return records.map((record) => record.id)

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -135,13 +135,7 @@ class MemberRepository {
       transaction,
     })
 
-    await MemberRepository.updateMemberOrganizations(
-      record,
-      data.organizations,
-      true,
-      transaction,
-      options,
-    )
+    await MemberRepository.updateMemberOrganizations(record, data.organizations, true, options)
 
     await record.setTasks(data.tasks || [], {
       transaction,
@@ -692,7 +686,6 @@ class MemberRepository {
       record,
       data.organizations,
       data.organizationsReplace,
-      transaction,
       options,
     )
 
@@ -709,11 +702,11 @@ class MemberRepository {
     }
 
     if (data.affiliations) {
-      await this.setAffiliations(id, data.affiliations, options)
+      await MemberRepository.setAffiliations(id, data.affiliations, options)
     }
 
     if (options.currentSegments && options.currentSegments.length > 0) {
-      await MemberRepository.includeMemberToSegments(record.id, { ...options, transaction })
+      await MemberRepository.includeMemberToSegments(record.id, options)
     }
 
     const seq = SequelizeRepository.getSequelize(options)
@@ -1019,7 +1012,7 @@ class MemberRepository {
       }
     }
 
-    data.affiliations = await this.getAffiliations(id, options)
+    data.affiliations = await MemberRepository.getAffiliations(id, options)
 
     return data
   }
@@ -3251,10 +3244,9 @@ class MemberRepository {
 
     output.affiliations = await this.getAffiliations(record.id, options)
 
-    const manualSyncRemote = await new MemberSyncRemoteRepository({
-      ...options,
-      transaction,
-    }).findMemberManualSync(record.id)
+    const manualSyncRemote = await new MemberSyncRemoteRepository(options).findMemberManualSync(
+      record.id,
+    )
 
     for (const syncRemote of manualSyncRemote) {
       if (output.attributes?.syncRemote) {
@@ -3273,7 +3265,6 @@ class MemberRepository {
     record,
     organizations,
     replace,
-    transaction,
     options: IRepositoryOptions,
   ) {
     if (!organizations) {
@@ -3299,10 +3290,7 @@ class MemberRepository {
       )
 
       for (const item of toDelete) {
-        await MemberRepository.deleteWorkExperience((item as any).id, {
-          transaction,
-          ...options,
-        })
+        await MemberRepository.deleteWorkExperience((item as any).id, options)
       }
     }
 
@@ -3317,15 +3305,9 @@ class MemberRepository {
           dateEnd: org.endDate,
           source: org.source,
         },
-        {
-          transaction,
-          ...options,
-        },
+        options,
       )
-      await OrganizationRepository.includeOrganizationToSegments(org.id, {
-        transaction,
-        ...options,
-      })
+      await OrganizationRepository.includeOrganizationToSegments(org.id, options)
     }
   }
 

--- a/backend/src/database/repositories/sequelizeRepository.ts
+++ b/backend/src/database/repositories/sequelizeRepository.ts
@@ -81,7 +81,7 @@ export default class SequelizeRepository {
   /**
    * Creates a database transaction.
    */
-  static async createTransaction(options) {
+  static async createTransaction(options: IRepositoryOptions) {
     if (options.transaction) {
       if (options.transaction.crowdNestedTransactions !== undefined) {
         options.transaction.crowdNestedTransactions++
@@ -93,6 +93,20 @@ export default class SequelizeRepository {
     }
 
     return options.database.sequelize.transaction()
+  }
+
+  /**
+   * Creates a transactional repository options instance
+   */
+  static async createTransactionalRepositoryOptions(
+    options: IRepositoryOptions,
+  ): Promise<IRepositoryOptions> {
+    const transaction = await this.createTransaction(options)
+
+    return {
+      ...options,
+      transaction,
+    }
   }
 
   /**

--- a/backend/src/database/repositories/tagRepository.ts
+++ b/backend/src/database/repositories/tagRepository.ts
@@ -153,6 +153,8 @@ class TagRepository {
 
     const currentTenant = SequelizeRepository.getCurrentTenant(options)
 
+    const transaction = SequelizeRepository.getTransaction(options)
+
     const where = {
       id: {
         [Op.in]: ids,
@@ -163,6 +165,7 @@ class TagRepository {
     const records = await options.database.tag.findAll({
       attributes: ['id'],
       where,
+      transaction,
     })
 
     return records.map((record) => record.id)

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -561,14 +561,15 @@ export default class MemberService extends LoggerBase {
         }
       }
 
-      tx = await SequelizeRepository.createTransaction(this.options)
-      const repoOptions: IRepositoryOptions = { ...this.options }
-      repoOptions.transaction = tx
+      const repoOptions: IRepositoryOptions =
+        await SequelizeRepository.createTransactionalRepositoryOptions(this.options)
+      tx = repoOptions.transaction
 
       const allIdentities = await MemberRepository.getIdentities(
         [originalId, toMergeId],
         repoOptions,
       )
+
       const originalIdentities = allIdentities.get(originalId)
       const toMergeIdentities = allIdentities.get(toMergeId)
       const identitiesToMove = []
@@ -616,6 +617,7 @@ export default class MemberService extends LoggerBase {
       await MemberRepository.removeToMerge(originalId, toMergeId, repoOptions)
 
       const secondMemberSegments = await MemberRepository.getMemberSegments(toMergeId, repoOptions)
+
       await MemberRepository.includeMemberToSegments(toMergeId, {
         ...repoOptions,
         currentSegments: secondMemberSegments,
@@ -626,9 +628,22 @@ export default class MemberService extends LoggerBase {
 
       await SequelizeRepository.commitTransaction(tx)
 
-      const searchSyncEmitter = await getSearchSyncWorkerEmitter()
-      await searchSyncEmitter.triggerMemberSync(this.options.currentTenant.id, originalId)
-      await searchSyncEmitter.triggerRemoveMember(this.options.currentTenant.id, toMergeId)
+      try {
+        // TODO replace this with synchroneous call
+        const searchSyncEmitter = await getSearchSyncWorkerEmitter()
+        await searchSyncEmitter.triggerMemberSync(this.options.currentTenant.id, originalId)
+        await searchSyncEmitter.triggerRemoveMember(this.options.currentTenant.id, toMergeId)
+      } catch (emitError) {
+        this.log.error(
+          emitError,
+          {
+            tenantId: this.options.currentTenant.id,
+            originalId,
+            toMergeId,
+          },
+          'Error while triggering member sync changes!',
+        )
+      }
 
       this.options.log.info({ originalId, toMergeId }, 'Members merged!')
       return { status: 200, mergedId: originalId }
@@ -830,44 +845,37 @@ export default class MemberService extends LoggerBase {
     }
   }
 
-  async update(id, data, passedTransaction?) {
-    const transaction =
-      passedTransaction || (await SequelizeRepository.createTransaction(this.options))
+  async update(id, data) {
+    let transaction
     const searchSyncEmitter = await getSearchSyncWorkerEmitter()
 
     try {
+      const repoOptions = await SequelizeRepository.createTransactionalRepositoryOptions(
+        this.options,
+      )
+      transaction = repoOptions.transaction
+
       if (data.activities) {
-        data.activities = await ActivityRepository.filterIdsInTenant(data.activities, {
-          ...this.options,
-          transaction,
-        })
+        data.activities = await ActivityRepository.filterIdsInTenant(data.activities, repoOptions)
       }
       if (data.tags) {
-        data.tags = await TagRepository.filterIdsInTenant(data.tags, {
-          ...this.options,
-          transaction,
-        })
+        data.tags = await TagRepository.filterIdsInTenant(data.tags, repoOptions)
       }
       if (data.noMerge) {
         data.noMerge = await MemberRepository.filterIdsInTenant(
           data.noMerge.filter((i) => i !== id),
-          { ...this.options, transaction },
+          repoOptions,
         )
       }
       if (data.toMerge) {
         data.toMerge = await MemberRepository.filterIdsInTenant(
           data.toMerge.filter((i) => i !== id),
-          { ...this.options, transaction },
+          repoOptions,
         )
       }
       if (data.username) {
         // need to filter out existing identities from the payload
-        const existingIdentities = (
-          await MemberRepository.getIdentities([id], {
-            ...this.options,
-            transaction,
-          })
-        ).get(id)
+        const existingIdentities = (await MemberRepository.getIdentities([id], repoOptions)).get(id)
 
         data.username = mapUsernameToIdentities(data.username, data.platform)
 
@@ -897,14 +905,18 @@ export default class MemberService extends LoggerBase {
         }
       }
 
-      const record = await MemberRepository.update(id, data, {
-        ...this.options,
-        transaction,
-      })
+      const record = await MemberRepository.update(id, data, repoOptions)
 
-      if (!passedTransaction) {
-        await SequelizeRepository.commitTransaction(transaction)
+      await SequelizeRepository.commitTransaction(transaction)
+      try {
+        // TODO replace this with synchroneous call
         await searchSyncEmitter.triggerMemberSync(this.options.currentTenant.id, record.id)
+      } catch (emitErr) {
+        this.log.error(
+          emitErr,
+          { tenantId: this.options.currentTenant.id, memberId: record.id },
+          'Error while triggering member sync changes!',
+        )
       }
 
       return record
@@ -921,7 +933,10 @@ export default class MemberService extends LoggerBase {
       } else {
         this.log.error(error, 'Error during member update!')
       }
-      await SequelizeRepository.rollbackTransaction(transaction)
+
+      if (transaction) {
+        await SequelizeRepository.rollbackTransaction(transaction)
+      }
 
       SequelizeRepository.handleUniqueFieldError(error, this.options.language, 'member')
 

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -108,7 +108,7 @@ export default class OrganizationService extends LoggerBase {
       }
 
       // Update original organization
-      await txService.update(originalId, toUpdate, repoOptions.transaction)
+      await txService.update(originalId, toUpdate)
 
       // update members that belong to source organization to destination org
       await OrganizationRepository.moveMembersBetweenOrganizations(

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -1,6 +1,9 @@
-import { IOrganization, IOrganizationIdentity, OrganizationMergeSuggestionType } from '@crowd/types'
-import { LoggerBase } from '@crowd/logging'
 import { websiteNormalizer } from '@crowd/common'
+import { LoggerBase } from '@crowd/logging'
+import { IOrganization, IOrganizationIdentity, OrganizationMergeSuggestionType } from '@crowd/types'
+import { IRepositoryOptions } from '@/database/repositories/IRepositoryOptions'
+import { getSearchSyncWorkerEmitter } from '@/serverless/utils/serviceSQS'
+import getObjectWithoutKey from '@/utils/getObjectWithoutKey'
 import { CLEARBIT_CONFIG, IS_TEST_ENV } from '../conf'
 import MemberRepository from '../database/repositories/memberRepository'
 import organizationCacheRepository from '../database/repositories/organizationCacheRepository'
@@ -11,15 +14,12 @@ import Plans from '../security/plans'
 import telemetryTrack from '../segment/telemetryTrack'
 import { IServiceOptions } from './IServiceOptions'
 import { enrichOrganization } from './helpers/enrichment'
-import { getSearchSyncWorkerEmitter } from '@/serverless/utils/serviceSQS'
 import merge from './helpers/merge'
 import {
   keepPrimary,
   keepPrimaryIfExists,
   mergeUniqueStringArrayItems,
 } from './helpers/mergeFunctions'
-import { IRepositoryOptions } from '@/database/repositories/IRepositoryOptions'
-import getObjectWithoutKey from '@/utils/getObjectWithoutKey'
 
 export default class OrganizationService extends LoggerBase {
   options: IServiceOptions
@@ -63,9 +63,9 @@ export default class OrganizationService extends LoggerBase {
         }
       }
 
-      tx = await SequelizeRepository.createTransaction(this.options)
-      const repoOptions: IRepositoryOptions = { ...this.options }
-      repoOptions.transaction = tx
+      const repoOptions: IRepositoryOptions =
+        await SequelizeRepository.createTransactionalRepositoryOptions(this.options)
+      tx = repoOptions.transaction
 
       const allIdentities = await OrganizationRepository.getIdentities(
         [originalId, toMergeId],
@@ -489,16 +489,17 @@ export default class OrganizationService extends LoggerBase {
     return OrganizationRepository.findOrganizationsWithMergeSuggestions(args, this.options)
   }
 
-  async update(id, data, passedTransaction?) {
-    const transaction =
-      passedTransaction || (await SequelizeRepository.createTransaction(this.options))
+  async update(id, data) {
+    let tx
 
     try {
+      const repoOptions = await SequelizeRepository.createTransactionalRepositoryOptions(
+        this.options,
+      )
+      tx = repoOptions.transaction
+
       if (data.members) {
-        data.members = await MemberRepository.filterIdsInTenant(data.members, {
-          ...this.options,
-          transaction,
-        })
+        data.members = await MemberRepository.filterIdsInTenant(data.members, repoOptions)
       }
 
       // Normalize the website URL if it exists
@@ -510,7 +511,7 @@ export default class OrganizationService extends LoggerBase {
         const originalIdentities = data.identities
 
         // check identities
-        await OrganizationRepository.checkIdentities(data, { ...this.options, transaction }, id)
+        await OrganizationRepository.checkIdentities(data, repoOptions, id)
 
         // if we found any strong identities sent already existing in another organization
         // instead of making it a weak identity we throw an error here, because this function
@@ -530,21 +531,27 @@ export default class OrganizationService extends LoggerBase {
         }
       }
 
-      const record = await OrganizationRepository.update(id, data, {
-        ...this.options,
-        transaction,
-      })
+      const record = await OrganizationRepository.update(id, data, repoOptions)
 
-      if (!passedTransaction) {
-        await SequelizeRepository.commitTransaction(transaction)
+      await SequelizeRepository.commitTransaction(tx)
+
+      try {
+        // TODO replace with synchroneous call
+        const searchSyncEmitter = await getSearchSyncWorkerEmitter()
+        await searchSyncEmitter.triggerOrganizationSync(this.options.currentTenant.id, record.id)
+      } catch (emitErr) {
+        this.log.error(
+          emitErr,
+          { tenantId: this.options.currentTenant.id, organizationId: record.id },
+          'Error while emitting organization sync!',
+        )
       }
-
-      const searchSyncEmitter = await getSearchSyncWorkerEmitter()
-      await searchSyncEmitter.triggerOrganizationSync(this.options.currentTenant.id, record.id)
 
       return record
     } catch (error) {
-      await SequelizeRepository.rollbackTransaction(transaction)
+      if (tx) {
+        await SequelizeRepository.rollbackTransaction(tx)
+      }
 
       SequelizeRepository.handleUniqueFieldError(error, this.options.language, 'organization')
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d24700</samp>

This pull request refactors the transaction handling in several database repository classes and service classes. It simplifies the code by passing the transaction object as part of the options parameter and using a helper method to create consistent repository options. It also improves the error handling and logging of some methods and fixes some minor code style and formatting issues.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d24700</samp>

> _Sing, O Muse, of the skillful refactorings_
> _That the wise developers wrought with their code_
> _To simplify transactions and queries_
> _In the repositories and services of old._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d24700</samp>

*  Refactor transaction handling in repository and service classes by using repository options instead of transaction parameters ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-987f06572bad79c47ef62d518a7a4e419dda775d942d365da55dc5509acf5291R293-R294), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-987f06572bad79c47ef62d518a7a4e419dda775d942d365da55dc5509acf5291R305), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL138-R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL695), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL712-R709), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3254-R3249), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3276), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL3302-R3293), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL657-R657), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR680-R681), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR698), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL2005-R2007), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-7387b5a28fca07f0f76d29f0d2396975b092f55cb9e74a37110b19821d775a9fR156-R157), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-7387b5a28fca07f0f76d29f0d2396975b092f55cb9e74a37110b19821d775a9fR168), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL564-R566), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL629-R646), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL833-R867), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL860-R878), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL900-R919), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L66-R68), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L492-R502), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L513-R514), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L533-R554))
* Add a new static method `createTransactionalRepositoryOptions` in `SequelizeRepository` to simplify transaction creation and return a repository options instance with the transaction included ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-9db36b6ff29d8472a654666df43dcbe269272d189dac126447c3ffa8751f7d87R99-R112))
* Add type annotation for the options parameter in `createTransaction` method in `SequelizeRepository` for better type checking and documentation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-9db36b6ff29d8472a654666df43dcbe269272d189dac126447c3ffa8751f7d87L84-R84))
* Add `MemberRepository` and `OrganizationRepository` prefixes to some static method calls for consistency and clarity ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL1022-R1015), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL758-R758))
* Remove unused imports and reorder some imports in `OrganizationService` for code formatting, readability, and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L1-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L21-L22))
* Add try-catch blocks around some calls to `triggerMemberSync`, `triggerRemoveMember`, and `triggerOrganizationSync` to improve error handling and logging in `MemberService` and `OrganizationService` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL900-R919), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL924-R940), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L533-R554))
* Add checks for the existence of the transaction before rolling it back in `MemberService` and `OrganizationService` to prevent errors if the transaction was not created successfully ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eL924-R940), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L533-R554))
* Remove some empty lines in `merge` method in `MemberService` for code formatting and readability ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eR572), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1673/files?diff=unified&w=0#diff-b3bd810e62d7a283a7a0e50043fe8b8297e449538c2a1ff0077b00c69e0e1f3eR620))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screehshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
