### PR TITLE
Increase requests to 10 in GitHub rate limiter

### DIFF
--- a/services/libs/integrations/src/integrations/github/processStream.ts
+++ b/services/libs/integrations/src/integrations/github/processStream.ts
@@ -71,7 +71,7 @@ export function getConcurrentRequestLimiter(
 ): IConcurrentRequestLimiter {
   if (concurrentRequestLimiter === undefined) {
     concurrentRequestLimiter = ctx.getConcurrentRequestLimiter(
-      7, // max 10 concurrent requests
+      10, // max 10 concurrent requests
       'github-concurrent-request-limiter',
     )
   }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e836077</samp>

Fixed a rate limit bug in the GitHub integration by adjusting the concurrent request limit in `processStream.ts`. This change improves the reliability and performance of the integration.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e836077</samp>

> _`getConcurrentRequestLimiter`_
> _Fixed bug with rate limit_
> _Autumn leaves fall gently_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e836077</samp>

* Fix bug that caused requests to be rejected due to rate limit by using correct value of 10 for concurrent requests to the GitHub API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1683/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L74-R74))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
