### PR TITLE
Fix custom identity display for organizations

### DIFF
--- a/frontend/src/modules/organization/components/view/organization-view-aside.vue
+++ b/frontend/src/modules/organization/components/view/organization-view-aside.vue
@@ -18,9 +18,10 @@
             rel="noopener noreferrer"
           >
             <div class="flex gap-3 items-center">
-              <app-platform :platform="identity.platform" custom-platform-icon-class="ri-community-fill" />
+              <app-platform :show-tooltip="true" :platform="identity.platform" custom-platform-icon-class="ri-community-fill" />
               <span class="text-gray-900 text-xs">
                 {{ getPlatformDetails(identity.platform)?.organization.handle(identity)
+                  ?? identity.name
                   ?? getPlatformDetails(identity.platform)?.name
                   ?? identity.platform }}</span>
             </div>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e70ac1</samp>

Improved the UI and UX of the `app-platform` component in the organization view. Added tooltips for platform icons and better fallback logic for identity names.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5e70ac1</samp>

> _Hover `app-platform`_
> _Tooltip reveals its name_
> _Fall leaves identity_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5e70ac1</samp>

* Show a tooltip with the platform name on hover for the `app-platform` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1687/files?diff=unified&w=0#diff-942ccbb5107365c60f397703c34cd6e88ff940f248e80350639452dc882f2103L21-R24))
* Use the identity name as a fallback if the platform does not provide a handle for the `app-platform` component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1687/files?diff=unified&w=0#diff-942ccbb5107365c60f397703c34cd6e88ff940f248e80350639452dc882f2103L21-R24))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
