### PR TITLE
Fix devto validation blocking onboarding

### DIFF
--- a/frontend/src/integrations/devto/components/devto-connect-drawer.vue
+++ b/frontend/src/integrations/devto/components/devto-connect-drawer.vue
@@ -454,7 +454,7 @@ const rules = {
 
 const $externalResults = ref({});
 
-const $v = useVuelidate(rules, form, { $externalResults });
+const $v = useVuelidate(rules, form, { $externalResults, $stopPropagation: true });
 
 watch(
   () => props.integration,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06d9cf6</samp>

Added `$stopPropagation` option to `useVuelidate` hook in `devto-connect-drawer.vue` to handle optional nested object validation. This allows users to connect to Dev.to without affecting the validation of the rest of the form.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 06d9cf6</samp>

> _`useVuelidate` hook_
> _adds `$stopPropagation`_
> _snowflakes are unique_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06d9cf6</samp>

*  Add `$stopPropagation` option to `useVuelidate` hook to prevent nested object validation from affecting parent object validation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1688/files?diff=unified&w=0#diff-29177a6b05b402fa38f9810dec54c27d2766c2c923b6cc66de32e647863366cfL457-R457))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
