### PR TITLE
Fix joined on custom platform

### DIFF
--- a/frontend/src/modules/dashboard/components/dashboard-members.vue
+++ b/frontend/src/modules/dashboard/components/dashboard-members.vue
@@ -68,17 +68,13 @@
               <span
                 v-if="
                   member.lastActivity
-                    && getPlatformDetails(
-                      member.lastActivity.platform,
-                    )
                 "
               >joined
                 {{ formatDateToTimeAgo(member.joinedAt) }}
                 on
                 {{
-                  getPlatformDetails(
-                    member.lastActivity.platform,
-                  ).name
+                  getPlatformDetails(member.lastActivity.platform)?.name
+                    ?? member.lastActivity.platform
                 }}</span>
             </app-dashboard-member-item>
             <app-dashboard-empty-state


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b34bfc8</samp>

Simplify and fix platform display logic for dashboard members. The file `dashboard-members.vue` is updated to handle null values and remove an extra condition for showing the last activity platform of dashboard members.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b34bfc8</samp>

> _`getPlatformDetails`_
> _Simpler and more robust now_
> _Autumn bugs swept away_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b34bfc8</samp>

*  Simplify and fix the logic for displaying the member's last activity platform in the dashboard ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1689/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L71-L73), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1689/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L79-R77))
  * Remove the unnecessary condition that checks if the platform is valid in `frontend/src/modules/dashboard/components/dashboard-members.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1689/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L71-L73))
  * Add optional chaining and nullish coalescing operators to the platform name expression in the same file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1689/files?diff=unified&w=0#diff-f0de975e9d85183718c27eec6fd5941784b7962529724410d40ecd316e1b0cb2L79-R77))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
