### PR TITLE
Data sink performance

### DIFF
--- a/services/apps/data_sink_worker/src/bin/process-results.ts
+++ b/services/apps/data_sink_worker/src/bin/process-results.ts
@@ -1,4 +1,4 @@
-import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
+import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG, SENTIMENT_CONFIG } from '../conf'
 import DataSinkRepository from '../repo/dataSink.repo'
 import DataSinkService from '../service/dataSink.service'
 import { DbStore, getDbConnection } from '@crowd/database'
@@ -6,6 +6,7 @@ import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import { NodejsWorkerEmitter, SearchSyncWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import { initializeSentimentAnalysis } from '@crowd/sentiment'
 
 const tracer = getServiceTracer()
 const log = getServiceLogger()
@@ -23,8 +24,12 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
   const redisClient = await getRedisClient(REDIS_CONFIG())
 
+  initializeSentimentAnalysis(SENTIMENT_CONFIG())
+
   const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, tracer, log)
+  await nodejsWorkerEmitter.init()
   const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
+  await searchSyncWorkerEmitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())
   const store = new DbStore(log, dbConnection)

--- a/services/apps/data_sink_worker/src/repo/organization.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/organization.repo.ts
@@ -458,6 +458,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
         table: 'organizations',
       },
     })
+    const updatedAt = new Date()
     const prepared = RepositoryBase.prepare(
       {
         ...data,
@@ -465,17 +466,18 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
           data?.weakIdentities?.length > 0 && {
             weakIdentities: JSON.stringify(data.weakIdentities),
           }),
-        updatedAt: new Date(),
+        updatedAt,
       },
       dynamicColumnSet,
     )
 
     const query = this.dbInstance.helpers.update(prepared, dynamicColumnSet)
-    const condition = this.format('where id = $(id)', { id })
+    const condition = this.format('where id = $(id) and "updatedAt" < $(updatedAt)', {
+      id,
+      updatedAt,
+    })
 
-    const result = await this.db().result(`${query} ${condition}`)
-
-    this.checkUpdateRowCount(result.rowCount, 1)
+    await this.db().result(`${query} ${condition}`)
   }
 
   public async addIdentity(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5265fa0</samp>

This pull request adds concurrency control to the `update` methods of the `MemberRepository` and `OrganizationRepository` classes in the `data_sink_worker` service. This ensures that the `member` and `organization` tables are updated consistently and avoid conflicts when multiple workers process data from different sources.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5265fa0</samp>

> _Oh we are the coders of the sea_
> _And we update our tables carefully_
> _We use `updatedAt` to avoid a mess_
> _And we check the conditions for success_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5265fa0</samp>

*  Add and use `updatedAt` variable to perform conditional updates on `member` and `organization` tables ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-b29056484026f565bb0ebf009aa7f93a9dbf0dc63b4594efb97e7af8f9ecdf45R155-R156), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-b29056484026f565bb0ebf009aa7f93a9dbf0dc63b4594efb97e7af8f9ecdf45L162-R164), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-b29056484026f565bb0ebf009aa7f93a9dbf0dc63b4594efb97e7af8f9ecdf45L168-R178), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853R459), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L466-R467), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1690/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853L472-R478))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
