### PR TITLE
await tracing

### DIFF
--- a/backend/src/bin/discord-ws.ts
+++ b/backend/src/bin/discord-ws.ts
@@ -58,7 +58,7 @@ async function spawnClient(
 
     logger.info({ payload }, 'Processing Discord WS Message!')
 
-    tracer.startActiveSpan('ProcessDiscordWSMessage', async (span) => {
+    await tracer.startActiveSpan('ProcessDiscordWSMessage', async (span) => {
       try {
         const integration = (await IntegrationRepository.findByIdentifier(
           guildId,

--- a/backend/src/bin/job-generator.ts
+++ b/backend/src/bin/job-generator.ts
@@ -10,7 +10,7 @@ for (const job of jobs) {
   const cronJob = new CronJob(
     job.cronTime,
     async () => {
-      tracer.startActiveSpan(`ProcessingJob:${job.name}`, async (span) => {
+      await tracer.startActiveSpan(`ProcessingJob:${job.name}`, async (span) => {
         log.info({ job: job.name }, 'Triggering job.')
         try {
           await job.onTrigger(log)

--- a/backend/src/bin/nodejs-worker.ts
+++ b/backend/src/bin/nodejs-worker.ts
@@ -57,7 +57,7 @@ async function handleDelayedMessages() {
     const message = await receive(true)
 
     if (message) {
-      tracer.startActiveSpan('ProcessDelayedMessage', async (span) => {
+      await tracer.startActiveSpan('ProcessDelayedMessage', async (span) => {
         try {
           const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
           const messageLogger = getChildLogger('messageHandler', serviceLogger, {
@@ -130,7 +130,7 @@ async function handleMessages() {
   handlerLogger.info('Listening for messages!')
 
   const processSingleMessage = async (message: Message): Promise<void> => {
-    tracer.startActiveSpan('ProcessMessage', async (span) => {
+    await tracer.startActiveSpan('ProcessMessage', async (span) => {
       const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
 
       const messageLogger = getChildLogger('messageHandler', serviceLogger, {

--- a/services/apps/data_sink_worker/src/queue/index.ts
+++ b/services/apps/data_sink_worker/src/queue/index.ts
@@ -32,7 +32,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 

--- a/services/apps/integration_data_worker/src/queue/index.ts
+++ b/services/apps/integration_data_worker/src/queue/index.ts
@@ -37,7 +37,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 

--- a/services/apps/integration_run_worker/src/queue/index.ts
+++ b/services/apps/integration_run_worker/src/queue/index.ts
@@ -40,7 +40,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 

--- a/services/apps/integration_stream_worker/src/queue/index.ts
+++ b/services/apps/integration_stream_worker/src/queue/index.ts
@@ -41,7 +41,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   override async processMessage(message: IQueueMessage, receiptHandle: string): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 

--- a/services/apps/integration_sync_worker/src/queue/index.ts
+++ b/services/apps/integration_sync_worker/src/queue/index.ts
@@ -43,7 +43,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   protected override async processMessage<T extends IQueueMessage>(message: T): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 

--- a/services/apps/search_sync_worker/src/queue/index.ts
+++ b/services/apps/search_sync_worker/src/queue/index.ts
@@ -108,7 +108,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   protected override async processMessage<T extends IQueueMessage>(message: T): Promise<void> {
-    this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
+    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
       try {
         this.log.trace({ messageType: message.type }, 'Processing message!')
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b916418</samp>

This pull request adds `await` keywords to the `this.tracer.startActiveSpan` method calls in the `processMessage` methods of the `WorkerQueueReceiver` classes in six different queue worker services. This fixes a bug where the spans were not properly closed and improves the tracing and logging of the queue workers.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b916418</samp>

> _`await` the span start_
> _tracing and logging workers_
> _autumn of refactor_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b916418</samp>

*  Add `await` keyword to `this.tracer.startActiveSpan` method call in `processMessage` method of `WorkerQueueReceiver` class in various queue workers to ensure asynchronous span operation completion ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dL35-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-12277011f40d74fd8e45c251022d6be74ee2d21600f9260395c1a478d3d10725L40-R40), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-09fa9a54fb9676e07d6450b24fecca1681f548aa0f07f167073e7350c98c98a7L43-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-673b87023293fc6c2f0d8403dd663ebefdbddccd4a63b313c2969ff63b141961L44-R44), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-d49612644b31d82fe8a429141517942c345668bc98a3606af53cf92e005fc7b9L46-R46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1693/files?diff=unified&w=0#diff-647479fd14d24e37603d47d52ff868bde71fb62fc5a15f7cc3fb04760da1bfafL111-R111))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
