### PR TITLE
Pagination and total_count improvements in organization merge suggestions

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1518,29 +1518,49 @@ class OrganizationRepository {
     const segmentIds = SequelizeRepository.getSegmentIds(options)
 
     const orgs = await options.database.sequelize.query(
-      `SELECT 
-      "organizationsToMerge".id, 
-      "organizationsToMerge"."toMergeId",
-      "organizationsToMerge"."total_count",
-      "organizationsToMerge"."similarity"
-    FROM 
-    (
-      SELECT DISTINCT ON (Greatest(Hashtext(Concat(org.id, otm."toMergeId")), Hashtext(Concat(otm."toMergeId", org.id)))) 
-          org.id, 
-          otm."toMergeId", 
-          org."createdAt", 
-          COUNT(*) OVER() AS total_count,
+      `WITH
+      cte AS (
+        SELECT
+          Greatest(Hashtext(Concat(org.id, otm."toMergeId")), Hashtext(Concat(otm."toMergeId", org.id))) as hash,
+          org.id,
+          otm."toMergeId",
+          org."createdAt",
           otm."similarity"
         FROM organizations org
-        INNER JOIN "organizationToMerge" otm ON org.id = otm."organizationId"
+        JOIN "organizationToMerge" otm ON org.id = otm."organizationId"
         JOIN "organizationSegments" os ON os."organizationId" = org.id
+        JOIN "organizationSegments" to_merge_segments on to_merge_segments."organizationId" = otm."toMergeId"
         WHERE org."tenantId" = :tenantId
           AND os."segmentId" IN (:segmentIds)
-        ORDER BY Greatest(Hashtext(Concat(org.id, otm."toMergeId")), Hashtext(Concat(otm."toMergeId", org.id))), org.id
-      ) AS "organizationsToMerge" 
-    ORDER BY 
-      "organizationsToMerge"."similarity" DESC, "organizationsToMerge".id 
-    LIMIT :limit OFFSET :offset
+          AND to_merge_segments."segmentId" IN (:segmentIds)
+      ),
+      
+      count_cte AS (
+        SELECT COUNT(DISTINCT hash) AS total_count
+        FROM cte
+      ),
+      
+      final_select AS (
+        SELECT DISTINCT ON (hash)
+          id,
+          "toMergeId",
+          "createdAt",
+          "similarity"
+        FROM cte
+        ORDER BY hash, id
+      )
+      
+      SELECT
+        "organizationsToMerge".id,
+        "organizationsToMerge"."toMergeId",
+        count_cte."total_count",
+        "organizationsToMerge"."similarity"
+      FROM
+        final_select AS "organizationsToMerge",
+        count_cte
+      ORDER BY
+        "organizationsToMerge"."similarity" DESC, "organizationsToMerge".id
+      LIMIT :limit OFFSET :offset
     `,
       {
         replacements: {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0eb3fc6</samp>

Rewrote and improved the SQL query to fetch the organizations to merge in `organizationRepository.ts`. The query now filters, counts, and orders the results more efficiently and correctly.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0eb3fc6</samp>

> _`CTEs` improve_
> _SQL query for merging_
> _Organizations_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0eb3fc6</samp>

*  Rewrite SQL query to fetch organizations to merge using CTEs, filters, count, and order by hash ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1701/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1521-R1563))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
