### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ copilot:walkthrough
 
 ## Checklist ✅
 - [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
-- [ ] Add screehshots to the PR description for relevant FE changes
+- [ ] Add screenshots to the PR description for relevant FE changes
 - [ ] New backend functionality has been unit-tested.
 - [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
 - [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.


### PR DESCRIPTION
Fixes #1710 
`screehshot` has been fixed to `screenshot`
### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2ad13b</samp>

Fixed a typo in the PR template file `.github/PULL_REQUEST_TEMPLATE.md`. This change ensures that PR authors spell `screenshots` correctly when adding them to their PR descriptions.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c2ad13b</samp>

> _`screehshots` no more_
> _A typo fixed in the template_
> _Winter of errors_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2ad13b</samp>

* Fix typo in PR template checklist item for screenshots ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1711/files?diff=unified&w=0#diff-18813c86948efc57e661623d7ba48ff94325c9b5421ec9177f724922dd553a35L16-R16))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
