### PR TITLE
Configure timeouts for postgres connections in api

### DIFF
--- a/backend/src/database/models/index.ts
+++ b/backend/src/database/models/index.ts
@@ -58,6 +58,9 @@ function models() {
       dialect: DB_CONFIG.dialect,
       dialectOptions: {
         application_name: SERVICE,
+        connectionTimeoutMillis: 5000,
+        query_timeout: 30000,
+        idle_in_transaction_session_timeout: 10000,
       },
       port: DB_CONFIG.port,
       replication: {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dcc16d4</samp>

Added timeout settings to the database connection pool in `backend/src/database/models/index.ts` to prevent database hang-ups. The settings follow the `pg` module's best practices for PostgreSQL.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at dcc16d4</samp>

> _`pg` pool config_
> _Avoid database hang-ups_
> _Winter's frozen grip_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dcc16d4</samp>

*  Add timeout settings to database connection pool ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1713/files?diff=unified&w=0#diff-9ce5e52d0b259da42e2d77e9dbc11a9bbd7b38df687b9b50abe436fe15d5d734R61-R63))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
