### PR TITLE
Batch activity updates while merging organizations

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1139,8 +1139,9 @@ class OrganizationRepository {
     let updatedRowsCount = 0
 
     do {
-
-      options.log.info(`[Move Activities] - Moving ${batchSize} activities from ${fromOrganizationId} to ${toOrganizationId}.`)
+      options.log.info(
+        `[Move Activities] - Moving ${batchSize} activities from ${fromOrganizationId} to ${toOrganizationId}.`,
+      )
 
       const query = `
         UPDATE "activities" 

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1162,7 +1162,7 @@ class OrganizationRepository {
         transaction,
       })
 
-      updatedRowsCount = rowCount ?? 0  
+      updatedRowsCount = rowCount ?? 0
     } while (updatedRowsCount === batchSize)
   }
 

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1139,6 +1139,9 @@ class OrganizationRepository {
     let updatedRowsCount = 0
 
     do {
+
+      options.log.info(`[Move Activities] - Moving ${batchSize} activities from ${fromOrganizationId} to ${toOrganizationId}.`)
+
       const query = `
         UPDATE "activities" 
         SET "organizationId" = :newOrganizationId

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1130,31 +1130,40 @@ class OrganizationRepository {
     fromOrganizationId: string,
     toOrganizationId: string,
     options: IRepositoryOptions,
+    batchSize = 10000,
   ): Promise<void> {
     const transaction = SequelizeRepository.getTransaction(options)
-
     const seq = SequelizeRepository.getSequelize(options)
-
     const tenant = SequelizeRepository.getCurrentTenant(options)
 
-    const query = `
-      update "activities" 
-      set 
-        "organizationId" = :newOrganizationId
-      where 
-        "tenantId" = :tenantId and 
-        "organizationId" = :oldOrganizationId 
-    `
+    let updatedRowsCount = 0
 
-    await seq.query(query, {
-      replacements: {
-        tenantId: tenant.id,
-        oldOrganizationId: fromOrganizationId,
-        newOrganizationId: toOrganizationId,
-      },
-      type: QueryTypes.UPDATE,
-      transaction,
-    })
+    do {
+      const query = `
+        UPDATE "activities" 
+        SET "organizationId" = :newOrganizationId
+        WHERE id IN (
+          SELECT id 
+          FROM "activities" 
+          WHERE "tenantId" = :tenantId 
+            AND "organizationId" = :oldOrganizationId
+          LIMIT :limit
+        )
+      `
+
+      const [, rowCount] = await seq.query(query, {
+        replacements: {
+          tenantId: tenant.id,
+          oldOrganizationId: fromOrganizationId,
+          newOrganizationId: toOrganizationId,
+          limit: batchSize,
+        },
+        type: QueryTypes.UPDATE,
+        transaction,
+      })
+
+      updatedRowsCount = rowCount ?? 0  
+    } while (updatedRowsCount === batchSize)
   }
 
   static async *getMergeSuggestions(

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1140,7 +1140,7 @@ class OrganizationRepository {
 
     do {
       options.log.info(
-        `[Move Activities] - Moving ${batchSize} activities from ${fromOrganizationId} to ${toOrganizationId}.`,
+        `[Move Activities] - Moving maximum of ${batchSize} activities from ${fromOrganizationId} to ${toOrganizationId}.`,
       )
 
       const query = `


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 555b22c</samp>

Improved the performance of `updateOrganizationInActivities` method in `organizationRepository.ts` by using a batch update strategy. This method is used to migrate activities when an organization is merged or deleted.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 555b22c</samp>

> _`updateOrganization`_
> _Batch strategy for speed_
> _Autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 555b22c</samp>

* Improve performance and avoid locking issues when updating activities for organization migration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1714/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1133-R1166))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
