### PR TITLE
Things that improved LF performance

### DIFF
--- a/backend/src/database/migrations/R__cubejs-materialized-views.sql
+++ b/backend/src/database/migrations/R__cubejs-materialized-views.sql
@@ -29,8 +29,12 @@ SELECT
         WHEN (a.sentiment->>'sentiment')::integer < 34 THEN 'negative'
         WHEN (a.sentiment->>'sentiment')::integer > 66 THEN 'positive'
         ELSE 'neutral'
-    END::VARCHAR(8) AS "sentimentMood"
+    END::VARCHAR(8) AS "sentimentMood",
+    a."organizationId",
+    a."segmentId",
+    a."conversationId"
 FROM activities a
+WHERE a."deletedAt" IS NULL
 ;
 
 DROP MATERIALIZED VIEW IF EXISTS mv_organizations_cube;
@@ -57,6 +61,7 @@ FROM segments
 
 CREATE INDEX IF NOT EXISTS mv_members_cube_tenant ON mv_members_cube ("tenantId");
 CREATE INDEX IF NOT EXISTS mv_activities_cube_timestamp ON mv_activities_cube (timestamp);
+CREATE INDEX IF NOT EXISTS mv_activities_cube_org_id ON mv_activities_cube ("organizationId");
 
 CREATE UNIQUE INDEX IF NOT EXISTS mv_members_cube_id ON mv_members_cube (id);
 CREATE UNIQUE INDEX IF NOT EXISTS mv_activities_cube_id ON mv_activities_cube (id);

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -132,7 +132,7 @@ async function createActivitiesForMembers(memberIds: string[], organizationId: s
           neutral: 0.02,
           mixed: 0.0,
           label: 'positive',
-          sentiment: 0.98,
+          sentiment: 98,
         },
         isContribution: true,
         username: 'test',
@@ -256,6 +256,9 @@ describe('OrganizationRepository tests', () => {
         mockIRepositoryOptions,
       )
       await createActivitiesForMembers(memberIds, organizationCreated.id, mockIRepositoryOptions)
+      await mockIRepositoryOptions.database.sequelize.query(
+        'REFRESH MATERIALIZED VIEW mv_activities_cube',
+      )
 
       organizationCreated = await OrganizationRepository.findById(
         organizationCreated.id,

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -3142,6 +3142,7 @@ class MemberRepository {
 
     output.activities = await record.getActivities({
       order: [['timestamp', 'DESC']],
+      limit: 20,
       transaction,
     })
 

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -2029,17 +2029,12 @@ class OrganizationRepository {
             count(distinct a."memberId")                                                        as "memberCount",
             count(distinct a.id)                                                        as "activityCount",
             case
-                when array_agg(distinct a.platform) = array [null] then array []::text[]
-                else array_agg(distinct a.platform) end                                 as "activeOn",
+                when array_agg(distinct a.platform::TEXT) = array [null] then array []::text[]
+                else array_agg(distinct a.platform::TEXT) end                                 as "activeOn",
             max(a.timestamp)                                                            as "lastActive",
             min(a.timestamp) filter ( where a.timestamp <> '1970-01-01T00:00:00.000Z' ) as "joinedAt"
           from leaf_segment_ids ls
-          join activities a
-                    on a."segmentId" = ls.id and a."organizationId" = :id and
-                      a."deletedAt" is null
-          join "organizationSegments" os on a."segmentId" = os."segmentId" and os."organizationId" = :id
-          join members m on a."memberId" = m.id and m."deletedAt" is null
-          join "memberOrganizations" mo on m.id = mo."memberId" and mo."organizationId" = :id and mo."dateEnd" is null
+          join mv_activities_cube a on a."segmentId" = ls.id and a."organizationId" = :id
           group by a."organizationId"
         ),
         organization_segments as (

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1972,90 +1972,104 @@ class OrganizationRepository {
     }
 
     // query for all leaf segment ids
-    let segmentsSubQuery = `
-    select id
-    from segments
-    where "tenantId" = :tenantId and "parentSlug" is not null and "grandparentSlug" is not null
+    let extraCTEs = `
+      leaf_segment_ids AS (
+        select id
+        from segments
+        where "tenantId" = :tenantId and "parentSlug" is not null and "grandparentSlug" is not null
+      ),
     `
 
     if (segmentId) {
       // we load data for a specific segment (can be leaf, parent or grand parent id)
       replacements.segmentId = segmentId
-      segmentsSubQuery = `
-      with input_segment as (select id,
-                                    slug,
-                                    "parentSlug",
-                                    "grandparentSlug"
-                            from segments
-                            where id = :segmentId
-                              and "tenantId" = :tenantId),
-                            segment_level as (select case
-                                        when "parentSlug" is not null and "grandparentSlug" is not null
-                                            then 'child'
-                                        when "parentSlug" is not null and "grandparentSlug" is null
-                                            then 'parent'
-                                        when "parentSlug" is null and "grandparentSlug" is null
-                                            then 'grandparent'
-                                        end as level,
-                                    id,
-                                    slug,
-                                    "parentSlug",
-                                    "grandparentSlug"
-                            from input_segment)
-                            select s.id
-                            from segments s
-                            join
-                            segment_level sl
-                            on
-                            (sl.level = 'child' and s.id = sl.id) or
-                            (sl.level = 'parent' and s."parentSlug" = sl.slug and s."grandparentSlug" is not null) or
-                            (sl.level = 'grandparent' and s."grandparentSlug" = sl.slug)`
+      extraCTEs = `
+        input_segment AS (
+          select
+            id,
+            slug,
+            "parentSlug",
+            "grandparentSlug"
+          from segments
+          where id = :segmentId
+            and "tenantId" = :tenantId
+        ),
+        segment_level AS (
+          select
+            case
+              when "parentSlug" is not null and "grandparentSlug" is not null
+                  then 'child'
+              when "parentSlug" is not null and "grandparentSlug" is null
+                  then 'parent'
+              when "parentSlug" is null and "grandparentSlug" is null
+                  then 'grandparent'
+              end as level,
+            id,
+            slug,
+            "parentSlug",
+            "grandparentSlug"
+          from input_segment
+        ),
+        leaf_segment_ids AS (
+          select s.id
+          from segments s
+          join segment_level sl on (sl.level = 'child' and s.id = sl.id)
+              or (sl.level = 'parent' and s."parentSlug" = sl.slug and s."grandparentSlug" is not null)
+              or (sl.level = 'grandparent' and s."grandparentSlug" = sl.slug)
+        ),
+      `
     }
 
     const query = `
-    with leaf_segment_ids as (${segmentsSubQuery}),
-    member_data as (select a."organizationId",
-        count(distinct a."memberId")                                                        as "memberCount",
-        count(distinct a.id)                                                        as "activityCount",
-        case
-            when array_agg(distinct a.platform) = array [null] then array []::text[]
-            else array_agg(distinct a.platform) end                                 as "activeOn",
-        max(a.timestamp)                                                            as "lastActive",
-        min(a.timestamp) filter ( where a.timestamp <> '1970-01-01T00:00:00.000Z' ) as "joinedAt"
-    from leaf_segment_ids ls
+      WITH
+        ${extraCTEs}
+        member_data AS (
+          select
+            a."organizationId",
+            count(distinct a."memberId")                                                        as "memberCount",
+            count(distinct a.id)                                                        as "activityCount",
+            case
+                when array_agg(distinct a.platform) = array [null] then array []::text[]
+                else array_agg(distinct a.platform) end                                 as "activeOn",
+            max(a.timestamp)                                                            as "lastActive",
+            min(a.timestamp) filter ( where a.timestamp <> '1970-01-01T00:00:00.000Z' ) as "joinedAt"
+          from leaf_segment_ids ls
           join activities a
                     on a."segmentId" = ls.id and a."organizationId" = :id and
                       a."deletedAt" is null
           join "organizationSegments" os on a."segmentId" = os."segmentId" and os."organizationId" = :id
           join members m on a."memberId" = m.id and m."deletedAt" is null
           join "memberOrganizations" mo on m.id = mo."memberId" and mo."organizationId" = :id and mo."dateEnd" is null
-    group by a."organizationId"),
-    organization_segments as (select "organizationId", array_agg("segmentId") as "segments"
+          group by a."organizationId"
+        ),
+        organization_segments as (
+          select "organizationId", array_agg("segmentId") as "segments"
           from "organizationSegments"
           where "organizationId" = :id
-          group by "organizationId"),
-    identities as (
-      SELECT oi."organizationId", jsonb_agg(oi) AS "identities"
-      FROM "organizationIdentities" oi
-      WHERE oi."organizationId" = :id
-      GROUP BY "organizationId"
-    )
-    select 
-      o.*,
-      coalesce(md."activityCount", 0)::integer as "activityCount",
-      coalesce(md."memberCount", 0)::integer   as "memberCount",
-      coalesce(md."activeOn", '{}')            as "activeOn",
-      coalesce(i.identities, '{}')            as identities,
-      coalesce(os.segments, '{}')              as segments,
-      md."lastActive",
-      md."joinedAt"
-    from organizations o
-    left join member_data md on md."organizationId" = o.id
-    left join organization_segments os on os."organizationId" = o.id
-    left join identities i on i."organizationId" = o.id
-    where o.id = :id
-    and o."tenantId" = :tenantId;
-`
+          group by "organizationId"
+        ),
+        identities as (
+          SELECT oi."organizationId", jsonb_agg(oi) AS "identities"
+          FROM "organizationIdentities" oi
+          WHERE oi."organizationId" = :id
+          GROUP BY "organizationId"
+        )
+        select
+          o.*,
+          coalesce(md."activityCount", 0)::integer as "activityCount",
+          coalesce(md."memberCount", 0)::integer   as "memberCount",
+          coalesce(md."activeOn", '{}')            as "activeOn",
+          coalesce(i.identities, '{}')            as identities,
+          coalesce(os.segments, '{}')              as segments,
+          md."lastActive",
+          md."joinedAt"
+        from organizations o
+        left join member_data md on md."organizationId" = o.id
+        left join organization_segments os on os."organizationId" = o.id
+        left join identities i on i."organizationId" = o.id
+        where o.id = :id
+        and o."tenantId" = :tenantId;
+    `
 
     const results = await sequelize.query(query, {
       replacements,

--- a/services/apps/search_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/member.repo.ts
@@ -227,18 +227,6 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
             WHERE mo."memberId" IN ($(ids:csv))
               AND mo."deletedAt" IS NULL
               AND o."deletedAt" IS NULL
-              AND (EXISTS (
-                  SELECT 1
-                  FROM activities a
-                  WHERE a."memberId" = mo."memberId"
-                    AND a."organizationId" = mo."organizationId"
-                    AND a."segmentId" = os."segmentId"
-              ) OR EXISTS (
-                  SELECT 1
-                  FROM members
-                  WHERE id = mo."memberId"
-                    AND "manuallyCreated"
-              ))
             GROUP BY mo."memberId", os."segmentId"
         ),
         identities AS (

--- a/services/apps/search_sync_worker/src/repo/member.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/member.repo.ts
@@ -172,125 +172,145 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
   public async getMemberData(ids: string[]): Promise<IDbMemberSyncData[]> {
     const results = await this.db().any(
       `
-      with to_merge_data as (select mtm."memberId",
-                                      array_agg(distinct mtm."toMergeId"::text) as to_merge_ids
-                              from "memberToMerge" mtm
-                                        inner join members m2 on mtm."toMergeId" = m2.id
-                              where mtm."memberId" in ($(ids:csv))
-                                and m2."deletedAt" is null
-                              group by mtm."memberId"),
-            no_merge_data as (select mnm."memberId",
-                                      array_agg(distinct mnm."noMergeId"::text) as no_merge_ids
-                              from "memberNoMerge" mnm
-                                        inner join members m2 on mnm."noMergeId" = m2.id
-                              where mnm."memberId" in ($(ids:csv))
-                                and m2."deletedAt" is null
-                              group by mnm."memberId"),
-            member_tags as (select mt."memberId",
-                                    json_agg(
-                                            json_build_object(
-                                                    'id', t.id,
-                                                    'name', t.name
-                                                )
-                                        )           as all_tags,
-                                    jsonb_agg(t.id) as all_ids
-                            from "memberTags" mt
-                                      inner join tags t on mt."tagId" = t.id
-                            where mt."memberId" in ($(ids:csv))
-                              and t."deletedAt" is null
-                            group by mt."memberId"),
-            member_organizations as (select mo."memberId",
-                                            os."segmentId",
-                                            json_agg(
-                                                    json_build_object(
-                                                            'id', o.id,
-                                                            'logo', o.logo,
-                                                            'displayName', o."displayName",
-                                                            'memberOrganizations', json_build_object(
-                                                                          'dateStart', mo."dateStart",
-                                                                          'dateEnd', mo."dateEnd",
-                                                                          'title', mo.title
-                                                            )
-                                                        )
-                                                )           as all_organizations,
-                                            jsonb_agg(o.id) as all_ids
-                                      from "memberOrganizations" mo
-                                              inner join organizations o on mo."organizationId" = o.id
-                                              inner join "organizationSegments" os on o.id = os."organizationId"
-                                      where mo."memberId" in ($(ids:csv))
-                                        and mo."deletedAt" is null
-                                        and o."deletedAt" is null
-                                        and (exists (select 1
-                                          from activities a
-                                          where a."memberId" = mo."memberId"
-                                            and a."organizationId" = mo."organizationId"
-                                            and a."segmentId" = os."segmentId") or
-                                            exists (select 1 from members where id = mo."memberId" and "manuallyCreated"))
-                                      group by mo."memberId", os."segmentId"),
-            identities as (select mi."memberId",
-                                  json_agg(
-                                          json_build_object(
-                                                  'platform', mi.platform,
-                                                  'username', mi.username
-                                              )
-                                      ) as identities
-                            from "memberIdentities" mi
-                            where mi."memberId" in ($(ids:csv))
-                            group by mi."memberId"),
-            activity_data as (select a."memberId",
-                                      a."segmentId",
-                                      count(a.id)                                                          as "activityCount",
-                                      max(a.timestamp)                                                     as "lastActive",
-                                      array_agg(distinct concat(a.platform, ':', a.type))
-                                      filter (where a.platform is not null)                                as "activityTypes",
-                                      array_agg(distinct a.platform) filter (where a.platform is not null) as "activeOn",
-                                      count(distinct a."timestamp"::date)                                  as "activeDaysCount",
-                                      round(avg(
-                                                    case
-                                                        when (a.sentiment ->> 'sentiment'::text) is not null
-                                                            then (a.sentiment ->> 'sentiment'::text)::double precision
-                                                        else null::double precision
-                                                        end)::numeric, 2)                                  as "averageSentiment"
-                              from activities a
-                              where a."memberId" in ($(ids:csv))
-                              group by a."memberId", a."segmentId")
-        select m.id,
-              m."tenantId",
-              ms."segmentId",
-              m."displayName",
-              m.attributes,
-              m.emails,
-              m.score,
-              m."lastEnriched",
-              m."joinedAt",
-              m."manuallyCreated",
-              m."createdAt",
-              (m.reach -> 'total')::integer                      as "totalReach",
-              coalesce(jsonb_array_length(m.contributions), 0)   as "numberOfOpenSourceContributions",
-
-              ad."activeOn",
-              ad."activityCount",
-              ad."activityTypes",
-              ad."activeDaysCount",
-              ad."lastActive",
-              ad."averageSentiment",
-
-              i.identities,
-              coalesce(mo.all_organizations, json_build_array()) as organizations,
-              coalesce(mt.all_tags, json_build_array())          as tags,
-              coalesce(tmd.to_merge_ids, array []::text[])       as "toMergeIds",
-              coalesce(nmd.no_merge_ids, array []::text[])       as "noMergeIds"
-        from "memberSegments" ms
-                inner join members m on ms."memberId" = m.id
-                inner join identities i on m.id = i."memberId"
-                left join activity_data ad on ms."memberId" = ad."memberId" and ms."segmentId" = ad."segmentId"
-                left join to_merge_data tmd on m.id = tmd."memberId"
-                left join no_merge_data nmd on m.id = nmd."memberId"
-                left join member_tags mt on ms."memberId" = mt."memberId"
-                left join member_organizations mo on ms."memberId" = mo."memberId" and ms."segmentId" = mo."segmentId"
-        where ms."memberId" in ($(ids:csv))
-          and m."deletedAt" is null
-          and (ad."memberId" is not null or m."manuallyCreated");`,
+        WITH to_merge_data AS (
+            SELECT
+                mtm."memberId",
+                array_agg(DISTINCT mtm."toMergeId"::text) AS to_merge_ids
+            FROM "memberToMerge" mtm
+            INNER JOIN members m2 ON mtm."toMergeId" = m2.id
+            WHERE mtm."memberId" IN ($(ids:csv))
+              AND m2."deletedAt" IS NULL
+            GROUP BY mtm."memberId"
+        ),
+        no_merge_data AS (
+            SELECT
+                mnm."memberId",
+                array_agg(DISTINCT mnm."noMergeId"::text) AS no_merge_ids
+            FROM "memberNoMerge" mnm
+            INNER JOIN members m2 ON mnm."noMergeId" = m2.id
+            WHERE mnm."memberId" IN ($(ids:csv))
+              AND m2."deletedAt" IS NULL
+            GROUP BY mnm."memberId"
+        ),
+        member_tags AS (
+            SELECT
+                mt."memberId",
+                json_agg(json_build_object(
+                  'id', t.id,
+                  'name', t.name
+                )) AS all_tags,
+                jsonb_agg(t.id) AS all_ids
+            FROM "memberTags" mt
+            INNER JOIN tags t ON mt."tagId" = t.id
+            WHERE mt."memberId" IN ($(ids:csv))
+              AND t."deletedAt" IS NULL
+            GROUP BY mt."memberId"
+        ),
+        member_organizations AS (
+            SELECT
+                mo."memberId",
+                os."segmentId",
+                json_agg(json_build_object(
+                  'id', o.id,
+                  'logo', o.logo,
+                  'displayName', o."displayName",
+                  'memberOrganizations', json_build_object(
+                    'dateStart', mo."dateStart",
+                    'dateEnd', mo."dateEnd",
+                    'title', mo.title
+                  )
+                )) AS all_organizations,
+                jsonb_agg(o.id) AS all_ids
+            FROM "memberOrganizations" mo
+            INNER JOIN organizations o ON mo."organizationId" = o.id
+            INNER JOIN "organizationSegments" os ON o.id = os."organizationId"
+            WHERE mo."memberId" IN ($(ids:csv))
+              AND mo."deletedAt" IS NULL
+              AND o."deletedAt" IS NULL
+              AND (EXISTS (
+                  SELECT 1
+                  FROM activities a
+                  WHERE a."memberId" = mo."memberId"
+                    AND a."organizationId" = mo."organizationId"
+                    AND a."segmentId" = os."segmentId"
+              ) OR EXISTS (
+                  SELECT 1
+                  FROM members
+                  WHERE id = mo."memberId"
+                    AND "manuallyCreated"
+              ))
+            GROUP BY mo."memberId", os."segmentId"
+        ),
+        identities AS (
+            SELECT
+                mi."memberId",
+                json_agg(json_build_object(
+                  'platform', mi.platform,
+                  'username', mi.username
+                )) AS identities
+            FROM "memberIdentities" mi
+            WHERE mi."memberId" IN ($(ids:csv))
+            GROUP BY mi."memberId"
+        ),
+        activity_data AS (
+            SELECT
+                a."memberId",
+                a."segmentId",
+                count(a.id) AS "activityCount",
+                max(a.timestamp) AS "lastActive",
+                array_agg(DISTINCT concat(a.platform, ':', a.type)) FILTER (WHERE a.platform IS NOT NULL) AS "activityTypes",
+                array_agg(DISTINCT a.platform) FILTER (WHERE a.platform IS NOT NULL) AS "activeOn",
+                count(DISTINCT a."timestamp"::date) AS "activeDaysCount",
+                round(avg(
+                    CASE WHEN (a.sentiment ->> 'sentiment'::text) IS NOT NULL THEN
+                        (a.sentiment ->> 'sentiment'::text)::double precision
+                    ELSE
+                        NULL::double precision
+                    END
+                )::numeric, 2) AS "averageSentiment"
+            FROM activities a
+            WHERE a."memberId" IN ($(ids:csv))
+            GROUP BY a."memberId", a."segmentId"
+        )
+        SELECT
+            m.id,
+            m."tenantId",
+            ms."segmentId",
+            m."displayName",
+            m.attributes,
+            m.emails,
+            m.score,
+            m."lastEnriched",
+            m."joinedAt",
+            m."manuallyCreated",
+            m."createdAt",
+            (m.reach -> 'total')::integer AS "totalReach",
+            coalesce(jsonb_array_length(m.contributions), 0) AS "numberOfOpenSourceContributions",
+            ad."activeOn",
+            ad."activityCount",
+            ad."activityTypes",
+            ad."activeDaysCount",
+            ad."lastActive",
+            ad."averageSentiment",
+            i.identities,
+            coalesce(mo.all_organizations, json_build_array()) AS organizations,
+            coalesce(mt.all_tags, json_build_array()) AS tags,
+            coalesce(tmd.to_merge_ids, ARRAY[]::text[]) AS "toMergeIds",
+            coalesce(nmd.no_merge_ids, ARRAY[]::text[]) AS "noMergeIds"
+        FROM "memberSegments" ms
+        INNER JOIN members m ON ms."memberId" = m.id
+        INNER JOIN identities i ON m.id = i."memberId"
+        LEFT JOIN activity_data ad ON ms."memberId" = ad."memberId"
+            AND ms."segmentId" = ad."segmentId"
+        LEFT JOIN to_merge_data tmd ON m.id = tmd."memberId"
+        LEFT JOIN no_merge_data nmd ON m.id = nmd."memberId"
+        LEFT JOIN member_tags mt ON ms."memberId" = mt."memberId"
+        LEFT JOIN member_organizations mo ON ms."memberId" = mo."memberId"
+            AND ms."segmentId" = mo."segmentId"
+        WHERE ms."memberId" IN ($(ids:csv))
+          AND m."deletedAt" IS NULL
+          AND (ad."memberId" IS NOT NULL OR m."manuallyCreated");
+      `,
       {
         ids,
       },

--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -10,50 +10,68 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
   public async getOrganizationData(ids: string[]): Promise<IDbOrganizationSyncData[]> {
     const results = await this.db().any(
       `
-      with organization_segments as (select "segmentId", "organizationId"
-                                    from "organizationSegments"
-                                    where "organizationId" in ($(ids:csv))),
-        to_merge_data as (
-            select otm."organizationId",
-                    array_agg(distinct otm."toMergeId"::text) as to_merge_ids
-            from "organizationToMerge" otm
-            inner join organizations o2 on otm."toMergeId" = o2.id
-            where otm."organizationId" in ($(ids:csv))
-                  and o2."deletedAt" is null
-            group by otm."organizationId"),
-        no_merge_data as (
-            select onm."organizationId",
-                    array_agg(distinct onm."noMergeId"::text) as no_merge_ids
-            from "organizationNoMerge" onm
-            inner join organizations o2 on onm."noMergeId" = o2.id
-            where onm."organizationId" in ($(ids:csv))
-                  and o2."deletedAt" is null
-            group by onm."organizationId"),
-          member_data as (select os."segmentId",
-                                  os."organizationId",
-                                  count(distinct a."memberId")                                               as "memberCount",
-                                  count(distinct a.id)                                                       as "activityCount",
-                                  case
-                                      when array_agg(distinct a.platform) = array [null] then array []::text[]
-                                      else array_agg(distinct a.platform) end                                as "activeOn",
-                                  max(a.timestamp)                                                           as "lastActive",
-                                  min(a.timestamp) filter ( where a.timestamp <> '1970-01-01T00:00:00.000Z') as "joinedAt"
-                          from organization_segments os
-                                    left join activities a
-                                              on a."organizationId" = os."organizationId"
-                                                  and a."segmentId" = os."segmentId" and a."deletedAt" is null
-                                    join members m on a."memberId" = m.id and m."deletedAt" is null
-                                    join "memberOrganizations" mo
-                                        on m.id = mo."memberId"
-                                            and a."organizationId" = mo."organizationId"
-                                            and mo."deletedAt" is null
-                                            and mo."dateEnd" is null
-                          group by os."segmentId", os."organizationId"),
-          identities as (select oi."organizationId", jsonb_agg(oi) as "identities"
-                          from "organizationIdentities" oi
-                          where oi."organizationId" in ($(ids:csv))
-                          group by oi."organizationId")
-      select o.id                                                          as "organizationId",
+        WITH organization_segments AS (
+            SELECT
+                "segmentId",
+                "organizationId"
+            FROM "organizationSegments"
+            WHERE "organizationId" IN ($(ids:csv))
+        ),
+        to_merge_data AS (
+            SELECT
+                otm."organizationId",
+                array_agg(DISTINCT otm."toMergeId"::text) AS to_merge_ids
+            FROM "organizationToMerge" otm
+            INNER JOIN organizations o2 ON otm."toMergeId" = o2.id
+            WHERE otm."organizationId" IN ($(ids:csv))
+              AND o2."deletedAt" IS NULL
+            GROUP BY otm."organizationId"
+        ),
+        no_merge_data AS (
+            SELECT
+                onm."organizationId",
+                array_agg(DISTINCT onm."noMergeId"::text) AS no_merge_ids
+            FROM "organizationNoMerge" onm
+            INNER JOIN organizations o2 ON onm."noMergeId" = o2.id
+            WHERE onm."organizationId" IN ($(ids:csv))
+              AND o2."deletedAt" IS NULL
+            GROUP BY onm."organizationId"
+        ),
+        member_data AS (
+            SELECT
+                os."segmentId",
+                os."organizationId",
+                count(DISTINCT a."memberId") AS "memberCount",
+                count(DISTINCT a.id) AS "activityCount",
+                CASE WHEN array_agg(DISTINCT a.platform) = ARRAY[NULL] THEN
+                    ARRAY[]::text[]
+                ELSE
+                    array_agg(DISTINCT a.platform)
+                END AS "activeOn",
+                max(a.timestamp) AS "lastActive",
+                min(a.timestamp) FILTER (WHERE a.timestamp <> '1970-01-01T00:00:00.000Z') AS "joinedAt"
+            FROM organization_segments os
+            LEFT JOIN activities a ON a."organizationId" = os."organizationId"
+                AND a."segmentId" = os."segmentId"
+                AND a."deletedAt" IS NULL
+            JOIN members m ON a."memberId" = m.id
+                AND m."deletedAt" IS NULL
+            JOIN "memberOrganizations" mo ON m.id = mo."memberId"
+                AND a."organizationId" = mo."organizationId"
+                AND mo."deletedAt" IS NULL
+                AND mo."dateEnd" IS NULL
+            GROUP BY os."segmentId", os."organizationId"
+        ),
+        identities AS (
+            SELECT
+                oi."organizationId",
+                jsonb_agg(oi) AS "identities"
+            FROM "organizationIdentities" oi
+            WHERE oi."organizationId" IN ($(ids:csv))
+            GROUP BY oi."organizationId"
+        )
+        SELECT
+            o.id AS "organizationId",
             md."segmentId",
             o."tenantId",
             o.address,
@@ -103,8 +121,8 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
             o."grossDeparturesByMonth",
             o."ultimateParent",
             o."immediateParent",
-            nullif(o."employeeChurnRate" -> '12_month', 'null')::decimal  as "employeeChurnRate12Month",
-            nullif(o."employeeGrowthRate" -> '12_month', 'null')::decimal as "employeeGrowthRate12Month",
+            nullif (o."employeeChurnRate" -> '12_month', 'null')::decimal AS "employeeChurnRate12Month",
+            nullif (o."employeeGrowthRate" -> '12_month', 'null')::decimal AS "employeeGrowthRate12Month",
             o.tags,
             md."joinedAt",
             md."lastActive",
@@ -115,14 +133,13 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
             coalesce(tmd.to_merge_ids, array []::text[])       as "toMergeIds",
             coalesce(nmd.no_merge_ids, array []::text[])       as "noMergeIds",
             o."weakIdentities"
-      from organizations o
-              left join member_data md on o.id = md."organizationId"
-              left join identities i on o.id = i."organizationId"
-              left join to_merge_data tmd on o.id = tmd."organizationId"
-              left join no_merge_data nmd on o.id = nmd."organizationId"
-      where o.id in ($(ids:csv))
-        and o."deletedAt" is null
-        and (md."organizationId" is not null or o."manuallyCreated");
+        FROM organizations o
+        LEFT JOIN member_data md ON o.id = md."organizationId"
+        LEFT JOIN identities i ON o.id = i."organizationId"
+        WHERE o.id IN ($(ids:csv))
+          AND o."deletedAt" IS NULL
+          AND (md."organizationId" IS NOT NULL
+              OR o."manuallyCreated");
       `,
       {
         ids,

--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -37,6 +37,23 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
               AND o2."deletedAt" IS NULL
             GROUP BY onm."organizationId"
         ),
+        activities_1 AS (
+            SELECT
+                a.id,
+                a."segmentId",
+                a."organizationId",
+                a."memberId",
+                a.timestamp,
+                a.platform::TEXT
+            FROM mv_activities_cube a
+            JOIN members m ON a."memberId" = m.id
+                AND m."deletedAt" IS NULL
+            JOIN "memberOrganizations" mo ON m.id = mo."memberId"
+                AND a."organizationId" = mo."organizationId"
+                AND mo."deletedAt" IS NULL
+                AND mo."dateEnd" IS NULL
+            WHERE a."organizationId" IN ($(ids:csv))
+        ),
         member_data AS (
             SELECT
                 os."segmentId",
@@ -51,15 +68,8 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
                 max(a.timestamp) AS "lastActive",
                 min(a.timestamp) FILTER (WHERE a.timestamp <> '1970-01-01T00:00:00.000Z') AS "joinedAt"
             FROM organization_segments os
-            LEFT JOIN activities a ON a."organizationId" = os."organizationId"
-                AND a."segmentId" = os."segmentId"
-                AND a."deletedAt" IS NULL
-            JOIN members m ON a."memberId" = m.id
-                AND m."deletedAt" IS NULL
-            JOIN "memberOrganizations" mo ON m.id = mo."memberId"
-                AND a."organizationId" = mo."organizationId"
-                AND mo."deletedAt" IS NULL
-                AND mo."dateEnd" IS NULL
+            LEFT JOIN activities_1 a ON a."organizationId" = os."organizationId"
+              AND a."segmentId" = os."segmentId"
             GROUP BY os."segmentId", os."organizationId"
         ),
         identities AS (


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a859ce</samp>

This pull request improves the database queries and views for fetching and analyzing organization and member data. It uses a materialized view `mv_activities_cube` to speed up queries on activities, simplifies and optimizes some subqueries and join conditions, and adds a limit to the query that fetchs members by ids. These changes aim to enhance the performance and readability of the backend and the search sync worker services.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a859ce</samp>

> _We are the masters of the query_
> _We unleash the power of the cube_
> _We optimize the data flow_
> _We crush the memory woe_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a859ce</samp>

*  Add organization, segment, and conversation columns and index to `mv_activities_cube` materialized view for better filtering and grouping in cube.js ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-23b6b1fdaba848ef8f3dbda6aa7e46bda8f734bd3471dd12a0aab65f5ea4046cL32-R37), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-23b6b1fdaba848ef8f3dbda6aa7e46bda8f734bd3471dd12a0aab65f5ea4046cR64))
*  Replace activities table with `mv_activities_cube` materialized view in `member.repo.ts` and cast platform column to text for faster and compatible queries ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-58e3a08705154d31681cf22d4f5eabd037994a686415ca44cf502451c11594a7L175-R301))
*  Use common table expressions and simplify join conditions in subqueries that fetch segment ids in `organizationRepository.ts` for more readability and efficiency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1962-R1967), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1971-R2054))
*  Format query and add CTE that joins `mv_activities_cube` with members and member organizations tables in `organization.repo.ts` for more readability and performance ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L13-R84))
*  Remove redundant and unused joins and conditions in query in `organization.repo.ts` for more simplicity and cleanliness ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L106-R135), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L118-R152))
*  Add limit of 20 to query that fetches members by ids in `memberRepository.ts` for more memory efficiency and pagination alignment ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1715/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbR3145))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
