### PR TITLE
Split init and start logic in services

### DIFF
--- a/services/apps/template_consumer/package-lock.json
+++ b/services/apps/template_consumer/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@crowd/archetype-consumer": "file:../../archetypes/consumer",
-        "@types/config": "^3.3.1",
         "@types/node": "^20.8.2",
-        "config": "^3.3.9",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.2.2"
@@ -461,11 +459,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
-    },
-    "node_modules/@types/config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/config/-/config-3.3.1.tgz",
-      "integrity": "sha512-ZhBk8IVIbc3cuES10j2I+xa3L68rpl1X35FdsNce/AiE7yJnhQaA7tvO5MRZblqpBny4OIddJ+WQL04I1933Zg=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
@@ -952,17 +945,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/config": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.9.tgz",
-      "integrity": "sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==",
-      "dependencies": {
-        "json5": "^2.2.3"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2961,11 +2943,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
-    "@types/config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/config/-/config-3.3.1.tgz",
-      "integrity": "sha512-ZhBk8IVIbc3cuES10j2I+xa3L68rpl1X35FdsNce/AiE7yJnhQaA7tvO5MRZblqpBny4OIddJ+WQL04I1933Zg=="
-    },
     "@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -3289,14 +3266,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "config": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.9.tgz",
-      "integrity": "sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==",
-      "requires": {
-        "json5": "^2.2.3"
-      }
     },
     "create-require": {
       "version": "1.1.1",

--- a/services/apps/template_consumer/package.json
+++ b/services/apps/template_consumer/package.json
@@ -15,9 +15,7 @@
   },
   "dependencies": {
     "@crowd/archetype-consumer": "file:../../archetypes/consumer",
-    "@types/config": "^3.3.1",
     "@types/node": "^20.8.2",
-    "config": "^3.3.9",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.2.2"

--- a/services/apps/template_consumer/src/main.ts
+++ b/services/apps/template_consumer/src/main.ts
@@ -4,7 +4,6 @@ import { ServiceConsumer, Options } from '@crowd/consumer'
 const config: Config = {
   producer: {
     enabled: false,
-    idempotent: true,
   },
   temporal: {
     enabled: true,
@@ -26,6 +25,7 @@ const options: Options = {
 const svc = new ServiceConsumer(config, options)
 
 setImmediate(async () => {
+  await svc.init()
   await svc.start()
 
   // await svc.consumer.run({

--- a/services/apps/template_worker/package-lock.json
+++ b/services/apps/template_worker/package-lock.json
@@ -10,9 +10,7 @@
       "dependencies": {
         "@crowd/archetype-worker": "file:../../archetypes/worker",
         "@temporalio/workflow": "~1.8.6",
-        "@types/config": "^3.3.1",
         "@types/node": "^20.8.2",
-        "config": "^3.3.9",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.2.2"
@@ -590,11 +588,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
-    "node_modules/@types/config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/config/-/config-3.3.1.tgz",
-      "integrity": "sha512-ZhBk8IVIbc3cuES10j2I+xa3L68rpl1X35FdsNce/AiE7yJnhQaA7tvO5MRZblqpBny4OIddJ+WQL04I1933Zg=="
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -1080,17 +1073,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/config": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.9.tgz",
-      "integrity": "sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==",
-      "dependencies": {
-        "json5": "^2.2.3"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -3227,11 +3209,6 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
-    "@types/config": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@types/config/-/config-3.3.1.tgz",
-      "integrity": "sha512-ZhBk8IVIbc3cuES10j2I+xa3L68rpl1X35FdsNce/AiE7yJnhQaA7tvO5MRZblqpBny4OIddJ+WQL04I1933Zg=="
-    },
     "@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -3555,14 +3532,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "config": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/config/-/config-3.3.9.tgz",
-      "integrity": "sha512-G17nfe+cY7kR0wVpc49NCYvNtelm/pPy8czHoFkAgtV1lkmcp7DHtWCdDu+C9Z7gb2WVqa9Tm3uF9aKaPbCfhg==",
-      "requires": {
-        "json5": "^2.2.3"
-      }
     },
     "create-require": {
       "version": "1.1.1",

--- a/services/apps/template_worker/package.json
+++ b/services/apps/template_worker/package.json
@@ -16,9 +16,7 @@
   "dependencies": {
     "@crowd/archetype-worker": "file:../../archetypes/worker",
     "@temporalio/workflow": "~1.8.6",
-    "@types/config": "^3.3.1",
     "@types/node": "^20.8.2",
-    "config": "^3.3.9",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.2.2"

--- a/services/apps/template_worker/src/main.ts
+++ b/services/apps/template_worker/src/main.ts
@@ -6,7 +6,7 @@ const config: Config = {
     enabled: false,
   },
   temporal: {
-    enabled: true,
+    enabled: false,
   },
   redis: {
     enabled: false,
@@ -15,12 +15,13 @@ const config: Config = {
 
 const options: Options = {
   postgres: {
-    enabled: true,
+    enabled: false,
   },
 }
 
 const svc = new ServiceWorker(config, options)
 
 setImmediate(async () => {
+  await svc.init()
   await svc.start()
 })

--- a/services/archetypes/consumer/src/index.ts
+++ b/services/archetypes/consumer/src/index.ts
@@ -39,16 +39,16 @@ export class ServiceConsumer extends Service {
     return this._consumer
   }
 
-  override async start() {
-    // We first need to ensure a standard service can run given the config and
-    // environment variables.
+  // We first need to ensure a standard service can be initialized given the config
+  // and environment variables.
+  override async init() {
     try {
-      await super.start()
+      await super.init()
     } catch (err) {
       throw new Error(err)
     }
 
-    // We can now start tasks specific to a consumer service. Before actually
+    // We can now init tasks specific to a consumer service. Before actually
     // starting the service, we need to ensure required environment variables
     // are set.
     const missing = []
@@ -70,8 +70,17 @@ export class ServiceConsumer extends Service {
         retry: this.options.retryPolicy,
       })
 
-      const topics = process.env['CROWD_KAFKA_TOPICS']
       await this._consumer.connect()
+    } catch (err) {
+      throw new Error(err)
+    }
+  }
+
+  // Actually start the consumer's subscription.
+  async start() {
+    const topics = process.env['CROWD_KAFKA_TOPICS']
+
+    try {
       await this._consumer.subscribe({
         topics: topics.split(','),
       })

--- a/services/archetypes/standard/src/index.ts
+++ b/services/archetypes/standard/src/index.ts
@@ -133,9 +133,9 @@ export class Service {
     return releaseLock(this._redisClient, key, value)
   }
 
-  async start() {
-    // Before actually starting the service we need to ensure required environment
-    // variables are set.
+  // Before actually starting the service we need to ensure required environment
+  // variables are set.
+  async init() {
     const missing = []
     envvars.base.forEach((envvar) => {
       if (!process.env[envvar]) {

--- a/services/archetypes/worker/src/index.ts
+++ b/services/archetypes/worker/src/index.ts
@@ -50,16 +50,16 @@ export class ServiceWorker extends Service {
     return this._postgres
   }
 
-  override async start() {
-    // We first need to ensure a standard service can run given the config and
-    // environment variables.
+  // We first need to ensure a standard service can be initialized given the config
+  // and environment variables.
+  override async init() {
     try {
-      await super.start()
+      await super.init()
     } catch (err) {
       throw new Error(err)
     }
 
-    // We can now start tasks specific to a consumer service. Before actually
+    // We can now init tasks specific to a consumer service. Before actually
     // starting the service, we need to ensure required environment variables
     // are set.
     const missing = []
@@ -123,8 +123,10 @@ export class ServiceWorker extends Service {
         throw new Error(err)
       }
     }
+  }
 
-    // If we made it here, we can run the Temporal worker.
+  // Actually start the Temporal worker.
+  async start() {
     try {
       await this._worker.run()
     } catch (err) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac26a19</samp>

This pull request removes unused dependencies and refactors the initialization and startup logic of the template consumer and worker services, as well as the service archetypes. This improves the performance, simplicity, and flexibility of the services and the codebase.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ac26a19</samp>

> _`config` removed_
> _services init and start_
> _spring cleaning codebase_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac26a19</samp>

*  Removed unused dependencies `@types/config` and `config` from `template_consumer` and `template_worker` services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-391c1ce737b1c9a20a01cb525bb9601d38cc9c5550cb897e96b1aedf5975cdbbL12-R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-391c1ce737b1c9a20a01cb525bb9601d38cc9c5550cb897e96b1aedf5975cdbbL465-L469), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-391c1ce737b1c9a20a01cb525bb9601d38cc9c5550cb897e96b1aedf5975cdbbL956-L966), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-391c1ce737b1c9a20a01cb525bb9601d38cc9c5550cb897e96b1aedf5975cdbbL2964-L2968), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-391c1ce737b1c9a20a01cb525bb9601d38cc9c5550cb897e96b1aedf5975cdbbL3293-L3300), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-7551e33fe0694e1e185a0d1fc0598c72d95c17ab6cc2ac7cf25e83307bab475eL18-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-99c11ffc3e0691a124f4f5a2b943b93c717ac613fe5718a32dd84a48543a0896L13-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-99c11ffc3e0691a124f4f5a2b943b93c717ac613fe5718a32dd84a48543a0896L593-L597), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-99c11ffc3e0691a124f4f5a2b943b93c717ac613fe5718a32dd84a48543a0896L1084-L1094), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-99c11ffc3e0691a124f4f5a2b943b93c717ac613fe5718a32dd84a48543a0896L3230-L3234), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-99c11ffc3e0691a124f4f5a2b943b93c717ac613fe5718a32dd84a48543a0896L3559-L3566), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-386d778609708470d9cfd81b6bfbb7f8dd86c7e23cd795e640d090703bb6d0d5L19-R19))
* Renamed `start` method to `init` and added separate `start` method for subscription and run logic in `ServiceConsumer` and `ServiceWorker` classes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-a610cb700a0e0919c8018f430688ee905fb288f5fbab79c8061bec0223d384ddL42-R51), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-a610cb700a0e0919c8018f430688ee905fb288f5fbab79c8061bec0223d384ddL73-R83), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-f8e573be8fec244d7f1e2ba1ee94edac9b4d375fb202d7cab06207461e19876aL136-R138), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-5b8cbfe8cc970dce5048d3827bd8e50d19e0211d53917abe8c2776cb97ad2e54L53-R62), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-5b8cbfe8cc970dce5048d3827bd8e50d19e0211d53917abe8c2776cb97ad2e54L126-R129))
* Called `init` method of `svc` instance in `main.ts` files of `template_consumer` and `template_worker` services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-e904cf1d6e8e1fa30fbab3e76c9103dd53776f871f2cdf8b7f88f47c2227877cR28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-088464fd4198c4ed373bac8ccdc1158aa3fa36947cdd1e4fb82440f89c9a41fdR25))
* Removed `idempotent` property from `config` value in `template_consumer` service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-e904cf1d6e8e1fa30fbab3e76c9103dd53776f871f2cdf8b7f88f47c2227877cL7))
* Disabled `temporal` and `postgres` options by default in `template_worker` service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-088464fd4198c4ed373bac8ccdc1158aa3fa36947cdd1e4fb82440f89c9a41fdL9-R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1720/files?diff=unified&w=0#diff-088464fd4198c4ed373bac8ccdc1158aa3fa36947cdd1e4fb82440f89c9a41fdL18-R18))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
