### PR TITLE
Add rate limit checker to Discord integration

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/errorHandler.ts
+++ b/services/libs/integrations/src/integrations/discord/api/errorHandler.ts
@@ -32,6 +32,12 @@ export const handleDiscordError = (
 
     return new RateLimitError(rateLimitResetSeconds, url, err)
   }
+
+  if (err && err.response && err.response.status === 403) {
+    logger.warn('No access to resourse, ignoring it', { input, err })
+    return undefined
+  }
+
   logger.error(err, { input }, `Error while calling Discord API URL: ${url}`)
   return err
 }

--- a/services/libs/integrations/src/integrations/discord/api/getChannel.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannel.ts
@@ -25,6 +25,8 @@ export const getChannel = async (
     return response.data
   } catch (err) {
     const newErr = handleDiscordError(err, config, { channelId }, ctx)
-    throw newErr
+    if (newErr) {
+      throw newErr
+    }
   }
 }

--- a/services/libs/integrations/src/integrations/discord/api/getChannel.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannel.ts
@@ -2,12 +2,14 @@ import axios, { AxiosRequestConfig } from 'axios'
 import { handleDiscordError } from './errorHandler'
 import { DiscordApiChannel } from '../types'
 import { IProcessStreamContext } from '../../../types'
+import { getRateLimiter } from './handleRateLimit'
 
 export const getChannel = async (
   channelId: string,
   token: string,
   ctx: IProcessStreamContext,
 ): Promise<DiscordApiChannel> => {
+  const rateLimiter = getRateLimiter(ctx)
   const config: AxiosRequestConfig = {
     method: 'get',
     url: `https://discord.com/api/v10/channels/${channelId}`,
@@ -17,6 +19,8 @@ export const getChannel = async (
   }
 
   try {
+    await rateLimiter.checkRateLimit('getChannel')
+    await rateLimiter.incrementRateLimit()
     const response = await axios(config)
     return response.data
   } catch (err) {

--- a/services/libs/integrations/src/integrations/discord/api/getChannels.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannels.ts
@@ -77,7 +77,9 @@ async function getChannels(
     return result
   } catch (err) {
     const newErr = handleDiscordError(err, config, { input }, ctx)
-    throw newErr
+    if (newErr) {
+      throw newErr
+    }
   }
 }
 

--- a/services/libs/integrations/src/integrations/discord/api/getMember.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMember.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios'
 import { DiscordApiMember } from '../types'
 import { handleDiscordError } from './errorHandler'
 import { IProcessStreamContext } from '../../../types'
+import { getRateLimiter } from './handleRateLimit'
 
 export const getMember = async (
   guildId: string,
@@ -9,6 +10,8 @@ export const getMember = async (
   token: string,
   ctx: IProcessStreamContext,
 ): Promise<DiscordApiMember> => {
+  const rateLimiter = getRateLimiter(ctx)
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const config: AxiosRequestConfig<any> = {
     method: 'get',
@@ -19,6 +22,8 @@ export const getMember = async (
   }
 
   try {
+    await rateLimiter.checkRateLimit('getMember')
+    await rateLimiter.incrementRateLimit()
     const response = await axios(config)
     return response.data
   } catch (err) {

--- a/services/libs/integrations/src/integrations/discord/api/getMember.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMember.ts
@@ -28,6 +28,8 @@ export const getMember = async (
     return response.data
   } catch (err) {
     const newErr = handleDiscordError(err, config, { guildId, userId }, ctx)
-    throw newErr
+    if (newErr) {
+      throw newErr
+    }
   }
 }

--- a/services/libs/integrations/src/integrations/discord/api/getMessage.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMessage.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { handleDiscordError } from './errorHandler'
 import { IProcessStreamContext } from '../../../types'
+import { getRateLimiter } from './handleRateLimit'
 
 export const getMessage = async (
   channelId: string,
@@ -8,6 +9,8 @@ export const getMessage = async (
   token: string,
   ctx: IProcessStreamContext,
 ) => {
+  const rateLimiter = getRateLimiter(ctx)
+
   const config: AxiosRequestConfig = {
     method: 'get',
     url: `https://discord.com/api/v10/channels/${channelId}/messages/${messageId}`,
@@ -17,6 +20,8 @@ export const getMessage = async (
   }
 
   try {
+    await rateLimiter.checkRateLimit('getMessage')
+    await rateLimiter.incrementRateLimit()
     const response = await axios(config)
     return response.data
   } catch (err) {

--- a/services/libs/integrations/src/integrations/discord/api/getThreads.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getThreads.ts
@@ -1,25 +1,29 @@
 import axios from 'axios'
 import { DiscordApiChannel, DiscordGetChannelsInput } from '../types'
 import { IProcessStreamContext } from '../../../types'
+import { getRateLimiter } from './handleRateLimit'
+import { handleDiscordError } from './errorHandler'
 
 async function getThreads(
   input: DiscordGetChannelsInput,
   ctx: IProcessStreamContext,
 ): Promise<DiscordApiChannel[]> {
+  const rateLimiter = getRateLimiter(ctx)
+  const config = {
+    method: 'get',
+    url: `https://discord.com/api/v10/guilds/${input.guildId}/threads/active?`,
+    headers: {
+      Authorization: input.token,
+    },
+  }
   try {
-    const config = {
-      method: 'get',
-      url: `https://discord.com/api/v10/guilds/${input.guildId}/threads/active?`,
-      headers: {
-        Authorization: input.token,
-      },
-    }
-
+    await rateLimiter.checkRateLimit('getThreads')
+    await rateLimiter.incrementRateLimit()
     const response = await axios(config)
     return response.data.threads
   } catch (err) {
-    ctx.log.error({ err, input }, 'Error while getting threads from Discord')
-    throw err
+    const newErr = handleDiscordError(err, config, { input }, ctx)
+    throw newErr
   }
 }
 

--- a/services/libs/integrations/src/integrations/discord/api/getThreads.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getThreads.ts
@@ -23,7 +23,9 @@ async function getThreads(
     return response.data.threads
   } catch (err) {
     const newErr = handleDiscordError(err, config, { input }, ctx)
-    throw newErr
+    if (newErr) {
+      throw newErr
+    }
   }
 }
 

--- a/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
+++ b/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
@@ -1,0 +1,9 @@
+import { IProcessStreamContext } from '../../../types'
+
+const DISCORD_RATE_LIMIT = 50
+const DISCORD_RATE_LIMIT_TIME = 1
+const REDIS_KEY = 'discord-request-count'
+
+export const getRateLimiter = (ctx: IProcessStreamContext) => {
+  return ctx.getRateLimiter(DISCORD_RATE_LIMIT, DISCORD_RATE_LIMIT_TIME, REDIS_KEY)
+}


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at afdb1ef</samp>

This pull request adds rate limiting and error handling to the Discord API integration. It uses the `handleRateLimit` module to create and use a rate limiter for each API function. This improves the performance and the reliability of the integration and prevents errors from exceeding the API's request limit. It affects the files `getChannel.ts`, `getChannels.ts`, `getMember.ts`, `getMembers.ts`, `getMessage.ts`, `getMessages.ts`, `getThreads.ts`, and `handleRateLimit.ts` in the `integrations/discord/api` module.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at afdb1ef</samp>

> _We face the wrath of the Discord API_
> _We must obey the rate limit or die_
> _We use the `handleRateLimit` module_
> _To tame the beast and make it stable_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at afdb1ef</samp>

*  Add the `handleRateLimit` module to create and use a rate limiter for the Discord API requests ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-3d5a451b8d038f975bcce284a1540221ea5701897bf84cbbf1b9d43fbdb4d19cR1-R9))
*  Import and initialize the rate limiter in the `getChannel`, `getChannels`, `getMember`, `getMembers`, `getMessage`, `getMessages`, and `getThreads` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-78d626d86f9b6f24ecfe390037b47a713247355ac0442d117d488b86a931bf13R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-78d626d86f9b6f24ecfe390037b47a713247355ac0442d117d488b86a931bf13R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97R6-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-44e8a253258647e2fbf3077aad12bbc88eb942c7b2facedd81d7a531510963b9R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-44e8a253258647e2fbf3077aad12bbc88eb942c7b2facedd81d7a531510963b9R13-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-a100bec833b4ab08237bd4bc75393a280f28fb4fc424cc5a9954867cb564fd1dR4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-a100bec833b4ab08237bd4bc75393a280f28fb4fc424cc5a9954867cb564fd1dR10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR12-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-bd44153d776cef51277afca54c8800d03d022736636cec42c420c38c081c0dbaR4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-bd44153d776cef51277afca54c8800d03d022736636cec42c420c38c081c0dbaR11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cR4-R5))
*  Check and increment the rate limit before and after making the requests to the Discord API in the `getChannel`, `getMember`, `getMessages`, and `getThreads` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-78d626d86f9b6f24ecfe390037b47a713247355ac0442d117d488b86a931bf13R22-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-44e8a253258647e2fbf3077aad12bbc88eb942c7b2facedd81d7a531510963b9R25-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-a100bec833b4ab08237bd4bc75393a280f28fb4fc424cc5a9954867cb564fd1dR24-R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR23-R24), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-bd44153d776cef51277afca54c8800d03d022736636cec42c420c38c081c0dbaR25-R26))
*  Import and use the `handleDiscordError` function to handle and log the possible errors from the Discord API in the `getChannels` and `getThreads` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97R6-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97L72-R80), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cR4-R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cL9-R26))
*  Simplify the code by removing the `try` blocks and moving the `config` variable declarations outside of them in the `getChannels` and `getThreads` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97L34-R48), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1722/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cL9-R26))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
