### PR TITLE
More tracing

### DIFF
--- a/services/libs/database/src/connection.ts
+++ b/services/libs/database/src/connection.ts
@@ -61,7 +61,7 @@ export const getDbConnection = async (
 
   dbConnection = dbInstance({
     ...config,
-    max: maxPoolSize || 5,
+    max: maxPoolSize || 20,
     // query_timeout: 30000,
     application_name: process.env.SERVICE || 'unknown-app',
   })

--- a/services/libs/tracing/package-lock.json
+++ b/services/libs/tracing/package-lock.json
@@ -15,6 +15,7 @@
         "@opentelemetry/instrumentation-bunyan": "~0.32.1",
         "@opentelemetry/instrumentation-express": "~0.33.1",
         "@opentelemetry/instrumentation-http": "~0.43.0",
+        "@opentelemetry/instrumentation-pg": "^0.36.2",
         "@opentelemetry/instrumentation-redis": "~0.35.1",
         "@opentelemetry/resource-detector-aws": "~1.3.1",
         "@opentelemetry/resources": "~1.17.0",
@@ -5185,6 +5186,43 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.36.2.tgz",
+      "integrity": "sha512-KUjI8OGi7kicml2Sd/PR/M8otZoZEdPArMfhznS6OQKit+RxFo0p5x6RVeka/cLQlmoc3eeGBizDeZetssbHgw==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/sql-common": "^0.40.0",
+        "@types/pg": "8.6.1",
+        "@types/pg-pool": "2.0.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.44.0.tgz",
+      "integrity": "sha512-B6OxJTRRCceAhhnPDBshyQO7K07/ltX3quOLu0icEvPK9QZ7r9P1y0RQX8O5DxB4vTv4URRkxkg+aFU/plNtQw==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-redis": {
       "version": "0.35.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.1.tgz",
@@ -5466,6 +5504,20 @@
         "node": ">=14"
       }
     },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.0.tgz",
+      "integrity": "sha512-vSqRJYUPJVjMFQpYkQS3ruexCPSZJ8esne3LazLwtCPaPRvzZ7WG3tX44RouAn7w4wMp8orKguBqtt+ng2UTnw==",
+      "dependencies": {
+        "@opentelemetry/core": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "license": "BSD-3-Clause"
@@ -5575,6 +5627,24 @@
     "node_modules/@types/node": {
       "version": "18.16.8",
       "license": "MIT"
+    },
+    "node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.4.tgz",
+      "integrity": "sha512-qZAvkv1K3QbmHHFYSNRYPkRjOWRLBYrL4B9c+wG0GSVGBw0NtJwPcgx/DSddeDJvRGMHCEQ4VMEVfuJ/0gZ3XQ==",
+      "dependencies": {
+        "@types/pg": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.8",
@@ -6870,6 +6940,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "dev": true,
@@ -6879,6 +6977,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {

--- a/services/libs/tracing/package-lock.json
+++ b/services/libs/tracing/package-lock.json
@@ -16,7 +16,7 @@
         "@opentelemetry/instrumentation-express": "~0.33.1",
         "@opentelemetry/instrumentation-http": "~0.43.0",
         "@opentelemetry/instrumentation-pg": "^0.36.2",
-        "@opentelemetry/instrumentation-redis": "~0.35.1",
+        "@opentelemetry/instrumentation-redis-4": "^0.35.3",
         "@opentelemetry/resource-detector-aws": "~1.3.1",
         "@opentelemetry/resources": "~1.17.0",
         "@opentelemetry/sdk-node": "~0.43.0",
@@ -5223,14 +5223,32 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.1.tgz",
-      "integrity": "sha512-zY7eTzGyJCMX/0o04Q9yLy7gllf7Zh4s+g7Kv1d2cMLtTt9zGSlncqj49uNCnneywnpMNRUIwcmd+Ch1bQeh+g==",
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.3.tgz",
+      "integrity": "sha512-fWMqJpEGLcE1Z76CTwhZPaFU7EGBZ/pNFKCLdHALddvud/9AxKbxLIn73QGh7sLU8MwhCBkTbuipj5UAy8g8TA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.2",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.44.0.tgz",
+      "integrity": "sha512-B6OxJTRRCceAhhnPDBshyQO7K07/ltX3quOLu0icEvPK9QZ7r9P1y0RQX8O5DxB4vTv4URRkxkg+aFU/plNtQw==",
+      "dependencies": {
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"

--- a/services/libs/tracing/package.json
+++ b/services/libs/tracing/package.json
@@ -26,6 +26,7 @@
     "@opentelemetry/instrumentation-bunyan": "~0.32.1",
     "@opentelemetry/instrumentation-express": "~0.33.1",
     "@opentelemetry/instrumentation-http": "~0.43.0",
+    "@opentelemetry/instrumentation-pg": "^0.36.2",
     "@opentelemetry/instrumentation-redis": "~0.35.1",
     "@opentelemetry/resource-detector-aws": "~1.3.1",
     "@opentelemetry/resources": "~1.17.0",

--- a/services/libs/tracing/package.json
+++ b/services/libs/tracing/package.json
@@ -27,7 +27,7 @@
     "@opentelemetry/instrumentation-express": "~0.33.1",
     "@opentelemetry/instrumentation-http": "~0.43.0",
     "@opentelemetry/instrumentation-pg": "^0.36.2",
-    "@opentelemetry/instrumentation-redis": "~0.35.1",
+    "@opentelemetry/instrumentation-redis-4": "^0.35.3",
     "@opentelemetry/resource-detector-aws": "~1.3.1",
     "@opentelemetry/resources": "~1.17.0",
     "@opentelemetry/sdk-node": "~0.43.0",

--- a/services/libs/tracing/src/tracer.ts
+++ b/services/libs/tracing/src/tracer.ts
@@ -17,6 +17,7 @@ import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk'
 import { KafkaJsInstrumentation } from 'opentelemetry-instrumentation-kafkajs'
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis'
 import { SequelizeInstrumentation } from 'opentelemetry-instrumentation-sequelize'
+import { PgInstrumentation } from '@opentelemetry/instrumentation-pg'
 
 let sdk: NodeSDK | undefined
 let isInitialized = false
@@ -54,6 +55,7 @@ export const getServiceTracer = (): Tracer => {
       new KafkaJsInstrumentation(),
       new RedisInstrumentation(),
       new SequelizeInstrumentation(),
+      new PgInstrumentation(),
     ],
   })
 

--- a/services/libs/tracing/src/tracer.ts
+++ b/services/libs/tracing/src/tracer.ts
@@ -15,7 +15,7 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http'
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express'
 import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk'
 import { KafkaJsInstrumentation } from 'opentelemetry-instrumentation-kafkajs'
-import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis'
+import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis-4'
 import { SequelizeInstrumentation } from 'opentelemetry-instrumentation-sequelize'
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg'
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9b4ca1</samp>

This pull request adds and updates OpenTelemetry instrumentation for Redis and PostgreSQL in the `services/libs/tracing` and `services/libs/database` modules. These changes enable tracing of database operations and improve the observability and performance monitoring of the service. The pull request also increases the maximum number of connections in the database pool.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f9b4ca1</samp>

> _We're sailing on the digital sea, with databases and traces_
> _We're instrumenting Redis and PG, to monitor our paces_
> _Heave ho, heave ho, on the count of three_
> _We're updating `dbConnection.max` to boost our concurrency_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9b4ca1</samp>

*  Increase the maximum number of connections in the database pool from 5 to 20 to improve performance and concurrency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-9e58f25937db0a6e39a8159f110097d74642b6f1f3188104950027074f86f81dL64-R64))
*  Replace the `@opentelemetry/instrumentation-redis` dependency with `@opentelemetry/instrumentation-redis-4` and add the `@opentelemetry/instrumentation-pg` dependency to update the tracing packages for Redis and PostgreSQL ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fL18-R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-6e02e427cb7cc4b1a02828f1bf61f7effc445897fbab901046441d98e54549bbL29-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-4947eaf91d0c076e0d3bfc4c28bec695614f2907be564b95e589c4bca62f6071L18-R20))
*  Remove the `@opentelemetry/instrumentation-redis` package from the `package-lock.json` file to reflect the dependency change ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fL5188-R5231))
*  Add the `@opentelemetry/instrumentation-pg` package and its dependencies to the `package-lock.json` file to reflect the dependency addition ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fR5242-R5259), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fR5525-R5538), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fR5649-R5666), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fR6961-R6988), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-eeb9f24c399204fa7389ac63787e29576827e5aefd0911aec93ddbf50012de7fR7000-R7034))
*  Add the `PgInstrumentation` instance to the array of instrumentations in the `getServiceTracer` function in `tracer.ts` to enable the tracing of PostgreSQL queries ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1725/files?diff=unified&w=0#diff-4947eaf91d0c076e0d3bfc4c28bec695614f2907be564b95e589c4bca62f6071R58))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
