### PR TITLE
Fix rate limiter and increase requests for Discord

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
+++ b/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
@@ -1,7 +1,7 @@
 import { IProcessStreamContext } from '../../../types'
 
-const DISCORD_RATE_LIMIT = 50
-const DISCORD_RATE_LIMIT_TIME = 1
+const DISCORD_RATE_LIMIT = 100
+const DISCORD_RATE_LIMIT_TIME = 1 // 1 second
 const REDIS_KEY = 'discord-request-count'
 
 export const getRateLimiter = (ctx: IProcessStreamContext) => {

--- a/services/libs/redis/src/rateLimiter.ts
+++ b/services/libs/redis/src/rateLimiter.ts
@@ -19,6 +19,10 @@ export class RateLimiter implements IRateLimiter {
     const requestCount = value === null ? 0 : parseInt(value)
     const canMakeRequest = requestCount < this.maxRequests
 
+    if (requestCount === 0) {
+      await this.cache.set(this.counterKey, '0', this.timeWindowSeconds)
+    }
+
     if (!canMakeRequest) {
       const sleepTime = this.timeWindowSeconds + Math.floor(Math.random() * this.maxRequests)
       throw new RateLimitError(sleepTime, endpoint)
@@ -26,7 +30,7 @@ export class RateLimiter implements IRateLimiter {
   }
 
   public async incrementRateLimit() {
-    await this.cache.increment(this.counterKey, 1, this.timeWindowSeconds)
+    await this.cache.increment(this.counterKey, 1)
   }
 }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cdd09e2</samp>

Increased the rate limit for Discord integration and optimized the Redis rate limiter. These changes improve the performance and reliability of the services that interact with external APIs.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cdd09e2</samp>

> _Sing, O Muse, of the swift and skillful coder_
> _Who tweaked the constants of the Discord bot_
> _And matched the rate limit of the sender_
> _To the mighty Discord's own allotted slot_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cdd09e2</samp>

* Increase the Discord API rate limit constant and comment the time unit ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1729/files?diff=unified&w=0#diff-3d5a451b8d038f975bcce284a1540221ea5701897bf84cbbf1b9d43fbdb4d19cL3-R4))
* Fix the Redis counter key initialization and expiration for the rate limiter ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1729/files?diff=unified&w=0#diff-e54ee1725503853d1505ffaa63c0553049b33099546c3e8baf8d90a4692c1800R22-R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1729/files?diff=unified&w=0#diff-e54ee1725503853d1505ffaa63c0553049b33099546c3e8baf8d90a4692c1800L29-R33))
* Remove the redundant argument from the cache increment method in `rateLimiter.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1729/files?diff=unified&w=0#diff-e54ee1725503853d1505ffaa63c0553049b33099546c3e8baf8d90a4692c1800L29-R33))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
