### PR TITLE
docs: Added a link that leads to the crowd.dev blogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Contributions are what make the open source community such an amazing place to l
 - Try the crowd.dev platform & API and give feedback by [creating new issues](https://github.com/CrowdDotDev/crowd.dev/issues/new/choose)
 - Help with [open issues](https://github.com/CrowdDotDev/crowd.dev/issues)
 - Add a new integration following our [framework](https://docs.crowd.dev/docs/integration-framework)
-- Help create tutorials and blog posts
+- Help create tutorials and [blog](https://www.crowd.dev/blog) posts
 - Improve [documentation](https://docs.crowd.dev/docs) by fixing incomplete or missing docs, bad wording, examples or explanations
 
 Any contributions you make are **greatly appreciated**. ❤️


### PR DESCRIPTION
# Changes proposed ✍️

### What
Added a link that leads to the blogs in the documentation​

### Screenshot:

Before making changes:
![image](https://github.com/CrowdDotDev/crowd.dev/assets/110753356/b63caf95-fe4b-45bc-bb6a-42c627ba5ede)

After making changes:
![image](https://github.com/CrowdDotDev/crowd.dev/assets/110753356/cde9a905-c135-425b-b8dc-827c20d8e05e)

### How
![image](https://github.com/CrowdDotDev/crowd.dev/assets/110753356/f05695f8-2347-4195-94fd-0dd9e5b13f70)


### Why
Since all other relevant links were added, adding a link leading to the official blogs improved consistency.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
