### PR TITLE
Query fix for org sync in search sync worker

### DIFF
--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -146,6 +146,8 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
         FROM organizations o
         LEFT JOIN member_data md ON o.id = md."organizationId"
         LEFT JOIN identities i ON o.id = i."organizationId"
+        LEFT JOIN to_merge_data tmd on o.id = tmd."organizationId"
+        LEFT JOIN no_merge_data nmd on o.id = nmd."organizationId"
         WHERE o.id IN ($(ids:csv))
           AND o."deletedAt" IS NULL
           AND (md."organizationId" IS NOT NULL


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be132e4</samp>

Added user preferences for merging duplicate organizations to the `search_sync_worker` query. This query fetchs organizations from the database and syncs them with Elasticsearch. The change supports a new web app feature for reviewing and merging duplicates.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at be132e4</samp>

> _`search_sync_worker`_
> _joins tables for merge prefs_
> _autumn of dupes_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at be132e4</samp>

*  Include user preferences for merging duplicate organizations in Elasticsearch index ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1736/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4R149-R150))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
