### PR TITLE
Revert using materialized view in search sync

### DIFF
--- a/services/apps/search_sync_worker/src/repo/organization.repo.ts
+++ b/services/apps/search_sync_worker/src/repo/organization.repo.ts
@@ -45,7 +45,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
                 a."memberId",
                 a.timestamp,
                 a.platform::TEXT
-            FROM mv_activities_cube a
+            FROM activities a
             JOIN members m ON a."memberId" = m.id
                 AND m."deletedAt" IS NULL
             JOIN "memberOrganizations" mo ON m.id = mo."memberId"


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca36731</samp>

Improved the search sync worker by querying the `activities` table directly instead of the `mv_activities_cube` materialized view. This fixed the issue of outdated and inaccurate data in the Elasticsearch index for organizations.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca36731</samp>

> _`activities` table_
> _faster and more accurate_
> _than old view - `cut`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca36731</samp>

* Improve search sync worker performance and accuracy by querying activities table instead of materialized view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1737/files?diff=unified&w=0#diff-b19f6edbf6995596f0f1d2eceabc6878c259899dab8d40fa27dd58eca0fc92f4L48-R48))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
