### PR TITLE
Remove rate limiter in Reddit

### DIFF
--- a/services/libs/integrations/src/integrations/reddit/api/errorHandler.ts
+++ b/services/libs/integrations/src/integrations/reddit/api/errorHandler.ts
@@ -1,0 +1,38 @@
+import { AxiosError, AxiosRequestConfig } from 'axios'
+import { RateLimitError } from '@crowd/types'
+import { IProcessStreamContext } from '../../../types'
+
+export const handleRedditError = (
+  err: AxiosError,
+  config: AxiosRequestConfig,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: any,
+  ctx: IProcessStreamContext,
+) => {
+  const logger = ctx.log
+
+  let url = config.url
+  if (config.params) {
+    const queryParams: string[] = []
+    for (const [key, value] of Object.entries(config.params)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      queryParams.push(`${key}=${encodeURIComponent(value as any)}`)
+    }
+
+    url = `${config.url}?${queryParams.join('&')}`
+  }
+
+  if (err && err.response && err.response.status === 429) {
+    logger.warn('Reddit API rate limit exceeded')
+    let rateLimitResetSeconds = 60
+
+    if (err.response.headers['x-ratelimit-reset']) {
+      rateLimitResetSeconds = parseInt(err.response.headers['x-ratelimit-reset'], 10)
+    }
+
+    return new RateLimitError(rateLimitResetSeconds, url, err)
+  }
+
+  logger.error(err, { input }, `Error while calling Reddit API URL: ${url}`)
+  return err
+}


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7004669</samp>

This pull request refactors the Reddit API integration functions to use a common error handler function `handleRedditError` from the `errorHandler.ts` module. This reduces code duplication, simplifies error handling logic, and improves logging of Reddit API errors.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7004669</samp>

> _We face the wrath of Reddit's gate_
> _We need a way to handle our fate_
> _We use the `handleRedditError` function_
> _To log the errors and avoid destruction_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7004669</samp>

*  Add a new module `errorHandler.ts` that handles common errors from the Reddit API and logs them with the appropriate context ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-6ab6df837851ba1edcdb52e1df6e6aeaf0d28cf906e80732d88d3c3b953475b9R1-R38))
*  Replace the import of the `getRateLimiter` function with the import of the `handleRedditError` function in the modules `getComments.ts`, `getMoreComments.ts`, and `getPosts.ts`, which fetch comments and posts from a sub-reddit ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L7-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL7-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L7-R7))
*  Remove the declaration and usage of the `rateLimiter` variable in the `getComments`, `getMoreComments`, and `getPosts` functions, which was used to check and increment the rate limit before and after making a request to the Reddit API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L19-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L28-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L45-R46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL20-R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL29-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL48-R49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L19-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L28-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L50-L52))
*  Move the declaration of the `config` variable outside the try block in the `getComments`, `getMoreComments`, and `getPosts` functions, so that it can be accessed by the `handleRedditError` function in the catch block ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L19-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL20-R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L19-R20))
*  Remove the `const` keyword from the assignment of the `config` variable in the `getComments` and `getMoreComments` functions, since it was already declared outside the try block ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L28-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL29-R31))
*  Add a call to the `handleRedditError` function in the catch block of the try-catch statement in the `getComments`, `getMoreComments`, and `getPosts` functions, passing the error, the config, the input, and the context as arguments. The function returns either the original error or a new error, depending on the type and status of the error, and the function throws the returned error ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-f5af5d01f35ca640d6ca13c22e459269a87011d2cfa6a8d4bb5bf3b08c95e8a9L45-R46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-af651613296e1cfe5a5343a579776920acb9419a573fa00d9b99084004f8e30eL48-R49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1741/files?diff=unified&w=0#diff-49a909f4ae617141ee9e1e83fb08511c80f7b90513f874f4c4bab600eed08929L72-R66))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
