### PR TITLE
Disable bot settings if team member filtering

### DIFF
--- a/frontend/src/modules/member/config/saved-views/settings/bot/MemberBotSetting.vue
+++ b/frontend/src/modules/member/config/saved-views/settings/bot/MemberBotSetting.vue
@@ -3,7 +3,7 @@
     <p class="text-xs font-semibold leading-5 mb-3">
       Bot contacts visibility
     </p>
-    <el-radio-group v-model="value">
+    <el-radio-group v-model="value" :disabled="props.settings?.teamMember === 'filter'">
       <el-radio :label="IncludeEnum.EXCLUDE" class="!h-5">
         <span class="text-xs">Exclude bot contacts</span>
       </el-radio>
@@ -16,22 +16,37 @@
 
 <script setup lang="ts">
 import { IncludeEnum } from '@/modules/member/config/saved-views/settings/common/types/IncludeEnum';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const props = defineProps<{
-  modelValue: IncludeEnum,
+  modelValue: IncludeEnum | '',
+  settings: Record<string, string>,
 }>();
 
-const emit = defineEmits<{(e: 'update:modelValue', value: IncludeEnum): any }>();
+const emit = defineEmits<{(e: 'update:modelValue', value: IncludeEnum | ''): any }>();
 
-const value = computed<IncludeEnum>({
+const value = computed<IncludeEnum | ''>({
   get() {
     return props.modelValue;
   },
-  set(val: IncludeEnum) {
+  set(val: IncludeEnum | '') {
     emit('update:modelValue', val);
   },
 });
+
+const previousSettings = ref<Record<string, string> | null>(null);
+
+watch(() => props.settings, (current) => {
+  if (current?.teamMember === 'filter') {
+    if (!previousSettings.value || previousSettings.value.teamMember !== 'filter') {
+      value.value = '';
+    }
+  }
+  if (previousSettings.value?.teamMember === 'filter' && current?.teamMember !== 'filter') {
+    value.value = IncludeEnum.EXCLUDE;
+  }
+  previousSettings.value = { ...current };
+}, { deep: true, immediate: true });
 </script>
 
 <script lang="ts">

--- a/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
+++ b/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
@@ -42,7 +42,7 @@
         <section v-if="Object.keys(settings).length > 0" class="px-6">
           <div class="border-b border-gray-200 pb-1">
             <div v-for="(setting, settingsKey) in settings" :key="settingsKey" class="pb-3">
-              <component :is="setting.settingsComponent" v-model="form.settings[settingsKey]" />
+              <component :is="setting.settingsComponent" v-model="form.settings[settingsKey]" :settings="form.settings" />
             </div>
           </div>
         </section>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b2cf226</samp>

The pull request adds a `settings` prop to the `SavedViewForm` and its dynamic settings components to improve the saved views functionality for members. It also implements a conditional logic for the `MemberBotSetting` component to disable or reset the bot contacts visibility option based on the team member filter.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b2cf226</samp>

> _`Settings` of doom, control your fate_
> _`Component` of power, react and create_
> _`MemberBotSetting`, disable the spy_
> _`Form.settings`, save your view or die_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b2cf226</samp>

*  Disable and clear bot contacts visibility option when team member filter is applied ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1743/files?diff=unified&w=0#diff-a869350f8d40af89805385265cdc889fd97668762bff087357a876a7ff6e1d95L6-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1743/files?diff=unified&w=0#diff-a869350f8d40af89805385265cdc889fd97668762bff087357a876a7ff6e1d95L19-R49))
  - Pass `settings` prop to `MemberBotSetting` component in `SavedViewForm` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1743/files?diff=unified&w=0#diff-d67ac150354dbab875db71ed04795973215d229a1209cec86ea6297b14176210L45-R45))
  - Add `disabled` prop to `el-radio-group` in `MemberBotSetting` that depends on `settings?.teamMember` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1743/files?diff=unified&w=0#diff-a869350f8d40af89805385265cdc889fd97668762bff087357a876a7ff6e1d95L6-R6))
  - Update `props` definition, `value` computed property, and add `watch` effect in `MemberBotSetting` to handle `settings.teamMember` changes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1743/files?diff=unified&w=0#diff-a869350f8d40af89805385265cdc889fd97668762bff087357a876a7ff6e1d95L19-R49))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
