### PR TITLE
Add Custom views tracking

### DIFF
--- a/frontend/src/shared/modules/saved-views/components/SavedViewManagement.vue
+++ b/frontend/src/shared/modules/saved-views/components/SavedViewManagement.vue
@@ -92,6 +92,7 @@ const onListChange = () => {
       }),
     ),
   ).then(() => {
+    (window as any).analytics.track('Custom views rearanged');
     emit('reload');
   });
 };
@@ -117,6 +118,10 @@ const remove = (view: SavedView) => {
     .then(() => {
       SavedViewsService.delete(view.id)
         .then(() => {
+          (window as any).analytics.track('Custom view deleted', {
+            placement: view.placement,
+            name: view.name,
+          });
           emit('reload');
           Message.success('View successfully deleted');
         })

--- a/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
+++ b/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
@@ -392,6 +392,16 @@ const submit = (): void => {
       .then(() => {
         SavedViewsService.update((props.view as SavedView).id, data)
           .then(() => {
+            (window as any).analytics.track('Custom view updated', {
+              placement: props.placement,
+              name: form.name,
+              visibility: form.shared ? 'tenant' : 'user',
+              relation: form.relation,
+              orderProperty: form.sorting.prop,
+              orderDirection: form.sorting.order,
+              settings: form.settings,
+              filters: form.filters,
+            });
             isDrawerOpen.value = false;
             reset();
             Message.success('View updated successfully!');
@@ -407,13 +417,24 @@ const submit = (): void => {
   } else {
     SavedViewsService.create(data)
       .then(() => {
-        isDrawerOpen.value = false;
-        reset();
         if (isDuplicate.value) {
           Message.success('View duplicated successfully!');
         } else {
           Message.success('View successfully created!');
         }
+        (window as any).analytics.track('Custom view created', {
+          placement: props.placement,
+          name: form.name,
+          visibility: form.shared ? 'tenant' : 'user',
+          relation: form.relation,
+          orderProperty: form.sorting.prop,
+          orderDirection: form.sorting.order,
+          settings: form.settings,
+          filters: form.filters,
+          duplicated: isDuplicate.value,
+        });
+        isDrawerOpen.value = false;
+        reset();
         emit('reload');
       })
       .catch(() => {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a19eeeb</samp>

Added analytics tracking for various actions related to custom views in the `saved-views` module. Fixed a bug in `SavedViewForm.vue` that affected the drawer and form behavior.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a19eeeb</samp>

> _Sing, O Muse, of the valiant deeds of the coders_
> _Who, with skill and wisdom, enhanced the `saved-views` module_
> _And added analytics tracking for the creation and update_
> _Of custom views from the drawer in `SavedViewForm.vue`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a19eeeb</samp>

*  Track user actions and metadata for custom views with analytics service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-d67ac150354dbab875db71ed04795973215d229a1209cec86ea6297b14176210R395-R404), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-d67ac150354dbab875db71ed04795973215d229a1209cec86ea6297b14176210R425-R437), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-4ed8d42aa5b0e5655632d18d5eb95cf221bdc8810e2544cf840bc98acd219fe3R95), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-4ed8d42aa5b0e5655632d18d5eb95cf221bdc8810e2544cf840bc98acd219fe3R121-R124))
*  Keep drawer open and form values unchanged after updating custom view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-d67ac150354dbab875db71ed04795973215d229a1209cec86ea6297b14176210L410-L411))
*  Close drawer and reset form after creating custom view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1752/files?diff=unified&w=0#diff-d67ac150354dbab875db71ed04795973215d229a1209cec86ea6297b14176210R425-R437))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
