### PR TITLE
view not updating

### DIFF
--- a/frontend/src/shared/modules/filters/components/partials/string/FilterInput.vue
+++ b/frontend/src/shared/modules/filters/components/partials/string/FilterInput.vue
@@ -1,6 +1,7 @@
 <template>
   <el-input
     v-model="model"
+    :type="props.type"
     class="filter-input-field"
     :placeholder="placeholder"
   >
@@ -18,20 +19,21 @@
 import { computed } from 'vue';
 
 const props = defineProps<{
-  modelValue: string,
+  modelValue: string | number,
   placeholder?: string,
   suffix?: string,
   prefix?: string,
+  type?: string,
 }>();
 
-const emit = defineEmits<{(e: 'update:modelValue', value: string): void}>();
+const emit = defineEmits<{(e: 'update:modelValue', value: string | number): void}>();
 
-const model = computed<string>({
+const model = computed<string | number>({
   get() {
     return props.modelValue;
   },
-  set(value: string) {
-    emit('update:modelValue', value);
+  set(value: string | number) {
+    emit('update:modelValue', props.type === 'number' ? +value : value);
   },
 });
 </script>

--- a/frontend/src/shared/modules/saved-views/components/SavedViews.vue
+++ b/frontend/src/shared/modules/saved-views/components/SavedViews.vue
@@ -38,15 +38,15 @@
       </el-tabs>
     </div>
     <div v-if="isEnabled" class="border-b-2 border-[#e4e7ed] flex-grow flex justify-end -mb-px pb-1">
-      <el-button v-if="hasChanged && selectedTab !== ''" class="btn btn-brand btn-brand--transparent btn--sm !leading-5 !h-8 mr-2" @click="reset()">
+      <el-button v-if="hasChanged" class="btn btn-brand btn-brand--transparent btn--sm !leading-5 !h-8 mr-2" @click="reset()">
         Reset view
       </el-button>
-      <el-dropdown v-if="hasChanged && selectedTab !== ''" placement="bottom-end">
+      <el-dropdown v-if="hasChanged" placement="bottom-end">
         <el-button class="btn btn-brand btn-brand--transparent btn--sm !h-8 !leading-5 mr-2">
           Save as...
         </el-button>
         <template #dropdown>
-          <el-dropdown-item v-if="selectedTab.length > 0 && selectedTab !== props.config.defaultView.id" @click="update()">
+          <el-dropdown-item v-if="selectedTab.length > 0 && selectedTab !== props.config.defaultView.id && selectedTab !== ''" @click="update()">
             <div class="w-40">
               <i class="ri-loop-left-line text-gray-400 text-base mr-2" />Update view
             </div>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab15850</samp>

This pull request enhances the `FilterInput` component to handle numeric filters and fixes a bug in the `SavedViews` component that could cause the default view to be overwritten. These changes improve the usability and reliability of the frontend filters and saved views features.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab15850</samp>

> _Oh we are the coders of the sea, we fix the bugs and make enhancements_
> _We heave and ho and pull the code, we test and review and ship it home_
> _We fixed the `SavedViews` component, no more empty names to lament_
> _We heave and ho and pull the code, we added `type` to `FilterInput` oh_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab15850</samp>

*  Add `type` prop to `FilterInput` component to accept string or number values ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1761/files?diff=unified&w=0#diff-8c319e4aa72bce0cafed84583ab5a2f9ee17966a101b92e554df87a6f8bc4f1dR4),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1761/files?diff=unified&w=0#diff-8c319e4aa72bce0cafed84583ab5a2f9ee17966a101b92e554df87a6f8bc4f1dL21-R36))
*  Convert input value to number or string based on `type` prop in `FilterInput.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1761/files?diff=unified&w=0#diff-8c319e4aa72bce0cafed84583ab5a2f9ee17966a101b92e554df87a6f8bc4f1dL21-R36))
*  Fix bug in `SavedViews` component that hid `Update view` option for empty tab name ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1761/files?diff=unified&w=0#diff-bdc80cebc47c951bd54a6e25b0c5a0ad699dc0708d7f59a1763bcfdb7d3cdd13L41-R49))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
