### PR TITLE
Limiting multi-select attribute options

### DIFF
--- a/backend/src/database/repositories/memberAttributeSettingsRepository.ts
+++ b/backend/src/database/repositories/memberAttributeSettingsRepository.ts
@@ -42,6 +42,11 @@ class MemberAttributeSettingsRepository {
     }
     const output = record.get({ plain: true })
 
+    // Only include first 10 options. TODO:: Implement autocomplete endpoints for options
+    if (output.options && output.options.length > 10) {
+      output.options = output.options.slice(0, 10)
+    }
+
     return output
   }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2137724</samp>

Reduced the number of options returned by `getMemberAttributeSettings` to improve performance. Added a comment to suggest autocomplete endpoints as a future enhancement.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2137724</samp>

> _`getMemberAttributeSettings`_
> _Returns fewer options now_
> _Autocomplete soon_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2137724</samp>

* Limit the number of options returned by `getMemberAttributeSettings` to 10 ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1762/files?diff=unified&w=0#diff-fb670be94a87927d703ffae6baf59895e5790fbc0f2519a310338ef908f6eaafR45-R49))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
