### PR TITLE
Add custom filters and fix string filter parsing

### DIFF
--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -54,7 +54,8 @@
       <cr-saved-views
         v-model="filters"
         :config="memberSavedViews"
-        :filters="{ ...memberFilters, ...customAttributesFilter }"
+        :filters="memberFilters"
+        :custom-filters="customAttributesFilter"
         :static-views="memberViews"
         placement="member"
         @update:model-value="memberFilter.alignFilterList($event)"

--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -54,7 +54,7 @@
       <cr-saved-views
         v-model="filters"
         :config="memberSavedViews"
-        :filters="memberFilters"
+        :filters="{ ...memberFilters, ...customAttributesFilter }"
         :static-views="memberViews"
         placement="member"
         @update:model-value="memberFilter.alignFilterList($event)"

--- a/frontend/src/shared/modules/filters/components/filterTypes/StringFilter.vue
+++ b/frontend/src/shared/modules/filters/components/filterTypes/StringFilter.vue
@@ -44,7 +44,6 @@ const form = computed<StringFilterValue>({
 
 const defaultForm: StringFilterValue = {
   value: '',
-  include: true,
   operator: FilterStringOperator.LIKE,
 };
 

--- a/frontend/src/shared/modules/filters/config/itemLabelRenderer/string.label.renderer.ts
+++ b/frontend/src/shared/modules/filters/config/itemLabelRenderer/string.label.renderer.ts
@@ -3,10 +3,9 @@ import { FilterStringOperator, stringOperatorLabels } from '@/shared/modules/fil
 
 export const stringItemLabelRenderer = (
   property: string,
-  { value, include, operator }: StringFilterValue,
+  { value, operator }: StringFilterValue,
 ): string => {
-  const excludeText = !include ? ' (exclude)' : '';
   const valueText = operator !== FilterStringOperator.EQ ? `${stringOperatorLabels[operator]} ${value}` : value;
 
-  return `<b>${property}${excludeText}:</b>${valueText}`;
+  return `<b>${property}:</b>${valueText}`;
 };

--- a/frontend/src/shared/modules/filters/types/filterTypes/StringFilterConfig.ts
+++ b/frontend/src/shared/modules/filters/types/filterTypes/StringFilterConfig.ts
@@ -7,7 +7,6 @@ export interface StringFilterOptions {}
 export interface StringFilterValue {
   operator: FilterStringOperator,
   value: string,
-  include: boolean
 }
 
 export interface StringFilterConfig extends BaseFilterConfig {

--- a/frontend/src/shared/modules/saved-views/components/SavedViews.vue
+++ b/frontend/src/shared/modules/saved-views/components/SavedViews.vue
@@ -84,6 +84,7 @@
     v-model="isFormOpen"
     :config="props.config"
     :filters="props.filters"
+    :custom-filters="props.customFilters"
     :placement="props.placement"
     :view="editView"
     @update:model-value="editView = null"
@@ -110,6 +111,7 @@ const props = defineProps<{
   modelValue: Filter,
   config: SavedViewsConfig,
   filters: Record<string, FilterConfig>,
+  customFilters?: Record<string, FilterConfig>,
   placement: string,
   staticViews: SavedView[],
 }>();

--- a/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
+++ b/frontend/src/shared/modules/saved-views/components/forms/SavedViewForm.vue
@@ -132,6 +132,20 @@
                     >
                       {{ filterConfig.label }}
                     </el-dropdown-item>
+                    <div
+                      v-if="filteredCustomFilters.length > 0"
+                      class="el-dropdown-title !my-3"
+                    >
+                      Custom Attributes
+                    </div>
+                    <el-dropdown-item
+                      v-for="[key, filterConfig] of filteredCustomFilters"
+                      :key="key"
+                      :disabled="filterList.includes(key)"
+                      @click="addFilter(key)"
+                    >
+                      {{ filterConfig.label }}
+                    </el-dropdown-item>
                   </div>
                 </div>
               </template>
@@ -210,6 +224,7 @@ const props = defineProps<{
   modelValue: boolean,
   config: SavedViewsConfig,
   filters: Record<string, FilterConfig>,
+  customFilters?: Record<string, FilterConfig>,
   placement: string,
   view: SavedView | SavedViewCreate | null,
 }>();
@@ -296,6 +311,9 @@ const dropdownSearch = ref<string>('');
 
 const filteredFilters = computed(() => Object.entries(props.filters)
   .filter(([_, config]: [string, FilterConfig]) => config.label.toLowerCase().includes(dropdownSearch.value.toLowerCase())));
+
+const filteredCustomFilters = computed(() => (props.customFilters ? Object.entries(props.customFilters)
+  .filter(([_, config]: [string, FilterConfig]) => config.label.toLowerCase().includes(dropdownSearch.value.toLowerCase())) : []));
 
 // Filter list management
 const filterList = ref<string[]>([]);


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30b2a7c</samp>

This pull request removes the `include` property from the string filters and replaces it with the `operator` property, which can handle both inclusion and exclusion scenarios. This simplifies the logic and the UI for the string filters and allows the user to filter the members by their custom attributes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 30b2a7c</samp>

> _`include` is gone_
> _`operator` handles all_
> _filtering in fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30b2a7c</samp>

*  Add custom attributes filter to member list page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1764/files?diff=unified&w=0#diff-a16a3f5998f30c771f491f0b40da862d53738e6efe842aa604353f3c8f74be05L57-R57))
* Simplify string filter logic by removing `include` property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1764/files?diff=unified&w=0#diff-7198fa4224615c06d396d4a80c95f7e205ac738c13facdfed653130678ad8914L47), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1764/files?diff=unified&w=0#diff-2442d686060ffbd5b04d3c6bdd4ddebeca4a030fd8d9c9bd161c7ef4362679a8L6-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1764/files?diff=unified&w=0#diff-0b6c633b042643a723502026542b52a001def509605e6974240e8eee8c17f191L10))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
