### PR TITLE
Discord fix when channels are not avaliable

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/getChannels.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannels.ts
@@ -73,6 +73,8 @@ async function getChannels(
     const newErr = handleDiscordError(err, config, { input }, ctx)
     if (newErr) {
       throw newErr
+    } else {
+      return []
     }
   }
 }

--- a/services/libs/integrations/src/integrations/discord/processStream.ts
+++ b/services/libs/integrations/src/integrations/discord/processStream.ts
@@ -110,6 +110,11 @@ const processRootStream: ProcessStreamHandler = async (ctx) => {
     ctx,
   )
 
+  if (fromDiscordApi.length === 0) {
+    ctx.log.warn(`No avaliable channels found for guild ${guildId}, skipping...`)
+    return
+  }
+
   for (const channel of fromDiscordApi) {
     try {
       const config = {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90302f2</samp>

Improved error handling and logging for Discord integration. Added fallback and early return cases to `getChannels` and `processRootStream` functions in `services/libs/integrations/src/integrations/discord` files.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 90302f2</samp>

> _`getChannels` fails_
> _empty array as fallback_
> _autumn leaves no trace_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90302f2</samp>

*  Add fallback case and check for empty channels in Discord integration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1767/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97R76-R77), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1767/files?diff=unified&w=0#diff-f6af734a90d3f04d788d0950d275f595cc00cda989795f4d4b639baf21bc1227R113-R117))
  - In `getChannels.ts`, return an empty array if the guild has no channels or the API request fails ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1767/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97R76-R77))
  - In `processStream.ts`, log a warning and return early if the stream contains no channels for a given guild ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1767/files?diff=unified&w=0#diff-f6af734a90d3f04d788d0950d275f595cc00cda989795f4d4b639baf21bc1227R113-R117))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
