### PR TITLE
Don't change message visibility when stream is triggered manually

### DIFF
--- a/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
+++ b/services/apps/integration_stream_worker/src/service/integrationStreamService.ts
@@ -505,6 +505,11 @@ export default class IntegrationStreamService extends LoggerBase {
         )
       },
       setMessageVisibilityTimeout: async (newTimeout: number) => {
+        if (!receiptHandle) {
+          // this stream was triggerd manually (not from SQS), skipping visibility change
+          this.log.trace('No receipt handle provided, cannot change message visibility!')
+          return
+        }
         this.log.trace(`Changing message visibility of ${receiptHandle} to ${newTimeout}!`)
         await this.streamWorkerEmitter.setMessageVisibilityTimeout(receiptHandle, newTimeout)
       },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35eb26b</samp>

Prevent visibility change errors for manual stream triggers. Add a check for `receiptHandle` in `changeMessageVisibility` method of `IntegrationStreamService` in `integration_stream_worker` service.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 35eb26b</samp>

> _`receiptHandle` check_
> _avoids errors in the stream_
> _a trace in spring rain_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35eb26b</samp>

*  Add condition to check `receiptHandle` in `changeMessageVisibility` method ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1776/files?diff=unified&w=0#diff-382cff5616bf9462cc20ec936783791077806a109d658fd2fc44316d65bf5278R508-R512))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
