### PR TITLE
Fix `memberCount` in organization profile to match the list

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -2072,6 +2072,9 @@ class OrganizationRepository {
             min(a.timestamp) filter ( where a.timestamp <> '1970-01-01T00:00:00.000Z' ) as "joinedAt"
           from leaf_segment_ids ls
           join mv_activities_cube a on a."segmentId" = ls.id and a."organizationId" = :id
+          join members m on a."memberId" = m.id and m."deletedAt" is null
+          join "memberOrganizations" mo on m.id = mo."memberId" and a."organizationId" = mo."organizationId"
+          and mo."deletedAt" is null and mo."dateEnd" is null
           group by a."organizationId"
         ),
         organization_segments as (


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43157f0</samp>

This change improves the query for active assignments in `organizationRepository.ts` by filtering out the ones from inactive or deleted members. This supports the feature of organization management.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43157f0</samp>

> _`join` condition_
> _filters assignments by `member`_
> _autumn leaves fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43157f0</samp>

*  Add join condition to query active assignments for organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1779/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR2075-R2077))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
