### PR TITLE
Temporal ssl fixes

### DIFF
--- a/backend/config/custom-environment-variables.json
+++ b/backend/config/custom-environment-variables.json
@@ -199,7 +199,6 @@
   "temporal": {
     "serverUrl": "CROWD_TEMPORAL_SERVER_URL",
     "namespace": "CROWD_TEMPORAL_NAMESPACE",
-    "rootCa": "CROWD_TEMPORAL_ROOT_CA",
     "certificate": "CROWD_TEMPORAL_CERTIFICATE",
     "privateKey": "CROWD_TEMPORAL_PRIVATE_KEY"
   }

--- a/scripts/services/docker/Dockerfile.automations_worker
+++ b/scripts/services/docker/Dockerfile.automations_worker
@@ -1,4 +1,4 @@
-FROM node:16-slim 
+FROM node:16-bookworm
 
 WORKDIR /usr/crowd/app
 

--- a/services/apps/data_sink_worker/config/custom-environment-variables.json
+++ b/services/apps/data_sink_worker/config/custom-environment-variables.json
@@ -34,7 +34,6 @@
   "temporal": {
     "serverUrl": "CROWD_TEMPORAL_SERVER_URL",
     "namespace": "CROWD_TEMPORAL_NAMESPACE",
-    "rootCa": "CROWD_TEMPORAL_ROOT_CA",
     "certificate": "CROWD_TEMPORAL_CERTIFICATE",
     "privateKey": "CROWD_TEMPORAL_PRIVATE_KEY"
   }

--- a/services/archetypes/worker/src/index.ts
+++ b/services/archetypes/worker/src/index.ts
@@ -95,8 +95,8 @@ export class ServiceWorker extends Service {
       this.log.info(
         {
           address: process.env['CROWD_TEMPORAL_SERVER_URL'],
-          certificate: certificate ? Buffer.from(certificate, 'base64').toString('ascii') : 'none',
-          privateKey: privateKey ? Buffer.from(privateKey, 'base64').toString('ascii') : 'none',
+          certificate: certificate ? 'yes' : 'no',
+          privateKey: privateKey ? 'yes' : 'no',
         },
         'Connecting to Temporal server as a worker!',
       )

--- a/services/archetypes/worker/src/index.ts
+++ b/services/archetypes/worker/src/index.ts
@@ -89,16 +89,23 @@ export class ServiceWorker extends Service {
     }
 
     try {
-      const rootCa = process.env['CROWD_TEMPORAL_ROOT_CA']
       const certificate = process.env['CROWD_TEMPORAL_CERTIFICATE']
       const privateKey = process.env['CROWD_TEMPORAL_PRIVATE_KEY']
+
+      this.log.info(
+        {
+          address: process.env['CROWD_TEMPORAL_SERVER_URL'],
+          certificate: certificate ? Buffer.from(certificate, 'base64').toString('ascii') : 'none',
+          privateKey: privateKey ? Buffer.from(privateKey, 'base64').toString('ascii') : 'none',
+        },
+        'Connecting to Temporal server as a worker!',
+      )
 
       const connection = await NativeConnection.connect({
         address: process.env['CROWD_TEMPORAL_SERVER_URL'],
         tls:
-          rootCa && certificate && privateKey
+          certificate && privateKey
             ? {
-                serverRootCACertificate: Buffer.from(rootCa, 'base64'),
                 clientCertPair: {
                   crt: Buffer.from(certificate, 'base64'),
                   key: Buffer.from(privateKey, 'base64'),

--- a/services/libs/temporal/package-lock.json
+++ b/services/libs/temporal/package-lock.json
@@ -8,9 +8,31 @@
       "name": "@crowd/temporal",
       "version": "1.0.0",
       "dependencies": {
+        "@crowd/logging": "file:../logging",
         "@temporalio/client": "~1.8.6"
       },
       "devDependencies": {
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
+        "@typescript-eslint/parser": "^5.59.2",
+        "eslint": "^8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.0.4"
+      }
+    },
+    "../logging": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@crowd/common": "file:../common",
+        "@crowd/tracing": "file:../tracing",
+        "bunyan": "^1.8.15",
+        "bunyan-format": "^0.2.1"
+      },
+      "devDependencies": {
+        "@types/bunyan": "^1.8.8",
+        "@types/bunyan-format": "^0.2.5",
         "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
@@ -29,6 +51,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@crowd/logging": {
+      "resolved": "../logging",
+      "link": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -2009,6 +2035,25 @@
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
+    },
+    "@crowd/logging": {
+      "version": "file:../logging",
+      "requires": {
+        "@crowd/common": "file:../common",
+        "@crowd/tracing": "file:../tracing",
+        "@types/bunyan": "^1.8.8",
+        "@types/bunyan-format": "^0.2.5",
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
+        "@typescript-eslint/parser": "^5.59.2",
+        "bunyan": "^1.8.15",
+        "bunyan-format": "^0.2.1",
+        "eslint": "^8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.0.4"
+      }
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/services/libs/temporal/package.json
+++ b/services/libs/temporal/package.json
@@ -19,6 +19,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@temporalio/client": "~1.8.6"
+    "@temporalio/client": "~1.8.6",
+    "@crowd/logging": "file:../logging"
   }
 }

--- a/services/libs/temporal/src/index.ts
+++ b/services/libs/temporal/src/index.ts
@@ -1,13 +1,15 @@
+import { getServiceChildLogger } from '@crowd/logging'
 import { Connection, Client } from '@temporalio/client'
 
 export interface ITemporalConfig {
   serverUrl: string
   namespace: string
   identity: string
-  rootCa?: string
   certificate?: string
   privateKey?: string
 }
+
+const log = getServiceChildLogger('temporal')
 
 let client: Client | undefined
 export const getTemporalClient = async (cfg: ITemporalConfig): Promise<Client> => {
@@ -15,12 +17,23 @@ export const getTemporalClient = async (cfg: ITemporalConfig): Promise<Client> =
     return client
   }
 
+  log.info(
+    {
+      serverUrl: cfg.serverUrl,
+      namespace: cfg.namespace,
+      identity: cfg.identity,
+      certificate: cfg.certificate
+        ? Buffer.from(cfg.certificate, 'base64').toString('ascii')
+        : 'none',
+      privateKey: cfg.privateKey ? Buffer.from(cfg.privateKey, 'base64').toString('ascii') : 'none',
+    },
+    'Creating temporal client!',
+  )
   const connection = await Connection.connect({
     address: cfg.serverUrl,
     tls:
-      cfg.rootCa && cfg.certificate && cfg.privateKey
+      cfg.certificate && cfg.privateKey
         ? {
-            serverRootCACertificate: Buffer.from(cfg.rootCa, 'base64'),
             clientCertPair: {
               crt: Buffer.from(cfg.certificate, 'base64'),
               key: Buffer.from(cfg.privateKey, 'base64'),

--- a/services/libs/temporal/src/index.ts
+++ b/services/libs/temporal/src/index.ts
@@ -22,10 +22,8 @@ export const getTemporalClient = async (cfg: ITemporalConfig): Promise<Client> =
       serverUrl: cfg.serverUrl,
       namespace: cfg.namespace,
       identity: cfg.identity,
-      certificate: cfg.certificate
-        ? Buffer.from(cfg.certificate, 'base64').toString('ascii')
-        : 'none',
-      privateKey: cfg.privateKey ? Buffer.from(cfg.privateKey, 'base64').toString('ascii') : 'none',
+      certificate: cfg.certificate ? 'yes' : 'no',
+      privateKey: cfg.privateKey ? 'yes' : 'no',
     },
     'Creating temporal client!',
   )


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7996a40</samp>

This pull request updates the `temporal` library and the services that use it to use the `@crowd/logging` library for consistent logging, and to remove the unnecessary `rootCa` parameter and environment variable from the Temporal server connection. It also updates the `automations_worker` Dockerfile to use a newer Node.js base image.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7996a40</samp>

> _We don't need the `rootCa` var_
> _To connect to Temporal from afar_
> _We use `@crowd/logging` instead_
> _To log what the server has said_
> _And we update the `node` base image by far_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7996a40</samp>

*  Remove `rootCa` environment variable and parameter from Temporal server connection configuration ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-1864d4b4c5aa5e63752d82bbde88df62b5e882497ff96c9135d31fcdeb2ef1e1L202), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-62b14cab6415fc5976640522e032b57bcd3ca7ec49e1ca246b43dc6843776f03L37), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-5b8cbfe8cc970dce5048d3827bd8e50d19e0211d53917abe8c2776cb97ad2e54L92-R108), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-a9fc57c62dce44992606afb438a74bf0c26d0c47ffba6a133b3afd1726cd4974L7-R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-a9fc57c62dce44992606afb438a74bf0c26d0c47ffba6a133b3afd1726cd4974L18-R34))
*  Add `@crowd/logging` library as a dependency and use it for logging Temporal server connection details in `temporal` library and `worker` archetype ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-2296c401b95745202f8a0af0e55729d61e08aab20c8fa1bf7d85ff3208f812e3R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-2296c401b95745202f8a0af0e55729d61e08aab20c8fa1bf7d85ff3208f812e3R25-R45), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-2296c401b95745202f8a0af0e55729d61e08aab20c8fa1bf7d85ff3208f812e3R55-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-2296c401b95745202f8a0af0e55729d61e08aab20c8fa1bf7d85ff3208f812e3R2039-R2057), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-807d23709d15b24b00dbf97f89580169ef2a9d4b09b8cdd7c1a173cb8f8eb02fL22-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-a9fc57c62dce44992606afb438a74bf0c26d0c47ffba6a133b3afd1726cd4974R1), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-5b8cbfe8cc970dce5048d3827bd8e50d19e0211d53917abe8c2776cb97ad2e54L92-R108))
*  Update base image for `automations_worker` Dockerfile to use Node.js 16 with `bookworm` feature flag ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1783/files?diff=unified&w=0#diff-18a732a73cf4491e5b461b41207f363a4d38365d368a27ba4198b300aa9525bfL1-R1))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
