### PR TITLE
Merging existing tags error when data.tags is not present

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -341,8 +341,8 @@ class OrganizationRepository {
           const existingOrg = existingOrgs.find((o) => o.id === org.id)
           if (existingOrg && existingOrg.tags) {
             // Merge existing and new tags without duplicates
-            const existingTags = org.tags || []
-            org.tags = lodash.uniq([...existingOrg.tags, ...existingTags])
+            const incomingTags = org.tags || []
+            org.tags = lodash.uniq([...existingOrg.tags, ...incomingTags])
           }
           return org
         })

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -341,7 +341,8 @@ class OrganizationRepository {
           const existingOrg = existingOrgs.find((o) => o.id === org.id)
           if (existingOrg && existingOrg.tags) {
             // Merge existing and new tags without duplicates
-            org.tags = lodash.uniq([...existingOrg.tags, ...org.tags])
+            const existingTags = org.tags || []
+            org.tags = lodash.uniq([...existingOrg.tags, ...existingTags])
           }
           return org
         })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1574f5</samp>

Fix a bug in `organizationRepository.ts` that overwrites organization tags. The change prevents losing existing tags when updating an organization's profile.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1574f5</samp>

> _`tags` undefined?_
> _Use empty array instead_
> _Preserve old values_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1574f5</samp>

*  Fix bug of overwriting organization tags when updating profile ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1784/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL344-R345))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
