### PR TITLE
Organization finding cache - also checking by name sent in payload

### DIFF
--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -353,9 +353,10 @@ export default class OrganizationService extends LoggerBase {
       const shouldDoEnrich = await this.shouldEnrich(enrichP)
 
       const primaryIdentity = data.identities[0]
+      const nameToCheckInCache = (data as any).name || primaryIdentity.name
 
       // check cache existing by name
-      let cache = await organizationCacheRepository.findByName(primaryIdentity.name, {
+      let cache = await organizationCacheRepository.findByName(nameToCheckInCache, {
         ...this.options,
         transaction,
       })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7d87594</samp>

Use data name instead of primary identity name for organization cache lookup. This allows creating or updating organizations with custom names that differ from the primary identity name. The change affects the file `backend/src/services/organizationService.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7d87594</samp>

> _`nameToCheckInCache`_
> _handles custom org names well_
> _fall is for updates_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7d87594</samp>

*  Support custom names for organizations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1792/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L356-R359))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
