### PR TITLE
Optimize GitHub integration

### DIFF
--- a/services/libs/integrations/src/integrations/github/processStream.ts
+++ b/services/libs/integrations/src/integrations/github/processStream.ts
@@ -122,7 +122,7 @@ async function getMemberData(ctx: IProcessStreamContext, login: string): Promise
 
 async function getOrganizationData(ctx: IProcessStreamContext, company: string): Promise<any> {
   if (company === '' || company === null || company === undefined) {
-    return ''
+    return null
   }
 
   const cache = ctx.globalCache
@@ -131,10 +131,10 @@ async function getOrganizationData(ctx: IProcessStreamContext, company: string):
   const existing = await cache.get(prefix(company))
   if (existing) {
     if (existing === 'null') {
-      return ''
+      return null
     }
 
-    return existing
+    return JSON.parse(existing)
   }
 
   const token = await getGithubToken(ctx)
@@ -149,7 +149,7 @@ async function getOrganizationData(ctx: IProcessStreamContext, company: string):
   }
 
   await cache.set(prefix(company), 'null', 60 * 60)
-  return ''
+  return null
 }
 
 async function getMemberEmail(ctx: IProcessStreamContext, login: string): Promise<string> {
@@ -212,12 +212,7 @@ export const prepareMember = async (
       orgs = [{ name: 'crowd.dev' }]
     } else {
       const company = memberFromApi.company.replace('@', '').trim()
-      const token = await getGithubToken(ctx)
-      const fromAPI = await getOrganization(company, token, getTokenRotator(ctx), {
-        concurrentRequestLimiter: getConcurrentRequestLimiter(ctx),
-        integrationId: ctx.integration.id,
-      })
-
+      const fromAPI = await getOrganizationData(ctx, company)
       orgs = fromAPI
     }
   }

--- a/services/libs/integrations/src/integrations/github/processStream.ts
+++ b/services/libs/integrations/src/integrations/github/processStream.ts
@@ -144,11 +144,11 @@ async function getOrganizationData(ctx: IProcessStreamContext, company: string):
   })
 
   if (fromAPI) {
-    await cache.set(prefix(company), JSON.stringify(fromAPI), 60 * 60)
+    await cache.set(prefix(company), JSON.stringify(fromAPI), 24 * 60 * 60)
     return fromAPI
   }
 
-  await cache.set(prefix(company), 'null', 60 * 60)
+  await cache.set(prefix(company), 'null', 24 * 60 * 60)
   return null
 }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ce814b</samp>

Improve GitHub integration by using cache and organization data. Refactor `processStream.ts` to use a global cache with a prefix and a new function to fetch and store the organization data from GitHub.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7ce814b</samp>

> _We are the masters of the cache_
> _We use the prefix to avoid the clash_
> _We get the data from the org_
> _We integrate with GitHub like a forge_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ce814b</samp>

*  Add a new function `getOrganizationData` to fetch the organization data from the GitHub API or the global cache with a prefix ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1796/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2R123-R154))
*  Refactor the `getMemberEmail` function to use the global cache and the prefix for the cache keys ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1796/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L128-R166), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1796/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L145-R182))
*  Simplify the `prepareMember` function by using the `getOrganizationData` function instead of repeating the logic ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1796/files?diff=unified&w=0#diff-98da262e5140f64998a47e4cff8ae3ccb081c8529f3e98c9ee581a5d52e993b2L182-R215))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
