### PR TITLE
Integrations - only update organization website when it exists

### DIFF
--- a/services/apps/data_sink_worker/src/service/organization.service.ts
+++ b/services/apps/data_sink_worker/src/service/organization.service.ts
@@ -188,7 +188,7 @@ export class OrganizationService extends LoggerBase {
             'weakIdentities',
           ]
           fields.forEach((field) => {
-            if (field === 'website' && !existing.website) {
+            if (field === 'website' && !existing.website && cached.website) {
               updateData[field] = cached[field]
             } else if (
               field !== 'website' &&


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b37e87</samp>

Fix a bug in `organization.service.ts` that erased the website field of an organization. Add a condition to check the cached website field before updating the database.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b37e87</samp>

> _`updateData` checks_
> _cached website not empty_
> _autumn bug is fixed_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b37e87</samp>

*  Fix a bug where the website field of an organization would be erased by empty cached data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1798/files?diff=unified&w=0#diff-c4775fb9079e4d3766f7b65b1d34e302fdf4b798a53e206c4cd85c683a4885d1L191-R191))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
