### PR TITLE
Fix cals links in automations

### DIFF
--- a/frontend/src/modules/automation/config/automation-types/hubspot/config.ts
+++ b/frontend/src/modules/automation/config/automation-types/hubspot/config.ts
@@ -76,7 +76,7 @@ export const hubspot: AutomationTypeConfig = {
     return {
       label: 'Upgrade plan',
       action: () => {
-        window.open('https://cal.com/team/crowddotdev/custom-plan', '_blank');
+        window.open('https://cal.com/team/crowddotdev/sales', '_blank');
       },
     };
   },

--- a/frontend/src/modules/automation/config/automation-types/hubspot/hubspot-paywall.vue
+++ b/frontend/src/modules/automation/config/automation-types/hubspot/hubspot-paywall.vue
@@ -14,7 +14,7 @@
       </p>
       <div class="flex justify-center pt-8">
         <a
-          href="https://cal.com/team/crowddotdev/custom-plan"
+          href="https://cal.com/team/crowddotdev/sales"
           target="_blank"
           rel="noopener noreferrer"
           class="btn btn--md btn--bordered"


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc368db</samp>

Changed the upgrade plan URLs for HubSpot automation to point to the sales page. This is to simplify the pricing and plan options for the users.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bc368db</samp>

> _`upgrade plan` link_
> _points to sales page now, not_
> _custom plan. Simpler._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc368db</samp>

* Change the URL for the upgrade plan button and link in the HubSpot automation config and paywall to point to the sales page ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1803/files?diff=unified&w=0#diff-2fe7ff0bb4fb943d95f477f1fa7f6806eb4e6a72f093e7b62bc91f6263338f51L79-R79), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1803/files?diff=unified&w=0#diff-3bca2b7600cd34c916cd5dbf5377a78185d4c45e5b31ba520e384e888486f643L17-R17))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
