### PR TITLE
Delay discord integration checks with 50% chance

### DIFF
--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -199,13 +199,35 @@ export class IntegrationTickProcessor extends LoggerBase {
                   integration.id,
                 )
               if (!existingRun) {
-                logger.info({ integrationId: integration.id }, 'Triggering new integration check!')
-                await emitter.triggerIntegrationRun(
-                  integration.tenantId,
-                  integration.platform,
-                  integration.id,
-                  false,
-                )
+                const rand = Math.random()
+                // 50% chance to delay the triggering of new integration checks for Discord integrations
+                if (newIntService.type === IntegrationType.DISCORD && rand > 0.5) {
+                  // Delay the triggering of new integration checks for Discord integrations
+                  const delay = 30 * 60 * 1000 // 30 minutes in milliseconds
+                  setTimeout(async () => {
+                    logger.info(
+                      { integrationId: integration.id },
+                      'Triggering new delayed integration check for Discord!',
+                    )
+                    await emitter.triggerIntegrationRun(
+                      integration.tenantId,
+                      integration.platform,
+                      integration.id,
+                      false,
+                    )
+                  }, delay)
+                } else {
+                  logger.info(
+                    { integrationId: integration.id },
+                    'Triggering new integration check!',
+                  )
+                  await emitter.triggerIntegrationRun(
+                    integration.tenantId,
+                    integration.platform,
+                    integration.id,
+                    false,
+                  )
+                }
               } else {
                 logger.info({ integrationId: integration.id }, 'Existing run found, skipping!')
               }

--- a/services/libs/integrations/src/integrations/discord/index.ts
+++ b/services/libs/integrations/src/integrations/discord/index.ts
@@ -9,7 +9,7 @@ import processWebhookStream from './processWebhookStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.DISCORD,
   memberAttributes: DISCORD_MEMBER_ATTRIBUTES,
-  checkEvery: 12 * 60, // 12 hours
+  checkEvery: 6 * 60, // 6 hours
   generateStreams,
   processStream,
   processData,

--- a/services/libs/integrations/src/integrations/discord/index.ts
+++ b/services/libs/integrations/src/integrations/discord/index.ts
@@ -9,7 +9,7 @@ import processWebhookStream from './processWebhookStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.DISCORD,
   memberAttributes: DISCORD_MEMBER_ATTRIBUTES,
-  checkEvery: 6 * 60, // 6 hours
+  checkEvery: 12 * 60, // 12 hours
   generateStreams,
   processStream,
   processData,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51e55c2</samp>

This pull request modifies the integration service to improve the handling of Discord integrations. It adds a random delay for triggering new integration checks to avoid Discord API rate limits, and reduces the check interval from 12 hours to 6 hours to sync member data more frequently.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 51e55c2</samp>

> _`Discord` members change_
> _Integration service adapts_
> _Delay or check soon_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 51e55c2</samp>

* Reduce the frequency of checking for new or updated members in Discord integrations from 12 hours to 6 hours to improve timeliness and accuracy of member data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1809/files?diff=unified&w=0#diff-32a69dfcf219006b886b7a3583b9cd4f40d55372f2688f2655cbc4dab5c44ebdL12-R12))
* Introduce a random delay for triggering new integration checks for Discord integrations to reduce the rate of hitting Discord API rate limits and prevent errors and failures ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1809/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L202-R230))
* Add logging messages to indicate whether the integration check is delayed or not for Discord integrations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1809/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L202-R230))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
