### PR TITLE
Automations - bugfix when processing activities

### DIFF
--- a/services/apps/automations_worker/src/repos/data.repo.ts
+++ b/services/apps/automations_worker/src/repos/data.repo.ts
@@ -93,8 +93,8 @@ export class DataRepository extends RepositoryBase<DataRepository> {
 
       // load members and object members
       let memberIds = results.filter((r) => r.memberId).map((r) => r.memberId)
-      memberIds = memberIds.concat(
-        results.filter((r) => r.objectMemberId).map((r) => r.objectMemberId),
+      memberIds = distinct(
+        memberIds.concat(results.filter((r) => r.objectMemberId).map((r) => r.objectMemberId)),
       )
       if (memberIds.length > 0) {
         promises.push(
@@ -184,7 +184,8 @@ export class DataRepository extends RepositoryBase<DataRepository> {
         m."manuallyCreated",
         m."createdAt",
         m."tenantId",
-        m."createdById"
+        m."createdById",
+        m.score
     from members m
     where m.id in ($(memberIds:csv))
       and m."deletedAt" is null;

--- a/services/apps/automations_worker/src/repos/types.ts
+++ b/services/apps/automations_worker/src/repos/types.ts
@@ -5,6 +5,7 @@ export interface IMemberData {
   tenantId: string
   attributes: any
 
+  score: number
   username: Record<string, string[]>
   identities: string[]
   segments: unknown[]


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63fe321</samp>

Added a `score` column and a `distinct` function to improve data loading for members. Updated the `IMemberData` interface and the `data.repo.ts` file to reflect the changes.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 63fe321</samp>

> _To match the schema and query_
> _The `score` property was added, you see_
> _To the `IMemberData` interface_
> _And to load data with grace_
> _A `distinct` function and a `score` column, nifty!_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63fe321</samp>

*  Add `score` property to `IMemberData` interface to store member's activity and reputation value ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1822/files?diff=unified&w=0#diff-d749ce4fa7c9046eede70a3c0fa626a54266228302a1ba12e6e3aa66724b7df3R8))
*  Include `score` column in SQL query to fetch member data from database in `data.repo.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1822/files?diff=unified&w=0#diff-0927ac2c55ef09851c8ca6f3c1df920d075258a27749fb648c6c988838276942L187-R188))
*  Remove duplicate member ids from array before querying database to improve performance and accuracy in `data.repo.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1822/files?diff=unified&w=0#diff-0927ac2c55ef09851c8ca6f3c1df920d075258a27749fb648c6c988838276942L96-R97))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screenshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
