### PR TITLE
Enhancement/optional feature flag redis caching

### DIFF
--- a/services/apps/data_sink_worker/src/bin/delete-stuck-pods.ts
+++ b/services/apps/data_sink_worker/src/bin/delete-stuck-pods.ts
@@ -1,0 +1,46 @@
+import { exec } from 'child_process'
+
+const getPods = async (): Promise<string[]> => {
+  return new Promise((resolve, reject) => {
+    exec('kubectl get pods -n platform', (err, stdout) => {
+      if (err) {
+        reject(err)
+      } else {
+        const lines = stdout.split('\n')
+        resolve(lines)
+      }
+    })
+  })
+}
+
+const executeCommand = async (command: string): Promise<string[]> => {
+  return new Promise((resolve, reject) => {
+    exec(command, (err, stdout) => {
+      if (err) {
+        reject(err)
+      } else {
+        const lines = stdout.split('\n')
+        resolve(lines)
+      }
+    })
+  })
+}
+
+setImmediate(async () => {
+  const lines = await getPods()
+  for (const line of lines) {
+    const split = line.split(' ').filter((x) => x.trim().length > 0)
+    const pod = split[0]
+    const state = split[2]
+    if (
+      state === 'Evicted' ||
+      state === 'OOMKilled' ||
+      state === 'ContainerStatusUnknown' ||
+      state === 'Error'
+    ) {
+      const command = `kubectl delete pod ${pod} --force --grace-period=0  -n platform`
+      const result = await executeCommand(command)
+      console.log(result)
+    }
+  }
+})

--- a/services/apps/data_sink_worker/src/bin/map-member-to-org.ts
+++ b/services/apps/data_sink_worker/src/bin/map-member-to-org.ts
@@ -1,4 +1,4 @@
-import { DB_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
+import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
 import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
@@ -14,6 +14,7 @@ import DataSinkRepository from '../repo/dataSink.repo'
 import { OrganizationService } from '../service/organization.service'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
+import { getRedisClient } from '@crowd/redis'
 
 const tracer = getServiceTracer()
 const log = getServiceLogger()
@@ -52,12 +53,15 @@ setImmediate(async () => {
   const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
   await searchSyncWorkerEmitter.init()
 
+  const redisClient = await getRedisClient(REDIS_CONFIG())
+
   const memberService = new MemberService(
     store,
     nodejsWorkerEmitter,
     searchSyncWorkerEmitter,
     unleash,
     temporal,
+    redisClient,
     log,
   )
   const orgService = new OrganizationService(store, log)

--- a/services/apps/data_sink_worker/src/bin/map-tenant-members-to-org.ts
+++ b/services/apps/data_sink_worker/src/bin/map-tenant-members-to-org.ts
@@ -1,4 +1,4 @@
-import { DB_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
+import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
 import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
@@ -14,6 +14,7 @@ import MemberService from '../service/member.service'
 import { OrganizationService } from '../service/organization.service'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
+import { getRedisClient } from '@crowd/redis'
 
 const tracer = getServiceTracer()
 const log = getServiceLogger()
@@ -55,12 +56,15 @@ setImmediate(async () => {
   const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
   await searchSyncWorkerEmitter.init()
 
+  const redisClient = await getRedisClient(REDIS_CONFIG())
+
   const memberService = new MemberService(
     store,
     nodejsWorkerEmitter,
     searchSyncWorkerEmitter,
     unleash,
     temporal,
+    redisClient,
     log,
   )
   const orgService = new OrganizationService(store, log)

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -104,6 +104,8 @@ export default class ActivityService extends LoggerBase {
             }
           },
           this.unleash,
+          this.redisClient,
+          60,
         )
       ) {
         const handle = await this.temporal.workflow.start('processNewActivityAutomation', {
@@ -422,6 +424,7 @@ export default class ActivityService extends LoggerBase {
             this.searchSyncWorkerEmitter,
             this.unleash,
             this.temporal,
+            this.redisClient,
             this.log,
           )
           const txActivityService = new ActivityService(

--- a/services/apps/data_sink_worker/src/service/dataSink.service.ts
+++ b/services/apps/data_sink_worker/src/service/dataSink.service.ts
@@ -136,6 +136,7 @@ export default class DataSinkService extends LoggerBase {
             this.searchSyncWorkerEmitter,
             this.unleash,
             this.temporal,
+            this.redisClient,
             this.log,
           )
           const memberData = data.data as IMemberData
@@ -169,6 +170,7 @@ export default class DataSinkService extends LoggerBase {
             this.searchSyncWorkerEmitter,
             this.unleash,
             this.temporal,
+            this.redisClient,
             this.log,
           )
           const memberData = data.data as IMemberData

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -27,6 +27,7 @@ import { OrganizationService } from './organization.service'
 import uniqby from 'lodash.uniqby'
 import { Unleash, isFeatureEnabled } from '@crowd/feature-flags'
 import { TEMPORAL_CONFIG } from '../conf'
+import { RedisClient } from '@crowd/redis'
 
 export default class MemberService extends LoggerBase {
   constructor(
@@ -35,6 +36,7 @@ export default class MemberService extends LoggerBase {
     private readonly searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
     private readonly unleash: Unleash | undefined,
     private readonly temporal: TemporalClient,
+    private readonly redisClient: RedisClient,
     parentLog: Logger,
   ) {
     super(parentLog)
@@ -135,6 +137,8 @@ export default class MemberService extends LoggerBase {
             }
           },
           this.unleash,
+          this.redisClient,
+          60,
         )
       ) {
         const handle = await this.temporal.workflow.start('processNewMemberAutomation', {
@@ -373,6 +377,7 @@ export default class MemberService extends LoggerBase {
           this.searchSyncWorkerEmitter,
           this.unleash,
           this.temporal,
+          this.redisClient,
           this.log,
         )
 
@@ -462,6 +467,7 @@ export default class MemberService extends LoggerBase {
           this.searchSyncWorkerEmitter,
           this.unleash,
           this.temporal,
+          this.redisClient,
           this.log,
         )
 

--- a/services/libs/feature-flags/package-lock.json
+++ b/services/libs/feature-flags/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@crowd/common": "file:../common",
         "@crowd/logging": "file:../logging",
+        "@crowd/redis": "file:../redis",
         "@crowd/types": "file:../types",
         "unleash-client": "^3.18.1"
       },
@@ -25,6 +26,7 @@
       }
     },
     "../common": {
+      "name": "@crowd/common",
       "version": "1.0.0",
       "dependencies": {
         "@crowd/logging": "file:../logging",
@@ -65,6 +67,25 @@
         "typescript": "^5.0.4"
       }
     },
+    "../redis": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@crowd/common": "file:../common",
+        "@crowd/logging": "file:../logging",
+        "@crowd/types": "file:../types",
+        "redis": "^4.6.6"
+      },
+      "devDependencies": {
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
+        "@typescript-eslint/parser": "^5.59.2",
+        "eslint": "^8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "typescript": "^5.0.4"
+      }
+    },
     "../types": {
       "name": "@crowd/types",
       "version": "1.0.0",
@@ -94,6 +115,10 @@
     },
     "node_modules/@crowd/logging": {
       "resolved": "../logging",
+      "link": true
+    },
+    "node_modules/@crowd/redis": {
+      "resolved": "../redis",
       "link": true
     },
     "node_modules/@crowd/types": {
@@ -2344,6 +2369,23 @@
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.8.8",
+        "typescript": "^5.0.4"
+      }
+    },
+    "@crowd/redis": {
+      "version": "file:../redis",
+      "requires": {
+        "@crowd/common": "file:../common",
+        "@crowd/logging": "file:../logging",
+        "@crowd/types": "file:../types",
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
+        "@typescript-eslint/parser": "^5.59.2",
+        "eslint": "^8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "prettier": "^2.8.8",
+        "redis": "^4.6.6",
         "typescript": "^5.0.4"
       }
     },

--- a/services/libs/feature-flags/package.json
+++ b/services/libs/feature-flags/package.json
@@ -22,6 +22,7 @@
     "@crowd/common": "file:../common",
     "@crowd/logging": "file:../logging",
     "@crowd/types": "file:../types",
+    "@crowd/redis": "file:../redis",
     "unleash-client": "^3.18.1"
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b8b8d2</samp>

This pull request adds Redis caching to the feature flag service and its consumers in the data sink worker. It modifies the `isFeatureEnabled` function and its calls in the `@crowd/feature-flags` package and the `ActivityService`, `DataSinkService`, and `MemberService` classes. It also updates the dependencies and the lock file accordingly. The goal is to improve the performance and consistency of the feature flag checks.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0b8b8d2</samp>

> _Oh we're the crew of the `@crowd` ship, and we sail the code sea_
> _We need to check our feature flags, with Redis caching_
> _So haul away the `package.json`, and update the dependencies_
> _And pass the `redisClient` along, to every service_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b8b8d2</samp>

*  Add `@crowd/redis` package as a dependency of `@crowd/feature-flags` package and import its types and functions in `index.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-506d29c95b05571e8b394ac5dccdaad873e45c780c86ffe9dfe2704dfba563c7R13), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5eaa9834fc93f2b173418202b156845c1e85a3d7591ff5d959b94a271a3b7ecaR25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-dd4485008db2a5e81e874b3ff6c4a9f14384a6d5fc8d6a0b8cc5a55b14c43d26R3))
*  Add optional `redis` and `redisTimeoutSeconds` parameters to `isFeatureEnabled` function and implement caching logic using `RedisCache` class in `@crowd/feature-flags` package ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-dd4485008db2a5e81e874b3ff6c4a9f14384a6d5fc8d6a0b8cc5a55b14c43d26R62-R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-dd4485008db2a5e81e874b3ff6c4a9f14384a6d5fc8d6a0b8cc5a55b14c43d26L74-R92))
*  Pass `redisClient` and `60` as arguments to `isFeatureEnabled` function calls in `ActivityService`, `DataSinkService`, and `MemberService` classes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR107-R108), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR427), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR139), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR173), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87R140-R141), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87R380), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87R470))
*  Add `redisClient` as a private property of `MemberService` class and inject it as a dependency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87R39))
*  Fix missing `name` property of `@crowd/common` package and link local `redis` package to root project in `package-lock.json` file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-506d29c95b05571e8b394ac5dccdaad873e45c780c86ffe9dfe2704dfba563c7R29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-506d29c95b05571e8b394ac5dccdaad873e45c780c86ffe9dfe2704dfba563c7R70-R88), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-506d29c95b05571e8b394ac5dccdaad873e45c780c86ffe9dfe2704dfba563c7R120-R123), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1824/files?diff=unified&w=0#diff-506d29c95b05571e8b394ac5dccdaad873e45c780c86ffe9dfe2704dfba563c7R2375-R2391))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screenshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
