### PR TITLE
Merge organizations asynchronously

### DIFF
--- a/backend/src/api/organization/organizationMerge.ts
+++ b/backend/src/api/organization/organizationMerge.ts
@@ -6,14 +6,17 @@ import PermissionChecker from '../../services/user/permissionChecker'
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.organizationEdit)
 
-  const payload = await new OrganizationService(req).merge(
-    req.params.organizationId,
-    req.body.organizationToMerge,
-  )
+  const primaryOrgId = req.params.organizationId
+  const secondaryOrgId = req.body.organizationToMerge
 
-  track('Merge organizations', { ...payload }, { ...req })
+  const requestPayload = {
+    primary: primaryOrgId,
+    secondary: secondaryOrgId,
+  }
 
-  const status = payload.status || 200
+  await new OrganizationService(req).mergeAsync(primaryOrgId, secondaryOrgId)
 
-  await req.responseHandler.success(req, res, payload, status)
+  track('Merge organizations', requestPayload, { ...req })
+
+  await req.responseHandler.success(req, res, requestPayload)
 }

--- a/backend/src/bin/scripts/merge-duplicated-organizations.ts
+++ b/backend/src/bin/scripts/merge-duplicated-organizations.ts
@@ -63,7 +63,7 @@ async function mergeOrganizationsWithSameWebsite(): Promise<void> {
       const primaryOrganizationId = orgInfo.organizationIds.shift()
       for (const orgId of orgInfo.organizationIds) {
         log.info(`Merging organization ${orgId} into ${primaryOrganizationId}!`)
-        await service.merge(primaryOrganizationId, orgId)
+        await service.mergeSync(primaryOrganizationId, orgId)
       }
     }
   } while (mergeableOrganizations.length > 0)

--- a/backend/src/bin/scripts/merge-organizations.ts
+++ b/backend/src/bin/scripts/merge-organizations.ts
@@ -87,7 +87,7 @@ if (parameters.help || !parameters.originalId || !parameters.toMergeId || !param
         log.info(`Merging ${toMergeId} into ${originalId}...`)
         const service = new OrganizationService(options)
         try {
-          await service.merge(originalId, toMergeId)
+          await service.mergeSync(originalId, toMergeId)
         } catch (err) {
           log.error(`Error merging organizations: ${err.message}`)
           process.exit(1)

--- a/backend/src/database/migrations/U1699357748__org-merge-status.sql
+++ b/backend/src/database/migrations/U1699357748__org-merge-status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizationToMerge" DROP COLUMN status;

--- a/backend/src/database/migrations/U1699459698__merge-actions.sql
+++ b/backend/src/database/migrations/U1699459698__merge-actions.sql
@@ -1,0 +1,1 @@
+DROP TABLE "mergeActions";

--- a/backend/src/database/migrations/V1699357748__org-merge-status.sql
+++ b/backend/src/database/migrations/V1699357748__org-merge-status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizationToMerge" ADD COLUMN status VARCHAR(16) NOT NULL DEFAULT 'ready';

--- a/backend/src/database/migrations/V1699459698__merge-actions.sql
+++ b/backend/src/database/migrations/V1699459698__merge-actions.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "mergeActions" (
+  id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+  "tenantId" UUID NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+  type VARCHAR(16) NOT NULL, -- org or member
+  "primaryId" UUID NOT NULL,
+  "secondaryId" UUID NOT NULL,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  "state" VARCHAR(16) NOT NULL, -- pending, in-progress, done
+  UNIQUE ("tenantId", type, "primaryId", "secondaryId")
+);
+
+CREATE INDEX "mergeActions_main_idx" ON "mergeActions" (type, "primaryId", "secondaryId");

--- a/backend/src/database/repositories/mergeActionsRepository.ts
+++ b/backend/src/database/repositories/mergeActionsRepository.ts
@@ -1,0 +1,86 @@
+import { QueryTypes } from 'sequelize'
+import { IRepositoryOptions } from './IRepositoryOptions'
+import SequelizeRepository from './sequelizeRepository'
+
+enum MergeActionType {
+  ORG = 'org',
+  MEMBER = 'member',
+}
+
+enum MergeActionState {
+  PENDING = 'pending',
+  IN_PROGRESS = 'in-progress',
+  DONE = 'done',
+  ERROR = 'error',
+}
+
+class MergeActionsRepository {
+  static async add(
+    type: MergeActionType,
+    primaryId: string,
+    secondaryId: string,
+    options: IRepositoryOptions,
+  ) {
+    const transaction = SequelizeRepository.getTransaction(options)
+    const tenantId = options.currentTenant.id
+
+    await options.database.sequelize.query(
+      `
+        INSERT INTO "mergeActions" ("tenantId", "type", "primaryId", "secondaryId", state)
+        VALUES (:tenantId, :type, :primaryId, :secondaryId, :state)
+        ON CONFLICT ("tenantId", "type", "primaryId", "secondaryId")
+        DO UPDATE SET state = :state
+      `,
+      {
+        replacements: {
+          tenantId,
+          type,
+          primaryId,
+          secondaryId,
+          state: MergeActionState.PENDING,
+        },
+        type: QueryTypes.INSERT,
+        transaction,
+      },
+    )
+  }
+
+  static async setState(
+    type: MergeActionType,
+    primaryId: string,
+    secondaryId: string,
+    state: MergeActionState,
+    options: IRepositoryOptions,
+  ) {
+    const transaction = SequelizeRepository.getTransaction(options)
+    const tenantId = options.currentTenant.id
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, rowCount] = await options.database.sequelize.query(
+      `
+        UPDATE "mergeActions"
+        SET state = :state
+        WHERE "tenantId" = :tenantId
+          AND type = :type
+          AND "primaryId" = :primaryId
+          AND "secondaryId" = :secondaryId
+          AND state != :state
+      `,
+      {
+        replacements: {
+          tenantId,
+          type,
+          primaryId,
+          secondaryId,
+          state,
+        },
+        type: QueryTypes.UPDATE,
+        transaction,
+      },
+    )
+
+    return rowCount > 0
+  }
+}
+
+export { MergeActionsRepository, MergeActionType, MergeActionState }

--- a/backend/src/serverless/microservices/nodejs/messageTypes.ts
+++ b/backend/src/serverless/microservices/nodejs/messageTypes.ts
@@ -86,3 +86,11 @@ export type OrganizationBulkEnrichMessage = {
   tenantId: string
   maxEnrichLimit: number
 }
+
+export type OrganizationMergeMessage = {
+  service: string
+  tenantId: string
+  primaryOrgId: string
+  secondaryOrgId: string
+  notifyFrontend?: boolean
+}

--- a/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
@@ -1,0 +1,62 @@
+import { getRedisClient, RedisPubSubEmitter } from '@crowd/redis'
+import { ApiWebsocketMessage } from '@crowd/types'
+import { REDIS_CONFIG } from '../../../../conf'
+import getUserContext from '../../../../database/utils/getUserContext'
+import OrganizationService from '../../../../services/organizationService'
+
+async function doNotifyFrontend({ log, success, tenantId, primaryOrgId, secondaryOrgId }) {
+  const redis = await getRedisClient(REDIS_CONFIG, true)
+  const apiPubSubEmitter = new RedisPubSubEmitter(
+    'api-pubsub',
+    redis,
+    (err) => {
+      log.error({ err }, 'Error in api-ws emitter!')
+    },
+    log,
+  )
+
+  apiPubSubEmitter.emit(
+    'user',
+    new ApiWebsocketMessage(
+      'org-merge',
+      JSON.stringify({
+        success,
+        tenantId,
+        primaryOrgId,
+        secondaryOrgId,
+      }),
+      undefined,
+      tenantId,
+    ),
+  )
+}
+
+async function orgMergeWorker(
+  tenantId: string,
+  primaryOrgId: string,
+  secondaryOrgId: string,
+  notifyFrontend: boolean,
+) {
+  const userContext = await getUserContext(tenantId)
+
+  const organizationService = new OrganizationService(userContext)
+
+  let success = true
+  try {
+    await organizationService.mergeSync(primaryOrgId, secondaryOrgId)
+  } catch (err) {
+    userContext.log.error({ err }, 'Error merging orgs')
+    success = false
+  }
+
+  if (notifyFrontend) {
+    await doNotifyFrontend({
+      log: userContext.log,
+      success,
+      tenantId,
+      primaryOrgId,
+      secondaryOrgId,
+    })
+  }
+}
+export { orgMergeWorker }

--- a/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
@@ -45,7 +45,7 @@ async function orgMergeWorker(
   try {
     await organizationService.mergeSync(primaryOrgId, secondaryOrgId)
   } catch (err) {
-    userContext.log.error({ err }, 'Error merging orgs')
+    userContext.log.error(err, 'Error merging orgs')
     success = false
   }
 

--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -13,6 +13,7 @@ import {
   EagleEyeEmailDigestMessage,
   IntegrationDataCheckerMessage,
   OrganizationBulkEnrichMessage,
+  OrganizationMergeMessage,
 } from './messageTypes'
 import newActivityWorker from './automation/workers/newActivityWorker'
 import newMemberWorker from './automation/workers/newMemberWorker'
@@ -26,6 +27,7 @@ import { eagleEyeEmailDigestWorker } from './eagle-eye-email-digest/eagleEyeEmai
 import { integrationDataCheckerWorker } from './integration-data-checker/integrationDataCheckerWorker'
 import { refreshSampleDataWorker } from './integration-data-checker/refreshSampleDataWorker'
 import { mergeSuggestionsWorker } from './merge-suggestions/mergeSuggestionsWorker'
+import { orgMergeWorker } from './org-merge/orgMergeWorker'
 import { BulkorganizationEnrichmentWorker } from './bulk-enrichment/bulkOrganizationEnrichmentWorker'
 import { API_CONFIG } from '../../../conf'
 
@@ -138,6 +140,15 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
         default:
           throw new Error(`Invalid automation trigger ${automationRequest.trigger}!`)
       }
+    case 'org-merge':
+      const orgMergeMessage = event as OrganizationMergeMessage
+      return orgMergeWorker(
+        orgMergeMessage.tenantId,
+        orgMergeMessage.primaryOrgId,
+        orgMergeMessage.secondaryOrgId,
+        orgMergeMessage.notifyFrontend,
+      )
+
     default:
       throw new Error(`Invalid microservice ${service}`)
   }

--- a/backend/src/serverless/utils/nodeWorkerSQS.ts
+++ b/backend/src/serverless/utils/nodeWorkerSQS.ts
@@ -152,3 +152,20 @@ export const sendBulkEnrichMessage = async (
   }
   await sendNodeWorkerMessage(tenant, payload as NodeWorkerMessageBase)
 }
+
+export const sendOrgMergeMessage = async (
+  tenantId: string,
+  primaryOrgId: string,
+  secondaryOrgId: string,
+  notifyFrontend: boolean = true,
+): Promise<void> => {
+  const payload = {
+    type: NodeWorkerMessageType.NODE_MICROSERVICE,
+    service: 'org-merge',
+    tenantId,
+    primaryOrgId,
+    secondaryOrgId,
+    notifyFrontend,
+  }
+  await sendNodeWorkerMessage(tenantId, payload as NodeWorkerMessageBase)
+}

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -20,6 +20,7 @@ import {
   mergeUniqueStringArrayItems,
 } from './helpers/mergeFunctions'
 import SearchSyncService from './searchSyncService'
+import { sendOrgMergeMessage } from '../serverless/utils/nodeWorkerSQS'
 
 export default class OrganizationService extends LoggerBase {
   options: IServiceOptions
@@ -37,7 +38,12 @@ export default class OrganizationService extends LoggerBase {
     return enrichP && (CLEARBIT_CONFIG.apiKey || IS_TEST_ENV)
   }
 
-  async merge(originalId, toMergeId) {
+  async mergeAsync(originalId, toMergeId) {
+    const tenantId = this.options.currentTenant.id
+    await sendOrgMergeMessage(tenantId, originalId, toMergeId)
+  }
+
+  async mergeSync(originalId, toMergeId) {
     this.options.log.info({ originalId, toMergeId }, 'Merging organizations!')
 
     const removeExtraFields = (organization: IOrganization): IOrganization =>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13bd026</samp>

The pull request adds support for asynchronous merge operation of organizations using a worker queue. It modifies the `OrganizationRepository`, `OrganizationService`, and `organizationMerge` API classes to handle the new status column and the `mergeAsync` function. It also adds new files and functions to create and process the `OrganizationMergeMessage` in the worker queue and optionally notify the frontend. It also includes SQL migration scripts to update the database schema.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 13bd026</samp>

> _We are the masters of the merge_
> _We send our commands to the queue_
> _We face the errors and the purge_
> _We notify the frontend with the truth_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13bd026</samp>

*  Refactor `merge` function in `OrganizationService` class to use worker queue ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-27cce446af4d87689b0a0f3713e7e2f88985d191e796ee9635bfcb48a5403514L9-R21),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L40-R54),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R80-R95),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R205-R207))
  * Destructure and rename function parameters for clarity ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-27cce446af4d87689b0a0f3713e7e2f88985d191e796ee9635bfcb48a5403514L9-R21))
  * Rename original function to `mergeSync` and add new function `mergeAsync` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L40-R54))
  * Update status of organization to merge to 'pending' in `mergeAsync` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L40-R54))
  * Send message to worker queue with `sendOrgMergeMessage` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-27cce446af4d87689b0a0f3713e7e2f88985d191e796ee9635bfcb48a5403514L9-R21),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L40-R54),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-20f166801e8067a398e9206de5dd17d9b76422cf500863bdd97026d339c50687R155-R171))
  * Update status of organization to merge to 'in-progress' in `mergeSync` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R80-R95))
  * Return 203 status code if merge operation was already in progress ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R80-R95))
  * Update status of organization to merge to 'ready' in `mergeSync` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R205-R207))
  * Do status updates outside and inside transaction as appropriate ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R80-R95),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79R205-R207))
* Add `orgMergeWorker` function to handle merge operation in worker queue ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R30),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R143-R151))
  * Receive tenant id, primary and secondary organization ids, and notify frontend flag as parameters ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62))
  * Create user context and organization service instance ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62))
  * Call `mergeSync` function to perform actual merge operation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62))
  * Catch and log any errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62))
  * Notify frontend with websocket message if flag is true ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR1-R62))
  * Add 'org-merge' service case to `workerFactory` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R30),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R143-R151))
  * Type check event parameter with `OrganizationMergeMessage` type ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-f540afd6079e352be077c96f26fc37c996860a5b2ab1fcc633646ccddc7dd6b8R16),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-5343d3507dbec3f8eea6c3604925d8343c6747aff9265316721c9ae5eaf9fee9R89-R96))
* Modify `findAndCountAllToMerge` function in `OrganizationRepository` class to include and filter by status column ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1565-R1566),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR1574),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1585-R1588),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1594-R1598))
  * Add status column to select query for organizations to merge ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1565-R1566))
  * Add filter condition to only select organizations with status 'ready' ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR1574))
  * Add status column to select query for cte ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1585-R1588))
  * Add status column to select query for final result set ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL1594-R1598))
* Add `setMergeStatus` function to `OrganizationRepository` class to update status of organization to merge ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR2862-R2888))
  * Use original and to merge ids as parameters ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR2862-R2888))
  * Return boolean indicating whether status was changed or not ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccR2862-R2888))
* Add SQL migration scripts to drop and add status column to organizationToMerge table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-c25ad88ec4c0541d50d77376571f3451a7e2b0b2f811085269a46c262fb3c359R1),[link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-c84aa37354178c3d95155428817cf40d813c18d65c5e929e373869acfb4c6713R1))
  * Drop status column in `U1699357748__org-merge-status.sql` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-c25ad88ec4c0541d50d77376571f3451a7e2b0b2f811085269a46c262fb3c359R1))
  * Add status column in `V1699357748__org-merge-status.sql` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1825/files?diff=unified&w=0#diff-c84aa37354178c3d95155428817cf40d813c18d65c5e929e373869acfb4c6713R1))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
