### PR TITLE
Obsolete name field updated to `displayName` when getting most active organizations

### DIFF
--- a/backend/src/serverless/microservices/nodejs/analytics/workers/weeklyAnalyticsEmailsWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/analytics/workers/weeklyAnalyticsEmailsWorker.ts
@@ -352,7 +352,7 @@ async function getAnalyticsData(tenantId: string) {
       await userContext.database.sequelize.query(
         `
       select count(a.id) as "activityCount",
-         o.name as name,
+         o."displayName" as name,
          o.logo as "avatarUrl"
       from organizations o
         inner join "memberOrganizations" mo


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65354d3</samp>

Updated the analytics query to use the `displayName` column for the organization name in the weekly emails. This reflects the new schema of the `organizations` table and improves the readability of the emails.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 65354d3</samp>

> _`displayName` used_
> _Query aligns with schema_
> _Winter emails change_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65354d3</samp>

*  Use `displayName` instead of `name` column from `organizations` table in analytics query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1827/files?diff=unified&w=0#diff-697ea4871953442b989256533e0a23185da4aa8cfb0ae3296326383d8e772477L355-R355))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
