### PR TITLE
Add loading status to all manual actions

### DIFF
--- a/frontend/src/modules/member/components/member-dropdown-content.vue
+++ b/frontend/src/modules/member/components/member-dropdown-content.vue
@@ -7,8 +7,7 @@
       },
     }"
     :class="{
-      'pointer-events-none cursor-not-allowed':
-        isEditLockedForSampleData,
+      'pointer-events-none cursor-not-allowed': isEditLockedForSampleData,
     }"
   >
     <button
@@ -16,16 +15,17 @@
       :disabled="isEditLockedForSampleData"
       type="button"
     >
-      <i
-        class="ri-pencil-line text-base mr-2"
-      /><span class="text-xs">Edit contact</span>
+      <i class="ri-pencil-line text-base mr-2" />
+      <span class="text-xs">Edit contact</span>
     </button>
   </router-link>
   <el-tooltip
     placement="top"
-    :content="!isEnrichmentFeatureEnabled()
-      ? 'Upgrade your plan to increase your quota of available contact enrichments'
-      : 'Contact enrichment requires an associated GitHub profile or Email'"
+    :content="
+      !isEnrichmentFeatureEnabled()
+        ? 'Upgrade your plan to increase your quota of available contact enrichments'
+        : 'Contact enrichment requires an associated GitHub profile or Email'
+    "
     :disabled="isEnrichmentDisabledForMember || isEnrichmentFeatureEnabled()"
     popper-class="max-w-[260px]"
   >
@@ -34,25 +34,21 @@
         class="h-10 el-dropdown-menu__item w-full mb-1"
         :disabled="isEnrichmentActionDisabled"
         type="button"
-        @click="handleCommand({
-          action: 'memberEnrich',
-          member,
-        })"
+        @click="
+          handleCommand({
+            action: Actions.ENRICH_CONTACT,
+            member,
+          })
+        "
       >
-        <app-svg
-          name="enrichment"
-          class="max-w-[16px] h-4"
-          color="#9CA3AF"
-        />
+        <app-svg name="enrichment" class="max-w-[16px] h-4" color="#9CA3AF" />
         <span
           class="ml-2 text-xs"
           :class="{
             'text-gray-400': isEnrichmentDisabledForMember,
           }"
         >{{
-          member.lastEnriched
-            ? 'Re-enrich contact'
-            : 'Enrich contact'
+          member.lastEnriched ? "Re-enrich contact" : "Enrich contact"
         }}</span>
       </button>
     </span>
@@ -61,14 +57,14 @@
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberMerge',
-      member,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MERGE_CONTACT,
+        member,
+      })
+    "
   >
-    <i class="ri-group-line text-base mr-2" /><span
-      class="text-xs"
-    >Merge contact</span>
+    <i class="ri-group-line text-base mr-2" /><span class="text-xs">Merge contact</span>
   </button>
 
   <!-- Hubspot -->
@@ -84,30 +80,30 @@
         class="h-10 el-dropdown-menu__item w-full"
         :disabled="isHubspotActionDisabled"
         type="button"
-        @click="handleCommand({
-          action: 'syncHubspot',
-          member,
-        })"
+        @click="
+          handleCommand({
+            action: Actions.SYNC_HUBSPOT,
+            member,
+          })
+        "
       >
         <app-svg name="hubspot" class="h-4 w-4 text-current" />
-        <span
-          class="text-xs pl-2"
-        >Sync with HubSpot</span>
+        <span class="text-xs pl-2">Sync with HubSpot</span>
       </button>
       <button
         v-else
         class="h-10 el-dropdown-menu__item w-full"
         :disabled="isHubspotActionDisabled"
         type="button"
-        @click="handleCommand({
-          action: 'stopSyncHubspot',
-          member,
-        })"
+        @click="
+          handleCommand({
+            action: Actions.STOP_SYNC_HUBSPOT,
+            member,
+          })
+        "
       >
         <app-svg name="hubspot" class="h-4 w-4 text-current" />
-        <span
-          class="text-xs pl-2"
-        >Stop sync with HubSpot</span>
+        <span class="text-xs pl-2">Stop sync with HubSpot</span>
       </button>
     </span>
   </el-tooltip>
@@ -117,68 +113,70 @@
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberMarkAsTeamMember',
-      member,
-      value: true,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MARK_CONTACT_AS_TEAM_CONTACT,
+        member,
+        value: true,
+      })
+    "
   >
-    <i
-      class="ri-bookmark-line text-base mr-2"
-    /><span class="text-xs">Mark as team contact</span>
+    <i class="ri-bookmark-line text-base mr-2" /><span class="text-xs">Mark as team contact</span>
   </button>
   <button
     v-if="member.attributes.isTeamMember?.default"
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberMarkAsTeamMember',
-      member,
-      value: false,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MARK_CONTACT_AS_TEAM_CONTACT,
+        member,
+        value: false,
+      })
+    "
   >
-    <i
-      class="ri-bookmark-2-line text-base mr-2"
-    /><span class="text-xs">Unmark as team contact</span>
+    <i class="ri-bookmark-2-line text-base mr-2" /><span class="text-xs">Unmark as team contact</span>
   </button>
   <button
     v-if="!member.attributes.isBot?.default"
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberMarkAsBot',
-      member,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MARK_CONTACT_AS_BOT,
+        member,
+      })
+    "
   >
-    <i class="ri-robot-line text-base mr-2" /><span
-      class="text-xs"
-    >Mark as bot</span>
+    <i class="ri-robot-line text-base mr-2" /><span class="text-xs">Mark as bot</span>
   </button>
   <button
     v-if="member.attributes.isBot?.default"
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberUnmarkAsBot',
-      member,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.UNMARK_CONTACT_AS_BOT,
+        member,
+      })
+    "
   >
-    <i class="ri-robot-line text-base mr-2" /><span
-      class="text-xs"
-    >Unmark as bot</span>
+    <i class="ri-robot-line text-base mr-2" /><span class="text-xs">Unmark as bot</span>
   </button>
   <el-divider class="border-gray-200" />
   <button
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isDeleteLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'memberDelete',
-      member,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.DELETE_CONTACT,
+        member,
+      })
+    "
   >
     <i
       class="ri-delete-bin-line text-base mr-2"
@@ -194,11 +192,8 @@
   </button>
 </template>
 
-<script setup>
-import {
-  mapActions,
-  mapGetters,
-} from '@/shared/vuex/vuex.helpers';
+<script setup lang="ts">
+import { mapActions, mapGetters } from '@/shared/vuex/vuex.helpers';
 import { MemberService } from '@/modules/member/member-service';
 import Message from '@/shared/message/message';
 import { MemberPermissions } from '@/modules/member/member-permissions';
@@ -213,14 +208,23 @@ import { FeatureFlag, FEATURE_FLAGS } from '@/utils/featureFlag';
 import { useStore } from 'vuex';
 import { useRoute } from 'vue-router';
 import { computed } from 'vue';
+import { Member } from '../types/Member';
 
-const emit = defineEmits(['merge', 'closeDropdown']);
-const props = defineProps({
-  member: {
-    type: Object,
-    default: () => {},
-  },
-});
+enum Actions {
+  DELETE_CONTACT = 'deleteContact',
+  SYNC_HUBSPOT = 'syncHubspot',
+  STOP_SYNC_HUBSPOT = 'stopSyncHubspot',
+  MARK_CONTACT_AS_TEAM_CONTACT = 'markContactAsTeamContact',
+  MARK_CONTACT_AS_BOT = 'markContactAsBot',
+  UNMARK_CONTACT_AS_BOT = 'unmarkContactAsBot',
+  MERGE_CONTACT = 'mergeContact',
+  ENRICH_CONTACT = 'enrichContact',
+}
+
+const emit = defineEmits<{(e: 'merge'): void, (e: 'closeDropdown'): void }>();
+const props = defineProps<{
+  member: Member;
+}>();
 
 const store = useStore();
 const route = useRoute();
@@ -229,151 +233,219 @@ const { currentUser, currentTenant } = mapGetters('auth');
 const { doFind, doEnrich } = mapActions('member');
 
 const memberStore = useMemberStore();
-const { fetchMembers } = memberStore;
 
-const isEditLockedForSampleData = computed(() => new MemberPermissions(
-  currentTenant.value,
-  currentUser.value,
-).editLockedForSampleData);
+const isEditLockedForSampleData = computed(
+  () => new MemberPermissions(currentTenant.value, currentUser.value)
+    .editLockedForSampleData,
+);
 
-const isDeleteLockedForSampleData = computed(() => new MemberPermissions(
-  currentTenant.value,
-  currentUser.value,
-).destroyLockedForSampleData);
+const isDeleteLockedForSampleData = computed(
+  () => new MemberPermissions(currentTenant.value, currentUser.value)
+    .destroyLockedForSampleData,
+);
 
-const isEnrichmentDisabledForMember = computed(() => (
-  !props.member.username?.github?.length
-            && !props.member.emails?.length
-));
+const isEnrichmentDisabledForMember = computed(
+  () => !props.member.username?.github?.length && !props.member.emails?.length,
+);
 
-const isEnrichmentActionDisabled = computed(() => isEnrichmentDisabledForMember.value
-  || isEditLockedForSampleData.value || !isEnrichmentFeatureEnabled());
+const isEnrichmentActionDisabled = computed(
+  () => isEnrichmentDisabledForMember.value
+    || isEditLockedForSampleData.value
+    || !isEnrichmentFeatureEnabled(),
+);
 
-const isSyncingWithHubspot = computed(() => props.member.attributes?.syncRemote?.hubspot || false);
+const isSyncingWithHubspot = computed(
+  () => props.member.attributes?.syncRemote?.hubspot || false,
+);
 
 const isHubspotConnected = computed(() => {
   const hubspot = CrowdIntegrations.getMappedConfig('hubspot', store);
   const enabledFor = hubspot.settings?.enabledFor || [];
 
-  return hubspot.status === 'done' && enabledFor.includes(HubspotEntity.MEMBERS);
+  return (
+    hubspot.status === 'done' && enabledFor.includes(HubspotEntity.MEMBERS)
+  );
 });
 
-const isHubspotDisabledForMember = computed(() => props.member.emails.length === 0);
+const isHubspotDisabledForMember = computed(
+  () => props.member.emails.length === 0,
+);
 
-const isHubspotFeatureEnabled = computed(() => FeatureFlag.isFlagEnabled(
-  FEATURE_FLAGS.hubspot,
-));
+const isHubspotFeatureEnabled = computed(() => FeatureFlag.isFlagEnabled(FEATURE_FLAGS.hubspot));
 
-const isHubspotActionDisabled = computed(() => !isHubspotConnected.value || isHubspotDisabledForMember.value || !isHubspotFeatureEnabled.value);
+const isHubspotActionDisabled = computed(
+  () => !isHubspotConnected.value
+    || isHubspotDisabledForMember.value
+    || !isHubspotFeatureEnabled.value,
+);
 
-const doDestroyWithConfirm = async (id) => {
-  try {
-    await ConfirmDialog({
+const doManualAction = async ({
+  loadingMessage,
+  actionFn,
+  successMessage,
+  errorMessage,
+}: {
+  loadingMessage?: string;
+  successMessage?: string;
+  errorMessage?: string;
+  actionFn: Promise<any>;
+}) => {
+  emit('closeDropdown');
+
+  if (loadingMessage) {
+    Message.info(null, {
+      title: loadingMessage,
+    });
+  }
+
+  return actionFn
+    .then(() => {
+      if (successMessage) {
+        Message.closeAll();
+        Message.success(successMessage);
+      }
+      Promise.resolve();
+    })
+    .catch(() => {
+      if (errorMessage) {
+        Message.closeAll();
+        Message.error(errorMessage);
+      }
+      Promise.reject();
+    });
+};
+
+const handleCommand = async (command: {
+  action: Actions;
+  member: Member;
+  value?: boolean;
+}) => {
+  // Delete contact
+  if (command.action === Actions.DELETE_CONTACT) {
+    ConfirmDialog({
       type: 'danger',
       title: 'Delete contact',
-      message:
-            "Are you sure you want to proceed? You can't undo this action",
+      message: "Are you sure you want to proceed? You can't undo this action",
       confirmButtonText: 'Confirm',
       cancelButtonText: 'Cancel',
       icon: 'ri-delete-bin-line',
-    });
-
-    await MemberService.destroyAll([id]);
-
-    Message.success('Contact successfully deleted');
-
-    emit('closeDropdown');
-
-    await fetchMembers({ reload: true });
-  } catch (error) {
-    // no
-  }
-  return null;
-};
-
-const handleCommand = async (command) => {
-  if (command.action === 'memberDelete') {
-    await doDestroyWithConfirm(command.member.id);
-  } else if (
-    command.action === 'syncHubspot' || command.action === 'stopSyncHubspot'
-  ) {
-    // Hubspot
-    const sync = command.action === 'syncHubspot';
-    (sync ? HubspotApiService.syncMember(command.member.id) : HubspotApiService.stopSyncMember(command.member.id))
-      .then(() => {
-        emit('closeDropdown');
-
-        if (route.name === 'member') {
-          fetchMembers({ reload: true });
-        } else {
-          doFind(command.member.id);
-        }
-        if (sync) {
-          Message.success('Contact is now syncing with HubSpot');
-        } else {
-          Message.success('Contact syncing stopped');
-        }
-      })
-      .catch(() => {
-        Message.error('There was an error');
+    }).then(() => {
+      doManualAction({
+        loadingMessage: 'Contact is being deleted',
+        successMessage: 'Contact successfully deleted',
+        errorMessage: 'Something went wrong',
+        actionFn: MemberService.destroyAll([command.member.id]),
+      }).then(() => {
+        memberStore.fetchMembers({ reload: true });
       });
-  } else if (
-    command.action === 'memberMarkAsTeamMember'
+    });
+
+    return;
+  }
+
+  // Sync with hubspot
+  if (
+    command.action === Actions.SYNC_HUBSPOT
+    || command.action === Actions.STOP_SYNC_HUBSPOT
   ) {
-    await MemberService.update(command.member.id, {
-      attributes: {
-        ...command.member.attributes,
-        isTeamMember: {
-          default: command.value,
-        },
-      },
+    const isSyncing = command.action === Actions.SYNC_HUBSPOT;
+
+    doManualAction({
+      loadingMessage: isSyncing
+        ? 'Contact is being synced with Hubspot'
+        : 'Contact syncing with Hubspot is being stopped',
+      successMessage: isSyncing
+        ? 'Contact is now syncing with HubSpot'
+        : 'Contact syncing stopped',
+      errorMessage: 'Something went wrong',
+      actionFn: isSyncing
+        ? HubspotApiService.syncMember(command.member.id)
+        : HubspotApiService.stopSyncMember(command.member.id),
+    }).then(() => {
+      if (route.name === 'member') {
+        memberStore.fetchMembers({ reload: true });
+      } else {
+        doFind(command.member.id);
+      }
     });
 
-    emit('closeDropdown');
+    return;
+  }
 
-    await fetchMembers({ reload: true });
-
-    Message.success('Contact updated successfully');
-
-    if (route.name === 'member') {
-      await fetchMembers({ reload: true });
-    } else {
-      doFind(command.member.id);
-    }
-  } else if (command.action === 'memberMarkAsBot' || command.action === 'memberUnmarkAsBot') {
-    await MemberService.update(command.member.id, {
-      attributes: {
-        ...command.member.attributes,
-        isBot: {
-          default: command.action === 'memberMarkAsBot',
+  // Mark as team contact
+  if (command.action === Actions.MARK_CONTACT_AS_TEAM_CONTACT) {
+    doManualAction({
+      loadingMessage: 'Contact is being updated',
+      successMessage: 'Contact updated successfully',
+      errorMessage: 'Something went wrong',
+      actionFn: MemberService.update(command.member.id, {
+        attributes: {
+          ...command.member.attributes,
+          isTeamMember: {
+            default: command.value,
+          },
         },
-      },
+      }),
+    }).then(() => {
+      if (route.name === 'member') {
+        memberStore.fetchMembers({ reload: true });
+      } else {
+        doFind(command.member.id);
+      }
     });
 
-    emit('closeDropdown');
+    return;
+  }
 
-    await fetchMembers({ reload: true });
-    Message.success('Contact updated successfully');
-    if (route.name === 'member') {
-      await fetchMembers({ reload: true });
-    } else {
-      doFind(command.member.id);
-    }
-  } else if (command.action === 'memberMerge') {
+  // Mark as bot
+  if (
+    command.action === Actions.MARK_CONTACT_AS_BOT
+    || command.action === Actions.UNMARK_CONTACT_AS_BOT
+  ) {
+    doManualAction({
+      loadingMessage: 'Contact is being updated',
+      successMessage: 'Contact updated successfully',
+      errorMessage: 'Something went wrong',
+      actionFn: MemberService.update(command.member.id, {
+        attributes: {
+          ...command.member.attributes,
+          isBot: {
+            default: command.action === Actions.MARK_CONTACT_AS_BOT,
+          },
+        },
+      }),
+    }).then(() => {
+      if (route.name === 'member') {
+        memberStore.fetchMembers({ reload: true });
+      } else {
+        doFind(command.member.id);
+      }
+    });
+
+    return;
+  }
+
+  // Merge contact
+  if (command.action === Actions.MERGE_CONTACT) {
     emit('closeDropdown');
     emit('merge');
-  } else if (command.action === 'memberEnrich') {
-    await doEnrich(command.member.id);
 
-    emit('closeDropdown');
+    return;
+  }
 
-    await fetchMembers({ reload: true });
+  // Enrich contact
+  if (command.action === Actions.ENRICH_CONTACT) {
+    doManualAction({
+      actionFn: doEnrich(command.member.id),
+    }).then(() => {
+      memberStore.fetchMembers({ reload: true });
+    });
+
+    return;
   }
 
   emit('closeDropdown');
-  return null;
 };
-
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/modules/member/types/Member.ts
+++ b/frontend/src/modules/member/types/Member.ts
@@ -5,6 +5,7 @@ export interface MemberAttribute {
   custom: string;
   github?: string;
   twitter?: string;
+  hubspot?: any;
 }
 
 export interface MemberContribution {

--- a/frontend/src/modules/organization/components/organization-dropdown-content.vue
+++ b/frontend/src/modules/organization/components/organization-dropdown-content.vue
@@ -1,32 +1,38 @@
 <template>
   <!-- Edit -->
-  <button
-    :disabled="isEditLockedForSampleData"
-    class="h-10 el-dropdown-menu__item w-full"
-    type="button"
-    @click="handleCommand({
-      action: 'organizationEdit',
-      organization,
-    })"
+  <router-link
+    :to="{
+      name: 'organizationEdit',
+      params: {
+        id: organization.id,
+      },
+    }"
+    :class="{
+      'pointer-events-none cursor-not-allowed': isEditLockedForSampleData,
+    }"
   >
-    <i class="ri-pencil-line text-base mr-2" /><span
-      class="text-xs"
-    >Edit organization</span>
-  </button>
+    <button
+      :disabled="isEditLockedForSampleData"
+      class="h-10 el-dropdown-menu__item w-full"
+      type="button"
+    >
+      <i class="ri-pencil-line text-base mr-2" /><span class="text-xs">Edit organization</span>
+    </button>
+  </router-link>
 
   <!-- Merge organization -->
   <button
     class="h-10 el-dropdown-menu__item w-full"
     type="button"
     :disabled="isEditLockedForSampleData"
-    @click="handleCommand({
-      action: 'organizationMerge',
-      organization,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MERGE_ORGANIZATION,
+        organization,
+      })
+    "
   >
-    <i class="ri-shuffle-line text-base mr-2" /><span
-      class="text-xs"
-    >Merge organization</span>
+    <i class="ri-shuffle-line text-base mr-2" /><span class="text-xs">Merge organization</span>
   </button>
 
   <!-- Hubspot -->
@@ -41,31 +47,36 @@
         v-if="!isSyncingWithHubspot(organization)"
         class="h-10 el-dropdown-menu__item w-full"
         type="button"
-        :disabled="!isHubspotConnected || (!organization.website && !organization.attributes?.sourceId?.hubspot) || !isHubspotEnabled"
-        @click="handleCommand({
-          action: 'syncHubspot',
-          organization,
-        })"
+        :disabled="
+          !isHubspotConnected
+            || (!organization.website
+              && !organization.attributes?.sourceId?.hubspot)
+            || !isHubspotEnabled
+        "
+        @click="
+          handleCommand({
+            action: Actions.SYNC_HUBSPOT,
+            organization,
+          })
+        "
       >
         <app-svg name="hubspot" class="h-4 w-4 text-current" />
-        <span
-          class="text-xs pl-2"
-        >Sync with HubSpot</span>
+        <span class="text-xs pl-2">Sync with HubSpot</span>
       </button>
       <button
         v-else
         class="h-10 el-dropdown-menu__item w-full"
         type="button"
         :disabled="!isHubspotConnected"
-        @click="handleCommand({
-          action: 'stopSyncHubspot',
-          organization,
-        })"
+        @click="
+          handleCommand({
+            action: Actions.STOP_SYNC_HUBSPOT,
+            organization,
+          })
+        "
       >
         <app-svg name="hubspot" class="h-4 w-4 text-current" />
-        <span
-          class="text-xs pl-2"
-        >Stop sync with HubSpot</span>
+        <span class="text-xs pl-2">Stop sync with HubSpot</span>
       </button>
     </span>
   </el-tooltip>
@@ -76,15 +87,15 @@
     class="h-10 el-dropdown-menu__item w-full"
     type="button"
     :disabled="isEditLockedForSampleData"
-    @click="handleCommand({
-      action: 'markOrganizationTeam',
-      organization,
-      value: true,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MARK_ORGANIZATION_AS_TEAM_ORGANIZATION,
+        organization,
+        value: true,
+      })
+    "
   >
-    <i
-      class="ri-bookmark-line text-base mr-2"
-    /><span class="text-xs">Mark as team organization</span>
+    <i class="ri-bookmark-line text-base mr-2" /><span class="text-xs">Mark as team organization</span>
   </button>
 
   <!-- Unmark as Team Organization -->
@@ -93,15 +104,15 @@
     type="button"
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isEditLockedForSampleData"
-    @click="handleCommand({
-      action: 'markOrganizationTeam',
-      organization,
-      value: false,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.MARK_ORGANIZATION_AS_TEAM_ORGANIZATION,
+        organization,
+        value: false,
+      })
+    "
   >
-    <i
-      class="ri-bookmark-2-line text-base mr-2"
-    /><span class="text-xs">Unmark as team organization</span>
+    <i class="ri-bookmark-2-line text-base mr-2" /><span class="text-xs">Unmark as team organization</span>
   </button>
 
   <el-divider class="border-gray-200 my-2" />
@@ -111,10 +122,12 @@
     class="h-10 el-dropdown-menu__item w-full"
     :disabled="isDeleteLockedForSampleData"
     type="button"
-    @click="handleCommand({
-      action: 'organizationDelete',
-      organization,
-    })"
+    @click="
+      handleCommand({
+        action: Actions.DELETE_ORGANIZATION,
+        organization,
+      })
+    "
   >
     <i
       class="ri-delete-bin-line text-base mr-2"
@@ -130,12 +143,10 @@
   </button>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed } from 'vue';
 import { useRouter } from 'vue-router';
-import {
-  mapGetters,
-} from '@/shared/vuex/vuex.helpers';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import Message from '@/shared/message/message';
 import { useOrganizationStore } from '@/modules/organization/store/pinia';
@@ -148,142 +159,179 @@ import { useStore } from 'vuex';
 import { FeatureFlag, FEATURE_FLAGS } from '@/utils/featureFlag';
 import { OrganizationService } from '../organization-service';
 import { OrganizationPermissions } from '../organization-permissions';
+import { Organization } from '../types/Organization';
+
+enum Actions {
+  DELETE_ORGANIZATION = 'deleteOrganization',
+  MERGE_ORGANIZATION = 'mergeOrganization',
+  SYNC_HUBSPOT = 'syncHubspot',
+  STOP_SYNC_HUBSPOT = 'stopSyncHubspot',
+  MARK_ORGANIZATION_AS_TEAM_ORGANIZATION = 'markOrganizationAsTeamOrganization',
+}
 
 const router = useRouter();
 
-defineProps({
-  organization: {
-    type: Object,
-    default: () => {},
-  },
-});
-
-const emit = defineEmits([
-  'merge',
-  'closeDropdown',
-]);
+const emit = defineEmits<{(e: 'merge'): void, (e: 'closeDropdown'): void }>();
+defineProps<{
+  organization: Organization;
+}>();
 
 const store = useStore();
 
 const { currentUser, currentTenant } = mapGetters('auth');
 
 const organizationStore = useOrganizationStore();
-const { fetchOrganizations, fetchOrganization } = organizationStore;
 
 const isEditLockedForSampleData = computed(
-  () => new OrganizationPermissions(
-    currentTenant.value,
-    currentUser.value,
-  ).editLockedForSampleData,
+  () => new OrganizationPermissions(currentTenant.value, currentUser.value)
+    .editLockedForSampleData,
 );
 const isDeleteLockedForSampleData = computed(
-  () => new OrganizationPermissions(
-    currentTenant.value,
-    currentUser.value,
-  ).destroyLockedForSampleData,
+  () => new OrganizationPermissions(currentTenant.value, currentUser.value)
+    .destroyLockedForSampleData,
 );
 
-const isHubspotEnabled = computed(() => FeatureFlag.isFlagEnabled(
-  FEATURE_FLAGS.hubspot,
-));
+const isHubspotEnabled = computed(() => FeatureFlag.isFlagEnabled(FEATURE_FLAGS.hubspot));
 
-const isSyncingWithHubspot = (organization) => organization.attributes?.syncRemote?.hubspot || false;
+const isSyncingWithHubspot = (organization: Organization) => organization.attributes?.syncRemote?.hubspot || false;
 
 const isHubspotConnected = computed(() => {
   const hubspot = CrowdIntegrations.getMappedConfig('hubspot', store);
   const enabledFor = hubspot.settings?.enabledFor || [];
-  return hubspot.status === 'done' && enabledFor.includes(HubspotEntity.ORGANIZATIONS);
+  return (
+    hubspot.status === 'done'
+    && enabledFor.includes(HubspotEntity.ORGANIZATIONS)
+  );
 });
 
-const doDestroyWithConfirm = async (id) => {
-  try {
-    await ConfirmDialog({
+const doManualAction = async ({
+  loadingMessage,
+  actionFn,
+  successMessage,
+  errorMessage,
+}: {
+  loadingMessage?: string;
+  successMessage?: string;
+  errorMessage?: string;
+  actionFn: Promise<any>;
+}) => {
+  emit('closeDropdown');
+
+  if (loadingMessage) {
+    Message.info(null, {
+      title: loadingMessage,
+    });
+  }
+
+  return actionFn
+    .then(() => {
+      if (successMessage) {
+        Message.closeAll();
+        Message.success(successMessage);
+      }
+      Promise.resolve();
+    })
+    .catch(() => {
+      if (errorMessage) {
+        Message.closeAll();
+        Message.error(errorMessage);
+      }
+      Promise.reject();
+    });
+};
+
+const handleCommand = (command: {
+  action: Actions;
+  organization: Organization;
+  value?: boolean;
+}) => {
+  // Delete organization
+  if (command.action === Actions.DELETE_ORGANIZATION) {
+    ConfirmDialog({
       type: 'danger',
       title: 'Delete organization',
-      message:
-        "Are you sure you want to proceed? You can't undo this action",
+      message: "Are you sure you want to proceed? You can't undo this action",
       confirmButtonText: 'Confirm',
       cancelButtonText: 'Cancel',
       icon: 'ri-delete-bin-line',
+    }).then(() => {
+      doManualAction({
+        loadingMessage: 'Organization is being deleted',
+        successMessage: i18n('entities.organization.destroy.success'),
+        errorMessage: 'Something went wrong',
+        actionFn: OrganizationService.destroyAll([command.organization.id]),
+      }).then(() => {
+        organizationStore.fetchOrganizations({
+          reload: true,
+        });
+      });
     });
 
-    await OrganizationService.destroyAll([id]);
-
-    Message.success(
-      i18n('entities.organization.destroy.success'),
-    );
-    emit('closeDropdown');
-
-    await fetchOrganizations({
-      reload: true,
-    });
-  } catch (error) {
-    console.error(error);
+    return;
   }
-  return null;
-};
 
-const handleCommand = (command) => {
-  if (command.action === 'organizationDelete') {
-    return doDestroyWithConfirm(command.organization.id);
-  } if (command.action === 'organizationEdit') {
-    emit('closeDropdown');
-    router.push({
-      name: 'organizationEdit',
-      params: {
-        id: command.organization.id,
-      },
-    });
-  } else if (command.action === 'organizationMerge') {
+  // Merge organization
+  if (command.action === Actions.MERGE_ORGANIZATION) {
     emit('closeDropdown');
     emit('merge');
-  } else if (
-    command.action === 'syncHubspot' || command.action === 'stopSyncHubspot'
-  ) {
-    // Hubspot
-    const sync = command.action === 'syncHubspot';
-    (sync ? HubspotApiService.syncOrganization(command.organization.id) : HubspotApiService.stopSyncOrganization(command.organization.id))
-      .then(() => {
-        emit('closeDropdown');
-        if (
-          router.currentRoute.value.name === 'organization'
-        ) {
-          fetchOrganizations({
-            reload: true,
-          });
-        } else {
-          fetchOrganization(command.organization.id);
-        }
-        if (sync) {
-          Message.success('Organization is now syncing with HubSpot');
-        } else {
-          Message.success('Organization syncing stopped');
-        }
-      })
-      .catch(() => {
-        Message.error('There was an error');
-      });
-  } else if (command.action === 'markOrganizationTeam') {
-    OrganizationService.update(command.organization.id, {
-      isTeamOrganization: command.value,
-    }).then(() => {
-      Message.success('Organization updated successfully');
-      emit('closeDropdown');
 
-      if (
-        router.currentRoute.value.name === 'organization'
-      ) {
-        fetchOrganizations({
+    return;
+  }
+
+  // Sync with hubspot
+  if (
+    command.action === Actions.SYNC_HUBSPOT
+    || command.action === Actions.STOP_SYNC_HUBSPOT
+  ) {
+    const isSyncing = command.action === Actions.SYNC_HUBSPOT;
+
+    doManualAction({
+      loadingMessage: isSyncing
+        ? 'Organization is being synced with Hubspot'
+        : 'Organization syncing with Hubspot is being stopped',
+      successMessage: isSyncing
+        ? 'Organization is now syncing with HubSpot'
+        : 'Organization syncing stopped',
+      errorMessage: 'Something went wrong',
+      actionFn: isSyncing
+        ? HubspotApiService.syncOrganization(command.organization.id)
+        : HubspotApiService.stopSyncOrganization(command.organization.id),
+    }).then(() => {
+      if (router.currentRoute.value.name === 'organization') {
+        organizationStore.fetchOrganizations({
           reload: true,
         });
       } else {
-        fetchOrganization(command.organization.id);
+        organizationStore.fetchOrganization(command.organization.id);
       }
     });
+
+    return;
+  }
+
+  // Mark as team organization
+  if (command.action === Actions.MARK_ORGANIZATION_AS_TEAM_ORGANIZATION) {
+    doManualAction({
+      loadingMessage: 'Organization is being updated',
+      successMessage: 'Organization updated successfully',
+      errorMessage: 'Something went wrong',
+      actionFn: OrganizationService.update(command.organization.id, {
+        isTeamOrganization: command.value,
+      }),
+    }).then(() => {
+      if (router.currentRoute.value.name === 'organization') {
+        organizationStore.fetchOrganizations({
+          reload: true,
+        });
+      } else {
+        organizationStore.fetchOrganization(command.organization.id);
+      }
+    });
+
+    return;
   }
 
   emit('closeDropdown');
-  return null;
 };
 </script>
 

--- a/frontend/src/modules/organization/types/Organization.ts
+++ b/frontend/src/modules/organization/types/Organization.ts
@@ -1,4 +1,11 @@
+export interface OrganizationAttribute {
+  default: string;
+  sourceId?: any;
+  hubspot?: any;
+}
+
 export interface Organization{
+  attributes: Record<string, OrganizationAttribute>,
   activeOn: string[];
   activityCount: number;
   address: Record<string, string>;

--- a/frontend/src/shared/dialog/confirm-dialog.js
+++ b/frontend/src/shared/dialog/confirm-dialog.js
@@ -20,11 +20,11 @@ export default ({
   distinguishCancelAndClose = false,
   autofocus = true,
   closeOnClickModal = true,
-  titleClass,
-  messageClass,
-  verticalCancelButtonClass,
-  verticalConfirmButtonClass,
-  verticalCustomClass,
+  titleClass = null,
+  messageClass = null,
+  verticalCancelButtonClass = null,
+  verticalConfirmButtonClass = null,
+  verticalCustomClass = null,
   hideCloseButton = false,
 }) => {
   let iconColorClass = 'text-yellow-600';


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b02eeac</samp>

This pull request improves the frontend code quality and functionality by refactoring the organization dropdown component, adding hubspot data to the member and organization entities, and adding default values to the confirmation dialog parameters.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b02eeac</samp>

> _We sync the data with hubspot, we store the attributes_
> _We refactor and type the code, we use the router states_
> _We show the dialog to confirm, we set the default classes_
> _We are the masters of the code, we face the doom of masses_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b02eeac</samp>

*  Add `hubspot` property to `MemberAttribute` interface to store hubspot data of members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-92613c1aff68635bbf46493e9de0ce387a15d4aac5eced41e1e724b49465902aR8))
*  Replace button elements with router-link elements for editing organizations to use Vue Router API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL3-R21))
*  Replace string literals with enum values for organization actions to improve type-safety and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL22-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL44-R64), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL60-R79), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL79-R98), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL96-R115), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL114-R130))
*  Add `lang="ts"` attribute and type annotations to `organization-dropdown-content.vue` script setup to enable TypeScript support ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL133-R149), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL151-R178))
*  Refactor `handleCommand` function to use helper function and enum values for organization actions to simplify code and avoid repetition ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-64a216a7196d0a503aa43529576e67ca9c1e00a89c91eda05a5c7d07a4915c5bL171-R334))
*  Add `attributes` property to `Organization` interface to store custom attributes of organizations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-c763c232d41974523c3c0ce4f4c4451e3d36b84b372ca6029a0d39d7149ef36aL1-R8))
*  Add default values of `null` to optional parameters of `ConfirmDialog` function to avoid passing undefined values to dialog component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1829/files?diff=unified&w=0#diff-9a0748516d80bc5243be3a0bd0892a6a21b80ca14a2594dafe065702ddef2c51L23-R27))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
