### PR TITLE
Add automatic retries to data-sink-worker

### DIFF
--- a/backend/src/database/migrations/V1699626027__add-retries-to-results.sql
+++ b/backend/src/database/migrations/V1699626027__add-retries-to-results.sql
@@ -1,0 +1,3 @@
+ALTER TABLE integration.results
+ADD COLUMN retries INT,
+ADD COLUMN "delayedUntil" TIMESTAMP with time zone NULL;

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -1,7 +1,7 @@
 import { processPaginated, singleOrDefault } from '@crowd/common'
 import { INTEGRATION_SERVICES } from '@crowd/integrations'
 import { LoggerBase, getChildLogger } from '@crowd/logging'
-import { IntegrationRunWorkerEmitter, IntegrationStreamWorkerEmitter } from '@crowd/sqs'
+import { IntegrationRunWorkerEmitter, IntegrationStreamWorkerEmitter, DataSinkWorkerEmitter } from '@crowd/sqs'
 import { IntegrationRunState, IntegrationType } from '@crowd/types'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import MicroserviceRepository from '@/database/repositories/microserviceRepository'
@@ -14,6 +14,7 @@ import { sendNodeWorkerMessage } from '../../utils/nodeWorkerSQS'
 import {
   getIntegrationRunWorkerEmitter,
   getIntegrationStreamWorkerEmitter,
+  getDataSinkWorkerEmitter,
 } from '../../utils/serviceSQS'
 import { IntegrationServiceBase } from './integrationServiceBase'
 
@@ -25,6 +26,8 @@ export class IntegrationTickProcessor extends LoggerBase {
   private intRunWorkerEmitter: IntegrationRunWorkerEmitter
 
   private intStreamWorkerEmitter: IntegrationStreamWorkerEmitter
+
+  private dataSinkWorkerEmitter: DataSinkWorkerEmitter
 
   constructor(
     options: IServiceOptions,
@@ -46,6 +49,7 @@ export class IntegrationTickProcessor extends LoggerBase {
     if (!this.emittersInitialized) {
       this.intRunWorkerEmitter = await getIntegrationRunWorkerEmitter()
       this.intStreamWorkerEmitter = await getIntegrationStreamWorkerEmitter()
+      this.dataSinkWorkerEmitter = await getDataSinkWorkerEmitter()
 
       this.emittersInitialized = true
     }
@@ -220,6 +224,7 @@ export class IntegrationTickProcessor extends LoggerBase {
     await this.initEmitters()
     await this.intRunWorkerEmitter.checkRuns()
     await this.intStreamWorkerEmitter.checkStreams()
+    await this.dataSinkWorkerEmitter.checkResults()
 
     // TODO check streams as well
     this.log.trace('Checking for delayed integration runs!')

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -1,7 +1,11 @@
 import { processPaginated, singleOrDefault } from '@crowd/common'
 import { INTEGRATION_SERVICES } from '@crowd/integrations'
 import { LoggerBase, getChildLogger } from '@crowd/logging'
-import { IntegrationRunWorkerEmitter, IntegrationStreamWorkerEmitter, DataSinkWorkerEmitter } from '@crowd/sqs'
+import {
+  IntegrationRunWorkerEmitter,
+  IntegrationStreamWorkerEmitter,
+  DataSinkWorkerEmitter,
+} from '@crowd/sqs'
 import { IntegrationRunState, IntegrationType } from '@crowd/types'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import MicroserviceRepository from '@/database/repositories/microserviceRepository'

--- a/backend/src/serverless/utils/serviceSQS.ts
+++ b/backend/src/serverless/utils/serviceSQS.ts
@@ -3,6 +3,7 @@ import {
   IntegrationStreamWorkerEmitter,
   IntegrationSyncWorkerEmitter,
   SearchSyncWorkerEmitter,
+  DataSinkWorkerEmitter,
   SqsClient,
   getSqsClient,
 } from '@crowd/sqs'
@@ -63,4 +64,13 @@ export const getIntegrationSyncWorkerEmitter = async (): Promise<IntegrationSync
   integrationSyncWorkerEmitter = new IntegrationSyncWorkerEmitter(getClient(), tracer, log)
   await integrationSyncWorkerEmitter.init()
   return integrationSyncWorkerEmitter
+}
+
+let dataSinkWorkerEmitter: DataSinkWorkerEmitter
+export const getDataSinkWorkerEmitter = async (): Promise<DataSinkWorkerEmitter> => {
+  if (dataSinkWorkerEmitter) return dataSinkWorkerEmitter
+
+  dataSinkWorkerEmitter = new DataSinkWorkerEmitter(getClient(), tracer, log)
+  await dataSinkWorkerEmitter.init()
+  return dataSinkWorkerEmitter
 }

--- a/services/apps/data_sink_worker/config/default.json
+++ b/services/apps/data_sink_worker/config/default.json
@@ -5,5 +5,8 @@
   "unleash": {},
   "temporal": {
     "automationsTaskQueue": "automations"
+  },
+  "worker": {
+    "maxStreamRetries": 5
   }
 }

--- a/services/apps/data_sink_worker/src/bin/process-results.ts
+++ b/services/apps/data_sink_worker/src/bin/process-results.ts
@@ -12,7 +12,12 @@ import { DbStore, getDbConnection } from '@crowd/database'
 import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
-import { NodejsWorkerEmitter, SearchSyncWorkerEmitter, getSqsClient } from '@crowd/sqs'
+import {
+  NodejsWorkerEmitter,
+  SearchSyncWorkerEmitter,
+  DataSinkWorkerEmitter,
+  getSqsClient,
+} from '@crowd/sqs'
 import { initializeSentimentAnalysis } from '@crowd/sentiment'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
@@ -49,6 +54,9 @@ setImmediate(async () => {
   const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
   await searchSyncWorkerEmitter.init()
 
+  const dataSinkWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  await dataSinkWorkerEmitter.init()
+
   const dbConnection = await getDbConnection(DB_CONFIG())
   const store = new DbStore(log, dbConnection)
 
@@ -56,6 +64,7 @@ setImmediate(async () => {
     store,
     nodejsWorkerEmitter,
     searchSyncWorkerEmitter,
+    dataSinkWorkerEmitter,
     redisClient,
     unleash,
     temporal,

--- a/services/apps/data_sink_worker/src/conf/index.ts
+++ b/services/apps/data_sink_worker/src/conf/index.ts
@@ -11,6 +11,18 @@ export interface ISlackAlertingConfig {
   url: string
 }
 
+export interface IWorkerConfig {
+  maxStreamRetries: number
+}
+
+let workerSettings: IWorkerConfig
+export const WORKER_SETTINGS = (): IWorkerConfig => {
+  if (workerSettings) return workerSettings
+
+  workerSettings = config.get<IWorkerConfig>('worker')
+  return workerSettings
+}
+
 let redisConfig: IRedisConfiguration
 export const REDIS_CONFIG = (): IRedisConfiguration => {
   if (redisConfig) return redisConfig

--- a/services/apps/data_sink_worker/src/jobs/processOldResults.ts
+++ b/services/apps/data_sink_worker/src/jobs/processOldResults.ts
@@ -3,7 +3,7 @@ import { DbConnection, DbStore } from '@crowd/database'
 import { Unleash } from '@crowd/feature-flags'
 import { Logger } from '@crowd/logging'
 import { RedisClient } from '@crowd/redis'
-import { NodejsWorkerEmitter, SearchSyncWorkerEmitter } from '@crowd/sqs'
+import { NodejsWorkerEmitter, SearchSyncWorkerEmitter, DataSinkWorkerEmitter } from '@crowd/sqs'
 import { Client as TemporalClient } from '@crowd/temporal'
 import DataSinkRepository from '../repo/dataSink.repo'
 import DataSinkService from '../service/dataSink.service'
@@ -16,6 +16,7 @@ export const processOldResultsJob = async (
   redis: RedisClient,
   nodejsWorkerEmitter: NodejsWorkerEmitter,
   searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
+  dataSinkWorkerEmitter: DataSinkWorkerEmitter,
   unleash: Unleash | undefined,
   temporal: TemporalClient,
   log: Logger,
@@ -26,6 +27,7 @@ export const processOldResultsJob = async (
     store,
     nodejsWorkerEmitter,
     searchSyncWorkerEmitter,
+    dataSinkWorkerEmitter,
     redis,
     unleash,
     temporal,

--- a/services/apps/data_sink_worker/src/queue/index.ts
+++ b/services/apps/data_sink_worker/src/queue/index.ts
@@ -5,6 +5,7 @@ import {
   DATA_SINK_WORKER_QUEUE_SETTINGS,
   NodejsWorkerEmitter,
   SearchSyncWorkerEmitter,
+  DataSinkWorkerEmitter,
   SqsClient,
   SqsQueueReceiver,
 } from '@crowd/sqs'
@@ -25,6 +26,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     private readonly dbConn: DbConnection,
     private readonly nodejsWorkerEmitter: NodejsWorkerEmitter,
     private readonly searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
+    private readonly dataSinkWorkerEmitter: DataSinkWorkerEmitter,
     private readonly redisClient: RedisClient,
     private readonly unleash: Unleash | undefined,
     private readonly temporal: TemporalClient,
@@ -44,6 +46,7 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
           new DbStore(this.log, this.dbConn, undefined, false),
           this.nodejsWorkerEmitter,
           this.searchSyncWorkerEmitter,
+          this.dataSinkWorkerEmitter,
           this.redisClient,
           this.unleash,
           this.temporal,
@@ -63,6 +66,10 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
               msg.integrationId,
               msg.activityData,
             )
+            break
+          }
+          case DataSinkWorkerQueueMessageType.CHECK_RESULTS: {
+            await service.checkResults()
             break
           }
 

--- a/services/apps/data_sink_worker/src/repo/dataSink.data.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.data.ts
@@ -17,6 +17,9 @@ export interface IResultData {
   plan: string
   isTrialPlan: boolean
   name: string
+
+  retries: number
+  delayedUntil: string | null
 }
 
 export interface IFailedResultData {

--- a/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
@@ -1,6 +1,6 @@
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
-import { IIntegrationResult, IntegrationResultState, TenantPlans } from '@crowd/types'
+import { IIntegrationResult, IntegrationResultState, PlatformType, TenantPlans } from '@crowd/types'
 import { IFailedResultData, IResultData } from './dataSink.data'
 
 export default class DataSinkRepository extends RepositoryBase<DataSinkRepository> {
@@ -18,6 +18,8 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
            r."streamId",
            r."apiDataId",
            r."integrationId",
+           r.retries,
+           r."delayedUntil",
            i.platform,
            t."hasSampleData", 
            t."plan",
@@ -206,7 +208,8 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
       `update integration.results
         set state = $(newState),
             error = null,
-            "updatedAt" = now()
+            "updatedAt" = now(),
+            "delayedUntil" = null
         where id in ($(resultIds:csv))`,
       {
         resultIds,
@@ -223,5 +226,51 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
     })
 
     return result.map((r) => r.id)
+  }
+
+  public async delayResult(resultId: string, until: Date): Promise<void> {
+    const result = await this.db().result(
+      `update integration.results
+       set  state = $(state),
+            "delayedUntil" = $(until),
+            retries = coalesce(retries, 0) + 1,
+            "updatedAt" = now()
+       where id = $(resultId)`,
+      {
+        resultId,
+        until,
+        state: IntegrationResultState.DELAYED,
+      },
+    )
+
+    this.checkUpdateRowCount(result.rowCount, 1)
+  }
+
+  public async getDelayedResults(
+    limit: number,
+  ): Promise<{ id: string; tenantId: string; platform: PlatformType }[]> {
+    this.ensureTransactional()
+
+    try {
+      const results = await this.db().any(
+        `
+        select r.id, r."tenantId", i.platform
+        from integration.results r
+        join integrations i on r."integrationId" = i.id
+        where r.state = $(delayedState)
+          and r."delayedUntil" < now()
+        limit ${limit}
+        for update skip locked;
+        `,
+        {
+          delayedState: IntegrationResultState.DELAYED,
+        },
+      )
+
+      return results.map((s) => ({ id: s.id, tenantId: s.tenantId, platform: s.platform }))
+    } catch (err) {
+      this.log.error(err, 'Failed to get delayed results!')
+      throw err
+    }
   }
 }

--- a/services/apps/data_sink_worker/src/service/dataSink.service.ts
+++ b/services/apps/data_sink_worker/src/service/dataSink.service.ts
@@ -80,6 +80,7 @@ export default class DataSinkService extends LoggerBase {
           result.platform,
           result.id,
           result.id,
+          `${result.id}-delayed-${Date.now()}`,
         )
       }
 

--- a/services/apps/data_sink_worker/src/service/dataSink.service.ts
+++ b/services/apps/data_sink_worker/src/service/dataSink.service.ts
@@ -1,7 +1,7 @@
 import { DbStore } from '@crowd/database'
 import { Logger, LoggerBase, getChildLogger } from '@crowd/logging'
 import { RedisClient } from '@crowd/redis'
-import { NodejsWorkerEmitter, SearchSyncWorkerEmitter } from '@crowd/sqs'
+import { NodejsWorkerEmitter, SearchSyncWorkerEmitter, DataSinkWorkerEmitter } from '@crowd/sqs'
 import {
   IActivityData,
   IMemberData,
@@ -16,6 +16,9 @@ import MemberService from './member.service'
 import { OrganizationService } from './organization.service'
 import { Unleash } from '@crowd/feature-flags'
 import { Client as TemporalClient } from '@crowd/temporal'
+import { IResultData } from '../repo/dataSink.data'
+import { addSeconds } from '@crowd/common'
+import { WORKER_SETTINGS } from '../conf'
 
 export default class DataSinkService extends LoggerBase {
   private readonly repo: DataSinkRepository
@@ -24,6 +27,7 @@ export default class DataSinkService extends LoggerBase {
     private readonly store: DbStore,
     private readonly nodejsWorkerEmitter: NodejsWorkerEmitter,
     private readonly searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
+    private readonly dataSinkWorkerEmitter: DataSinkWorkerEmitter,
     private readonly redisClient: RedisClient,
     private readonly unleash: Unleash | undefined,
     private readonly temporal: TemporalClient,
@@ -35,13 +39,13 @@ export default class DataSinkService extends LoggerBase {
   }
 
   private async triggerResultError(
-    resultId: string,
+    resultInfo: IResultData,
     location: string,
     message: string,
     metadata?: unknown,
     error?: Error,
   ): Promise<void> {
-    await this.repo.markResultError(resultId, {
+    await this.repo.markResultError(resultInfo.id, {
       location,
       message,
       metadata,
@@ -49,6 +53,40 @@ export default class DataSinkService extends LoggerBase {
       errorStack: error?.stack,
       errorString: error ? JSON.stringify(error) : undefined,
     })
+
+    if (resultInfo.retries + 1 <= WORKER_SETTINGS().maxStreamRetries) {
+      // delay for #retries * 2 minutes
+      const until = addSeconds(new Date(), (resultInfo.retries + 1) * 2 * 60)
+      this.log.warn({ until: until.toISOString() }, 'Retrying result!')
+      await this.repo.delayResult(resultInfo.id, until)
+    }
+  }
+
+  public async checkResults(): Promise<void> {
+    this.log.info('Checking for delayed results!')
+
+    let results = await this.repo.transactionally(async (txRepo) => {
+      return await txRepo.getDelayedResults(10)
+    })
+
+    while (results.length > 0) {
+      this.log.info({ count: results.length }, 'Found delayed results!')
+
+      for (const result of results) {
+        this.log.info({ resultId: result.id }, 'Restarting delayed stream!')
+        await this.repo.resetResults([result.id])
+        await this.dataSinkWorkerEmitter.triggerResultProcessing(
+          result.tenantId,
+          result.platform,
+          result.id,
+          result.id,
+        )
+      }
+
+      results = await this.repo.transactionally(async (txRepo) => {
+        return await txRepo.getDelayedResults(10)
+      })
+    }
   }
 
   public async createAndProcessActivityResult(
@@ -194,7 +232,7 @@ export default class DataSinkService extends LoggerBase {
       this.log.error(err, 'Error processing result.')
       try {
         await this.triggerResultError(
-          resultId,
+          resultInfo,
           'process-result',
           'Error processing result.',
           undefined,

--- a/services/libs/sqs/src/instances/dataSinkWorker.ts
+++ b/services/libs/sqs/src/instances/dataSinkWorker.ts
@@ -20,8 +20,13 @@ export class DataSinkWorkerEmitter extends SqsQueueEmitter {
     platform: string,
     resultId: string,
     sourceId: string,
+    deduplicationId?: string,
   ) {
-    await this.sendMessage(sourceId, new ProcessIntegrationResultQueueMessage(resultId), resultId)
+    await this.sendMessage(
+      sourceId,
+      new ProcessIntegrationResultQueueMessage(resultId),
+      deduplicationId || resultId,
+    )
   }
 
   public async createAndProcessActivityResult(

--- a/services/libs/sqs/src/instances/dataSinkWorker.ts
+++ b/services/libs/sqs/src/instances/dataSinkWorker.ts
@@ -6,6 +6,7 @@ import {
   CreateAndProcessActivityResultQueueMessage,
   IActivityData,
   ProcessIntegrationResultQueueMessage,
+  CheckResultsQueueMessage,
 } from '@crowd/types'
 import { Tracer } from '@crowd/tracing'
 
@@ -33,5 +34,9 @@ export class DataSinkWorkerEmitter extends SqsQueueEmitter {
       new Date().toISOString(),
       new CreateAndProcessActivityResultQueueMessage(tenantId, segmentId, integrationId, activity),
     )
+  }
+
+  public async checkResults() {
+    await this.sendMessage('global', new CheckResultsQueueMessage())
   }
 }

--- a/services/libs/types/src/enums/integrations.ts
+++ b/services/libs/types/src/enums/integrations.ts
@@ -41,6 +41,7 @@ export enum IntegrationResultState {
   PROCESSING = 'processing',
   PROCESSED = 'processed',
   ERROR = 'error',
+  DELAYED = 'delayed',
 }
 
 export enum IntegrationResultType {

--- a/services/libs/types/src/queue/data_sink_worker/index.ts
+++ b/services/libs/types/src/queue/data_sink_worker/index.ts
@@ -5,6 +5,7 @@ export enum DataSinkWorkerQueueMessageType {
   PROCESS_INTEGRATION_RESULT = 'process_integration_result',
   CALCULATE_SENTIMENT = 'calculate_sentiment',
   CREATE_AND_PROCESS_ACTIVITY_RESULT = 'create_and_process_activity_result',
+  CHECK_RESULTS = 'check_results',
 }
 
 export class ProcessIntegrationResultQueueMessage implements IQueueMessage {
@@ -28,4 +29,8 @@ export class CreateAndProcessActivityResultQueueMessage implements IQueueMessage
     public readonly integrationId: string,
     public readonly activityData: IActivityData,
   ) {}
+}
+
+export class CheckResultsQueueMessage implements IQueueMessage {
+  public readonly type: string = DataSinkWorkerQueueMessageType.CHECK_RESULTS
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ea4963</samp>

This pull request adds a feature to the data sink worker app and its related modules to retry and delay results that fail or take too long to process. It uses the `DataSinkWorkerEmitter` class from the `@crowd/sqs` library to communicate with the data sink worker queue and the `DataSinkRepository` class to update the result state and timestamps. It also adds new columns, types, and messages to support this feature.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1ea4963</samp>

> _Oh, we are the data sink workers, and we process the results_
> _We use the `DataSinkWorkerEmitter` to send and receive the messages_
> _But when a result is failing or slow, we don't give up so quick_
> _We retry and delay it with the `IResultData` trick_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ea4963</samp>

*  Add retries and delays for failed or slow results ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-0a204a75fef343b96cc13dc9cc0744aa25017516b801bf030f4485453608913bR1-R3), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-aab8acce4ba505536619b7e1c9a9b122ee5f4316e4a44dc73efefd4c7f5f00c1R8-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e29380fc70a8bb77de4d8a5f826fca2ba75dedf01761d8aaa1a39b1df1be6042R20-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L209-R212), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2R230-R275), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL52-R91), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bee69c14664dadfdb3ce6a56d01c020ac1eecc04a65670cfc2ef01e242c3fcd3R44), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-588675d0e1b46df5e2ccf0a85b9118004f581ddef8b51e0b289067bdb8eb88f4R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-588675d0e1b46df5e2ccf0a85b9118004f581ddef8b51e0b289067bdb8eb88f4R33-R36))
  * Add two new columns `retries` and `delayedUntil` to the `integration.results` table in `V1699626027__add-retries-to-results.sql` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-0a204a75fef343b96cc13dc9cc0744aa25017516b801bf030f4485453608913bR1-R3))
  * Add the `retries` and `delayedUntil` properties to the `IResultData` interface in `dataSink.data.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e29380fc70a8bb77de4d8a5f826fca2ba75dedf01761d8aaa1a39b1df1be6042R20-R22))
  * Set the `delayedUntil` column to null when marking a result as success in `dataSink.repo.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L209-R212))
  * Add methods `delayResult` and `getDelayedResults` to the `DataSinkRepository` class in `dataSink.repo.ts` to update and select delayed results ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2R230-R275))
  * Add logic to check and increment the `retries` value and calculate the `delayedUntil` timestamp in the `triggerResultError` method of the `DataSinkService` class in `dataSink.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL52-R91))
  * Add a new value `DELAYED` to the `IntegrationResultState` enum in `integrations.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bee69c14664dadfdb3ce6a56d01c020ac1eecc04a65670cfc2ef01e242c3fcd3R44))
  * Add a new value `CHECK_RESULTS` to the `DataSinkWorkerQueueMessageType` enum and a new class `CheckResultsQueueMessage` in `index.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-588675d0e1b46df5e2ccf0a85b9118004f581ddef8b51e0b289067bdb8eb88f4R8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-588675d0e1b46df5e2ccf0a85b9118004f581ddef8b51e0b289067bdb8eb88f4R33-R36))
* Add communication with the data sink worker queue using the `DataSinkWorkerEmitter` class from the `@crowd/sqs` library ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L4-R4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R30-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R52), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R227), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bcca7873a982a395cc717a15cb91709b5ccfd28908271d66bffa7290673db2c1R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bcca7873a982a395cc717a15cb91709b5ccfd28908271d66bffa7290673db2c1R68-R76), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922L6-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922R19), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7L4-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R56-R57), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R63), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R75), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R89), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR71-R74), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL4-R4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR19-R21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL38-R42), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408R38-R41))
  * Import the `DataSinkWorkerEmitter` class in `integrationTickProcessor.ts`, `serviceSQS.ts`, `processOldResults.ts`, `main.ts`, `index.ts`, `dataSink.service.ts`, and `dataSinkWorker.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L4-R4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bcca7873a982a395cc717a15cb91709b5ccfd28908271d66bffa7290673db2c1R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922L6-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7L4-R10), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR8), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL4-R4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408R9))
  * Add a function `getDataSinkWorkerEmitter` in `serviceSQS.ts` to get an instance of the `DataSinkWorkerEmitter` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-bcca7873a982a395cc717a15cb91709b5ccfd28908271d66bffa7290673db2c1R68-R76))
  * Add a property `dataSinkWorkerEmitter` to the `IntegrationTickProcessor` and `WorkerQueueReceiver` classes in `integrationTickProcessor.ts` and `index.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R30-R31), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR29))
  * Assign the `dataSinkWorkerEmitter` property in the constructors of the `IntegrationTickProcessor` and `WorkerQueueReceiver` classes using the `getDataSinkWorkerEmitter` function or the parameter ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R52), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR49))
  * Pass the `dataSinkWorkerEmitter` parameter or constant to the `DataSinkService` constructor in `integrationTickProcessor.ts`, `processOldResults.ts`, and `index.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R227), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-cb38f2e7b2ea0ee1bddbc2f1686db01d421e4d49ff5a408ba7d8e8d113b5f922R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR49))
  * Pass the `dataSinkWorkerEmitter` constant to the `processOldResultsJob` function in `main.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R89))
  * Create a constant `dataWorkerEmitter` that holds an instance of the `DataSinkWorkerEmitter` class in `main.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R56-R57))
  * Add the `dataWorkerEmitter` constant to the list of parameters passed to the `WorkerQueueReceiver` constructor in `main.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R63))
  * Call the `init` method of the `dataWorkerEmitter` constant in `main.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-e281667cfba6cb6bf612b557fe650dd0ee13a2f429c1bc6284a1e031e37da3e7R75))
  * Add a method `checkResults` to the `DataSinkWorkerEmitter` class in `dataSinkWorker.ts` to send a message to the data sink worker queue to check for delayed results ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408R38-R41))
  * Call the `checkResults` method of the `dataSinkWorkerEmitter` property in `integrationTickProcessor.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R227))
  * Add a case for the `CHECK_RESULTS` message type in the `handleQueueMessage` method of the `WorkerQueueReceiver` class in `index.ts` to call the `checkResults` method of the `DataSinkService` instance ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-d0b6127d72d552fd600570cf4cb646a360f86ac1dd67b85b11821324000dc12dR71-R74))
  * Import the `CheckResultsQueueMessage` class in `dataSinkWorker.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f64108b6c00ccbcd18c4ad574487bc3516912ae82cb45ec2a48478d93776d408R9))
  * Import the `IResultData` interface, the `addSeconds` function, and the `WORKER_SETTINGS` function in `dataSink.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR19-R21))
  * Add a property `dataSinkWorkerEmitter` to the `DataSinkService` class in `dataSink.service.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cR30))
  * Change the type of the `resultId` parameter and argument of the `triggerResultError` method of the `DataSinkService` class in `dataSink.service.ts` and `index.ts` to `IResultData` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL38-R42), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-af5e149e9e0cbf22a599bbeeab282e4c1a482f648e9cd0682c4f10fabe80d86cL197-R235))
* Import the `PlatformType` enum from the `@crowd/types` library in `dataSink.repo.ts` to identify the platform of a result ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1842/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L3-R3))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
