### PR TITLE
Fix data-sink-worker when activity marked deleted

### DIFF
--- a/services/apps/data_sink_worker/src/repo/activity.data.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.data.ts
@@ -22,6 +22,7 @@ export interface IDbActivity {
   url?: string
   sentiment: ISentimentAnalysisResult
   organizationId?: string
+  deletedAt?: string
 }
 
 export interface IDbActivityCreateData {

--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -39,12 +39,12 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
             title,
             channel,
             url,
-            sentiment
+            sentiment,
+            "deletedAt"
     from activities
     where "tenantId" = $(tenantId)
       and "segmentId" = $(segmentId)
       and "sourceId" = $(sourceId)
-      and "deletedAt" is null
   `
   public async findExisting(
     tenantId: string,

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -453,6 +453,15 @@ export default class ActivityService extends LoggerBase {
           // find existing activity
           const dbActivity = await txRepo.findExisting(tenantId, segmentId, activity.sourceId)
 
+          if (dbActivity && dbActivity?.deletedAt) {
+            // we found an existing activity but it's deleted - nothing to do here
+            this.log.trace(
+              { activityId: dbActivity.id },
+              'Found existing activity but it is deleted, nothing to do here.',
+            )
+            return
+          }
+
           let createActivity = false
 
           if (dbActivity) {
@@ -846,7 +855,9 @@ export default class ActivityService extends LoggerBase {
         }
       })
 
-      await this.searchSyncWorkerEmitter.triggerMemberSync(tenantId, memberId)
+      if (memberId) {
+        await this.searchSyncWorkerEmitter.triggerMemberSync(tenantId, memberId)
+      }
       if (objectMemberId) {
         await this.searchSyncWorkerEmitter.triggerMemberSync(tenantId, objectMemberId)
       }


### PR DESCRIPTION
…marked deleted

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b3e86e</samp>

This pull request adds support for soft-deleting activities and handling member syncs in the `ActivityService` of the `data_sink_worker` app. It updates the `IDbActivity` interface, the `ActivityRepo` class, and the `processActivity` method to use the new `deletedAt` property.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b3e86e</samp>

> _Oh we are the `ActivityService` crew_
> _We process the data old and new_
> _We mark the deleted ones with `deletedAt`_
> _And sync the members in a snap_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b3e86e</samp>

*  Add `deletedAt` property to `IDbActivity` interface to mark deleted activities ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1846/files?diff=unified&w=0#diff-790bda91d27ee20ca8e7a06c8f9934baff7af04361fc999d76c359da40eba2cdR25))
*  Modify `findExisting` method in `ActivityRepo` to include `deletedAt` column in query result ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1846/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL42-R47))
*  Skip processing activities that have `deletedAt` value in `processActivity` method in `ActivityService` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1846/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bR456-R464))
*  Trigger member sync only for activities that have `memberId` value in `processActivity` method in `ActivityService` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1846/files?diff=unified&w=0#diff-6176384bd8fdd60a54c6a90222085ce8c0e964c33ea6902cfb2ccd2ab8de774bL849-R860))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
