### PR TITLE
Trigger discord integration checks in 3 chunks

### DIFF
--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -207,15 +207,20 @@ export class IntegrationTickProcessor extends LoggerBase {
                   integration.id,
                 )
               if (!existingRun) {
-                const rand = Math.random()
-                // 50% chance to delay the triggering of new integration checks for Discord integrations
-                if (newIntService.type === IntegrationType.DISCORD && rand > 0.5) {
-                  // Delay the triggering of new integration checks for Discord integrations
-                  const delay = 30 * 60 * 1000 // 30 minutes in milliseconds
+                const CHUNKS = 3 // Define the number of chunks
+                const DELAY_BETWEEN_CHUNKS = 30 * 60 * 1000 // Define the delay between chunks in milliseconds
+                const rand = Math.random() * CHUNKS
+                const chunkIndex = Math.min(Math.floor(rand), CHUNKS - 1)
+                const delay = chunkIndex * DELAY_BETWEEN_CHUNKS
+
+                // Divide integrations into chunks for Discord
+                if (newIntService.type === IntegrationType.DISCORD) {
                   setTimeout(async () => {
                     logger.info(
                       { integrationId: integration.id },
-                      'Triggering new delayed integration check for Discord!',
+                      `Triggering new delayed integration check for Discord in ${
+                        delay / 60 / 1000
+                      } minutes!`,
                     )
                     await emitter.triggerIntegrationRun(
                       integration.tenantId,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 430bd47</samp>

Improved Discord integration performance and reliability by splitting them into chunks and adding delays. Modified `backend/src/serverless/integrations/services/integrationTickProcessor.ts` to implement the new logic.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 430bd47</samp>

> _Discord integrations_
> _Spread over time with `delay`_
> _Avoid winter frost_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 430bd47</samp>

* Improve performance and reliability of Discord integrations by spreading them out over time ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1849/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L210-R223))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
