### PR TITLE
Fix signin regex validation

### DIFF
--- a/backend/src/api/tenant/index.ts
+++ b/backend/src/api/tenant/index.ts
@@ -15,6 +15,7 @@ export default (app) => {
   app.get(`/tenant`, safeWrap(require('./tenantList').default))
   app.get(`/tenant/url`, safeWrap(require('./tenantFind').default))
   app.get(`/tenant/:id`, safeWrap(require('./tenantFind').default))
+  app.get(`/tenant/:id/name`, safeWrap(require('./tenantFindName').default))
   app.get(`/tenant/:tenantId/membersToMerge`, safeWrap(require('./tenantMembersToMerge').default))
   app.get(
     `/tenant/:tenantId/organizationsToMerge`,

--- a/backend/src/api/tenant/tenantFind.ts
+++ b/backend/src/api/tenant/tenantFind.ts
@@ -1,10 +1,13 @@
 import identifyTenant from '../../segment/identifyTenant'
 import TenantService from '../../services/tenantService'
 import Error404 from '../../errors/Error404'
+import PermissionChecker from '../../services/user/permissionChecker'
+import Permissions from '../../security/permissions'
 
 export default async (req, res) => {
+  req.currentTenant = { id: req.params.id }
+  new PermissionChecker(req).validateHas(Permissions.values.memberRead)
   let payload
-
   if (req.params.id) {
     payload = await new TenantService(req).findById(req.params.id)
   } else {

--- a/backend/src/api/tenant/tenantFindName.ts
+++ b/backend/src/api/tenant/tenantFindName.ts
@@ -1,0 +1,23 @@
+import identifyTenant from '../../segment/identifyTenant'
+import TenantService from '../../services/tenantService'
+import Error404 from '../../errors/Error404'
+
+export default async (req, res) => {
+  // This endpoint is unauthenticated on purpose, but public reprots.
+  const payload = await new TenantService(req).findById(req.params.id)
+
+  if (payload) {
+    if (req.currentUser) {
+      identifyTenant({ ...req, currentTenant: payload })
+    }
+
+    const payloadOut = {
+      name: payload.name,
+      id: payload.id,
+    }
+
+    await req.responseHandler.success(req, res, payloadOut)
+  } else {
+    throw new Error404()
+  }
+}

--- a/backend/src/database/repositories/userRepository.ts
+++ b/backend/src/database/repositories/userRepository.ts
@@ -547,11 +547,21 @@ export default class UserRepository {
         status: 'active',
       },
     })
+
     record = {
       ...record,
       ...record.json,
     }
     delete record.json
+
+    // Remove sensitive fields
+    delete record.password
+    delete record.emailVerificationToken
+    delete record.emailVerificationTokenExpiresAt
+    delete record.providerId
+    delete record.passwordResetToken
+    delete record.passwordResetTokenExpiresAt
+    delete record.jwtTokenInvalidBefore
 
     if (!record) {
       throw new Error404()

--- a/backend/src/i18n/en.ts
+++ b/backend/src/i18n/en.ts
@@ -45,6 +45,8 @@ const en = {
       invalidToken: 'Invalid or expired password reset link',
       error: `Invalid email`,
     },
+    passwordInvalid:
+      'Passwords must have at least one letter, one number, one symbol, and be at least 8 characters long.',
     emailAddressVerificationEmail: {
       invalidToken: 'Invalid or expired email verification link.',
       error: `Email not recognized.`,

--- a/backend/src/security/permissions.ts
+++ b/backend/src/security/permissions.ts
@@ -99,7 +99,7 @@ class Permissions {
       },
       userRead: {
         id: 'userRead',
-        allowedRoles: [roles.admin, roles.readonly],
+        allowedRoles: [roles.admin],
         allowedPlans: [
           plans.essential,
           plans.growth,
@@ -110,7 +110,7 @@ class Permissions {
       },
       userAutocomplete: {
         id: 'userAutocomplete',
-        allowedRoles: [roles.admin, roles.readonly],
+        allowedRoles: [roles.admin],
         allowedPlans: [
           plans.essential,
           plans.growth,

--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -38,6 +38,12 @@ class AuthService {
 
       const existingUser = await UserRepository.findByEmail(email, options)
 
+      const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/
+
+      if (!passwordRegex.test(password)) {
+        throw new Error400(options.language, 'auth.passwordInvalid')
+      }
+
       // Generates a hashed password to hide the original one.
       const hashedPassword = await bcrypt.hash(password, BCRYPT_SALT_ROUNDS)
 

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -813,7 +813,7 @@ const en = {
   /* eslint-disable */
   validation: {
     mixed: {
-      default: 'path} is invalid',
+      default: '{path} is invalid',
       required: 'This field is required',
       oneOf:
         '{path} must be one of the following values: ${values}',

--- a/frontend/src/modules/auth/pages/signin-page.vue
+++ b/frontend/src/modules/auth/pages/signin-page.vue
@@ -72,6 +72,11 @@
                 class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
               />
               <span
+                v-if="error === 'Password is invalid'"
+                class="pl-1 text-2xs text-red-500 leading-4.5"
+              >Passwords must have at least one letter, one number, one symbol, and be at least 8 characters long.</span>
+              <span
+                v-else
                 class="pl-1 text-2xs text-red-500 leading-4.5"
               >{{ error }}</span>
             </div>

--- a/frontend/src/modules/auth/pages/signin-page.vue
+++ b/frontend/src/modules/auth/pages/signin-page.vue
@@ -171,7 +171,7 @@ export default {
     return {
       rules: {
         email: fields.email.forFormRules(),
-        password: fields.password.forFormRules(),
+        password: fields.passwordSignin.forFormRules(),
         rememberMe: fields.rememberMe.forFormRules(),
       },
       model: {

--- a/frontend/src/modules/auth/pages/signup-page.vue
+++ b/frontend/src/modules/auth/pages/signup-page.vue
@@ -129,6 +129,11 @@
                 class="h-4 flex items-center ri-error-warning-line text-base text-red-500"
               />
               <span
+                v-if="error === 'Password is invalid'"
+                class="pl-1 text-2xs text-red-500 leading-4.5"
+              >Passwords must have at least one letter, one number, one symbol, and be at least 8 characters long.</span>
+              <span
+                v-else
                 class="pl-1 text-2xs text-red-500 leading-4.5"
               >{{ error }}</span>
             </div>

--- a/frontend/src/modules/layout/components/menu/workspace/menu-workspace-popover.vue
+++ b/frontend/src/modules/layout/components/menu/workspace/menu-workspace-popover.vue
@@ -15,7 +15,7 @@
               :disable-active-class="true"
               link-class="!p-3 !h-10 !mb-0 !mt-1 !text-xs"
             />
-            <div class="px-1">
+            <div v-if="hasPermissionsForSettings" class="px-1">
               <div class="p-3 h-10 text-xs text-black mt-1 rounded hover:bg-gray-50 cursor-pointer" @click.stop="emit('edit', tenant)">
                 Edit workspace
               </div>
@@ -25,8 +25,14 @@
       </section>
 
       <!-- Add workspace -->
-      <section class="px-2 pb-3 border-b border-gray-100">
+      <section
+        class="border-b border-gray-100"
+        :class="{
+          'px-2 pb-3': hasPermissionsForSettings,
+        }"
+      >
         <div
+          v-if="hasPermissionsForSettings"
           class="px-3 h-10 text-sm font-normal rounded hover:bg-gray-50 cursor-pointer flex items-center text-brand-500"
           @click="emit('add')"
         >
@@ -102,6 +108,7 @@ import { computed } from 'vue';
 import { useUserStore } from '@/modules/user/store/pinia';
 import { storeToRefs } from 'pinia';
 import { FeatureFlag } from '@/utils/featureFlag';
+import { SettingsPermissions } from '@/modules/settings/settings-permissions';
 
 const emit = defineEmits<{(e:'add'): any, (e: 'edit', value: TenantModel): any}>();
 
@@ -112,6 +119,17 @@ const { doSelectTenant, doSignout } = mapActions('auth');
 const userStore = useUserStore();
 const { isDeveloperModeActive } = storeToRefs(userStore);
 const { updateDeveloperMode } = userStore;
+
+const hasPermissionsForSettings = computed(
+  () => {
+    const settingsPermissions = new SettingsPermissions(
+      currentTenant.value,
+      currentUser.value,
+    );
+
+    return settingsPermissions.edit || settingsPermissions.lockedForCurrentPlan;
+  },
+);
 
 const tenants = computed<TenantModel[]>(() => {
   const currentTenantId = currentTenant.value.id;

--- a/frontend/src/modules/layout/config/links/api-keys.ts
+++ b/frontend/src/modules/layout/config/links/api-keys.ts
@@ -1,4 +1,5 @@
 import { MenuLink } from '@/modules/layout/types/MenuLink';
+import { SettingsPermissions } from '@/modules/settings/settings-permissions';
 
 const apiKeys: MenuLink = {
   id: 'api-keys',
@@ -7,7 +8,14 @@ const apiKeys: MenuLink = {
   routeOptions: {
     query: { activeTab: 'api-keys' },
   },
-  display: () => true,
+  display: ({ user, tenant }) => {
+    const settingsPermissions = new SettingsPermissions(
+      tenant,
+      user,
+    );
+
+    return settingsPermissions.edit || settingsPermissions.lockedForCurrentPlan;
+  },
   disable: () => false,
 };
 

--- a/frontend/src/modules/layout/config/links/plans-billing.ts
+++ b/frontend/src/modules/layout/config/links/plans-billing.ts
@@ -1,4 +1,5 @@
 import { MenuLink } from '@/modules/layout/types/MenuLink';
+import { SettingsPermissions } from '@/modules/settings/settings-permissions';
 
 const plansBilling: MenuLink = {
   id: 'plans-billing',
@@ -7,7 +8,14 @@ const plansBilling: MenuLink = {
   routeOptions: {
     query: { activeTab: 'plans' },
   },
-  display: () => true,
+  display: ({ user, tenant }) => {
+    const settingsPermissions = new SettingsPermissions(
+      tenant,
+      user,
+    );
+
+    return settingsPermissions.edit || settingsPermissions.lockedForCurrentPlan;
+  },
   disable: () => false,
 };
 

--- a/frontend/src/modules/layout/config/links/users-permissions.ts
+++ b/frontend/src/modules/layout/config/links/users-permissions.ts
@@ -1,4 +1,5 @@
 import { MenuLink } from '@/modules/layout/types/MenuLink';
+import { SettingsPermissions } from '@/modules/settings/settings-permissions';
 
 const usersPermissions: MenuLink = {
   id: 'users-permissions',
@@ -7,7 +8,14 @@ const usersPermissions: MenuLink = {
   routeOptions: {
     query: { activeTab: 'users' },
   },
-  display: () => true,
+  display: ({ user, tenant }) => {
+    const settingsPermissions = new SettingsPermissions(
+      tenant,
+      user,
+    );
+
+    return settingsPermissions.edit || settingsPermissions.lockedForCurrentPlan;
+  },
   disable: () => false,
 };
 

--- a/frontend/src/modules/report/pages/report-view-page-public.vue
+++ b/frontend/src/modules/report/pages/report-view-page-public.vue
@@ -267,7 +267,7 @@ export default {
         id: this.id,
         tenantId: this.tenantId,
       });
-      this.currentTenant = await TenantService.find(
+      this.currentTenant = await TenantService.findName(
         this.tenantId,
       );
     } else {

--- a/frontend/src/modules/tenant/tenant-service.js
+++ b/frontend/src/modules/tenant/tenant-service.js
@@ -119,6 +119,11 @@ export class TenantService {
     return response.data;
   }
 
+  static async findName(id) {
+    const response = await authAxios.get(`/tenant/${id}/name`);
+    return response.data;
+  }
+
   static async findByUrl(url) {
     const response = await authAxios.get('/tenant/url', {
       params: { url },

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -31,6 +31,7 @@ const fields = {
   }),
   password: new StringField('password', label('password'), {
     required: true,
+    matches: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
   }),
   passwordConfirmation: new StringField(
     'passwordConfirmation',

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -33,6 +33,9 @@ const fields = {
     required: true,
     matches: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
   }),
+  passwordSignin: new StringField('password', label('password'), {
+    required: true,
+  }),
   passwordConfirmation: new StringField(
     'passwordConfirmation',
     label('passwordConfirmation'),


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9b4bcb6</samp>

This pull request enhances the security, usability, and performance of the user, tenant, and report features in the backend and frontend. It adds password validation, permission checks, and a new tenantFindName endpoint. It also fixes a typo and improves the error messages for signing in and signing up. It affects the files `backend/src/database/repositories/userRepository.ts`, `backend/src/security/permissions.ts`, `backend/src/api/tenant/*`, `backend/src/services/auth/authService.ts`, `backend/src/i18n/en.ts`, `frontend/src/modules/auth/pages/*`, `frontend/src/modules/layout/components/menu/workspace/menu-workspace-popover.vue`, `frontend/src/modules/layout/config/links/*`, `frontend/src/modules/report/pages/report-view-page-public.vue`, `frontend/src/modules/tenant/tenant-service.js`, `frontend/src/modules/user/user-model.js`, and `frontend/src/i18n/en.js`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9b4bcb6</samp>

> _We are the tenants of the public eye_
> _We show our names but we don't reveal our secrets_
> _We face the regex of the password hell_
> _We fight for our permissions in the settings_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9b4bcb6</samp>

*  Add a new endpoint to the tenant API that returns the tenant name and id by its id for public reports ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-502d13a4b2f93f0cb7c3148dec42b540d61a228816bf2c50e695968ba65f4e9aR18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-6562815fe833d7d8e6e93ff36778fe13d1ec1d83b18b9d2157e20c5da1ee2c59R1-R23))
*  Add a new method to the TenantService class that makes a GET request to the new endpoint ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-960dd2f94a2e2318f35365228e9b209dac4429ec7412ea844c4c444d4914c99aR122-R126))
*  Modify the report-view-page-public component to use the new method instead of fetching the whole tenant data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-e322b83f849c8cd00726ccb37dc6ce9b63ba4c3f83daba7b3fae46c309893c89L270-R270))
*  Add a regex validation to the password before creating or updating a user in the AuthService class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeR41-R46))
*  Add a new translation key for the 'Password is invalid' error message in the `backend/src/i18n/en.ts` and `frontend/src/i18n/en.js` modules ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-6a88ce6d5affb414df7246a768daca54d00ca443cda5acd68217218b20233dafR48-R49), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87L816-R816))
*  Add a conditional rendering to the signin-page and signup-page components to display the error message if the password is invalid ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-d540583828a2bd9fe431fbe7bb1b9f421fed34fc3b34efc49f21cc247f58f219L75-R80), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-583ea076be1f7d8d4901ce4705e7099bd4fdb989dbc9c45342fed7eac260ed92L132-R137))
*  Modify the user-model module to separate the password field for signing up and changing the password from the passwordSignin field for signing in ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b6b75b69c63070201830d91dddfdf6206935de13ed9e3f94d828812b11ababecL34-R38))
*  Modify the signin-page component to use the passwordSignin field instead of the password field for validation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-d540583828a2bd9fe431fbe7bb1b9f421fed34fc3b34efc49f21cc247f58f219L169-R174))
*  Add a new module for the SettingsPermissions class that checks the user's permissions for settings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b85aea707706909b0923b1001b9d30fb813f07f752453d624db7319ebdda1b9cR111), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-2638af4616103143e8e40ab387c13fc663592a1a3c6fd748e1a00c20de09560fR2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b6e989de7b30fce2f311c989b0195ca75b20e6f79019e23d3c845f4427a077a0R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-faa2567c051c1477d91e52279d956fb0f14f46137239966acfea9c2d79ecd179R2))
*  Modify the menu-workspace-popover, api-keys, plans-billing, and users-permissions modules to use the SettingsPermissions class to conditionally render or display the links and options for settings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b85aea707706909b0923b1001b9d30fb813f07f752453d624db7319ebdda1b9cL18-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b85aea707706909b0923b1001b9d30fb813f07f752453d624db7319ebdda1b9cL28-R35), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b85aea707706909b0923b1001b9d30fb813f07f752453d624db7319ebdda1b9cR123-R133), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-2638af4616103143e8e40ab387c13fc663592a1a3c6fd748e1a00c20de09560fL10-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-b6e989de7b30fce2f311c989b0195ca75b20e6f79019e23d3c845f4427a077a0L10-R18), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-faa2567c051c1477d91e52279d956fb0f14f46137239966acfea9c2d79ecd179L10-R18))
*  Modify the userRead and userAutocomplete permissions in the Permissions class to only allow the admin role to access them ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L102-R102), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L113-R113))
*  Add a PermissionChecker to the tenantFind module to validate the user's permission to read members of the tenant ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-5bb4d1488af81df72e5afff59c861574d80bbcdd716092cd77c0d56654d006c4L4-R10))
*  Delete sensitive fields from the user record before returning it in the userRepository module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-9555b647a84703df075fcbd0c730b992e06d88e42d4102819ec1d60b3a7a675eR557-R565))
*  Fix a typo in the validation message '{path} is invalid' in the `frontend/src/i18n/en.js` module ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-9ba9bffc669e5a3b99ce78a959864d5db1df507e60b6061f436191fb05bd2e87L816-R816))
*  Add a blank line to the userRepository module for readability ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1850/files?diff=unified&w=0#diff-9555b647a84703df075fcbd0c730b992e06d88e42d4102819ec1d60b3a7a675eR550))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
