### PR TITLE
webhook api shouldnt kill db client connections at all

### DIFF
--- a/backend/src/segment/track.ts
+++ b/backend/src/segment/track.ts
@@ -1,9 +1,9 @@
 import { getServiceChildLogger } from '@crowd/logging'
 import { Edition } from '@crowd/types'
 import { API_CONFIG, IS_TEST_ENV, SEGMENT_CONFIG } from '../conf'
-import getTenatUser from './trackHelper'
-import addProductData, { CROWD_ANALYTICS_PLATORM_NAME } from './addProductDataToCrowdTenant'
 import SequelizeRepository from '../database/repositories/sequelizeRepository'
+import { CROWD_ANALYTICS_PLATORM_NAME } from './addProductDataToCrowdTenant'
+import getTenatUser from './trackHelper'
 
 const log = getServiceChildLogger('segment')
 

--- a/services/apps/webhook_api/src/main.ts
+++ b/services/apps/webhook_api/src/main.ts
@@ -20,7 +20,7 @@ setImmediate(async () => {
 
   const sqsClient = getSqsClient(SQS_CONFIG())
 
-  const dbConnection = await getDbConnection(DB_CONFIG(), 3)
+  const dbConnection = await getDbConnection(DB_CONFIG(), 3, 0)
 
   app.use((req, res, next) => {
     // Groups.io doesn't send a content-type header,

--- a/services/libs/database/src/connection.ts
+++ b/services/libs/database/src/connection.ts
@@ -63,7 +63,7 @@ export const getDbConnection = async (
   dbConnection = dbInstance({
     ...config,
     max: maxPoolSize || 20,
-    idleTimeoutMillis: idleTimeoutMillis || 10000,
+    idleTimeoutMillis: idleTimeoutMillis !== undefined ? idleTimeoutMillis : 10000,
     // query_timeout: 30000,
     application_name: process.env.SERVICE || 'unknown-app',
   })

--- a/services/libs/database/src/connection.ts
+++ b/services/libs/database/src/connection.ts
@@ -47,6 +47,7 @@ let dbConnection: DbConnection | undefined
 export const getDbConnection = async (
   config: IDatabaseConfig,
   maxPoolSize?: number,
+  idleTimeoutMillis?: number,
 ): Promise<DbConnection> => {
   if (dbConnection) {
     return dbConnection
@@ -62,6 +63,7 @@ export const getDbConnection = async (
   dbConnection = dbInstance({
     ...config,
     max: maxPoolSize || 20,
+    idleTimeoutMillis: idleTimeoutMillis || 10000,
     // query_timeout: 30000,
     application_name: process.env.SERVICE || 'unknown-app',
   })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbbc0eb</samp>

Added a feature to configure the idle timeout of database connections in the `webhook_api` service. This was done by adding a new parameter to the `getDbConnection` function in the `database` library and passing it from the `main.ts` file.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbbc0eb</samp>

> _To manage the database pool_
> _We added a parameter cool_
> _`idleTimeoutMillis`_
> _Can prevent some spillage_
> _By closing connections that drool_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fbbc0eb</samp>

*  Add `idleTimeoutMillis` parameter to database connection configuration and function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1853/files?diff=unified&w=0#diff-4d0bb96426ff483c76835f5019710944e1d79f47d64dd8c49a2ecc3fb4af8228L23-R23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1853/files?diff=unified&w=0#diff-9e58f25937db0a6e39a8159f110097d74642b6f1f3188104950027074f86f81dR50), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1853/files?diff=unified&w=0#diff-9e58f25937db0a6e39a8159f110097d74642b6f1f3188104950027074f86f81dR66))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
