### PR TITLE
Fix signup regex

### DIFF
--- a/backend/src/services/auth/authService.ts
+++ b/backend/src/services/auth/authService.ts
@@ -38,7 +38,7 @@ class AuthService {
 
       const existingUser = await UserRepository.findByEmail(email, options)
 
-      const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/
+      const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d])([^ \t]{8,})$/
 
       if (!passwordRegex.test(password)) {
         throw new Error400(options.language, 'auth.passwordInvalid')

--- a/frontend/src/modules/user/user-model.js
+++ b/frontend/src/modules/user/user-model.js
@@ -31,7 +31,7 @@ const fields = {
   }),
   password: new StringField('password', label('password'), {
     required: true,
-    matches: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
+    matches: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d])([^ \t]{8,})$/,
   }),
   passwordSignin: new StringField('password', label('password'), {
     required: true,


### PR DESCRIPTION
# Changes proposed ✍️

(?=.*[A-Za-z]): This is a positive lookahead, which asserts that at least one alphabetical character (either lowercase or uppercase) must be present somewhere in the string.

(?=.*\d): This is another positive lookahead, which asserts that at least one digit (0-9) must be present somewhere in the string.

(?=.*[^A-Za-z\d]): This is yet another positive lookahead. Here, [^A-Za-z\d] corresponds to any character that is NOT a number or a letter. This assertion ensures that the password includes at least one such symbol.

([^ \t]{8,}): This part defines what exactly we accept within the password. [^ \t] means any character that is NOT a space or a tab. {8,} makes sure that the password string's length is at least 8 characters.

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd7247b</samp>

Updated password regex in both backend and frontend to enforce a new password policy. The policy aims to improve security by requiring more complex passwords.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd7247b</samp>

> _`password` must change_
> _no spaces, one symbol, please_
> _autumn of old rules_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at dd7247b</samp>

*  Update password regex to match new policy ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1856/files?diff=unified&w=0#diff-9a960a7047333c42ea59b7d48d1a0b9cedd8fc8c3562bafee6e7273db7c19deeL41-R41), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1856/files?diff=unified&w=0#diff-b6b75b69c63070201830d91dddfdf6206935de13ed9e3f94d828812b11ababecL34-R34))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
