### PR TITLE
Add retry wrapper to all discord endpoints

### DIFF
--- a/services/libs/integrations/src/integrations/discord/api/getChannel.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannel.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios'
 import { handleDiscordError } from './errorHandler'
 import { DiscordApiChannel } from '../types'
 import { IProcessStreamContext } from '../../../types'
+import { retryWrapper } from './handleRateLimit'
 
 export const getChannel = async (
   channelId: string,
@@ -16,13 +17,15 @@ export const getChannel = async (
     },
   }
 
-  try {
-    const response = await axios(config)
-    return response.data
-  } catch (err) {
-    const newErr = handleDiscordError(err, config, { channelId }, ctx)
-    if (newErr) {
-      throw newErr
+  return await retryWrapper(3, async () => {
+    try {
+      const response = await axios(config)
+      return response.data
+    } catch (err) {
+      const newErr = handleDiscordError(err, config, { channelId }, ctx)
+      if (newErr) {
+        throw newErr
+      }
     }
-  }
+  })
 }

--- a/services/libs/integrations/src/integrations/discord/api/getChannels.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getChannels.ts
@@ -4,6 +4,7 @@ import { DiscordApiChannel, DiscordGetChannelsInput, DiscordGetMessagesInput } f
 import getMessages from './getMessages'
 import { IProcessStreamContext } from '../../../types'
 import { handleDiscordError } from './errorHandler'
+import { retryWrapper } from './handleRateLimit'
 
 /**
  * Try if a channel is readable
@@ -40,43 +41,45 @@ async function getChannels(
     },
   }
 
-  try {
-    const response = await axios(config)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: any = response.data
-
-    if (tryChannels) {
+  return await retryWrapper(3, async () => {
+    try {
+      const response = await axios(config)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const out: any[] = []
-      for (const channel of result) {
-        const limit = await tryChannel(
-          {
-            channelId: channel.id,
-            token: input.token,
-            perPage: 1,
-            page: undefined,
-          },
-          ctx,
-        )
-        if (limit) {
-          out.push(channel)
-          if (limit <= 1 && limit !== false) {
-            await timeout(5 * 1000)
+      const result: any = response.data
+
+      if (tryChannels) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const out: any[] = []
+        for (const channel of result) {
+          const limit = await tryChannel(
+            {
+              channelId: channel.id,
+              token: input.token,
+              perPage: 1,
+              page: undefined,
+            },
+            ctx,
+          )
+          if (limit) {
+            out.push(channel)
+            if (limit <= 1 && limit !== false) {
+              await timeout(5 * 1000)
+            }
           }
         }
+        return out
       }
-      return out
-    }
 
-    return result
-  } catch (err) {
-    const newErr = handleDiscordError(err, config, { input }, ctx)
-    if (newErr) {
-      throw newErr
-    } else {
-      return []
+      return result
+    } catch (err) {
+      const newErr = handleDiscordError(err, config, { input }, ctx)
+      if (newErr) {
+        throw newErr
+      } else {
+        return []
+      }
     }
-  }
+  })
 }
 
 export default getChannels

--- a/services/libs/integrations/src/integrations/discord/api/getMessage.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getMessage.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios'
 import { handleDiscordError } from './errorHandler'
 import { IProcessStreamContext } from '../../../types'
+import { retryWrapper } from './handleRateLimit'
 
 export const getMessage = async (
   channelId: string,
@@ -16,45 +17,47 @@ export const getMessage = async (
     },
   }
 
-  try {
-    const response = await axios(config)
-    return response.data
-  } catch (err) {
-    if (
-      err.response &&
-      err.response.status === 404 &&
-      err.response.data &&
-      err.response.data.message === 'Unknown Channel' &&
-      err.response.data.code === 10003
-    ) {
-      ctx.log.warn(
-        { channelId, messageId },
-        'Discord API returned Unknown Channel error when fetching message during webhook processing, skipping message.',
-      )
-      return null
-    } else if (
-      err.response &&
-      err.response.status === 404 &&
-      err.response.data &&
-      err.response.data.message === 'Unknown Message' &&
-      err.response.data.code === 10008
-    ) {
-      ctx.log.warn(
-        { channelId, messageId },
-        'Discord API returned Unknown Message error when fetching message during webhook processing, skipping message.',
-      )
-      return null
-    } else if (err.response && err.response.status === 404) {
-      ctx.log.warn(
-        { channelId, messageId },
-        'Discord API returned 404 error when fetching message during webhook processing, skipping message.',
-      )
-      return null
-    } else {
-      const newErr = handleDiscordError(err, config, { channelId, messageId }, ctx)
-      if (newErr) {
-        throw newErr
+  return await retryWrapper(3, async () => {
+    try {
+      const response = await axios(config)
+      return response.data
+    } catch (err) {
+      if (
+        err.response &&
+        err.response.status === 404 &&
+        err.response.data &&
+        err.response.data.message === 'Unknown Channel' &&
+        err.response.data.code === 10003
+      ) {
+        ctx.log.warn(
+          { channelId, messageId },
+          'Discord API returned Unknown Channel error when fetching message during webhook processing, skipping message.',
+        )
+        return null
+      } else if (
+        err.response &&
+        err.response.status === 404 &&
+        err.response.data &&
+        err.response.data.message === 'Unknown Message' &&
+        err.response.data.code === 10008
+      ) {
+        ctx.log.warn(
+          { channelId, messageId },
+          'Discord API returned Unknown Message error when fetching message during webhook processing, skipping message.',
+        )
+        return null
+      } else if (err.response && err.response.status === 404) {
+        ctx.log.warn(
+          { channelId, messageId },
+          'Discord API returned 404 error when fetching message during webhook processing, skipping message.',
+        )
+        return null
+      } else {
+        const newErr = handleDiscordError(err, config, { channelId, messageId }, ctx)
+        if (newErr) {
+          throw newErr
+        }
       }
     }
-  }
+  })
 }

--- a/services/libs/integrations/src/integrations/discord/api/getThreads.ts
+++ b/services/libs/integrations/src/integrations/discord/api/getThreads.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { DiscordApiChannel, DiscordGetChannelsInput } from '../types'
 import { IProcessStreamContext } from '../../../types'
 import { handleDiscordError } from './errorHandler'
+import { retryWrapper } from './handleRateLimit'
 
 async function getThreads(
   input: DiscordGetChannelsInput,
@@ -14,15 +15,18 @@ async function getThreads(
       Authorization: input.token,
     },
   }
-  try {
-    const response = await axios(config)
-    return response.data.threads
-  } catch (err) {
-    const newErr = handleDiscordError(err, config, { input }, ctx)
-    if (newErr) {
-      throw newErr
+
+  return await retryWrapper(3, async () => {
+    try {
+      const response = await axios(config)
+      return response.data.threads
+    } catch (err) {
+      const newErr = handleDiscordError(err, config, { input }, ctx)
+      if (newErr) {
+        throw newErr
+      }
     }
-  }
+  })
 }
 
 export default getThreads

--- a/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
+++ b/services/libs/integrations/src/integrations/discord/api/handleRateLimit.ts
@@ -1,4 +1,5 @@
 import { IProcessStreamContext } from '../../../types'
+import { RateLimitError } from '@crowd/types'
 
 const DISCORD_RATE_LIMIT = 100000
 const DISCORD_RATE_LIMIT_TIME = 100 // 100 seconds
@@ -6,4 +7,19 @@ const REDIS_KEY = 'discord-ratelimits-requests-count'
 
 export const getRateLimiter = (ctx: IProcessStreamContext) => {
   return ctx.getRateLimiter(DISCORD_RATE_LIMIT, DISCORD_RATE_LIMIT_TIME, REDIS_KEY)
+}
+
+export const retryWrapper = async (maxRetries, fn) => {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const result = await fn()
+      return result
+    } catch (err) {
+      if (err instanceof RateLimitError && i < maxRetries - 1) {
+        await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000))
+        continue
+      }
+      throw err
+    }
+  }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d44144d</samp>

This pull request improves the Discord integration by adding retry logic to handle rate limit errors from the Discord API. It refactors several functions in the `integrations/discord/api` directory to use the `retryWrapper` function from the `handleRateLimit` module. It also defines a custom `RateLimitError` class to distinguish rate limit errors from other types of errors.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d44144d</samp>

> _To handle the Discord API_
> _We use a `retryWrapper` to retry_
> _When we hit a rate limit_
> _We don't throw a fit_
> _We just wait and then call it again_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d44144d</samp>

*  Add `retryWrapper` function to handle rate limit errors from Discord API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-3d5a451b8d038f975bcce284a1540221ea5701897bf84cbbf1b9d43fbdb4d19cR11-R25))
*  Import `retryWrapper` function and use it to wrap API calls in `getChannel`, `getChannels`, `getMember`, `getMembers`, `getMessage`, `getMessages`, and `getThreads` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-78d626d86f9b6f24ecfe390037b47a713247355ac0442d117d488b86a931bf13R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-78d626d86f9b6f24ecfe390037b47a713247355ac0442d117d488b86a931bf13L19-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-42cf897a506c53cc0abee81a41cb3de92c47f36d589a227d4719adcccc4a4d97L43-R82), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-44e8a253258647e2fbf3077aad12bbc88eb942c7b2facedd81d7a531510963b9R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-44e8a253258647e2fbf3077aad12bbc88eb942c7b2facedd81d7a531510963b9L21-R32), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-a100bec833b4ab08237bd4bc75393a280f28fb4fc424cc5a9954867cb564fd1dR5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-a100bec833b4ab08237bd4bc75393a280f28fb4fc424cc5a9954867cb564fd1dL22-R43), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aR4), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-45ac6491daf53caefe51c7f60328395c6e77d42bd58e712ce751be934962fb1aL19-R62), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-bd44153d776cef51277afca54c8800d03d022736636cec42c420c38c081c0dbaR5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-bd44153d776cef51277afca54c8800d03d022736636cec42c420c38c081c0dbaL24-R53), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cR5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-fcff57842d744b7dacb2ff0714fd5479115edfc8442cfee0f6bedc7b519fa51cL17-R29))
*  Import `RateLimitError` class from `@crowd/types` and use it in `handleDiscordError` and `retryWrapper` functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1857/files?diff=unified&w=0#diff-3d5a451b8d038f975bcce284a1540221ea5701897bf84cbbf1b9d43fbdb4d19cR2))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
