### PR TITLE
User cache limit fix

### DIFF
--- a/frontend/src/modules/auth/auth-service.js
+++ b/frontend/src/modules/auth/auth-service.js
@@ -74,8 +74,13 @@ export class AuthService {
   static fetchMe() {
     return authAxios.get('/auth/me').then((response) => {
       const { data } = response;
-      localStorage.setItem('user', JSON.stringify(data));
-      localStorage.setItem('userDateTime', `${new Date().getTime()}`);
+      try {
+        localStorage.setItem('user', JSON.stringify(data));
+        localStorage.setItem('userDateTime', `${new Date().getTime()}`);
+      } catch (err) {
+        return data;
+      }
+
       return data;
     });
   }

--- a/frontend/src/modules/auth/auth-service.js
+++ b/frontend/src/modules/auth/auth-service.js
@@ -72,7 +72,16 @@ export class AuthService {
   }
 
   static fetchMe() {
-    return authAxios.get('/auth/me').then((response) => response.data);
+    return authAxios.get('/auth/me').then((response) => {
+      const { data } = response;
+      localStorage.setItem('user', JSON.stringify(data));
+      localStorage.setItem('userDateTime', `${new Date().getTime()}`);
+      return data;
+    });
+  }
+
+  static fetchMeLocally() {
+    return JSON.parse(localStorage.getItem('user'));
   }
 
   static signout() {

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -19,8 +19,22 @@ export default {
     try {
       const token = AuthToken.get();
       if (token) {
-        const currentUser = await AuthService.fetchMe();
+        const userDate = localStorage.getItem('userDateTime');
+        if (userDate) {
+          const dateDiff = new Date().getTime() - +userDate;
+          if (dateDiff > (7 * 24 * 60 * 60 * 1000)) {
+            localStorage.removeItem('user');
+            localStorage.removeItem('userDateTime');
+          }
+        }
+        const currentUserLocally = AuthService.fetchMeLocally();
         connectSocket(token);
+        if (currentUserLocally) {
+          commit('AUTH_INIT_SUCCESS', { currentUser: currentUserLocally });
+
+          return currentUserLocally;
+        }
+        const currentUser = await AuthService.fetchMe();
         commit('AUTH_INIT_SUCCESS', { currentUser });
         return currentUser;
       }
@@ -31,6 +45,7 @@ export default {
     } catch (error) {
       console.error(error);
       disconnectSocket();
+      console.log(error);
       commit('AUTH_INIT_ERROR');
       dispatch('doSignout');
       return null;
@@ -149,6 +164,7 @@ export default {
     commit('AUTH_SUCCESS', {
       currentUser: null,
     });
+    localStorage.removeItem('user');
     router.push('/auth/signin');
   },
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e49a74</samp>

Updated the `auth` module and the `AuthService` class to use the local storage for user data. This reduces the number of requests to the server and improves the authentication performance and user experience.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e49a74</samp>

> _We are the users of the dark_
> _We don't need to fetch from the server_
> _We have the power of the `local storage`_
> _We are the masters of our own data_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e49a74</samp>

* Optimize authentication process and reduce network traffic by using cached user data from local storage if available ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1864/files?diff=unified&w=0#diff-b492030f92c8e05b88fbf58bb1fd74c92f3275d7748af1cea0db88e9d4078a9dL75-R91), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1864/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L22-R37))
* Clear user data from local storage when user signs out ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1864/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R167))
* Improve error handling and debugging ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1864/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R48))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
