### PR TITLE
Fix dashboard refresh

### DIFF
--- a/frontend/src/modules/auth/auth-current-tenant.js
+++ b/frontend/src/modules/auth/auth-current-tenant.js
@@ -97,7 +97,7 @@ export default class AuthCurrentTenant {
     return null;
   }
 
-  static async set(tenant) {
+  static set(tenant) {
     if (!tenant) {
       return this.clear();
     }

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -264,18 +264,20 @@ export default {
       });
   },
 
-  async doSelectTenant({ dispatch }, { tenant, redirect = true }) {
+  async doSelectTenant({ dispatch, state }, { tenant, redirect = true }) {
     if (tenantSubdomain.isEnabled) {
       tenantSubdomain.redirectAuthenticatedTo(tenant.url);
       return;
     }
 
+    state.currentTenant = tenant;
     AuthCurrentTenant.set(tenant);
-    await dispatch('doRefreshCurrentUser');
 
     const initialState = buildInitialState(true);
 
     store.replaceState(initialState);
+
+    await dispatch('doRefreshCurrentUser');
 
     if (redirect) {
       router.push('/');


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 415a8ad</samp>

Refactored some `auth` store actions and simplified the `AuthCurrentTenant` class to improve the frontend data management of tenants and users.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 415a8ad</samp>

> _We are the tenants of the night_
> _We `set` our fate with fire and light_
> _We `doSelect` and `doRefresh` our souls_
> _We sync our state and defy the trolls_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 415a8ad</samp>

*  Simplify `set` method of `AuthCurrentTenant` class by removing `async` keyword ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-44bedcce6ae08b6bcebde20cedcf90423f71825d7c34f0c52f0d7411460c41f9L100-R100))
  - Receive `state` parameter and assign selected tenant to `currentTenant` property of state object ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L267-R267), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L273-R274))
  - Call `set` method of `AuthCurrentTenant` class to update local storage with current tenant ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L273-R274))
  - Call `doRefreshCurrentUser` action to fetch and update current user data from backend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L273-R274), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R280-R281))
*  Move `doRefreshCurrentUser` action call from `frontend/src/modules/auth/auth-current-tenant.js` to `frontend/src/modules/auth/store/actions.js` to ensure consistency between state, local storage, and backend ( [link](https://github.com/CrowdDotDev/crowd.dev/pull/1871/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R280-R281))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
