### PR TITLE
Don't fire automations if activity is older than automation

### DIFF
--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -29,9 +29,17 @@ export const shouldProcessActivity = async (
   const settings = automation.settings as NewActivitySettings
 
   let process = true
+  
+  // check if activity created after automation was created
+  if (new Date(automation.createdAt) > new Date(activity.timestamp)) {
+    log.warn(
+      `Ignoring automation ${automation.id} - Activity ${activity.id} was created before automation!`,
+    )
+    process = false
+  }
 
   // check whether activity type matches
-  if (settings.types && settings.types.length > 0) {
+  if (process && settings.types && settings.types.length > 0) {
     if (!settings.types.includes(activity.type)) {
       log.warn(
         `Ignoring automation ${automation.id} - Activity ${activity.id} type '${

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newActivityWorker.ts
@@ -29,7 +29,7 @@ export const shouldProcessActivity = async (
   const settings = automation.settings as NewActivitySettings
 
   let process = true
-  
+
   // check if activity created after automation was created
   if (new Date(automation.createdAt) > new Date(activity.timestamp)) {
     log.warn(

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
@@ -30,12 +30,9 @@ export const shouldProcessMember = async (
 
   // check if member joined after automation was created
   if (new Date(automation.createdAt) > new Date(member.joinedAt)) {
-    log.warn(
-      `Ignoring automation ${automation.id} - Member ${member.id} joined before automation!`,
-    )
+    log.warn(`Ignoring automation ${automation.id} - Member ${member.id} joined before automation!`)
     process = false
   }
-
 
   // check whether member platforms matches
   if (process && settings.platforms && settings.platforms.length > 0) {

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
@@ -28,6 +28,15 @@ export const shouldProcessMember = async (
 
   let process = true
 
+  // check if member joined after automation was created
+  if (new Date(automation.createdAt) > new Date(member.joinedAt)) {
+    log.warn(
+      `Ignoring automation ${automation.id} - Member ${member.id} joined before automation!`,
+    )
+    process = false
+  }
+
+
   // check whether member platforms matches
   if (settings.platforms && settings.platforms.length > 0) {
     const platforms = Object.keys(member.username)

--- a/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/automation/workers/newMemberWorker.ts
@@ -38,7 +38,7 @@ export const shouldProcessMember = async (
 
 
   // check whether member platforms matches
-  if (settings.platforms && settings.platforms.length > 0) {
+  if (process && settings.platforms && settings.platforms.length > 0) {
     const platforms = Object.keys(member.username)
     if (!platforms.some((platform) => settings.platforms.includes(platform))) {
       log.warn(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67ed1e3</samp>

Added conditions to `newActivityWorker.ts` and `newMemberWorker.ts` to filter out old activities and members that are not relevant for automations. This avoids unnecessary or unwanted automation triggers.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67ed1e3</samp>

> _`shouldProcess` checks_
> _automation creation date_
> _old ones are ignored_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 67ed1e3</samp>

*  Prevent triggering automations for old activities or members ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1873/files?diff=unified&w=0#diff-38ef99903ebbf342c27ff354fbc7dfaa8727b41b09bbdef36f31f7d2a9dab7bbL32-R42), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1873/files?diff=unified&w=0#diff-3efbe70b24e1f065e9ab611bede33299afb6b09c90893d8140d06b7771ea2afaR31-R39))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
