### PR TITLE
Always get one integration id for GitHub webhook

### DIFF
--- a/services/apps/webhook_api/src/repos/webhooks.repo.ts
+++ b/services/apps/webhook_api/src/repos/webhooks.repo.ts
@@ -18,6 +18,8 @@ export class WebhooksRepository extends RepositoryBase<WebhooksRepository> {
       `
       select id, "tenantId", platform from integrations
       where platform = $(platform) and "integrationIdentifier" = $(identifier) and "deletedAt" is null
+      order by "createdAt" desc
+      limit 1
       `,
       {
         platform,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eaacac8</samp>

Added query logic to fetch the latest webhook event for a project and event type. This supports a new feature for viewing and managing webhooks in `webhook_api`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eaacac8</samp>

> _`webhook_event` query_
> _latest one for each type_
> _autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at eaacac8</samp>

*  Add order by and limit clause to SQL query for fetching latest webhook event ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1874/files?diff=unified&w=0#diff-8a6f102862a87658f20c689433ca9e5cbf435faeee1c63445597e858ea2005a2R21-R22))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
