### PR TITLE
Fix slack automation flow

### DIFF
--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -27,13 +27,18 @@ export default {
             localStorage.removeItem('userDateTime');
           }
         }
-        const currentUserLocally = AuthService.fetchMeLocally();
         connectSocket(token);
-        if (currentUserLocally) {
-          commit('AUTH_INIT_SUCCESS', { currentUser: currentUserLocally });
+        const { pathname } = window.location;
+        if (!['/automations'].includes(pathname)) {
+          const currentUserLocally = AuthService.fetchMeLocally();
 
-          return currentUserLocally;
+          if (currentUserLocally) {
+            commit('AUTH_INIT_SUCCESS', { currentUser: currentUserLocally });
+
+            return currentUserLocally;
+          }
         }
+
         const currentUser = await AuthService.fetchMe();
         commit('AUTH_INIT_SUCCESS', { currentUser });
         return currentUser;


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at feae430</samp>

Fixed a bug that caused outdated user data on the `/automations` page by skipping local fetch in `actions.js`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at feae430</samp>

> _`/automations` path_
> _needs fresh user data always_
> _skip local fetch - cut_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at feae430</samp>

* Skip fetching current user locally on `/automations` page to avoid inconsistencies or errors ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1876/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L30-R41))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
