### PR TITLE
Improve data sink worker performance

### DIFF
--- a/services/apps/data_sink_worker/src/jobs/processOldResults.ts
+++ b/services/apps/data_sink_worker/src/jobs/processOldResults.ts
@@ -8,8 +8,8 @@ import { Client as TemporalClient } from '@crowd/temporal'
 import DataSinkRepository from '../repo/dataSink.repo'
 import DataSinkService from '../service/dataSink.service'
 
-const MAX_CONCURRENT_PROMISES = 10
-const MAX_RESULTS_TO_LOAD = 100
+const MAX_CONCURRENT_PROMISES = 2
+const MAX_RESULTS_TO_LOAD = 10
 
 export const processOldResultsJob = async (
   dbConn: DbConnection,

--- a/services/apps/data_sink_worker/src/jobs/processOldResults.ts
+++ b/services/apps/data_sink_worker/src/jobs/processOldResults.ts
@@ -8,8 +8,8 @@ import { Client as TemporalClient } from '@crowd/temporal'
 import DataSinkRepository from '../repo/dataSink.repo'
 import DataSinkService from '../service/dataSink.service'
 
-const MAX_CONCURRENT_PROMISES = 50
-const MAX_RESULTS_TO_LOAD = 200
+const MAX_CONCURRENT_PROMISES = 10
+const MAX_RESULTS_TO_LOAD = 100
 
 export const processOldResultsJob = async (
   dbConn: DbConnection,

--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -45,17 +45,23 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
     where "tenantId" = $(tenantId)
       and "segmentId" = $(segmentId)
       and "sourceId" = $(sourceId)
+      and platform = $(platform)
+      and type = $(type)
     limit 1;
   `
   public async findExisting(
     tenantId: string,
     segmentId: string,
     sourceId: string,
+    platform: string,
+    type: string,
   ): Promise<IDbActivity | null> {
     const result = await this.db().oneOrNone(this.findExistingActivityQuery, {
       tenantId,
       segmentId,
       sourceId,
+      platform,
+      type,
     })
 
     return result

--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -45,16 +45,23 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
     where "tenantId" = $(tenantId)
       and "segmentId" = $(segmentId)
       and "sourceId" = $(sourceId)
+      and platform = $(platform)
+      and type = $(type)
+    limit 1;
   `
   public async findExisting(
     tenantId: string,
     segmentId: string,
     sourceId: string,
+    platform: string,
+    type: string,
   ): Promise<IDbActivity | null> {
     const result = await this.db().oneOrNone(this.findExistingActivityQuery, {
       tenantId,
       segmentId,
       sourceId,
+      platform,
+      type,
     })
 
     return result

--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -45,23 +45,17 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
     where "tenantId" = $(tenantId)
       and "segmentId" = $(segmentId)
       and "sourceId" = $(sourceId)
-      and platform = $(platform)
-      and type = $(type)
     limit 1;
   `
   public async findExisting(
     tenantId: string,
     segmentId: string,
     sourceId: string,
-    platform: string,
-    type: string,
   ): Promise<IDbActivity | null> {
     const result = await this.db().oneOrNone(this.findExistingActivityQuery, {
       tenantId,
       segmentId,
       sourceId,
-      platform,
-      type,
     })
 
     return result

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -451,7 +451,13 @@ export default class ActivityService extends LoggerBase {
           }
 
           // find existing activity
-          const dbActivity = await txRepo.findExisting(tenantId, segmentId, activity.sourceId)
+          const dbActivity = await txRepo.findExisting(
+            tenantId,
+            segmentId,
+            activity.sourceId,
+            platform,
+            activity.type,
+          )
 
           if (dbActivity && dbActivity?.deletedAt) {
             // we found an existing activity but it's deleted - nothing to do here

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -451,13 +451,7 @@ export default class ActivityService extends LoggerBase {
           }
 
           // find existing activity
-          const dbActivity = await txRepo.findExisting(
-            tenantId,
-            segmentId,
-            activity.sourceId,
-            activity.platform,
-            activity.type,
-          )
+          const dbActivity = await txRepo.findExisting(tenantId, segmentId, activity.sourceId)
 
           if (dbActivity && dbActivity?.deletedAt) {
             // we found an existing activity but it's deleted - nothing to do here

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -451,7 +451,13 @@ export default class ActivityService extends LoggerBase {
           }
 
           // find existing activity
-          const dbActivity = await txRepo.findExisting(tenantId, segmentId, activity.sourceId)
+          const dbActivity = await txRepo.findExisting(
+            tenantId,
+            segmentId,
+            activity.sourceId,
+            activity.platform,
+            activity.type,
+          )
 
           if (dbActivity && dbActivity?.deletedAt) {
             // we found an existing activity but it's deleted - nothing to do here

--- a/services/apps/integration_data_worker/src/main.ts
+++ b/services/apps/integration_data_worker/src/main.ts
@@ -5,13 +5,13 @@ import { getRedisClient } from '@crowd/redis'
 import { getDbConnection } from '@crowd/database'
 import { DataSinkWorkerEmitter, IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { WorkerQueueReceiver } from './queue'
-import { processOldDataJob } from './jobs/processOldData'
+// import { processOldDataJob } from './jobs/processOldData'
 
 const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 3
-const PROCESSING_INTERVAL_MINUTES = 5
+// const PROCESSING_INTERVAL_MINUTES = 5
 
 setImmediate(async () => {
   log.info('Starting integration data worker...')
@@ -39,25 +39,25 @@ setImmediate(async () => {
     await streamWorkerEmitter.init()
     await dataSinkWorkerEmitter.init()
 
-    let processing = false
-    setInterval(async () => {
-      try {
-        if (!processing) {
-          processing = true
-          await processOldDataJob(
-            dbConnection,
-            redisClient,
-            streamWorkerEmitter,
-            dataSinkWorkerEmitter,
-            log,
-          )
-        }
-      } catch (err) {
-        log.error(err, 'Failed to process old data!')
-      } finally {
-        processing = false
-      }
-    }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
+    // let processing = false
+    // setInterval(async () => {
+    //   try {
+    //     if (!processing) {
+    //       processing = true
+    //       await processOldDataJob(
+    //         dbConnection,
+    //         redisClient,
+    //         streamWorkerEmitter,
+    //         dataSinkWorkerEmitter,
+    //         log,
+    //       )
+    //     }
+    //   } catch (err) {
+    //     log.error(err, 'Failed to process old data!')
+    //   } finally {
+    //     processing = false
+    //   }
+    // }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
     await queue.start()
   } catch (err) {
     log.error({ err }, 'Failed to start queues!')

--- a/services/apps/integration_data_worker/src/main.ts
+++ b/services/apps/integration_data_worker/src/main.ts
@@ -5,13 +5,13 @@ import { getRedisClient } from '@crowd/redis'
 import { getDbConnection } from '@crowd/database'
 import { DataSinkWorkerEmitter, IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { WorkerQueueReceiver } from './queue'
-// import { processOldDataJob } from './jobs/processOldData'
+import { processOldDataJob } from './jobs/processOldData'
 
 const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 3
-// const PROCESSING_INTERVAL_MINUTES = 5
+const PROCESSING_INTERVAL_MINUTES = 5
 
 setImmediate(async () => {
   log.info('Starting integration data worker...')
@@ -39,25 +39,25 @@ setImmediate(async () => {
     await streamWorkerEmitter.init()
     await dataSinkWorkerEmitter.init()
 
-    // let processing = false
-    // setInterval(async () => {
-    //   try {
-    //     if (!processing) {
-    //       processing = true
-    //       await processOldDataJob(
-    //         dbConnection,
-    //         redisClient,
-    //         streamWorkerEmitter,
-    //         dataSinkWorkerEmitter,
-    //         log,
-    //       )
-    //     }
-    //   } catch (err) {
-    //     log.error(err, 'Failed to process old data!')
-    //   } finally {
-    //     processing = false
-    //   }
-    // }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
+    let processing = false
+    setInterval(async () => {
+      try {
+        if (!processing) {
+          processing = true
+          await processOldDataJob(
+            dbConnection,
+            redisClient,
+            streamWorkerEmitter,
+            dataSinkWorkerEmitter,
+            log,
+          )
+        }
+      } catch (err) {
+        log.error(err, 'Failed to process old data!')
+      } finally {
+        processing = false
+      }
+    }, PROCESSING_INTERVAL_MINUTES * 60 * 1000)
     await queue.start()
   } catch (err) {
     log.error({ err }, 'Failed to start queues!')

--- a/services/libs/integrations/src/integrations/discord/index.ts
+++ b/services/libs/integrations/src/integrations/discord/index.ts
@@ -9,7 +9,6 @@ import processWebhookStream from './processWebhookStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.DISCORD,
   memberAttributes: DISCORD_MEMBER_ATTRIBUTES,
-  checkEvery: 12 * 60, // 12 hours
   generateStreams,
   processStream,
   processData,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d6c470</samp>

Fixed a bug in `activity.repo.ts` that could cause multiple activity records to be returned for a single task. Added a `limit 1` clause to the SQL query in `getActivityByTaskId`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d6c470</samp>

> _`getActivityByTaskId`_
> _Query now limits results_
> _A crisp autumn fix_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 1d6c470</samp>

*  Add a `limit 1` clause to the SQL query in `getActivityByTaskId` to ensure only one activity record is returned for a given task id ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1880/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aR48))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
