### PR TITLE
Prevent form submissions in integrations

### DIFF
--- a/frontend/src/integrations/devto/components/devto-connect-drawer.vue
+++ b/frontend/src/integrations/devto/components/devto-connect-drawer.vue
@@ -11,7 +11,7 @@
       <img class="w-6 h-6 mr-2" :src="logoUrl" alt="DEV logo" />
     </template>
     <template #content>
-      <el-form class="form integration-devto-form">
+      <el-form class="form integration-devto-form" @submit.prevent>
         <app-form-item
           class="mb-6"
           :validation="$v.apiKey"

--- a/frontend/src/integrations/discourse/components/discourse-connect-drawer.vue
+++ b/frontend/src/integrations/discourse/components/discourse-connect-drawer.vue
@@ -20,6 +20,7 @@
       <el-form
         label-position="top"
         class="form"
+        @submit.prevent
       >
         <app-form-item
           class="mb-6"

--- a/frontend/src/integrations/groupsio/components/groupsio-connect-drawer.vue
+++ b/frontend/src/integrations/groupsio/components/groupsio-connect-drawer.vue
@@ -21,7 +21,11 @@
           Connect a Groups.io account. You must be a group owner to authenticate.
         </div>
       </div>
-      <el-form label-position="top" class="form">
+      <el-form
+        label-position="top"
+        class="form"
+        @submit.prevent
+      >
         <app-form-item
           v-if="!isAPIConnectionValid"
           class="

--- a/frontend/src/integrations/hackernews/components/hackerNews-connect-drawer.vue
+++ b/frontend/src/integrations/hackernews/components/hackerNews-connect-drawer.vue
@@ -39,7 +39,7 @@
           placeholder="e.g. crowd.dev, crowddev, CrowdDotDev"
         />
       </div>
-      <el-form class="form integration-hackerNews-form">
+      <el-form class="form integration-hackerNews-form" @submit.prevent>
         <div class="flex flex-col gap-2 items-start">
           <span class="text-sm font-medium">Track your URL</span>
           <span


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac214f2</samp>

Added `@submit.prevent` modifier to `el-form` elements in various integration components to prevent page reload on form submission. Reformatted `el-form` element in `groupsio-connect-drawer.vue` for readability.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac214f2</samp>

> _`@submit.prevent`_
> _A modifier for all forms_
> _No page reloads_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ac214f2</samp>

*  Prevent default form submission and page reload in four integration components (`@submit.prevent` modifier in [link](https://github.com/CrowdDotDev/crowd.dev/pull/1885/files?diff=unified&w=0#diff-29177a6b05b402fa38f9810dec54c27d2766c2c923b6cc66de32e647863366cfL14-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1885/files?diff=unified&w=0#diff-1164628887ea89d5785b752c86290813b84a9e58feaba47918fa2b5527feb82eR23), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1885/files?diff=unified&w=0#diff-f3b67321581a1c6f121558e0a91729b0aae4d21b69cc839189acb1c263244b81L24-R28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1885/files?diff=unified&w=0#diff-a88c59438531bc39a018fd9b2c49d9f6902e7a87fa04d1926f1b0770bc164a15L42-R42))
*  Reformat `el-form` element in `groupsio-connect-drawer.vue` for readability and consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1885/files?diff=unified&w=0#diff-f3b67321581a1c6f121558e0a91729b0aae4d21b69cc839189acb1c263244b81L24-R28))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
