### PR TITLE
Remove OTEL tracing from our code

### DIFF
--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -3,7 +3,6 @@ import { getUnleashClient } from '@crowd/feature-flags'
 import { getServiceLogger } from '@crowd/logging'
 import { getOpensearchClient } from '@crowd/opensearch'
 import { getRedisClient, getRedisPubSubPair, RedisPubSubReceiver } from '@crowd/redis'
-import { getServiceTracer } from '@crowd/tracing'
 import { ApiWebsocketMessage, Edition } from '@crowd/types'
 import bodyParser from 'body-parser'
 import bunyanMiddleware from 'bunyan-middleware'
@@ -37,7 +36,6 @@ import WebSockets from './websockets'
 import { databaseInit } from '@/database/databaseConnection'
 
 const serviceLogger = getServiceLogger()
-getServiceTracer()
 
 const app = express()
 

--- a/backend/src/bin/job-generator.ts
+++ b/backend/src/bin/job-generator.ts
@@ -1,32 +1,19 @@
 import { CronJob } from 'cron'
 import { getServiceLogger } from '@crowd/logging'
-import { SpanStatusCode, getServiceTracer } from '@crowd/tracing'
 import jobs from './jobs'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 for (const job of jobs) {
   const cronJob = new CronJob(
     job.cronTime,
     async () => {
-      await tracer.startActiveSpan(`ProcessingJob:${job.name}`, async (span) => {
-        log.info({ job: job.name }, 'Triggering job.')
-        try {
-          await job.onTrigger(log)
-          span.setStatus({
-            code: SpanStatusCode.OK,
-          })
-        } catch (err) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err,
-          })
-          log.error(err, { job: job.name }, 'Error while executing a job!')
-        } finally {
-          span.end()
-        }
-      })
+      log.info({ job: job.name }, 'Triggering job.')
+      try {
+        await job.onTrigger(log)
+      } catch (err) {
+        log.error(err, { job: job.name }, 'Error while executing a job!')
+      }
     },
     null,
     true,

--- a/backend/src/bin/nodejs-worker.ts
+++ b/backend/src/bin/nodejs-worker.ts
@@ -8,7 +8,6 @@ import {
   receiveMessage,
   sendMessage,
 } from '@crowd/sqs'
-import { SpanStatusCode, getServiceTracer } from '@crowd/tracing'
 import moment from 'moment'
 import { SQS_CONFIG } from '../conf'
 import { processDbOperationsMessage } from '../serverless/dbOperations/workDispatcher'
@@ -21,7 +20,6 @@ import { SQS_CLIENT } from '@/serverless/utils/serviceSQS'
 
 /* eslint-disable no-constant-condition */
 
-const tracer = getServiceTracer()
 const serviceLogger = getServiceLogger()
 
 let exiting = false
@@ -70,55 +68,38 @@ async function handleDelayedMessages() {
     const message = await receive(true)
 
     if (message) {
-      await tracer.startActiveSpan('ProcessDelayedMessage', async (span) => {
-        try {
-          const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
-          const messageLogger = getChildLogger('messageHandler', serviceLogger, {
-            messageId: message.MessageId,
-            type: msg.type,
-          })
-
-          if (message.MessageAttributes && message.MessageAttributes.remainingDelaySeconds) {
-            // re-delay
-            const newDelay = parseInt(
-              message.MessageAttributes.remainingDelaySeconds.StringValue,
-              10,
-            )
-            const tenantId = message.MessageAttributes.tenantId.StringValue
-            messageLogger.debug({ newDelay, tenantId }, 'Re-delaying message!')
-            await sendNodeWorkerMessage(tenantId, msg, newDelay)
-          } else {
-            // just emit to the normal queue for processing
-            const tenantId = message.MessageAttributes.tenantId.StringValue
-
-            if (message.MessageAttributes.targetQueueUrl) {
-              const targetQueueUrl = message.MessageAttributes.targetQueueUrl.StringValue
-              messageLogger.debug({ tenantId, targetQueueUrl }, 'Successfully delayed a message!')
-              await sendMessage(SQS_CLIENT(), {
-                QueueUrl: targetQueueUrl,
-                MessageGroupId: tenantId,
-                MessageDeduplicationId: `${tenantId}-${moment().valueOf()}`,
-                MessageBody: JSON.stringify(msg),
-              })
-            } else {
-              messageLogger.debug({ tenantId }, 'Successfully delayed a message!')
-              await sendNodeWorkerMessage(tenantId, msg)
-            }
-          }
-
-          await removeFromQueue(message.ReceiptHandle, true)
-          span.setStatus({
-            code: SpanStatusCode.OK,
-          })
-        } catch (err) {
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: err,
-          })
-        } finally {
-          span.end()
-        }
+      const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
+      const messageLogger = getChildLogger('messageHandler', serviceLogger, {
+        messageId: message.MessageId,
+        type: msg.type,
       })
+
+      if (message.MessageAttributes && message.MessageAttributes.remainingDelaySeconds) {
+        // re-delay
+        const newDelay = parseInt(message.MessageAttributes.remainingDelaySeconds.StringValue, 10)
+        const tenantId = message.MessageAttributes.tenantId.StringValue
+        messageLogger.debug({ newDelay, tenantId }, 'Re-delaying message!')
+        await sendNodeWorkerMessage(tenantId, msg, newDelay)
+      } else {
+        // just emit to the normal queue for processing
+        const tenantId = message.MessageAttributes.tenantId.StringValue
+
+        if (message.MessageAttributes.targetQueueUrl) {
+          const targetQueueUrl = message.MessageAttributes.targetQueueUrl.StringValue
+          messageLogger.debug({ tenantId, targetQueueUrl }, 'Successfully delayed a message!')
+          await sendMessage(SQS_CLIENT(), {
+            QueueUrl: targetQueueUrl,
+            MessageGroupId: tenantId,
+            MessageDeduplicationId: `${tenantId}-${moment().valueOf()}`,
+            MessageBody: JSON.stringify(msg),
+          })
+        } else {
+          messageLogger.debug({ tenantId }, 'Successfully delayed a message!')
+          await sendNodeWorkerMessage(tenantId, msg)
+        }
+      }
+
+      await removeFromQueue(message.ReceiptHandle, true)
     } else {
       delayedHandlerLogger.trace('No message received!')
     }
@@ -143,83 +124,71 @@ async function handleMessages() {
   handlerLogger.info('Listening for messages!')
 
   const processSingleMessage = async (message: SqsMessage): Promise<void> => {
-    await tracer.startActiveSpan('ProcessMessage', async (span) => {
-      const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
+    const msg: NodeWorkerMessageBase = JSON.parse(message.Body)
 
-      const messageLogger = getChildLogger('messageHandler', serviceLogger, {
-        messageId: message.MessageId,
-        type: msg.type,
-      })
-
-      try {
-        if (
-          msg.type === NodeWorkerMessageType.NODE_MICROSERVICE &&
-          (msg as any).service === 'enrich_member_organizations'
-        ) {
-          messageLogger.warn(
-            'Skipping enrich_member_organizations message! Purging the queue because they are not needed anymore!',
-          )
-          await removeFromQueue(message.ReceiptHandle)
-          return
-        }
-
-        messageLogger.info(
-          { messageType: msg.type, messagePayload: JSON.stringify(msg) },
-          'Received a new queue message!',
-        )
-
-        let processFunction: (msg: NodeWorkerMessageBase, logger?: Logger) => Promise<void>
-
-        switch (msg.type) {
-          case NodeWorkerMessageType.INTEGRATION_PROCESS:
-            processFunction = processIntegration
-            break
-          case NodeWorkerMessageType.NODE_MICROSERVICE:
-            processFunction = processNodeMicroserviceMessage
-            break
-          case NodeWorkerMessageType.DB_OPERATIONS:
-            processFunction = processDbOperationsMessage
-            break
-          case NodeWorkerMessageType.PROCESS_WEBHOOK:
-            processFunction = processWebhook
-            break
-
-          default:
-            messageLogger.error('Error while parsing queue message! Invalid type.')
-        }
-
-        if (processFunction) {
-          await logExecutionTimeV2(
-            async () => {
-              // remove the message from the queue as it's about to be processed
-              await removeFromQueue(message.ReceiptHandle)
-              messagesInProgress.set(message.MessageId, msg)
-              try {
-                await processFunction(msg, messageLogger)
-              } catch (err) {
-                messageLogger.error(err, 'Error while processing queue message!')
-              } finally {
-                messagesInProgress.delete(message.MessageId)
-              }
-            },
-            messageLogger,
-            'Processing queue message!',
-          )
-        }
-
-        span.setStatus({
-          code: SpanStatusCode.OK,
-        })
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err,
-        })
-        messageLogger.error(err, { payload: msg }, 'Error while processing queue message!')
-      } finally {
-        span.end()
-      }
+    const messageLogger = getChildLogger('messageHandler', serviceLogger, {
+      messageId: message.MessageId,
+      type: msg.type,
     })
+
+    try {
+      if (
+        msg.type === NodeWorkerMessageType.NODE_MICROSERVICE &&
+        (msg as any).service === 'enrich_member_organizations'
+      ) {
+        messageLogger.warn(
+          'Skipping enrich_member_organizations message! Purging the queue because they are not needed anymore!',
+        )
+        await removeFromQueue(message.ReceiptHandle)
+        return
+      }
+
+      messageLogger.info(
+        { messageType: msg.type, messagePayload: JSON.stringify(msg) },
+        'Received a new queue message!',
+      )
+
+      let processFunction: (msg: NodeWorkerMessageBase, logger?: Logger) => Promise<void>
+
+      switch (msg.type) {
+        case NodeWorkerMessageType.INTEGRATION_PROCESS:
+          processFunction = processIntegration
+          break
+        case NodeWorkerMessageType.NODE_MICROSERVICE:
+          processFunction = processNodeMicroserviceMessage
+          break
+        case NodeWorkerMessageType.DB_OPERATIONS:
+          processFunction = processDbOperationsMessage
+          break
+        case NodeWorkerMessageType.PROCESS_WEBHOOK:
+          processFunction = processWebhook
+          break
+
+        default:
+          messageLogger.error('Error while parsing queue message! Invalid type.')
+      }
+
+      if (processFunction) {
+        await logExecutionTimeV2(
+          async () => {
+            // remove the message from the queue as it's about to be processed
+            await removeFromQueue(message.ReceiptHandle)
+            messagesInProgress.set(message.MessageId, msg)
+            try {
+              await processFunction(msg, messageLogger)
+            } catch (err) {
+              messageLogger.error(err, 'Error while processing queue message!')
+            } finally {
+              messagesInProgress.delete(message.MessageId)
+            }
+          },
+          messageLogger,
+          'Processing queue message!',
+        )
+      }
+    } catch (err) {
+      messageLogger.error(err, { payload: msg }, 'Error while processing queue message!')
+    }
   }
 
   // noinspection InfiniteLoopJS

--- a/backend/src/serverless/utils/serviceSQS.ts
+++ b/backend/src/serverless/utils/serviceSQS.ts
@@ -8,10 +8,8 @@ import {
   getSqsClient,
 } from '@crowd/sqs'
 import { getServiceChildLogger } from '@crowd/logging'
-import { getServiceTracer } from '@crowd/tracing'
 import { SQS_CONFIG } from '../../conf'
 
-const tracer = getServiceTracer()
 const log = getServiceChildLogger('service.sqs')
 
 let sqsClient: SqsClient
@@ -33,7 +31,7 @@ let runWorkerEmitter: IntegrationRunWorkerEmitter
 export const getIntegrationRunWorkerEmitter = async (): Promise<IntegrationRunWorkerEmitter> => {
   if (runWorkerEmitter) return runWorkerEmitter
 
-  runWorkerEmitter = new IntegrationRunWorkerEmitter(SQS_CLIENT(), tracer, log)
+  runWorkerEmitter = new IntegrationRunWorkerEmitter(SQS_CLIENT(), log)
   await runWorkerEmitter.init()
   return runWorkerEmitter
 }
@@ -43,7 +41,7 @@ export const getIntegrationStreamWorkerEmitter =
   async (): Promise<IntegrationStreamWorkerEmitter> => {
     if (streamWorkerEmitter) return streamWorkerEmitter
 
-    streamWorkerEmitter = new IntegrationStreamWorkerEmitter(SQS_CLIENT(), tracer, log)
+    streamWorkerEmitter = new IntegrationStreamWorkerEmitter(SQS_CLIENT(), log)
     await streamWorkerEmitter.init()
     return streamWorkerEmitter
   }
@@ -52,7 +50,7 @@ let searchSyncWorkerEmitter: SearchSyncWorkerEmitter
 export const getSearchSyncWorkerEmitter = async (): Promise<SearchSyncWorkerEmitter> => {
   if (searchSyncWorkerEmitter) return searchSyncWorkerEmitter
 
-  searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(SQS_CLIENT(), tracer, log)
+  searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(SQS_CLIENT(), log)
   await searchSyncWorkerEmitter.init()
   return searchSyncWorkerEmitter
 }
@@ -61,7 +59,7 @@ let integrationSyncWorkerEmitter: IntegrationSyncWorkerEmitter
 export const getIntegrationSyncWorkerEmitter = async (): Promise<IntegrationSyncWorkerEmitter> => {
   if (integrationSyncWorkerEmitter) return integrationSyncWorkerEmitter
 
-  integrationSyncWorkerEmitter = new IntegrationSyncWorkerEmitter(SQS_CLIENT(), tracer, log)
+  integrationSyncWorkerEmitter = new IntegrationSyncWorkerEmitter(SQS_CLIENT(), log)
   await integrationSyncWorkerEmitter.init()
   return integrationSyncWorkerEmitter
 }
@@ -70,7 +68,7 @@ let dataSinkWorkerEmitter: DataSinkWorkerEmitter
 export const getDataSinkWorkerEmitter = async (): Promise<DataSinkWorkerEmitter> => {
   if (dataSinkWorkerEmitter) return dataSinkWorkerEmitter
 
-  dataSinkWorkerEmitter = new DataSinkWorkerEmitter(SQS_CLIENT(), tracer, log)
+  dataSinkWorkerEmitter = new DataSinkWorkerEmitter(SQS_CLIENT(), log)
   await dataSinkWorkerEmitter.init()
   return dataSinkWorkerEmitter
 }

--- a/services/apps/data_sink_worker/src/bin/map-member-to-org.ts
+++ b/services/apps/data_sink_worker/src/bin/map-member-to-org.ts
@@ -1,6 +1,5 @@
 import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import {
   DataSinkWorkerEmitter,
@@ -16,7 +15,6 @@ import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
 import { getRedisClient } from '@crowd/redis'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -38,7 +36,7 @@ setImmediate(async () => {
   }
 
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())
@@ -47,10 +45,10 @@ setImmediate(async () => {
   const dataSinkRepo = new DataSinkRepository(store, log)
   const memberRepo = new MemberRepository(store, log)
 
-  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, tracer, log)
+  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, log)
   await nodejsWorkerEmitter.init()
 
-  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
+  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, log)
   await searchSyncWorkerEmitter.init()
 
   const redisClient = await getRedisClient(REDIS_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/map-tenant-members-to-org.ts
+++ b/services/apps/data_sink_worker/src/bin/map-tenant-members-to-org.ts
@@ -1,6 +1,5 @@
 import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG, TEMPORAL_CONFIG, UNLEASH_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import {
   DataSinkWorkerEmitter,
@@ -16,7 +15,6 @@ import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
 import { getRedisClient } from '@crowd/redis'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -38,7 +36,7 @@ setImmediate(async () => {
   }
 
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())
@@ -50,10 +48,10 @@ setImmediate(async () => {
   const segmentIds = await dataSinkRepo.getSegmentIds(tenantId)
   const segmentId = segmentIds[segmentIds.length - 1] // leaf segment id
 
-  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, tracer, log)
+  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, log)
   await nodejsWorkerEmitter.init()
 
-  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
+  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, log)
   await searchSyncWorkerEmitter.init()
 
   const redisClient = await getRedisClient(REDIS_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/process-results.ts
+++ b/services/apps/data_sink_worker/src/bin/process-results.ts
@@ -9,7 +9,6 @@ import {
 import DataSinkRepository from '../repo/dataSink.repo'
 import DataSinkService from '../service/dataSink.service'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -22,7 +21,6 @@ import { initializeSentimentAnalysis } from '@crowd/sentiment'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -48,13 +46,13 @@ setImmediate(async () => {
 
   initializeSentimentAnalysis(SENTIMENT_CONFIG())
 
-  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, tracer, log)
+  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, log)
   await nodejsWorkerEmitter.init()
 
-  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
+  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, log)
   await searchSyncWorkerEmitter.init()
 
-  const dataSinkWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const dataSinkWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, log)
   await dataSinkWorkerEmitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/restart-all-failed-results.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-all-failed-results.ts
@@ -2,19 +2,17 @@ import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import DataSinkRepository from '../repo/dataSink.repo'
 import { partition } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
 
 const batchSize = 500
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/restart-failed-results.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-failed-results.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import DataSinkRepository from '../repo/dataSink.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -20,7 +18,7 @@ const runId = processArguments[0]
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/restart-result.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-result.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import DataSinkRepository from '../repo/dataSink.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -20,7 +18,7 @@ const resultIds = processArguments[0].split(',')
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/data_sink_worker/src/bin/restart-x-failed-results.ts
+++ b/services/apps/data_sink_worker/src/bin/restart-x-failed-results.ts
@@ -2,14 +2,12 @@ import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import DataSinkRepository from '../repo/dataSink.repo'
 import { partition } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DataSinkWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { ProcessIntegrationResultQueueMessage } from '@crowd/types'
 
 const MAX_TO_PROCESS = 500
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -25,7 +23,7 @@ numResults = Math.min(numResults, MAX_TO_PROCESS)
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new DataSinkWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/data_sink_worker/src/main.ts
+++ b/services/apps/data_sink_worker/src/main.ts
@@ -1,5 +1,4 @@
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import {
   NodejsWorkerEmitter,
@@ -22,7 +21,6 @@ import { processOldResultsJob } from './jobs/processOldResults'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { Client as TemporalClient, getTemporalClient } from '@crowd/temporal'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 5
@@ -49,11 +47,11 @@ setImmediate(async () => {
     initializeSentimentAnalysis(SENTIMENT_CONFIG())
   }
 
-  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, tracer, log)
+  const nodejsWorkerEmitter = new NodejsWorkerEmitter(sqsClient, log)
 
-  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
+  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, log)
 
-  const dataWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const dataWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, log)
 
   const queue = new WorkerQueueReceiver(
     sqsClient,
@@ -64,7 +62,6 @@ setImmediate(async () => {
     redisClient,
     unleash,
     temporal,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/integration_data_worker/src/bin/process-data-for-tenant.ts
+++ b/services/apps/integration_data_worker/src/bin/process-data-for-tenant.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationDataRepository from '../repo/integrationData.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationDataWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { IntegrationStreamDataState } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -20,7 +18,7 @@ const tenantId = processArguments[0]
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationDataWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_data_worker/src/bin/process-data.ts
+++ b/services/apps/integration_data_worker/src/bin/process-data.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationDataRepository from '../repo/integrationData.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationDataWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { IntegrationStreamDataState } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -20,7 +18,7 @@ const dataIds = processArguments[0].split(',')
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationDataWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_data_worker/src/main.ts
+++ b/services/apps/integration_data_worker/src/main.ts
@@ -1,4 +1,3 @@
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from './conf'
 import { getRedisClient } from '@crowd/redis'
@@ -7,7 +6,6 @@ import { DataSinkWorkerEmitter, IntegrationStreamWorkerEmitter, getSqsClient } f
 import { WorkerQueueReceiver } from './queue'
 import { processOldDataJob } from './jobs/processOldData'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 3
@@ -21,8 +19,8 @@ setImmediate(async () => {
   const dbConnection = await getDbConnection(DB_CONFIG(), MAX_CONCURRENT_PROCESSING)
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
 
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
-  const dataSinkWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, tracer, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
+  const dataSinkWorkerEmitter = new DataSinkWorkerEmitter(sqsClient, log)
 
   const queue = new WorkerQueueReceiver(
     sqsClient,
@@ -30,7 +28,6 @@ setImmediate(async () => {
     dbConnection,
     streamWorkerEmitter,
     dataSinkWorkerEmitter,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/integration_data_worker/src/queue/index.ts
+++ b/services/apps/integration_data_worker/src/queue/index.ts
@@ -1,4 +1,3 @@
-import { Tracer, Span, SpanStatusCode } from '@crowd/tracing'
 import { Logger } from '@crowd/logging'
 import { DbConnection, DbStore } from '@crowd/database'
 import { RedisClient } from '@crowd/redis'
@@ -23,54 +22,34 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     private readonly dbConn: DbConnection,
     private readonly streamWorkerEmitter: IntegrationStreamWorkerEmitter,
     private readonly dataSinkWorkerEmitter: DataSinkWorkerEmitter,
-    tracer: Tracer,
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
-    super(
-      client,
-      INTEGRATION_DATA_WORKER_QUEUE_SETTINGS,
-      maxConcurrentProcessing,
-      tracer,
-      parentLog,
-    )
+    super(client, INTEGRATION_DATA_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog)
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {
-    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
-      try {
-        this.log.trace({ messageType: message.type }, 'Processing message!')
+    try {
+      this.log.trace({ messageType: message.type }, 'Processing message!')
 
-        const service = new IntegrationStreamService(
-          this.redisClient,
-          this.streamWorkerEmitter,
-          this.dataSinkWorkerEmitter,
-          new DbStore(this.log, this.dbConn),
-          this.log,
-        )
+      const service = new IntegrationStreamService(
+        this.redisClient,
+        this.streamWorkerEmitter,
+        this.dataSinkWorkerEmitter,
+        new DbStore(this.log, this.dbConn),
+        this.log,
+      )
 
-        switch (message.type) {
-          case IntegrationDataWorkerQueueMessageType.PROCESS_STREAM_DATA:
-            await service.processData((message as ProcessStreamDataQueueMessage).dataId)
-            break
-          default:
-            throw new Error(`Unknown message type: ${message.type}`)
-        }
-
-        span.setStatus({
-          code: SpanStatusCode.OK,
-        })
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err,
-        })
-
-        this.log.error(err, 'Error while processing message!')
-        throw err
-      } finally {
-        span.end()
+      switch (message.type) {
+        case IntegrationDataWorkerQueueMessageType.PROCESS_STREAM_DATA:
+          await service.processData((message as ProcessStreamDataQueueMessage).dataId)
+          break
+        default:
+          throw new Error(`Unknown message type: ${message.type}`)
       }
-    })
+    } catch (err) {
+      this.log.error(err, 'Error while processing message!')
+      throw err
+    }
   }
 }

--- a/services/apps/integration_run_worker/src/bin/continue-run.ts
+++ b/services/apps/integration_run_worker/src/bin/continue-run.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import IntegrationRunRepository from '../repo/integrationRun.repo'
 import { IntegrationRunState } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -15,7 +13,7 @@ const runId = processArguments[0]
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_run_worker/src/bin/onboard-integration.ts
+++ b/services/apps/integration_run_worker/src/bin/onboard-integration.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationRunWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import IntegrationRunRepository from '../repo/integrationRun.repo'
 import { IntegrationState } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -16,7 +14,7 @@ const isOnboarding = processArguments[1] ? processArguments[1] === 'true' : true
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationRunWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_run_worker/src/bin/process-repo.ts
+++ b/services/apps/integration_run_worker/src/bin/process-repo.ts
@@ -1,6 +1,5 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationRunWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import IntegrationRunRepository from '../repo/integrationRun.repo'
@@ -34,7 +33,6 @@ const mapStreamTypeToEnum = (stream: string): GithubManualStreamType => {
 // example call
 // npm run script:process-repo 5f8b1a3a-0b0a-4c0a-8b0a-4c0a8b0a4c0a  CrowdDotDev/crowd.dev stars
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -67,7 +65,7 @@ setImmediate(async () => {
   }
 
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationRunWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_run_worker/src/bin/trigger-all-onboardings.ts
+++ b/services/apps/integration_run_worker/src/bin/trigger-all-onboardings.ts
@@ -3,16 +3,14 @@ import IntegrationRunRepository from '../repo/integrationRun.repo'
 import { singleOrDefault, timeout } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
 import { INTEGRATION_SERVICES } from '@crowd/integrations'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationRunWorkerEmitter, getSqsClient } from '@crowd/sqs'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationRunWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_run_worker/src/bin/trigger-stream-processed.ts
+++ b/services/apps/integration_run_worker/src/bin/trigger-stream-processed.ts
@@ -1,10 +1,8 @@
 import { SQS_CONFIG } from '../conf'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationRunWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { StreamProcessedQueueMessage } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -18,7 +16,7 @@ const runIds = processArguments[0].split(',')
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationRunWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   for (const runId of runIds) {

--- a/services/apps/integration_run_worker/src/main.ts
+++ b/services/apps/integration_run_worker/src/main.ts
@@ -1,5 +1,4 @@
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import {
   IntegrationRunWorkerEmitter,
@@ -12,7 +11,6 @@ import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from './conf'
 import { WorkerQueueReceiver } from './queue'
 import { ApiPubSubEmitter, getRedisClient } from '@crowd/redis'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
@@ -25,10 +23,10 @@ setImmediate(async () => {
   const dbConnection = await getDbConnection(DB_CONFIG(), MAX_CONCURRENT_PROCESSING)
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
 
-  const runWorkerEmitter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
-  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, tracer, log)
-  const integrationSyncWorkerEmitter = new IntegrationSyncWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmitter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
+  const searchSyncWorkerEmitter = new SearchSyncWorkerEmitter(sqsClient, log)
+  const integrationSyncWorkerEmitter = new IntegrationSyncWorkerEmitter(sqsClient, log)
 
   const apiPubSubEmitter = new ApiPubSubEmitter(redisClient, log)
 
@@ -41,7 +39,6 @@ setImmediate(async () => {
     searchSyncWorkerEmitter,
     integrationSyncWorkerEmitter,
     apiPubSubEmitter,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/integration_run_worker/src/queue/index.ts
+++ b/services/apps/integration_run_worker/src/queue/index.ts
@@ -1,4 +1,3 @@
-import { Tracer, Span, SpanStatusCode } from '@crowd/tracing'
 import { Logger } from '@crowd/logging'
 import { DbConnection, DbStore } from '@crowd/database'
 import { ApiPubSubEmitter, RedisClient } from '@crowd/redis'
@@ -32,67 +31,53 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     private readonly searchSyncWorkerEmitter: SearchSyncWorkerEmitter,
     private readonly integrationSyncWorkerEmitter: IntegrationSyncWorkerEmitter,
     private readonly apiPubSubEmitter: ApiPubSubEmitter,
-    tracer: Tracer,
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
-    super(client, INTEGRATION_RUN_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, tracer, parentLog)
+    super(client, INTEGRATION_RUN_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog)
   }
 
   override async processMessage(message: IQueueMessage): Promise<void> {
-    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
-      try {
-        this.log.trace({ messageType: message.type }, 'Processing message!')
+    try {
+      this.log.trace({ messageType: message.type }, 'Processing message!')
 
-        const service = new IntegrationRunService(
-          this.redisClient,
-          this.streamWorkerEmitter,
-          this.runWorkerEmitter,
-          this.searchSyncWorkerEmitter,
-          this.integrationSyncWorkerEmitter,
-          this.apiPubSubEmitter,
-          new DbStore(this.log, this.dbConn),
-          this.log,
-        )
+      const service = new IntegrationRunService(
+        this.redisClient,
+        this.streamWorkerEmitter,
+        this.runWorkerEmitter,
+        this.searchSyncWorkerEmitter,
+        this.integrationSyncWorkerEmitter,
+        this.apiPubSubEmitter,
+        new DbStore(this.log, this.dbConn),
+        this.log,
+      )
 
-        switch (message.type) {
-          case IntegrationRunWorkerQueueMessageType.CHECK_RUNS:
-            await service.checkRuns()
-            break
-          case IntegrationRunWorkerQueueMessageType.START_INTEGRATION_RUN:
-            const msg = message as StartIntegrationRunQueueMessage
-            await service.startIntegrationRun(
-              msg.integrationId,
-              msg.onboarding,
-              msg.isManualRun,
-              msg.manualSettings,
-            )
-            break
-          case IntegrationRunWorkerQueueMessageType.GENERATE_RUN_STREAMS:
-            const msg2 = message as GenerateRunStreamsQueueMessage
-            await service.generateStreams(msg2.runId, msg2.isManualRun, msg2.manualSettings)
-            break
-          case IntegrationRunWorkerQueueMessageType.STREAM_PROCESSED:
-            await service.handleStreamProcessed((message as StreamProcessedQueueMessage).runId)
-            break
-          default:
-            throw new Error(`Unknown message type: ${message.type}`)
-        }
-
-        span.setStatus({
-          code: SpanStatusCode.OK,
-        })
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err,
-        })
-
-        this.log.error(err, 'Error while processing message!')
-        throw err
-      } finally {
-        span.end()
+      switch (message.type) {
+        case IntegrationRunWorkerQueueMessageType.CHECK_RUNS:
+          await service.checkRuns()
+          break
+        case IntegrationRunWorkerQueueMessageType.START_INTEGRATION_RUN:
+          const msg = message as StartIntegrationRunQueueMessage
+          await service.startIntegrationRun(
+            msg.integrationId,
+            msg.onboarding,
+            msg.isManualRun,
+            msg.manualSettings,
+          )
+          break
+        case IntegrationRunWorkerQueueMessageType.GENERATE_RUN_STREAMS:
+          const msg2 = message as GenerateRunStreamsQueueMessage
+          await service.generateStreams(msg2.runId, msg2.isManualRun, msg2.manualSettings)
+          break
+        case IntegrationRunWorkerQueueMessageType.STREAM_PROCESSED:
+          await service.handleStreamProcessed((message as StreamProcessedQueueMessage).runId)
+          break
+        default:
+          throw new Error(`Unknown message type: ${message.type}`)
       }
-    })
+    } catch (err) {
+      this.log.error(err, 'Error while processing message!')
+      throw err
+    }
   }
 }

--- a/services/apps/integration_stream_worker/src/bin/process-all-streams-for-integration.ts
+++ b/services/apps/integration_stream_worker/src/bin/process-all-streams-for-integration.ts
@@ -2,7 +2,6 @@ import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationStreamService from '../service/integrationStreamService'
 import { timeout } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -16,7 +15,6 @@ import { IntegrationStreamState } from '@crowd/types'
 const BATCH_SIZE = 100
 const MAX_CONCURRENT = 1
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -43,9 +41,9 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   await runWorkerEmiiter.init()
   await dataWorkerEmitter.init()

--- a/services/apps/integration_stream_worker/src/bin/process-all-streams.ts
+++ b/services/apps/integration_stream_worker/src/bin/process-all-streams.ts
@@ -2,7 +2,6 @@ import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationStreamService from '../service/integrationStreamService'
 import { timeout } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -16,7 +15,6 @@ import { IntegrationStreamState } from '@crowd/types'
 const BATCH_SIZE = 100
 const MAX_CONCURRENT = 3
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 async function processStream(
@@ -34,9 +32,9 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   await runWorkerEmiiter.init()
   await dataWorkerEmitter.init()

--- a/services/apps/integration_stream_worker/src/bin/process-all-webhooks.ts
+++ b/services/apps/integration_stream_worker/src/bin/process-all-webhooks.ts
@@ -2,7 +2,6 @@ import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationStreamService from '../service/integrationStreamService'
 import { timeout } from '@crowd/common'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -16,7 +15,6 @@ import { WebhookType } from '@crowd/types'
 const BATCH_SIZE = 100
 const MAX_CONCURRENT = 3
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 async function processWebhook(
@@ -34,9 +32,9 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   await runWorkerEmiiter.init()
   await dataWorkerEmitter.init()

--- a/services/apps/integration_stream_worker/src/bin/process-stream.ts
+++ b/services/apps/integration_stream_worker/src/bin/process-stream.ts
@@ -2,7 +2,6 @@ import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationStreamRepository from '../repo/integrationStream.repo'
 import IntegrationStreamService from '../service/integrationStreamService'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -13,7 +12,6 @@ import {
 } from '@crowd/sqs'
 import { IntegrationStreamState } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -29,9 +27,9 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   await runWorkerEmiiter.init()
   await dataWorkerEmitter.init()

--- a/services/apps/integration_stream_worker/src/bin/process-webhook.ts
+++ b/services/apps/integration_stream_worker/src/bin/process-webhook.ts
@@ -1,7 +1,6 @@
 import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from '../conf'
 import IntegrationStreamService from '../service/integrationStreamService'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import {
@@ -11,7 +10,6 @@ import {
   getSqsClient,
 } from '@crowd/sqs'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -27,9 +25,9 @@ setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   await runWorkerEmiiter.init()
   await dataWorkerEmitter.init()

--- a/services/apps/integration_stream_worker/src/bin/trigger-all-failed-webhooks.ts
+++ b/services/apps/integration_stream_worker/src/bin/trigger-all-failed-webhooks.ts
@@ -1,18 +1,16 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import IncomingWebhookRepository from '../repo/incomingWebhook.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 
 const batchSize = 500
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_stream_worker/src/bin/trigger-all-streams-for-integration.ts
+++ b/services/apps/integration_stream_worker/src/bin/trigger-all-streams-for-integration.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 
 const BATCH_SIZE = 100
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -21,7 +19,7 @@ const integrationId = processArguments[0]
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
-  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_stream_worker/src/bin/trigger-all-streams.ts
+++ b/services/apps/integration_stream_worker/src/bin/trigger-all-streams.ts
@@ -1,18 +1,16 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 
 const BATCH_SIZE = 100
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
 
-  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_stream_worker/src/bin/trigger-webhook.ts
+++ b/services/apps/integration_stream_worker/src/bin/trigger-webhook.ts
@@ -1,12 +1,10 @@
 import { DB_CONFIG, SQS_CONFIG } from '../conf'
 import IncomingWebhookRepository from '../repo/incomingWebhook.repo'
 import { DbStore, getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { IntegrationStreamWorkerEmitter, getSqsClient } from '@crowd/sqs'
 import { WebhookState, WebhookType } from '@crowd/types'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const processArguments = process.argv.slice(2)
@@ -20,7 +18,7 @@ const webhookIds = processArguments[0].split(',')
 
 setImmediate(async () => {
   const sqsClient = getSqsClient(SQS_CONFIG())
-  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const emitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
   await emitter.init()
 
   const dbConnection = await getDbConnection(DB_CONFIG())

--- a/services/apps/integration_stream_worker/src/main.ts
+++ b/services/apps/integration_stream_worker/src/main.ts
@@ -1,4 +1,3 @@
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { DB_CONFIG, REDIS_CONFIG, SQS_CONFIG } from './conf'
 import { getRedisClient } from '@crowd/redis'
@@ -12,7 +11,6 @@ import {
 import { WorkerQueueReceiver } from './queue'
 import { processOldStreamsJob } from './jobs/processOldStreams'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
@@ -26,9 +24,9 @@ setImmediate(async () => {
   const dbConnection = await getDbConnection(DB_CONFIG(), MAX_CONCURRENT_PROCESSING)
   const redisClient = await getRedisClient(REDIS_CONFIG(), true)
 
-  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, tracer, log)
-  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, tracer, log)
-  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, tracer, log)
+  const runWorkerEmiiter = new IntegrationRunWorkerEmitter(sqsClient, log)
+  const dataWorkerEmitter = new IntegrationDataWorkerEmitter(sqsClient, log)
+  const streamWorkerEmitter = new IntegrationStreamWorkerEmitter(sqsClient, log)
 
   const queue = new WorkerQueueReceiver(
     sqsClient,
@@ -37,7 +35,6 @@ setImmediate(async () => {
     runWorkerEmiiter,
     dataWorkerEmitter,
     streamWorkerEmitter,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/integration_sync_worker/src/main.ts
+++ b/services/apps/integration_sync_worker/src/main.ts
@@ -1,12 +1,10 @@
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getSqsClient } from '@crowd/sqs'
 import { DB_CONFIG, OPENSEARCH_CONFIG, SQS_CONFIG } from './conf'
 import { WorkerQueueReceiver } from './queue'
 import { getOpensearchClient } from '@crowd/opensearch'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
@@ -24,7 +22,6 @@ setImmediate(async () => {
     sqsClient,
     dbConnection,
     opensearchClient,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/integration_sync_worker/src/queue/index.ts
+++ b/services/apps/integration_sync_worker/src/queue/index.ts
@@ -1,4 +1,3 @@
-import { Tracer, Span, SpanStatusCode } from '@crowd/tracing'
 import { Logger } from '@crowd/logging'
 import { DbConnection, DbStore } from '@crowd/database'
 import { MemberSyncService } from '../service/member.sync.service'
@@ -17,17 +16,10 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     client: SqsClient,
     private readonly dbConn: DbConnection,
     private readonly openSearchClient: Client,
-    tracer: Tracer,
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
-    super(
-      client,
-      INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS,
-      maxConcurrentProcessing,
-      tracer,
-      parentLog,
-    )
+    super(client, INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS, maxConcurrentProcessing, parentLog)
   }
 
   private initMemberService(): MemberSyncService {
@@ -43,94 +35,81 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   protected override async processMessage<T extends IQueueMessage>(message: T): Promise<void> {
-    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
-      try {
-        this.log.trace({ messageType: message.type }, 'Processing message!')
+    try {
+      this.log.trace({ messageType: message.type }, 'Processing message!')
 
-        const type = message.type as IntegrationSyncWorkerQueueMessageType
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data = message as any
+      const type = message.type as IntegrationSyncWorkerQueueMessageType
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = message as any
 
-        switch (type) {
-          // members
-          case IntegrationSyncWorkerQueueMessageType.SYNC_ALL_MARKED_MEMBERS:
-            await this.initMemberService().syncAllMarkedMembers(data.tenantId, data.integrationId)
+      switch (type) {
+        // members
+        case IntegrationSyncWorkerQueueMessageType.SYNC_ALL_MARKED_MEMBERS:
+          await this.initMemberService().syncAllMarkedMembers(data.tenantId, data.integrationId)
 
-            break
-          case IntegrationSyncWorkerQueueMessageType.SYNC_MEMBER:
-            await this.initMemberService().syncMember(
+          break
+        case IntegrationSyncWorkerQueueMessageType.SYNC_MEMBER:
+          await this.initMemberService().syncMember(
+            data.tenantId,
+            data.integrationId,
+            data.memberId,
+            data.syncRemoteId,
+          )
+          break
+        case IntegrationSyncWorkerQueueMessageType.SYNC_ORGANIZATION:
+          await this.initOrganizationService().syncOrganization(
+            data.tenantId,
+            data.integrationId,
+            data.organizationId,
+            data.syncRemoteId,
+          )
+          break
+        case IntegrationSyncWorkerQueueMessageType.SYNC_ALL_MARKED_ORGANIZATIONS:
+          await this.initOrganizationService().syncAllMarkedOrganizations(
+            data.tenantId,
+            data.integrationId,
+          )
+          break
+        case IntegrationSyncWorkerQueueMessageType.ONBOARD_AUTOMATION:
+          if (data.automationTrigger === AutomationSyncTrigger.MEMBER_ATTRIBUTES_MATCH) {
+            await this.initMemberService().syncAllFilteredMembers(
               data.tenantId,
               data.integrationId,
-              data.memberId,
-              data.syncRemoteId,
+              data.automationId,
             )
-            break
-          case IntegrationSyncWorkerQueueMessageType.SYNC_ORGANIZATION:
-            await this.initOrganizationService().syncOrganization(
-              data.tenantId,
-              data.integrationId,
-              data.organizationId,
-              data.syncRemoteId,
-            )
-            break
-          case IntegrationSyncWorkerQueueMessageType.SYNC_ALL_MARKED_ORGANIZATIONS:
-            await this.initOrganizationService().syncAllMarkedOrganizations(
-              data.tenantId,
-              data.integrationId,
-            )
-            break
-          case IntegrationSyncWorkerQueueMessageType.ONBOARD_AUTOMATION:
-            if (data.automationTrigger === AutomationSyncTrigger.MEMBER_ATTRIBUTES_MATCH) {
-              await this.initMemberService().syncAllFilteredMembers(
+          } else if (
+            data.automationTrigger === AutomationSyncTrigger.ORGANIZATION_ATTRIBUTES_MATCH
+          ) {
+            const organizationIds =
+              await this.initOrganizationService().syncAllFilteredOrganizations(
                 data.tenantId,
                 data.integrationId,
                 data.automationId,
               )
-            } else if (
-              data.automationTrigger === AutomationSyncTrigger.ORGANIZATION_ATTRIBUTES_MATCH
-            ) {
-              const organizationIds =
-                await this.initOrganizationService().syncAllFilteredOrganizations(
-                  data.tenantId,
-                  data.integrationId,
-                  data.automationId,
-                )
 
-              // also sync organization members if syncAllFilteredOrganizations return the ids
-              while (organizationIds.length > 0) {
-                const organizationId = organizationIds.shift()
-                await this.initMemberService().syncOrganizationMembers(
-                  data.tenantId,
-                  data.integrationId,
-                  data.automationId,
-                  organizationId,
-                )
-              }
-            } else {
-              const errorMessage = `Unsupported trigger for onboard automation message!`
-              this.log.error({ message }, errorMessage)
-              throw new Error(errorMessage)
+            // also sync organization members if syncAllFilteredOrganizations return the ids
+            while (organizationIds.length > 0) {
+              const organizationId = organizationIds.shift()
+              await this.initMemberService().syncOrganizationMembers(
+                data.tenantId,
+                data.integrationId,
+                data.automationId,
+                organizationId,
+              )
             }
-            break
+          } else {
+            const errorMessage = `Unsupported trigger for onboard automation message!`
+            this.log.error({ message }, errorMessage)
+            throw new Error(errorMessage)
+          }
+          break
 
-          default:
-            throw new Error(`Unknown message type: ${message.type}`)
-        }
-
-        span.setStatus({
-          code: SpanStatusCode.OK,
-        })
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err,
-        })
-
-        this.log.error(err, 'Error while processing message!')
-        throw err
-      } finally {
-        span.end()
+        default:
+          throw new Error(`Unknown message type: ${message.type}`)
       }
-    })
+    } catch (err) {
+      this.log.error(err, 'Error while processing message!')
+      throw err
+    }
   }
 }

--- a/services/apps/search_sync_worker/src/main.ts
+++ b/services/apps/search_sync_worker/src/main.ts
@@ -1,5 +1,4 @@
 import { getDbConnection } from '@crowd/database'
-import { getServiceTracer } from '@crowd/tracing'
 import { getServiceLogger } from '@crowd/logging'
 import { getRedisClient } from '@crowd/redis'
 import { getSqsClient } from '@crowd/sqs'
@@ -8,7 +7,6 @@ import { WorkerQueueReceiver } from './queue'
 import { InitService } from './service/init.service'
 import { OpenSearchService } from './service/opensearch.service'
 
-const tracer = getServiceTracer()
 const log = getServiceLogger()
 
 const MAX_CONCURRENT_PROCESSING = 2
@@ -29,7 +27,6 @@ setImmediate(async () => {
     sqsClient,
     dbConnection,
     openSearchService,
-    tracer,
     log,
     MAX_CONCURRENT_PROCESSING,
   )

--- a/services/apps/search_sync_worker/src/queue/index.ts
+++ b/services/apps/search_sync_worker/src/queue/index.ts
@@ -1,5 +1,4 @@
 import { BatchProcessor } from '@crowd/common'
-import { Tracer, Span, SpanStatusCode } from '@crowd/tracing'
 import { DbConnection, DbStore } from '@crowd/database'
 import { Logger } from '@crowd/logging'
 import { ActivitySyncService } from '../service/activity.sync.service'
@@ -21,7 +20,6 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
     client: SqsClient,
     private readonly dbConn: DbConnection,
     private readonly openSearchService: OpenSearchService,
-    tracer: Tracer,
     parentLog: Logger,
     maxConcurrentProcessing: number,
   ) {
@@ -29,7 +27,6 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
       client,
       SEARCH_SYNC_WORKER_QUEUE_SETTINGS,
       maxConcurrentProcessing,
-      tracer,
       parentLog,
       true,
       5 * 60,
@@ -108,132 +105,119 @@ export class WorkerQueueReceiver extends SqsQueueReceiver {
   }
 
   protected override async processMessage<T extends IQueueMessage>(message: T): Promise<void> {
-    await this.tracer.startActiveSpan('ProcessMessage', async (span: Span) => {
-      try {
-        this.log.trace({ messageType: message.type }, 'Processing message!')
+    try {
+      this.log.trace({ messageType: message.type }, 'Processing message!')
 
-        const type = message.type as SearchSyncWorkerQueueMessageType
-        const data = message as any
+      const type = message.type as SearchSyncWorkerQueueMessageType
+      const data = message as any
 
-        switch (type) {
-          // members
-          case SearchSyncWorkerQueueMessageType.SYNC_MEMBER:
-            if (data.memberId) {
-              await this.memberBatchProcessor.addToBatch(data.memberId)
-            }
+      switch (type) {
+        // members
+        case SearchSyncWorkerQueueMessageType.SYNC_MEMBER:
+          if (data.memberId) {
+            await this.memberBatchProcessor.addToBatch(data.memberId)
+          }
 
-            break
-          // this one taks a while so we can't relly on it to be finished in time and the queue message might pop up again so we immediatelly return
-          case SearchSyncWorkerQueueMessageType.SYNC_TENANT_MEMBERS:
-            if (data.tenantId) {
-              this.initMemberService()
-                .syncTenantMembers(data.tenantId)
-                .catch((err) => this.log.error(err, 'Error while syncing tenant members!'))
-            }
+          break
+        // this one taks a while so we can't relly on it to be finished in time and the queue message might pop up again so we immediatelly return
+        case SearchSyncWorkerQueueMessageType.SYNC_TENANT_MEMBERS:
+          if (data.tenantId) {
+            this.initMemberService()
+              .syncTenantMembers(data.tenantId)
+              .catch((err) => this.log.error(err, 'Error while syncing tenant members!'))
+          }
 
-            break
-          case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION_MEMBERS:
-            if (data.organizationId) {
-              this.initMemberService()
-                .syncOrganizationMembers(data.organizationId)
-                .catch((err) => this.log.error(err, 'Error while syncing organization members!'))
-            }
+          break
+        case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION_MEMBERS:
+          if (data.organizationId) {
+            this.initMemberService()
+              .syncOrganizationMembers(data.organizationId)
+              .catch((err) => this.log.error(err, 'Error while syncing organization members!'))
+          }
 
-            break
-          // this one taks a while so we can't relly on it to be finished in time and the queue message might pop up again so we immediatelly return
-          case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_MEMBERS:
-            if (data.tenantId) {
-              this.initMemberService()
-                .cleanupMemberIndex(data.tenantId)
-                .catch((err) => this.log.error(err, 'Error while cleaning up tenant members!'))
-            }
+          break
+        // this one taks a while so we can't relly on it to be finished in time and the queue message might pop up again so we immediatelly return
+        case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_MEMBERS:
+          if (data.tenantId) {
+            this.initMemberService()
+              .cleanupMemberIndex(data.tenantId)
+              .catch((err) => this.log.error(err, 'Error while cleaning up tenant members!'))
+          }
 
-            break
-          case SearchSyncWorkerQueueMessageType.REMOVE_MEMBER:
-            if (data.memberId) {
-              await this.initMemberService().removeMember(data.memberId)
-            }
-            break
+          break
+        case SearchSyncWorkerQueueMessageType.REMOVE_MEMBER:
+          if (data.memberId) {
+            await this.initMemberService().removeMember(data.memberId)
+          }
+          break
 
-          // activities
-          case SearchSyncWorkerQueueMessageType.SYNC_ACTIVITY:
-            if (data.activityId) {
-              await this.activityBatchProcessor.addToBatch(data.activityId)
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.SYNC_TENANT_ACTIVITIES:
-            if (data.tenantId) {
-              this.initActivityService()
-                .syncTenantActivities(data.tenantId)
-                .catch((err) => this.log.error(err, 'Error while syncing tenant activities!'))
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION_ACTIVITIES:
-            if (data.organizationId) {
-              this.initActivityService()
-                .syncOrganizationActivities(data.organizationId)
-                .catch((err) => this.log.error(err, 'Error while syncing organization activities!'))
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_ACTIVITIES:
-            if (data.tenantId) {
-              this.initActivityService()
-                .cleanupActivityIndex(data.tenantId)
-                .catch((err) => this.log.error(err, 'Error while cleaning up tenant activities!'))
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.REMOVE_ACTIVITY:
-            if (data.activityId) {
-              await this.initActivityService().removeActivity(data.activityId)
-            }
-            break
+        // activities
+        case SearchSyncWorkerQueueMessageType.SYNC_ACTIVITY:
+          if (data.activityId) {
+            await this.activityBatchProcessor.addToBatch(data.activityId)
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.SYNC_TENANT_ACTIVITIES:
+          if (data.tenantId) {
+            this.initActivityService()
+              .syncTenantActivities(data.tenantId)
+              .catch((err) => this.log.error(err, 'Error while syncing tenant activities!'))
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION_ACTIVITIES:
+          if (data.organizationId) {
+            this.initActivityService()
+              .syncOrganizationActivities(data.organizationId)
+              .catch((err) => this.log.error(err, 'Error while syncing organization activities!'))
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_ACTIVITIES:
+          if (data.tenantId) {
+            this.initActivityService()
+              .cleanupActivityIndex(data.tenantId)
+              .catch((err) => this.log.error(err, 'Error while cleaning up tenant activities!'))
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.REMOVE_ACTIVITY:
+          if (data.activityId) {
+            await this.initActivityService().removeActivity(data.activityId)
+          }
+          break
 
-          // organizations
-          case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION:
-            if (data.organizationId) {
-              await this.organizationBatchProcessor.addToBatch(data.organizationId)
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.SYNC_TENANT_ORGANIZATIONS:
-            if (data.tenantId) {
-              this.initOrganizationService()
-                .syncTenantOrganizations(data.tenantId)
-                .catch((err) => this.log.error(err, 'Error while syncing tenant organizations!'))
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_ORGANIZATIONS:
-            if (data.tenantId) {
-              this.initOrganizationService()
-                .cleanupOrganizationIndex(data.tenantId)
-                .catch((err) => {
-                  this.log.error(err, 'Error while cleaning up tenant organizations!')
-                })
-            }
-            break
-          case SearchSyncWorkerQueueMessageType.REMOVE_ORGANIZATION:
-            if (data.organizationId) {
-              await this.initOrganizationService().removeOrganization(data.organizationId)
-            }
-            break
+        // organizations
+        case SearchSyncWorkerQueueMessageType.SYNC_ORGANIZATION:
+          if (data.organizationId) {
+            await this.organizationBatchProcessor.addToBatch(data.organizationId)
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.SYNC_TENANT_ORGANIZATIONS:
+          if (data.tenantId) {
+            this.initOrganizationService()
+              .syncTenantOrganizations(data.tenantId)
+              .catch((err) => this.log.error(err, 'Error while syncing tenant organizations!'))
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.CLEANUP_TENANT_ORGANIZATIONS:
+          if (data.tenantId) {
+            this.initOrganizationService()
+              .cleanupOrganizationIndex(data.tenantId)
+              .catch((err) => {
+                this.log.error(err, 'Error while cleaning up tenant organizations!')
+              })
+          }
+          break
+        case SearchSyncWorkerQueueMessageType.REMOVE_ORGANIZATION:
+          if (data.organizationId) {
+            await this.initOrganizationService().removeOrganization(data.organizationId)
+          }
+          break
 
-          default:
-            throw new Error(`Unknown message type: ${message.type}`)
-        }
-
-        span.setStatus({
-          code: SpanStatusCode.OK,
-        })
-      } catch (err) {
-        span.setStatus({
-          code: SpanStatusCode.ERROR,
-          message: err,
-        })
-
-        this.log.error(err, 'Error while processing message!')
-        throw err
-      } finally {
-        span.end()
+        default:
+          throw new Error(`Unknown message type: ${message.type}`)
       }
-    })
+    } catch (err) {
+      this.log.error(err, 'Error while processing message!')
+      throw err
+    }
   }
 }

--- a/services/apps/webhook_api/src/routes/discourse.ts
+++ b/services/apps/webhook_api/src/routes/discourse.ts
@@ -1,13 +1,10 @@
 import { asyncWrap } from '../middleware/error'
 import { WebhooksRepository } from '../repos/webhooks.repo'
 import { Error400BadRequest } from '@crowd/common'
-import { getServiceTracer } from '@crowd/tracing'
 import { IntegrationStreamWorkerEmitter } from '@crowd/sqs'
 import { PlatformType, WebhookType } from '@crowd/types'
 import express from 'express'
 import { verifyWebhookSignature } from 'utils/crypto'
-
-const tracer = getServiceTracer()
 
 export const installDiscourseRoutes = async (app: express.Express) => {
   let emitter: IntegrationStreamWorkerEmitter
@@ -60,7 +57,7 @@ export const installDiscourseRoutes = async (app: express.Express) => {
         )
 
         if (!emitter) {
-          emitter = new IntegrationStreamWorkerEmitter(req.sqs, tracer, req.log)
+          emitter = new IntegrationStreamWorkerEmitter(req.sqs, req.log)
           await emitter.init()
         }
 

--- a/services/apps/webhook_api/src/routes/github.ts
+++ b/services/apps/webhook_api/src/routes/github.ts
@@ -1,12 +1,9 @@
 import { asyncWrap } from '../middleware/error'
 import { WebhooksRepository } from '../repos/webhooks.repo'
 import { Error400BadRequest } from '@crowd/common'
-import { getServiceTracer } from '@crowd/tracing'
 import { IntegrationStreamWorkerEmitter } from '@crowd/sqs'
 import { PlatformType, WebhookType } from '@crowd/types'
 import express from 'express'
-
-const tracer = getServiceTracer()
 
 const SIGNATURE_HEADER = 'x-hub-signature'
 const EVENT_HEADER = 'x-github-event'
@@ -51,7 +48,7 @@ export const installGithubRoutes = async (app: express.Express) => {
         )
 
         if (!emitter) {
-          emitter = new IntegrationStreamWorkerEmitter(req.sqs, tracer, req.log)
+          emitter = new IntegrationStreamWorkerEmitter(req.sqs, req.log)
           await emitter.init()
         }
 

--- a/services/apps/webhook_api/src/routes/groupsio.ts
+++ b/services/apps/webhook_api/src/routes/groupsio.ts
@@ -1,12 +1,9 @@
 import { asyncWrap } from '../middleware/error'
 import { WebhooksRepository } from '../repos/webhooks.repo'
 import { Error400BadRequest } from '@crowd/common'
-import { getServiceTracer } from '@crowd/tracing'
 import { IntegrationStreamWorkerEmitter } from '@crowd/sqs'
 import { WebhookType } from '@crowd/types'
 import express from 'express'
-
-const tracer = getServiceTracer()
 
 export const installGroupsIoRoutes = async (app: express.Express) => {
   let emitter: IntegrationStreamWorkerEmitter
@@ -43,7 +40,7 @@ export const installGroupsIoRoutes = async (app: express.Express) => {
         )
 
         if (!emitter) {
-          emitter = new IntegrationStreamWorkerEmitter(req.sqs, tracer, req.log)
+          emitter = new IntegrationStreamWorkerEmitter(req.sqs, req.log)
           await emitter.init()
         }
 

--- a/services/archetypes/standard/src/index.ts
+++ b/services/archetypes/standard/src/index.ts
@@ -3,12 +3,10 @@ import { Kafka, Producer as KafkaProducer } from 'kafkajs'
 import { IIntegrationDescriptor, INTEGRATION_SERVICES } from '@crowd/integrations'
 import { getServiceLogger, Logger } from '@crowd/logging'
 import { acquireLock, getRedisClient, RedisClient, releaseLock } from '@crowd/redis'
-import { getServiceTracer, Tracer } from '@crowd/tracing'
 import { getTemporalClient, Client as TemporalClient } from '@crowd/temporal'
 import { Unleash as UnleashClient, getUnleashClient } from '@crowd/feature-flags'
 
-// Retrieve automatically configured tracer and logger.
-const tracer = getServiceTracer()
+// Retrieve automatically configured logger.
 const logger = getServiceLogger()
 
 // List all required environment variables, grouped per "component".
@@ -53,7 +51,6 @@ Service holds all details and methods to run any kind of services at crowd.dev.
 */
 export class Service {
   readonly name: string
-  readonly tracer: Tracer
   readonly log: Logger
   readonly config: Config
   readonly integrations: IIntegrationDescriptor[]
@@ -67,7 +64,6 @@ export class Service {
 
   constructor(config: Config) {
     this.name = process.env['SERVICE']
-    this.tracer = tracer
     this.log = logger
     this.config = config
     this.integrations = INTEGRATION_SERVICES

--- a/services/libs/logging/src/index.ts
+++ b/services/libs/logging/src/index.ts
@@ -1,16 +1,3 @@
-// Importing and initializing the tracer here allows to import and initialize
-// OpenTelemetry instrumentations for Bunyan **before** importing the logging
-// library. Otherwise, automatic instrumentation and correlation with the logger
-// won't work. Since the logger is the first library imported on services, this
-// also allows to leverage automatic instrumentation for other libraries such as
-// Sequelize, Express, and SQS. Details:
-// https://opentelemetry.io/blog/2022/troubleshooting-nodejs/#enable-before-require
-import { IS_TEST_ENV } from '@crowd/common'
-import { getServiceTracer } from '@crowd/tracing'
-if (!IS_TEST_ENV) {
-  getServiceTracer()
-}
-
 export * from './logError'
 export * from './logger'
 export * from './loggerBase'

--- a/services/libs/sqs/src/instances/dataSinkWorker.ts
+++ b/services/libs/sqs/src/instances/dataSinkWorker.ts
@@ -8,11 +8,10 @@ import {
   ProcessIntegrationResultQueueMessage,
   CheckResultsQueueMessage,
 } from '@crowd/types'
-import { Tracer } from '@crowd/tracing'
 
 export class DataSinkWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, DATA_SINK_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async triggerResultProcessing(

--- a/services/libs/sqs/src/instances/integrationDataWorker.ts
+++ b/services/libs/sqs/src/instances/integrationDataWorker.ts
@@ -3,11 +3,10 @@ import { INTEGRATION_DATA_WORKER_QUEUE_SETTINGS } from '../config'
 import { SqsQueueEmitter } from '../queue'
 import { SqsClient } from '../types'
 import { ProcessStreamDataQueueMessage } from '@crowd/types'
-import { Tracer } from '@crowd/tracing'
 
 export class IntegrationDataWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, INTEGRATION_DATA_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, INTEGRATION_DATA_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async triggerDataProcessing(tenantId: string, platform: string, dataId: string) {

--- a/services/libs/sqs/src/instances/integrationRunWorker.ts
+++ b/services/libs/sqs/src/instances/integrationRunWorker.ts
@@ -8,11 +8,10 @@ import {
   StartIntegrationRunQueueMessage,
   CheckRunsQueueMessage,
 } from '@crowd/types'
-import { Tracer } from '@crowd/tracing'
 
 export class IntegrationRunWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, INTEGRATION_RUN_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, INTEGRATION_RUN_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async checkRuns() {

--- a/services/libs/sqs/src/instances/integrationStreamWorker.ts
+++ b/services/libs/sqs/src/instances/integrationStreamWorker.ts
@@ -9,11 +9,10 @@ import {
   ProcessWebhookStreamQueueMessage,
 } from '@crowd/types'
 import { generateUUIDv1 } from '@crowd/common'
-import { Tracer } from '@crowd/tracing'
 
 export class IntegrationStreamWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, INTEGRATION_STREAM_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, INTEGRATION_STREAM_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async checkStreams() {

--- a/services/libs/sqs/src/instances/integrationSyncWorker.ts
+++ b/services/libs/sqs/src/instances/integrationSyncWorker.ts
@@ -1,11 +1,10 @@
 import { Logger } from '@crowd/logging'
 import { AutomationSyncTrigger, IntegrationSyncWorkerQueueMessageType } from '@crowd/types'
 import { INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS, SqsClient, SqsQueueEmitter } from '..'
-import { Tracer } from '@crowd/tracing'
 
 export class IntegrationSyncWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async triggerSyncMarkedMembers(tenantId: string, integrationId: string): Promise<void> {

--- a/services/libs/sqs/src/instances/nodejsWorker.ts
+++ b/services/libs/sqs/src/instances/nodejsWorker.ts
@@ -7,11 +7,10 @@ import {
   NewActivityAutomationQueueMessage,
   NewMemberAutomationQueueMessage,
 } from '@crowd/types'
-import { Tracer } from '@crowd/tracing'
 
 export class NodejsWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, NODEJS_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, NODEJS_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public override sendMessage(

--- a/services/libs/sqs/src/instances/searchSyncWorker.ts
+++ b/services/libs/sqs/src/instances/searchSyncWorker.ts
@@ -1,11 +1,10 @@
 import { Logger } from '@crowd/logging'
 import { SearchSyncWorkerQueueMessageType } from '@crowd/types'
 import { SEARCH_SYNC_WORKER_QUEUE_SETTINGS, SqsClient, SqsQueueEmitter } from '..'
-import { Tracer } from '@crowd/tracing'
 
 export class SearchSyncWorkerEmitter extends SqsQueueEmitter {
-  constructor(client: SqsClient, tracer: Tracer, parentLog: Logger) {
-    super(client, SEARCH_SYNC_WORKER_QUEUE_SETTINGS, tracer, parentLog)
+  constructor(client: SqsClient, parentLog: Logger) {
+    super(client, SEARCH_SYNC_WORKER_QUEUE_SETTINGS, parentLog)
   }
 
   public async triggerMemberSync(tenantId: string, memberId: string) {

--- a/services/libs/sqs/src/queue.ts
+++ b/services/libs/sqs/src/queue.ts
@@ -18,18 +18,15 @@ import {
 } from './client'
 import { ISqsQueueConfig, SqsClient, SqsMessage, SqsQueueType } from './types'
 import { IQueueMessage, ISqsQueueEmitter } from '@crowd/types'
-import { Tracer } from '@crowd/tracing'
 
 export abstract class SqsQueueBase extends LoggerBase {
   private readonly queueName: string
   private queueUrl: string | undefined
   protected readonly isFifo: boolean
-  tracer: Tracer
 
   constructor(
     protected readonly sqsClient: SqsClient,
     public readonly queueConf: ISqsQueueConfig,
-    tracer: Tracer,
     parentLog: Logger,
   ) {
     super(parentLog, {
@@ -37,7 +34,6 @@ export abstract class SqsQueueBase extends LoggerBase {
       type: queueConf.type,
     })
 
-    this.tracer = tracer
     this.isFifo = queueConf.type === SqsQueueType.FIFO
 
     let env = ''
@@ -111,13 +107,12 @@ export abstract class SqsQueueReceiver extends SqsQueueBase {
     sqsClient: SqsClient,
     queueConf: ISqsQueueConfig,
     private readonly maxConcurrentMessageProcessing: number,
-    tracer: Tracer,
     parentLog: Logger,
     private readonly deleteMessageImmediately = false,
     private readonly visibilityTimeoutSeconds?: number,
     private readonly receiveMessageCount?: number,
   ) {
-    super(sqsClient, queueConf, tracer, parentLog)
+    super(sqsClient, queueConf, parentLog)
   }
 
   private isAvailable(): boolean {
@@ -215,8 +210,8 @@ export abstract class SqsQueueReceiver extends SqsQueueBase {
 }
 
 export abstract class SqsQueueEmitter extends SqsQueueBase implements ISqsQueueEmitter {
-  constructor(sqsClient: SqsClient, queueConf: ISqsQueueConfig, tracer: Tracer, parentLog: Logger) {
-    super(sqsClient, queueConf, tracer, parentLog)
+  constructor(sqsClient: SqsClient, queueConf: ISqsQueueConfig, parentLog: Logger) {
+    super(sqsClient, queueConf, parentLog)
   }
 
   public async sendMessage<T extends IQueueMessage>(


### PR DESCRIPTION
What we noticed so far is that sometimes, even though is no actual activity or work in the service, the services starts consuming all the CPU it has available. At the same time, the service doesn't actually do any other work during that time. If the service has, for instance, an express.js server, during that period it won't accept any requests at all.

Profiling the nodejs code in that state showed some grpc code being executed over and over, making me think it's OTEL.

What's worse is that this kind of state doesn't go away by itself, but requires a restart of the service.

Removing tracing proved to prevent this issue from appearing — no issues in `search-sync-api` and `nodejs-worker` since 15 hours.

Keeping the tracing library in our code until later.