### PR TITLE
child workflow ids, retry attemtps and undefined fix

### DIFF
--- a/services/apps/automations_worker/src/repos/data.repo.ts
+++ b/services/apps/automations_worker/src/repos/data.repo.ts
@@ -126,11 +126,11 @@ export class DataRepository extends RepositoryBase<DataRepository> {
       await Promise.all(promises)
     }
 
-    // TODO calculate display
-
     // calculate engagement
-    for (const activity of results) {
-      activity.engagement = activity.member.score || 0
+    if (loadChildTables) {
+      for (const activity of results) {
+        activity.engagement = activity.member.score || 0
+      }
     }
 
     return results

--- a/services/apps/automations_worker/src/workflows/newActivityAutomations.ts
+++ b/services/apps/automations_worker/src/workflows/newActivityAutomations.ts
@@ -1,4 +1,9 @@
-import { executeChild, proxyActivities } from '@temporalio/workflow'
+import {
+  WorkflowIdReusePolicy,
+  executeChild,
+  proxyActivities,
+  workflowInfo,
+} from '@temporalio/workflow'
 import * as activities from '../activities/newActivityAutomations'
 import { IProcessNewActivityAutomationArgs, ITriggerActivityAutomationArgs } from '@crowd/types'
 
@@ -12,10 +17,17 @@ export async function processNewActivityAutomation(
     args.activityId,
   )
 
+  const info = workflowInfo()
+
   if (automationsToTrigger.length > 0) {
     await Promise.all(
       automationsToTrigger.map((a) =>
         executeChild(triggerActivityAutomationExecution, {
+          workflowId: `${info.workflowId}-${a}`,
+          workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+          retry: {
+            maximumAttempts: info.retryPolicy?.maximumAttempts ?? 100,
+          },
           args: [
             {
               automationId: a,

--- a/services/apps/automations_worker/src/workflows/newMemberAutomations.ts
+++ b/services/apps/automations_worker/src/workflows/newMemberAutomations.ts
@@ -1,4 +1,9 @@
-import { executeChild, proxyActivities } from '@temporalio/workflow'
+import {
+  WorkflowIdReusePolicy,
+  executeChild,
+  proxyActivities,
+  workflowInfo,
+} from '@temporalio/workflow'
 import * as activities from '../activities/newMemberAutomations'
 import { IProcessNewMemberAutomationArgs, ITriggerMemberAutomationArgs } from '@crowd/types'
 
@@ -13,11 +18,18 @@ export async function processNewMemberAutomation(
     args.memberId,
   )
 
+  const info = workflowInfo()
+
   // if there are any automations to trigger, trigger them
   if (automationsToTrigger.length > 0) {
     await Promise.all(
       automationsToTrigger.map((a) =>
         executeChild(triggerMemberAutomationExecution, {
+          workflowId: `${info.workflowId}-${a}`,
+          workflowIdReusePolicy: WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE,
+          retry: {
+            maximumAttempts: info.retryPolicy?.maximumAttempts ?? 100,
+          },
           args: [
             {
               automationId: a,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcc20</samp>

This pull request improves the automations worker service by using the latest Temporal API for child workflows, and by optimizing the data repo logic for loading activity engagement. It affects the files `newActivityAutomations.ts`, `newMemberAutomations.ts`, and `data.repo.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcc20</samp>

> _To optimize the engagement stats_
> _We added a condition that checks_
> _If `loadChildTables` is true_
> _Or else we skip the query queue_
> _And save some computation and requests_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 35dcc20</samp>

*  Add options to execute child workflows for automation triggers in `newActivityAutomations` and `newMemberAutomations` workflows ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-74e6d045d9231540d2b457d5f0aa75c4a22370ac297905c819d903fcfb18a17eL1-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-74e6d045d9231540d2b457d5f0aa75c4a22370ac297905c819d903fcfb18a17eL15-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-776f57b080b25eaa6f049defd1d588d2e7215892539c800ee9b3e74d3b3c939dL1-R6), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-776f57b080b25eaa6f049defd1d588d2e7215892539c800ee9b3e74d3b3c939dR21-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-776f57b080b25eaa6f049defd1d588d2e7215892539c800ee9b3e74d3b3c939dR28-R32))
*  Use `workflowInfo` function to get current workflow execution information in `newMemberAutomations` workflow ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-776f57b080b25eaa6f049defd1d588d2e7215892539c800ee9b3e74d3b3c939dR21-R22))
*  Add condition to calculate engagement only if `loadChildTables` is true in `data.repo.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1887/files?diff=unified&w=0#diff-0927ac2c55ef09851c8ca6f3c1df920d075258a27749fb648c6c988838276942L129-R133))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
