### PR TITLE
Add main entrypoint to types lib

### DIFF
--- a/services/libs/types/package.json
+++ b/services/libs/types/package.json
@@ -2,6 +2,7 @@
   "name": "@crowd/types",
   "version": "1.0.0",
   "private": true,
+  "main": "./src",
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ext .ts src --max-warnings=0",
     "format": "./node_modules/.bin/prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6834eab</samp>

Added `main` field to `types` library's `package.json` file. This enables simpler and cleaner imports of the types from other modules.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6834eab</samp>

> _`main` field added_
> _to `package.json` file_
> _autumn of imports_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6834eab</samp>

*  Add `main` field to `package.json` of `types` library to specify entry point ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1892/files?diff=unified&w=0#diff-320f6adcec1dc5e12f111fa0c4de82f63b609d64643fb9f225a92b3379545ac5R5))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
