### PR TITLE
Stop overwriting existing non-null fields from the organization cache

### DIFF
--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -528,21 +528,19 @@ export default class OrganizationService extends LoggerBase {
           'weakIdentities',
         ]
         fields.forEach((field) => {
-          if (field === 'website' && !existing.website && cache.website) {
-            updateData[field] = cache[field]
-          } else if (
-            field !== 'website' &&
-            cache[field] &&
-            !isEqual(cache[field], existing[field])
-          ) {
+          if (!existing[field] && cache[field]) {
             updateData[field] = cache[field]
           }
         })
 
-        record = await OrganizationRepository.update(existing.id, updateData, {
-          ...this.options,
-          transaction,
-        })
+        if (Object.keys(updateData).length > 0) {
+          record = await OrganizationRepository.update(existing.id, updateData, {
+            ...this.options,
+            transaction,
+          })
+        } else {
+          record = existing
+        }
       } else {
         await OrganizationRepository.checkIdentities(data, this.options)
 

--- a/services/apps/data_sink_worker/src/service/organization.service.ts
+++ b/services/apps/data_sink_worker/src/service/organization.service.ts
@@ -188,13 +188,7 @@ export class OrganizationService extends LoggerBase {
             'weakIdentities',
           ]
           fields.forEach((field) => {
-            if (field === 'website' && !existing.website && cached.website) {
-              updateData[field] = cached[field]
-            } else if (
-              field !== 'website' &&
-              cached[field] &&
-              !isEqual(cached[field], existing[field])
-            ) {
+            if (!existing[field] && cached[field]) {
               updateData[field] = cached[field]
             }
           })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ab25ab0</samp>

Refactor the organization service logic to simplify the update from cache and avoid unnecessary updates. Apply the same logic to both `backend/src/services/organizationService.ts` and `services/apps/data_sink_worker/src/service/organization.service.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ab25ab0</samp>

> _`org` service logic_
> _simplified and unified_
> _autumn leaves fall fast_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ab25ab0</samp>

*  Simplify and unify the logic for updating organization data from the cache in both the backend and the data sink worker ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1894/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L531-R543), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1894/files?diff=unified&w=0#diff-c4775fb9079e4d3766f7b65b1d34e302fdf4b798a53e206c4cd85c683a4885d1L191-R192))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
