### PR TITLE
Enable eagle eye for readonly users

### DIFF
--- a/backend/src/api/auth/authMe.ts
+++ b/backend/src/api/auth/authMe.ts
@@ -12,21 +12,18 @@ export default async (req, res) => {
 
   const payload = req.currentUser
 
-  console.log('getting user', new Date().getTime())
-
   const csvExportCountCache = new RedisCache(
     FeatureFlagRedisKey.CSV_EXPORT_COUNT,
     req.redis,
     req.log,
   )
-  console.log('csv export', new Date().getTime())
+
   const memberEnrichmentCountCache = new RedisCache(
     FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
     req.redis,
     req.log,
   )
 
-  console.log('enrichment count', new Date().getTime())
   payload.tenants = await Promise.all(
     payload.tenants.map(async (tenantUser) => {
       tenantUser.tenant.dataValues = {
@@ -54,13 +51,10 @@ export default async (req, res) => {
         activityChannels,
         slackWebHook: !!tenantUser.tenant.settings[0].dataValues.slackWebHook,
       }
-      console.log('mapping settings', new Date().getTime())
 
       return tenantUser
     }),
   )
-
-  console.log('tenants mapped', new Date().getTime())
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/security/permissions.ts
+++ b/backend/src/security/permissions.ts
@@ -868,7 +868,7 @@ class Permissions {
       },
       eagleEyeActionCreate: {
         id: 'eagleEyeActionCreate',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.growth,
           plans.essential,
@@ -879,7 +879,7 @@ class Permissions {
       },
       eagleEyeActionDestroy: {
         id: 'eagleEyeActionDestroy',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.growth,
           plans.essential,
@@ -890,7 +890,7 @@ class Permissions {
       },
       eagleEyeContentCreate: {
         id: 'eagleEyeContentCreate',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.growth,
           plans.essential,
@@ -912,7 +912,7 @@ class Permissions {
       },
       eagleEyeContentSearch: {
         id: 'eagleEyeContentSearch',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.growth,
           plans.essential,
@@ -923,7 +923,7 @@ class Permissions {
       },
       eagleEyeContentEdit: {
         id: 'eagleEyeContentEdit',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.growth,
           plans.essential,

--- a/frontend/src/security/permissions.js
+++ b/frontend/src/security/permissions.js
@@ -681,7 +681,7 @@ class Permissions {
       },
       eagleEyeRead: {
         id: 'eagleEyeRead',
-        allowedRoles: [roles.admin],
+        allowedRoles: [roles.admin, roles.readonly],
         allowedPlans: [
           plans.essential,
           plans.eagleEye,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f4199f</samp>

This pull request implements the read-only role for the Eagle Eye feature in the backend and frontend code. It updates the permissions logic in `backend/src/security/permissions.ts` and `frontend/src/security/permissions.js` to allow read-only users to access and manipulate Eagle Eye data. It also removes some unnecessary console log statements from `backend/src/api/auth/authMe.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f4199f</samp>

> _`roles.readonly` grants you the power to see_
> _But not to change the Eagle Eye destiny_
> _You can watch the actions and the content unfold_
> _But you can't touch the secrets that they hold_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0f4199f</samp>

*  Remove unnecessary console log statements from `authMe` endpoint and related functions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L15-L16), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L22-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L57), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L63-L64))
*  Add `roles.readonly` role to Eagle Eye permissions to allow read-only users to access and use the feature ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L871-R871), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L882-R882), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L893-R893), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L915-R915), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-8ee5d616f50e901f2b2c0fb118649ca6ec358a7e615ab2bf9df0e061ebb939b8L926-R926), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1895/files?diff=unified&w=0#diff-0e09062fc2c86ce9490bfbd2117e20613eb73e9cb7e7c7232a879213e76696d6L684-R684))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
