### PR TITLE
Fix when no email address in EagleEye settings

### DIFF
--- a/services/apps/emails_worker/src/activities/eagleeye-digest/sendEmail.ts
+++ b/services/apps/emails_worker/src/activities/eagleeye-digest/sendEmail.ts
@@ -8,7 +8,7 @@ a user's email address using the SendGrid API.
 */
 export async function eagleeyeSendEmail(toSend: EmailToSend): Promise<EmailSent> {
   const email: MailDataRequired = {
-    to: toSend.settings.eagleEye.emailDigest.email,
+    to: toSend.settings.eagleEye.emailDigest?.email || toSend.email,
     from: {
       name: process.env['CROWD_SENDGRID_NAME_FROM'],
       email: process.env['CROWD_SENDGRID_EMAIL_FROM'],

--- a/services/apps/emails_worker/src/activities/updateEmailHistory.ts
+++ b/services/apps/emails_worker/src/activities/updateEmailHistory.ts
@@ -10,9 +10,16 @@ informing a new recurring email has been sent to the user.
 export async function updateEmailHistory(emailSent: UserTenantWithEmailSent): Promise<void> {
   try {
     await svc.postgres.writer.connection().query(
-      `INSERT INTO "recurringEmailsHistory" ("id", "type", "tenantId", "emailSentAt", "emailSentTo")
-        VALUES ($1, $2, $3, $4, $5);`,
-      [uuid(), emailSent.type, emailSent.tenantId, emailSent.sentAt, emailSent.emails],
+      `INSERT INTO "recurringEmailsHistory" ("id", "type", "tenantId", "emailSentAt", "emailSentTo", "weekOfYear")
+        VALUES ($1, $2, $3, $4, $5, $6);`,
+      [
+        uuid(),
+        emailSent.type,
+        emailSent.tenantId,
+        emailSent.sentAt,
+        emailSent.emails,
+        emailSent.weekOfYear || null,
+      ],
     )
   } catch (err) {
     throw new Error(err)

--- a/services/apps/emails_worker/src/types/user.ts
+++ b/services/apps/emails_worker/src/types/user.ts
@@ -14,4 +14,5 @@ export interface UserTenantWithEmailSent extends UserTenant {
   type: string
   sentAt: Date
   emails: string[]
+  weekOfYear?: string
 }

--- a/services/apps/emails_worker/src/workflows/eagleye-digest/sendEmailAndUpdateHistory.ts
+++ b/services/apps/emails_worker/src/workflows/eagleye-digest/sendEmailAndUpdateHistory.ts
@@ -56,6 +56,7 @@ export async function eagleeyeSendEmailAndUpdateHistory(row: UserTenant): Promis
   }
 
   const email = await eagleeyeSendEmail({
+    email: row.email,
     userId: row.userId,
     tenantId: row.tenantId,
     settings: row.settings,

--- a/services/apps/emails_worker/src/workflows/weekly-analytics/sendEmailAndUpdateHistory.ts
+++ b/services/apps/emails_worker/src/workflows/weekly-analytics/sendEmailAndUpdateHistory.ts
@@ -207,6 +207,7 @@ export async function weeklySendEmailAndUpdateHistory(
     emails: users.map((user) => user.email),
     type: 'weekly-analytics',
     sentAt: new Date(),
+    weekOfYear: moment().utc().startOf('isoWeek').subtract(7, 'days').isoWeek().toString(),
   })
 
   return


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05b0fc6</samp>

This pull request adds a fallback email option and a week of year column for the eagle eye email digest feature. The fallback email option uses the user's own email address if they have not set a specific one for the feature. The week of year column records the week when the email was sent in the `recurringEmailsHistory` table. The changes affect the files `sendEmail.ts`, `updateEmailHistory.ts`, `user.ts`, `sendEmailAndUpdateHistory.ts`, and `weekly-analytics/sendEmailAndUpdateHistory.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05b0fc6</samp>

> _Eagle eye digest_
> _`email` and `weekOfYear`_
> _Fall back to winter_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05b0fc6</samp>

*  Add fallback option for eagle eye email recipient using user's own email address ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-637407ed42fb64a3282cd3ad173c2e392058cf2f9db297e3994a1260e7c6e172L11-R11), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-cf18edfd6787e6fb81e737c63c7be0563dd2d21463ab769c2a78be6ceeaae52dR59))
*  Add week of year column to recurring emails history table for eagle eye email digest ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-c62949b5702d17e720f72632475c3177e94781b19f8f7e2edd0d5d9fe583ab0eL13-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-3d28193d64547afc9470073d25a6223c82a93870e327ba45812b728a37d51917R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-3408103e9fba4a224f7bf7f968e85423e4622fcd969ba9a3a00fdc05c798a9b7R210))
*  Calculate and pass week of year value to `updateEmailHistory` function using `moment` library in `sendEmailAndUpdateHistory.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1897/files?diff=unified&w=0#diff-3408103e9fba4a224f7bf7f968e85423e4622fcd969ba9a3a00fdc05c798a9b7R210))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
