### PR TITLE
Fix next email time in EagleEye settings

### DIFF
--- a/services/apps/emails_worker/src/activities/eagleeye-digest/updateEmailHistory.ts
+++ b/services/apps/emails_worker/src/activities/eagleeye-digest/updateEmailHistory.ts
@@ -10,8 +10,8 @@ export async function eagleeyeUpdateNextEmailAt(emailSent: UserTenantWithEmailSe
   try {
     await svc.postgres.writer.connection().query(
       `UPDATE "tenantUsers"
-        SET settings = jsonb_set(settings, '{eagleEye,emailDigest}', '{"nextEmailAt": $1~}'::JSONB, TRUE)
-        WHERE "tenantId" = $2 AND "userId" = $3;`,
+      SET settings = jsonb_set(settings, '{eagleEye,emailDigest,nextEmailAt}', to_jsonb($1::TEXT), TRUE)
+      WHERE "tenantId" = $2 AND "userId" = $3;`,
       [nextEmailAt(emailSent.settings.eagleEye.emailDigest), emailSent.tenantId, emailSent.userId],
     )
   } catch (err) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d5b6a98</samp>

Fixed a bug in the `eagleeye-digest` feature that prevented the next email date from being updated correctly. Modified the SQL query in `updateEmailHistory.ts` to use a valid JSONB format.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d5b6a98</samp>

> _`next_email_at` fixed_
> _JSONB path and value_
> _Winter bug no more_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d5b6a98</samp>

* Fix SQL query for updating next email at date for eagle eye digest feature ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1899/files?diff=unified&w=0#diff-91231dc4b45a4b803b507b28125c961a92206aec1d605351b103617d5233bf92L13-R14))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
