### PR TITLE
Eagle eye disable upgrade for readonly users

### DIFF
--- a/frontend/src/modules/layout/pages/paywall-page.vue
+++ b/frontend/src/modules/layout/pages/paywall-page.vue
@@ -27,16 +27,19 @@
           <div class="text-gray-500 italic text-2xs">
             Available in {{ computedFeaturePlan }}
           </div>
-          <router-link
-            :to="{
-              name: 'settings',
-              query: { activeTab: 'plans' },
-            }"
-          >
-            <el-button class="btn btn--md btn--primary">
-              Upgrade plan
-            </el-button>
-          </router-link>
+          <el-tooltip content="Only admins can manage tenant plans" trigger="hover" placement="top" :disabled="upgradeEnabled">
+            <component
+              :is="upgradeEnabled ? 'router-link' : 'div'"
+              :to="{
+                name: 'settings',
+                query: { activeTab: 'plans' },
+              }"
+            >
+              <el-button class="btn btn--md btn--primary" :disabled="!upgradeEnabled">
+                Upgrade plan
+              </el-button>
+            </component>
+          </el-tooltip>
         </div>
       </div>
 
@@ -103,8 +106,12 @@ import config from '@/config';
 import AppPageWrapper from '@/shared/layout/page-wrapper.vue';
 import { pageContent } from '@/modules/layout/layout-page-content';
 import { FeatureFlag } from '@/utils/featureFlag';
+import { SettingsPermissions } from '@/modules/settings/settings-permissions';
+import { mapGetters } from '@/shared/vuex/vuex.helpers';
 
 const router = useRouter();
+
+const { currentUser, currentTenant } = mapGetters('auth');
 
 const section = computed(
   () => router.currentRoute.value.name,
@@ -114,6 +121,14 @@ const computedFeaturePlan = computed(() => {
   if (config.isCommunityVersion) return 'Custom plan';
   if (page.value.headerTitle === 'Eagle Eye') return 'Scale and Eagle Eye plans';
   return 'Scale plan';
+});
+
+const upgradeEnabled = computed(() => {
+  const settingsPermissions = new SettingsPermissions(
+    currentTenant.value,
+    currentUser.value,
+  );
+  return settingsPermissions.edit;
 });
 </script>
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cfb7d78</samp>

Prevent non-admin users from upgrading tenant plan on paywall page. Use a tooltip, a permissions class, and a computed property to disable and explain the upgrade button in `paywall-page.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cfb7d78</samp>

> _Sing, O Muse, of the cunning code that thwarted_
> _The greedy users who sought to upgrade their plan_
> _Without the blessing of the admin, the mighty guardian_
> _Of the tenant settings, the source of lawful order._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cfb7d78</samp>

*  Add a tooltip component and disable the upgrade plan button for non-admin users ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1907/files?diff=unified&w=0#diff-9c20bd2f8990b3330e45ce21542b37007de0a0d6ee2f31fb61c4a76ea85445ceL30-R42))
*  Import the SettingsPermissions class and the mapGetters helper from the auth module to access and check user and tenant permissions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1907/files?diff=unified&w=0#diff-9c20bd2f8990b3330e45ce21542b37007de0a0d6ee2f31fb61c4a76ea85445ceL106-R115))
*  Define a computed property upgradeEnabled that returns a boolean value based on the settings permissions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1907/files?diff=unified&w=0#diff-9c20bd2f8990b3330e45ce21542b37007de0a0d6ee2f31fb61c4a76ea85445ceR125-R132))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
