### PR TITLE
Enable workspace creation for readonly users

### DIFF
--- a/frontend/src/modules/layout/components/menu/workspace/menu-workspace-popover.vue
+++ b/frontend/src/modules/layout/components/menu/workspace/menu-workspace-popover.vue
@@ -26,13 +26,9 @@
 
       <!-- Add workspace -->
       <section
-        class="border-b border-gray-100"
-        :class="{
-          'px-2 pb-3': hasPermissionsForSettings,
-        }"
+        class="border-b border-gray-100 px-2 pb-3"
       >
         <div
-          v-if="hasPermissionsForSettings"
           class="px-3 h-10 text-sm font-normal rounded hover:bg-gray-50 cursor-pointer flex items-center text-brand-500"
           @click="emit('add')"
         >


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39b76d2</samp>

Refactored `menu-workspace-popover.vue` component to use a new design and functionality. Removed unused code and simplified conditional class binding.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39b76d2</samp>

> _`hasPermissionsForSettings`_
> _Gone with the old design_
> _Simpler code for spring_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 39b76d2</samp>

*  Removed unused and redundant class binding and computed property from `menu-workspace-popover.vue` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1908/files?diff=unified&w=0#diff-b85aea707706909b0923b1001b9d30fb813f07f752453d624db7319ebdda1b9cL29-R31))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
