### PR TITLE
Improve organization merge suggestions with lowercase normalizer

### DIFF
--- a/backend/src/serverless/microservices/nodejs/workerFactory.ts
+++ b/backend/src/serverless/microservices/nodejs/workerFactory.ts
@@ -57,7 +57,7 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
         await isFeatureEnabled(
           FeatureFlag.TEMPORAL_EMAILS,
           async () => ({
-            tenant,
+            tenantId: tenant,
           }),
           unleash,
         )
@@ -71,7 +71,7 @@ async function workerFactory(event: NodeMicroserviceMessage): Promise<any> {
         await isFeatureEnabled(
           FeatureFlag.TEMPORAL_EMAILS,
           async () => ({
-            tenant,
+            tenantId: tenant,
           }),
           unleash,
         )

--- a/services/apps/search_sync_worker/package.json
+++ b/services/apps/search_sync_worker/package.json
@@ -32,6 +32,7 @@
     "script:create-versioned-index": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/create-versioned-index.ts",
     "script:reindex": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/reindex.ts",
     "script:create-alias": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/create-alias.ts",
+    "script:set-alias-to-index": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/set-alias-to-index.ts",
     "script:get-doc-count": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/get-doc-count.ts"
   },
   "dependencies": {

--- a/services/apps/search_sync_worker/src/bin/set-alias-to-index.ts
+++ b/services/apps/search_sync_worker/src/bin/set-alias-to-index.ts
@@ -1,0 +1,30 @@
+import { OpenSearchService } from '../service/opensearch.service'
+import { getServiceLogger } from '@crowd/logging'
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(2)
+
+if (processArguments.length !== 2) {
+  log.error('Expected 2 arguments: indexNameWithVersion and alias')
+  process.exit(1)
+}
+
+const index = processArguments[0]
+const alias = processArguments[1]
+
+setImmediate(async () => {
+  const openSearchService = new OpenSearchService(log)
+
+  // check index name is with version
+  if (!index.includes('_v')) {
+    log.error('Index name must include version')
+    process.exit(1)
+  }
+
+  await openSearchService.setAliasToIndex(index, alias)
+
+  log.info(`Alias ${alias} is set to ${index}!`)
+
+  process.exit(0)
+})

--- a/services/apps/search_sync_worker/src/service/opensearch.service.ts
+++ b/services/apps/search_sync_worker/src/service/opensearch.service.ts
@@ -113,7 +113,7 @@ export class OpenSearchService extends LoggerBase {
     }
   }
 
-  private async pointAliasToCorrectIndex(indexName: string, aliasName: string): Promise<void> {
+  public async setAliasToIndex(indexName: string, aliasName: string): Promise<void> {
     try {
       // Updates alias by removing existing references and points it to the new index
       await this.client.indices.updateAliases({

--- a/services/apps/search_sync_worker/src/types.ts
+++ b/services/apps/search_sync_worker/src/types.ts
@@ -7,9 +7,9 @@ export enum OpenSearchIndex {
 // Keeps track of version numbers for all OpenSearch indexes, aiding in managing documents.
 // for eg: members_v1, activities_v1, etc.
 export const IndexVersions = new Map<OpenSearchIndex, number>()
-IndexVersions.set(OpenSearchIndex.MEMBERS, 2)
-IndexVersions.set(OpenSearchIndex.ACTIVITIES, 2)
-IndexVersions.set(OpenSearchIndex.ORGANIZATIONS, 2)
+IndexVersions.set(OpenSearchIndex.MEMBERS, 3)
+IndexVersions.set(OpenSearchIndex.ACTIVITIES, 3)
+IndexVersions.set(OpenSearchIndex.ORGANIZATIONS, 3)
 
 const prefixedMapping = {
   dynamic_templates: [
@@ -64,6 +64,7 @@ const prefixedMapping = {
         path_match: '.*',
         mapping: {
           type: 'keyword',
+          normalizer: 'lowercase_normalizer',
         },
       },
     },
@@ -582,6 +583,12 @@ const prefixedSettings = {
       lowercase_keyword_analyzer: {
         type: 'custom',
         tokenizer: 'keyword',
+        filter: ['lowercase'],
+      },
+    },
+    normalizer: {
+      lowercase_normalizer: {
+        type: 'custom',
         filter: ['lowercase'],
       },
     },


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f8c04d</samp>

The pull request improves the search functionality for members, activities, and organizations by making their names case-insensitive. It modifies the `types.ts` file to update the Elasticsearch index configurations and versions.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f8c04d</samp>

> _Sing, O Muse, of the mighty pull request_
> _That updated the mappings and settings of `Elasticsearch`_
> _To enable the search of names, regardless of case_
> _And reindex the data with a new version and grace_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7f8c04d</samp>

*  Increment index versions for members, activities, and organizations to trigger reindexing ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1915/files?diff=unified&w=0#diff-36cca9b447f39c975dd7b6299743714aeab97905a2a972cda56e76c8958c93f9L10-R12))
*  Add `normalizer` property to `name` field of `members` index mapping to enable case-insensitive matching ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1915/files?diff=unified&w=0#diff-36cca9b447f39c975dd7b6299743714aeab97905a2a972cda56e76c8958c93f9R67))
*  Define `lowercase_normalizer` as a custom normalizer that applies `lowercase` filter to input text in `prefixedSettings` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1915/files?diff=unified&w=0#diff-36cca9b447f39c975dd7b6299743714aeab97905a2a972cda56e76c8958c93f9R589-R594))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
