### PR TITLE
Fix enrich error

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -45,7 +45,7 @@ i18nInit();
   const isSocialOnboardRequested = AuthService.isSocialOnboardRequested();
 
   AuthToken.applyFromLocationUrlIfExists();
-  await TenantService.fetchAndApply();
+  store.state.auth.currentTenant = await TenantService.fetchAndApply();
   if (isSocialOnboardRequested) {
     await AuthService.socialOnboard();
   }

--- a/frontend/src/modules/auth/store/mutations.js
+++ b/frontend/src/modules/auth/store/mutations.js
@@ -1,12 +1,8 @@
-import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
 import formbricks, { setupFormbricks } from '@/plugins/formbricks';
 
 export default {
   CURRENT_USER_REFRESH_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
-    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
-      payload.currentUser,
-    );
   },
 
   AUTH_START(state) {
@@ -16,9 +12,6 @@ export default {
   AUTH_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
 
-    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
-      payload.currentUser,
-    );
     state.loading = false;
 
     if (state.currentUser) {
@@ -109,9 +102,6 @@ export default {
   AUTH_INIT_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
 
-    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
-      payload.currentUser,
-    );
     state.loadingInit = false;
 
     if (state.currentUser) {

--- a/frontend/src/modules/member/member-enrichment.js
+++ b/frontend/src/modules/member/member-enrichment.js
@@ -55,9 +55,9 @@ export const showEnrichmentSuccessMessage = ({
   isBulk,
 }) => {
   const commonMessage = `${formatNumber(
-    memberEnrichmentCount,
+    memberEnrichmentCount || 0,
   )} out of ${formatNumber(
-    planEnrichmentCountMax,
+    planEnrichmentCountMax || 0,
   )} enrichments used this month.`;
 
   const essentialMessage = h('span', null, [

--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -197,9 +197,9 @@ export default {
       // Show enrichment loading message
       showEnrichmentLoadingMessage({ isBulk: false });
 
-      const response = await MemberService.enrichMember(id);
+      // const response = await MemberService.enrichMember(id);
 
-      commit('UPDATE_SUCCESS', response);
+      commit('UPDATE_SUCCESS', {});
 
       await dispatch('auth/doRefreshCurrentUser', null, {
         root: true,
@@ -226,6 +226,7 @@ export default {
         await dispatch('doFind', id);
       }
     } catch (error) {
+      console.log(error);
       Message.closeAll();
       Errors.handle(error);
 

--- a/frontend/src/modules/member/store/actions.js
+++ b/frontend/src/modules/member/store/actions.js
@@ -197,9 +197,9 @@ export default {
       // Show enrichment loading message
       showEnrichmentLoadingMessage({ isBulk: false });
 
-      // const response = await MemberService.enrichMember(id);
+      const response = await MemberService.enrichMember(id);
 
-      commit('UPDATE_SUCCESS', {});
+      commit('UPDATE_SUCCESS', response);
 
       await dispatch('auth/doRefreshCurrentUser', null, {
         root: true,
@@ -226,7 +226,6 @@ export default {
         await dispatch('doFind', id);
       }
     } catch (error) {
-      console.log(error);
       Message.closeAll();
       Errors.handle(error);
 

--- a/frontend/src/modules/tenant/tenant-service.js
+++ b/frontend/src/modules/tenant/tenant-service.js
@@ -18,8 +18,8 @@ export class TenantService {
     // If there is a subdomain with the tenant url,
     // it must fetch the settings form that subdomain no matter
     // which one is on local storage
+    let currentTenant;
     if (tenantUrl) {
-      let currentTenant;
       try {
         currentTenant = await this.findByUrl(tenantUrl);
       } catch (error) {
@@ -37,13 +37,15 @@ export class TenantService {
     const tenantId = AuthCurrentTenant.get();
     if (tenantId && !tenantUrl) {
       try {
-        const currentTenant = await this.find(tenantId);
+        currentTenant = await this.find(tenantId);
 
         AuthCurrentTenant.set(currentTenant);
       } catch (error) {
         console.error(error);
       }
     }
+    // eslint-disable-next-line consistent-return
+    return currentTenant;
   }
 
   static async update(id, data) {
@@ -115,6 +117,7 @@ export class TenantService {
   }
 
   static async find(id) {
+    console.error(id);
     const response = await authAxios.get(`/tenant/${id}`);
     return response.data;
   }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c472843</samp>

The pull request improves the handling of the current tenant in the frontend by refactoring the auth store and the tenant service. It also fixes some potential bugs and errors in the member enrichment module. The main files affected are `frontend/src/modules/auth/store/actions.js`, `frontend/src/modules/auth/store/mutations.js`, `frontend/src/modules/tenant/tenant-service.js`, `frontend/src/main.ts`, and `frontend/src/modules/member/member-enrichment.js`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c472843</samp>

> _Sing, O Muse, of the valiant coder who reforged the auth store_
> _And made it harmonize with the tenant service, that cunning artificer_
> _Who fetched and applied the current tenant, `store.state.auth.currentTenant`_
> _And gave it default values, like a wise and prudent ruler_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c472843</samp>

*  Assign current tenant from `TenantService.fetchAndApply()` to `store.state.auth.currentTenant` in `frontend/src/main.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-a235fca1f464b6af0fb049401b64264244eda9d624234c1fee162f6c663cee7bL48-R48))
* Dispatch `doRefreshTenant` action after sign out, registration, sign in, and refresh current user actions in `frontend/src/modules/auth/store/actions.js` to update current tenant in state and local storage ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R117), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R145), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532R173-R174))
* Add `dispatch` parameter to `doRegisterEmailAndPassword`, `doSigninWithEmailAndPassword`, and `doRefreshCurrentUser` actions in `frontend/src/modules/auth/store/actions.js` to enable dispatching other actions within them ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L90-R96), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L122-R129), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L157-R165))
* Remove `console.log(error)` statement from `frontend/src/modules/auth/store/actions.js` as it is not a good practice to expose errors to the console in production ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L34))
* Remove redundant and potentially inconsistent assignments of `state.currentTenant` from `frontend/src/modules/auth/store/mutations.js` as the current tenant is handled by `TenantService.fetchAndApply()` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL1), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL7-L9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL19-L21), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL112-L114))
* Give default values of `0` to `memberEnrichmentCount` and `planEnrichmentCountMax` variables in `frontend/src/modules/member/member-enrichment.js` to avoid errors in the `formatNumber` function and the string interpolation ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-44a780e6a3997fcccbdef31f04d51c635d02e2f108718aa6ca6a39f9703143edL58-R60))
* Move `currentTenant` declaration outside of the `if (tenantUrl)` block and reuse it in the `if (tenantId && !tenantUrl)` block in `frontend/src/modules/tenant/tenant-service.js` to avoid confusion and duplication ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-960dd2f94a2e2318f35365228e9b209dac4429ec7412ea844c4c444d4914c99aL21-R22), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-960dd2f94a2e2318f35365228e9b209dac4429ec7412ea844c4c444d4914c99aL40-R40))
* Add `return currentTenant` statement to the `fetchAndApply` method in `frontend/src/modules/tenant/tenant-service.js` to return the current tenant object to the caller for further use or assignment ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-960dd2f94a2e2318f35365228e9b209dac4429ec7412ea844c4c444d4914c99aR47-R48))
* Add `console.error(id)` statement to the `find` method in `frontend/src/modules/tenant/tenant-service.js` to log the tenant id in case of an error for debugging purposes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1918/files?diff=unified&w=0#diff-960dd2f94a2e2318f35365228e9b209dac4429ec7412ea844c4c444d4914c99aR120))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
