### PR TITLE
Add index info scripts to search-sync-worker

### DIFF
--- a/services/apps/search_sync_worker/package.json
+++ b/services/apps/search_sync_worker/package.json
@@ -32,8 +32,9 @@
     "script:create-versioned-index": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/create-versioned-index.ts",
     "script:reindex": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/reindex.ts",
     "script:create-alias": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/create-alias.ts",
-    "script:set-alias-to-index": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/set-alias-to-index.ts",
-    "script:get-doc-count": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/get-doc-count.ts"
+    "script:remove-alias": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/remove-alias.ts",
+    "script:get-doc-count": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/get-doc-count.ts",
+    "script:get-index-info": "SERVICE=script TS_NODE_TRANSPILE_ONLY=true node -r tsconfig-paths/register -r ts-node/register src/bin/get-index-info.ts"
   },
   "dependencies": {
     "@crowd/common": "file:../../libs/common",

--- a/services/apps/search_sync_worker/src/bin/get-index-info.ts
+++ b/services/apps/search_sync_worker/src/bin/get-index-info.ts
@@ -1,0 +1,21 @@
+import { OpenSearchService } from '../service/opensearch.service'
+import { getServiceLogger } from '@crowd/logging'
+
+const log = getServiceLogger()
+
+const processArguments = process.argv.slice(2)
+
+if (processArguments.length !== 1) {
+  log.error('Expected 1 arguments: IndexName')
+  process.exit(1)
+}
+
+const index = processArguments[0]
+
+setImmediate(async () => {
+  const openSearchService = new OpenSearchService(log)
+
+  const result = await openSearchService.getIndexInfo(index)
+  console.log(result)
+  process.exit(0)
+})

--- a/services/apps/search_sync_worker/src/bin/remove-alias.ts
+++ b/services/apps/search_sync_worker/src/bin/remove-alias.ts
@@ -22,7 +22,7 @@ setImmediate(async () => {
     process.exit(1)
   }
 
-  await openSearchService.setAliasToIndex(index, alias)
+  await openSearchService.removeAlias(index, alias)
 
   log.info(`Alias ${alias} is set to ${index}!`)
 

--- a/services/apps/search_sync_worker/src/service/opensearch.service.ts
+++ b/services/apps/search_sync_worker/src/service/opensearch.service.ts
@@ -101,6 +101,18 @@ export class OpenSearchService extends LoggerBase {
     }
   }
 
+  public async getIndexInfo(indexName: string): Promise<unknown> {
+    try {
+      const response = await this.client.indices.get({
+        index: indexName,
+      })
+      return response
+    } catch (err) {
+      this.log.error(err, { indexName }, 'Failed to get index info!')
+      throw err
+    }
+  }
+
   public async createAlias(indexName: string, aliasName: string): Promise<void> {
     try {
       await this.client.indices.putAlias({
@@ -113,20 +125,14 @@ export class OpenSearchService extends LoggerBase {
     }
   }
 
-  public async setAliasToIndex(indexName: string, aliasName: string): Promise<void> {
+  public async removeAlias(indexName: string, aliasName: string): Promise<void> {
     try {
-      // Updates alias by removing existing references and points it to the new index
-      await this.client.indices.updateAliases({
-        body: {
-          actions: [
-            { remove: { index: '*', alias: aliasName } },
-            { add: { index: indexName, alias: aliasName } },
-          ],
-        },
+      await this.client.indices.deleteAlias({
+        name: aliasName,
+        index: indexName,
       })
-      this.log.info('Alias successfully updated', { aliasName, indexName })
     } catch (err) {
-      this.log.error(err, { aliasName, indexName }, 'Failed to update alias!')
+      this.log.error(err, { aliasName, indexName }, 'Failed to remove alias!')
     }
   }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 452f813</samp>

This pull request improves the OpenSearchService class and adds new scripts to manage OpenSearch indices and aliases. It removes an unused and risky function and enhances the debugging and maintenance capabilities of the search sync worker service.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 452f813</samp>

> _To manage the OpenSearch indices_
> _We added some scripts and fixes_
> _We can get info and remove alias_
> _No more setting alias to index_
> _That function was full of glitches_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 452f813</samp>

*  Add and remove scripts for managing OpenSearch indices and aliases ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1919/files?diff=unified&w=0#diff-fa62bb4e81ec11bf20d4c339335cae69d081afdc36a4528e25b378da21c0488aL35-R37))
*  Implement `getIndexInfo` function to get information about an OpenSearch index ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1919/files?diff=unified&w=0#diff-f9964b2ee3e44130d55941c0b2fe7a3b5c0ba9bdb5e22659a73393b0eda3c7adR104-R115))
*  Replace `setAliasToIndex` function with `removeAlias` function to delete an alias from an index ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1919/files?diff=unified&w=0#diff-f9964b2ee3e44130d55941c0b2fe7a3b5c0ba9bdb5e22659a73393b0eda3c7adL116-R135))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
