### PR TITLE
Fix tenant setting and blank screen

### DIFF
--- a/backend/src/api/auth/authMe.ts
+++ b/backend/src/api/auth/authMe.ts
@@ -1,4 +1,7 @@
 import { Error403 } from '@crowd/common'
+import { RedisCache } from '@crowd/redis'
+import { FeatureFlagRedisKey } from '@crowd/types'
+import AutomationRepository from '@/database/repositories/automationRepository'
 
 export default async (req, res) => {
   if (!req.currentUser || !req.currentUser.id) {
@@ -6,5 +9,34 @@ export default async (req, res) => {
     return
   }
 
-  await req.responseHandler.success(req, res, req.currentUser)
+  const payload = req.currentUser
+
+  const csvExportCountCache = new RedisCache(
+    FeatureFlagRedisKey.CSV_EXPORT_COUNT,
+    req.redis,
+    req.log,
+  )
+
+  const memberEnrichmentCountCache = new RedisCache(
+    FeatureFlagRedisKey.MEMBER_ENRICHMENT_COUNT,
+    req.redis,
+    req.log,
+  )
+
+  payload.tenants = await Promise.all(
+    payload.tenants.map(async (tenantUser) => {
+      tenantUser.tenant.dataValues = {
+        ...tenantUser.tenant.dataValues,
+        csvExportCount: Number(await csvExportCountCache.get(tenantUser.tenant.id)) || 0,
+        automationCount:
+          Number(await AutomationRepository.countAllActive(req.database, tenantUser.tenant.id)) ||
+          0,
+        memberEnrichmentCount:
+          Number(await memberEnrichmentCountCache.get(tenantUser.tenant.id)) || 0,
+      }
+      return tenantUser
+    }),
+  )
+
+  await req.responseHandler.success(req, res, payload)
 }

--- a/frontend/src/modules/auth/store/actions.js
+++ b/frontend/src/modules/auth/store/actions.js
@@ -15,14 +15,15 @@ import {
 } from '@/modules/auth/auth-socket';
 
 export default {
-  async doInit({ commit, dispatch }) {
+  async doInit({ commit, dispatch, state }) {
     try {
       const token = AuthToken.get();
       if (token) {
         connectSocket(token);
         const currentUser = await AuthService.fetchMe();
         commit('AUTH_INIT_SUCCESS', { currentUser });
-        dispatch('doRefreshTenant');
+
+        state.loadingInit = false;
         return currentUser;
       }
 
@@ -37,12 +38,6 @@ export default {
       return null;
     } finally {
       ProgressBar.done();
-    }
-  },
-
-  async doRefreshTenant({ state }) {
-    if (state.currentTenant.id !== AuthCurrentTenant.get()) {
-      state.currentTenant = await TenantService.fetchAndApply();
     }
   },
 
@@ -114,7 +109,6 @@ export default {
         commit('AUTH_SUCCESS', {
           currentUser,
         });
-        dispatch('doRefreshTenant');
 
         router.push('/');
       })
@@ -142,7 +136,6 @@ export default {
         commit('AUTH_SUCCESS', {
           currentUser: currentUser || null,
         });
-        dispatch('doRefreshTenant');
         router.push('/');
       })
       .catch((error) => {
@@ -162,7 +155,7 @@ export default {
     router.push('/auth/signin');
   },
 
-  doRefreshCurrentUser({ commit, dispatch }) {
+  doRefreshCurrentUser({ commit }) {
     const token = AuthToken.get();
     if (token) {
       return AuthService.fetchMe()
@@ -171,7 +164,6 @@ export default {
             currentUser,
           });
 
-          dispatch('doRefreshTenant');
           return currentUser;
         })
         .catch((error) => {

--- a/frontend/src/modules/auth/store/mutations.js
+++ b/frontend/src/modules/auth/store/mutations.js
@@ -1,8 +1,12 @@
 import formbricks, { setupFormbricks } from '@/plugins/formbricks';
+import AuthCurrentTenant from '@/modules/auth/auth-current-tenant';
 
 export default {
   CURRENT_USER_REFRESH_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
+    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
+      payload.currentUser,
+    );
   },
 
   AUTH_START(state) {
@@ -11,7 +15,9 @@ export default {
 
   AUTH_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
-
+    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
+      payload.currentUser,
+    );
     state.loading = false;
 
     if (state.currentUser) {
@@ -102,8 +108,9 @@ export default {
   AUTH_INIT_SUCCESS(state, payload) {
     state.currentUser = payload.currentUser || null;
 
-    state.loadingInit = false;
-
+    state.currentTenant = AuthCurrentTenant.selectAndSaveOnStorageFor(
+      payload.currentUser,
+    );
     if (state.currentUser) {
       // initialize Formbricks
       setupFormbricks(state.currentUser);


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a9f5e2</samp>

This pull request improves the authentication and authorization features of the backend and frontend by adding more tenant-specific data and logic. It enhances the `authMe` endpoint in `backend/src/api/auth/authMe.ts` to return more information about the current tenant for the user. It also simplifies and updates the auth store in `frontend/src/modules/auth/store/actions.js` and `frontend/src/modules/auth/store/mutations.js` to use the `AuthCurrentTenant` module and select and save the current tenant.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a9f5e2</samp>

> _Sing, O Muse, of the valiant pull request_
> _That enhanced the `authMe` endpoint's power_
> _And gave the user more data to possess_
> _About the tenant of their chosen hour._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2a9f5e2</samp>

*  Add additional data to the `authMe` endpoint response payload for each tenant, such as csv export count, automation count, and member enrichment count, fetched from Redis cache or database ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660L9-R41))
* Import Redis cache, feature flag keys, and automation repository modules in the `authMe` endpoint file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-9c667dd2f1ab60ab24f17da4c95157cc9418e6cb265dba148371e8f1dc085660R2-R4))
* Remove `doRefreshTenant` action and calls from the auth store, since the current tenant is now handled by the `AuthCurrentTenant` module and the mutations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L25-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L43-L48), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L117), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L145), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L174))
* Add `state` parameter to the `doInit` action in the auth store, and set the `loadingInit` state variable to false after the auth initialization is successful ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L18-R18))
* Remove `dispatch` parameter from the `doRefreshCurrentUser` action, since it is no longer needed and used ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-77b6feee07566157369003e63213fced8744cdc8dfb9f7a6180368a291470532L165-R158))
* Import the `AuthCurrentTenant` module in the auth store mutations, and use its `selectAndSaveOnStorageFor` method to set and save the current tenant based on the current user payload in the `AUTH_SUCCESS` and `AUTH_INIT_SUCCESS` mutations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL2-R9), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL14-R20), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1920/files?diff=unified&w=0#diff-4a3c2e948556b673bbe18e0f4943172ccc52310a3c5baf877b95422e0983e53eL105-R113))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
