### PR TITLE
Check if body is defined

### DIFF
--- a/services/apps/automations_worker/src/services/automation.service.ts
+++ b/services/apps/automations_worker/src/services/automation.service.ts
@@ -125,7 +125,7 @@ export class AutomationService {
     }
 
     // check whether activity content contains any of the keywords
-    if (shouldProcess && settings.keywords && settings.keywords.length > 0) {
+    if (shouldProcess && settings.keywords && settings.keywords.length > 0 && activity.body) {
       const body = (activity.body as string).toLowerCase()
       if (!settings.keywords.some((keyword) => body.includes(keyword.trim().toLowerCase()))) {
         this.log.warn(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61a3581</samp>

Fix a bug in the automation service that could cause an error when processing activities with no body content. Add a null check for `activity.body` in `automation.service.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61a3581</samp>

> _`activity.body`_
> _null check avoids an error_
> _autumn bug is fixed_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61a3581</samp>

* Add null check for activity body before keyword matching ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1924/files?diff=unified&w=0#diff-3a6c492f628b64e1f8f814e946c721937201c69e5f5ae093472031cbcfc226a1L128-R128))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
