### PR TITLE
Payload consistency between frontend and API for members.findById

### DIFF
--- a/backend/src/api/member/memberFind.ts
+++ b/backend/src/api/member/memberFind.ts
@@ -22,7 +22,7 @@ import PermissionChecker from '../../services/user/permissionChecker'
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberRead)
 
-  const segmentId = req.query.segmentId
+  const segmentId = req.query.segments.length > 0 ? req.query.segments[0] : null
   if (!segmentId) {
     const segmentsEnabled = await isFeatureEnabled(FeatureFlag.SEGMENTS, req)
     if (segmentsEnabled) {

--- a/backend/src/api/member/memberFind.ts
+++ b/backend/src/api/member/memberFind.ts
@@ -22,7 +22,7 @@ import PermissionChecker from '../../services/user/permissionChecker'
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberRead)
 
-  const segmentId = req.query.segments.length > 0 ? req.query.segments[0] : null
+  const segmentId = req.query.segments?.length > 0 ? req.query.segments[0] : null
   if (!segmentId) {
     const segmentsEnabled = await isFeatureEnabled(FeatureFlag.SEGMENTS, req)
     if (segmentsEnabled) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -953,10 +953,7 @@ class MemberRepository {
     `
 
     const data: ActivityAggregates[] = await seq.query(query, {
-      replacements: {
-        memberId,
-        tenantId: currentTenant.id,
-      },
+      replacements,
       type: QueryTypes.SELECT,
       transaction,
     })


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7dc5672</samp>

The pull request enhances the member API to support multiple segments filtering and refactors the member repository to use a common query object. These changes improve the functionality and maintainability of the backend code.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7dc5672</samp>

> _`segments` array_
> _filter members by many_
> _autumn leaves falling_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7dc5672</samp>

* Support multiple segments in member find API ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1927/files?diff=unified&w=0#diff-db4efef4b8589d409602c5f6254036ac148559bbfa7eec90c328298905db13daL25-R25))
* Refactor SQL query in member repository ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1927/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL956-R956))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
