### PR TITLE
Tracking correct properties with segment

### DIFF
--- a/backend/src/api/activity/activityCreate.ts
+++ b/backend/src/api/activity/activityCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new ActivityService(req).upsert(req.body)
 
-  track('Activity Manually Created', { ...payload }, { ...req })
+  track('Activity Manually Created', { ...req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/activity/activityQuery.ts
+++ b/backend/src/api/activity/activityQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new ActivityService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Activities Advanced Filter', { ...payload }, { ...req })
+    track('Activities Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/automation/automationCreate.ts
+++ b/backend/src/api/automation/automationCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new AutomationService(req).create(req.body.data)
 
-  track('Automation Created', { ...payload }, { ...req })
+  track('Automation Created', { ...req.body.data }, { ...req })
 
   identifyTenant(req)
 

--- a/backend/src/api/automation/automationUpdate.ts
+++ b/backend/src/api/automation/automationUpdate.ts
@@ -22,7 +22,11 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.automationUpdate)
   const payload = await new AutomationService(req).update(req.params.automationId, req.body.data)
 
-  track('Automation Updated', { ...payload }, { ...req })
+  track(
+    'Automation Updated',
+    { automationId: req.params.automationId, data: req.body.data },
+    { ...req },
+  )
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/conversation/conversationQuery.ts
+++ b/backend/src/api/conversation/conversationQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new ConversationService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Conversations Advanced Filter', { ...payload }, { ...req })
+    track('Conversations Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/customViews/customViewCreate.ts
+++ b/backend/src/api/customViews/customViewCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new CustomViewService(req).create(req.body)
 
-  track('Custom view Manually Created', { ...payload }, { ...req })
+  track('Custom view Manually Created', { ...req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/customViews/customViewQuery.ts
+++ b/backend/src/api/customViews/customViewQuery.ts
@@ -25,7 +25,7 @@ export default async (req, res) => {
   const payload = await new CustomViewService(req).findAll(req.query)
 
   if (req.query.filter && Object.keys(req.query.filter).length > 0) {
-    track('Custom views Filter', { ...payload }, { ...req })
+    track('Custom views Filter', { ...req.query }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/eagleEyeContent/eagleEyeContentQuery.ts
+++ b/backend/src/api/eagleEyeContent/eagleEyeContentQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new EagleEyeContentService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('EagleEyeContent Advanced Filter', { ...payload }, { ...req })
+    track('EagleEyeContent Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/eagleEyeContent/eagleEyeContentSearch.ts
+++ b/backend/src/api/eagleEyeContent/eagleEyeContentSearch.ts
@@ -7,6 +7,6 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.eagleEyeActionCreate)
 
   const payload = await new EagleEyeContentService(req).search()
-  track('EagleEye backend search', { ...req.body }, { ...req })
+  track('EagleEye backend search', {}, { ...req })
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/integration/integrationQuery.ts
+++ b/backend/src/api/integration/integrationQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new IntegrationService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Integrations Advanced Filter', { ...payload }, { ...req })
+    track('Integrations Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/member/memberCreate.ts
+++ b/backend/src/api/member/memberCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new MemberService(req).upsert(req.body)
 
-  track('Member Manually Created', { ...payload }, { ...req })
+  track('Member Manually Created', { ...req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/member/memberExport.ts
+++ b/backend/src/api/member/memberExport.ts
@@ -43,7 +43,7 @@ export default async (req, res) => {
 
   identifyTenant(req)
 
-  track('Member CSV Export', {}, { ...req }, req.currentUser.id)
+  track('Member CSV Export', {}, { ...req.body }, req.currentUser.id)
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/member/memberMerge.ts
+++ b/backend/src/api/member/memberMerge.ts
@@ -8,7 +8,11 @@ export default async (req, res) => {
 
   const payload = await new MemberService(req).merge(req.params.memberId, req.body.memberToMerge)
 
-  track('Merge members', { ...payload }, { ...req })
+  track(
+    'Merge members',
+    { memberId: req.params.memberId, memberToMergeId: req.body.memberToMerge },
+    { ...req },
+  )
 
   const status = payload.status || 200
 

--- a/backend/src/api/member/memberNotMerge.ts
+++ b/backend/src/api/member/memberNotMerge.ts
@@ -10,7 +10,11 @@ export default async (req, res) => {
     req.body.memberToNotMerge,
   )
 
-  track('Ignore merge members', { ...payload }, { ...req })
+  track(
+    'Ignore merge members',
+    { memberId: req.params.memberId, memberToNotMergeId: req.body.memberToNotMerge },
+    { ...req },
+  )
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/microservice/microserviceQuery.ts
+++ b/backend/src/api/microservice/microserviceQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new MicroserviceService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Microservices Advanced Filter', { ...payload }, { ...req })
+    track('Microservices Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/note/noteCreate.ts
+++ b/backend/src/api/note/noteCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new NoteService(req).create(req.body)
 
-  track('Note Created', { id: payload.id }, { ...req })
+  track('Note Created', { ...req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/note/noteDestroy.ts
+++ b/backend/src/api/note/noteDestroy.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = true
 
-  track('Note Destroyed', {}, { ...req })
+  track('Note Destroyed', { noteIds: req.query.ids }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/note/noteQuery.ts
+++ b/backend/src/api/note/noteQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new NoteService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Notes Advanced Filter', { ...payload }, { ...req })
+    track('Notes Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/note/noteUpdate.ts
+++ b/backend/src/api/note/noteUpdate.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
 
   const payload = await new NoteService(req).update(req.params.id, req.body)
 
-  track('Note Updated', { id: payload.id }, { ...req })
+  track('Note Updated', { id: payload.id, data: req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationCreate.ts
+++ b/backend/src/api/organization/organizationCreate.ts
@@ -23,7 +23,7 @@ export default async (req, res) => {
 
   const payload = await new OrganizationService(req).createOrUpdate(req.body)
 
-  track('Organization Manually Created', { ...payload }, { ...req })
+  track('Organization Manually Created', { ...req.body }, { ...req })
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/organization/organizationNotMerge.ts
+++ b/backend/src/api/organization/organizationNotMerge.ts
@@ -10,7 +10,14 @@ export default async (req, res) => {
     req.body.organizationToNotMerge,
   )
 
-  track('Ignore merge organizations', {}, { ...req })
+  track(
+    'Ignore merge organizations',
+    {
+      organizationId: req.params.organizationId,
+      organizationToNotMergeId: req.body.organizationToNotMerge,
+    },
+    { ...req },
+  )
 
   await req.responseHandler.success(req, res, { status: 200 })
 }

--- a/backend/src/api/organization/organizationQuery.ts
+++ b/backend/src/api/organization/organizationQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new OrganizationService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Organizations Advanced Filter', { ...payload }, { ...req })
+    track('Organizations Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/report/reportQuery.ts
+++ b/backend/src/api/report/reportQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new ReportService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Reports Advanced Filter', { ...payload }, { ...req })
+    track('Reports Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/tag/tagQuery.ts
+++ b/backend/src/api/tag/tagQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new TagService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Tags Advanced Filter', { ...payload }, { ...req })
+    track('Tags Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/task/taskQuery.ts
+++ b/backend/src/api/task/taskQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new TaskService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Tasks Advanced Filter', { ...payload }, { ...req })
+    track('Tasks Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/widget/widgetQuery.ts
+++ b/backend/src/api/widget/widgetQuery.ts
@@ -24,7 +24,7 @@ export default async (req, res) => {
   const payload = await new WidgetService(req).query(req.body)
 
   if (req.body?.filter && Object.keys(req.body.filter).length > 0) {
-    track('Widgets Advanced Filter', { ...payload }, { ...req })
+    track('Widgets Advanced Filter', { ...req.body }, { ...req })
   }
 
   await req.responseHandler.success(req, res, payload)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a810dde</samp>

This pull request modifies the `track` function calls in various API files to pass different arguments that capture more relevant data for the analytics and reporting of the user actions. The main goal is to send the original or filter data that was used by the user, rather than the transformed or result data that was returned by the services. This change affects the files related to activity, automation, conversation, custom view, eagle eye content, integration, member, microservice, note, and organization.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a810dde</samp>

> _`track` function changed_
> _To capture user input_
> _Analytics blossom_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a810dde</samp>

*  Pass original request data instead of transformed response data to track function for analytics and reporting purposes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-2fe5bd179374ff5339c393d85c541db3b4f65d7247c9ac343378a8570302555dL26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-69baa13cc6cce5a195a561a5bf1d7f15a4dad52a4ccc69006ccfb2338142f176L27-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-b043b738110f8dac5ccd9185358ea0d36aa01cd69b95071aa6a312a61f5af35bL26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-6bec3f40f15278fd16918cd647c702eba29783fbaf6c7ab557337c3ba51df976L25-R29), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-71296755602169c6b493f3b24c0087f6dd6e3414ffbe1bd09341a6e078b04177L26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-00b246c93e2d97d166a951c226cdec0823a8fbce8fb32b0e0507ed79d7998224L26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-3c6bea5e33132d64b6f9d0ef60df1e8e019965c84c84d5833467aca647f9dcc8L26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-28bc733770d4c30cabcc5b0e45db0bdee832ff6b30885a0e6ec090bf7da8cddeL26-R26))
*  Pass request query or body data as filter criteria to track function for analytics and reporting purposes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-c83af5383470b0fac0e4397d04a475f7d204341bb81461247ab2756742be6f34L27-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-ff508864ab94848280100c6e8b022781d37bbdae0a631ed3ffd3414fadd58d4eL28-R28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-9b61e3e8b452cdf777c2ce94e84ecea06732d894c8e5c612f06b206a2565fc12L27-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-dd567fedd955c2d6035202e3730a9358747eb368e1338c04805b82c1945aa4ddL27-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-b9064e7445da35453d5a7b8642d171967ff7f6bbad2b499e56c75e0ae6e2a373L46-R46), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-6e4483c1010eb24f95bae41c737d46529a248e52481562464f4c46440fbfdf19L27-R27), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-5033cbd647af20e768ba3ae5ae44b702ebaf0c4a7e47c4370a0e883f2680e27dL27-R27))
*  Pass object with relevant ids and data to track function for analytics and reporting purposes ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-909df190acc06de5b6e8b9ec376658d29ee455ad8f35c3afad3ea7fb4ac96d8dL11-R15), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-0afd8ba6ee0e2d19b73203c9609bd8328b25ea31dcbf9adabcc666708e4e8fa9L13-R17), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-865299939e2102aae728940437d91e92d3bcf60a01834dd7bb4ee3107955ff88L26-R26), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-8ff6b67d888884d0441dcc7e7d578c6741ddf57039bfbe386126e83a68530897L27-R27))
*  Pass empty object to track function for security and performance reasons in `eagleEyeContentSearch.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1928/files?diff=unified&w=0#diff-f7f43e26cac0e61c2edf39c749271c3d5a2314652fd14c63f9af8cc7d9332586L10-R10))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
