### PR TITLE
Add segmentId parameter to updateParentIds method

### DIFF
--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -73,6 +73,7 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
 
   private async updateParentIds(
     tenantId: string,
+    segmentId: string,
     id: string,
     data: IDbActivityCreateData | IDbActivityUpdateData,
   ): Promise<void> {
@@ -81,10 +82,12 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
         `
         update activities set "parentId" = $(id)
         where "tenantId" = $(tenantId) and "sourceParentId" = $(sourceId)
+        and "segmentId" = $(segmentId)
       `,
         {
           id,
           tenantId,
+          segmentId,
           sourceId: data.sourceId,
         },
       ),
@@ -94,12 +97,13 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
       promises.push(
         this.db().none(
           `
-          update activities set "parentId" = (select id from activities where "tenantId" = $(tenantId) and "sourceId" = $(sourceParentId) and "deletedAt" IS NULL limit 1)
-          where "id" = $(id) and "tenantId" = $(tenantId)
+          update activities set "parentId" = (select id from activities where "tenantId" = $(tenantId) and "sourceId" = $(sourceParentId) and  "segmentId" = $(segmentId) and "deletedAt" IS NULL limit 1)
+          where "id" = $(id) and "tenantId" = $(tenantId) and "segmentId" = $(segmentId)
           `,
           {
             id,
             tenantId,
+            segmentId,
             sourceParentId: data.sourceParentId,
           },
         ),
@@ -124,7 +128,7 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
 
     await this.db().none(query)
 
-    await this.updateParentIds(tenantId, id, data)
+    await this.updateParentIds(tenantId, segmentId, id, data)
 
     return id
   }
@@ -152,6 +156,6 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
 
     this.checkUpdateRowCount(result.rowCount, 1)
 
-    await this.updateParentIds(tenantId, id, data)
+    await this.updateParentIds(tenantId, segmentId, id, data)
   }
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 087c818</samp>

Added support for segmenting activities by tenant in `ActivityRepo`. Updated queries to use `segmentId` in `activity.repo.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 087c818</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A subtle scheme to segment the activities by tenant,_
> _Adding `segmentId` to the `ActivityRepo` methods,_
> _And altering the queries with cunning and prudence._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 087c818</samp>

*  Add `segmentId` parameter to `create` and `updateParentIds` methods of `ActivityRepo` class to identify and maintain activity segments ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aR76), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL84-R90), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL97-R106), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL127-R131), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL155-R159))
*  Modify `update activities` queries in `updateParentIds` method to include `segmentId` in where clauses and values to ensure parent-child relationship within segments ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL84-R90), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1931/files?diff=unified&w=0#diff-d1c9016c149d43206c4b82a277d3636774b217990b155c85482c64977673341aL97-R106))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
