### PR TITLE
Fix member attribute default settings

### DIFF
--- a/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
@@ -22,18 +22,6 @@ export default class MemberAttributeService extends LoggerBase {
     }
 
     for (const attributeName of Object.keys(attributes)) {
-      if (typeof attributes[attributeName] === 'string') {
-        try {
-          attributes[attributeName] = JSON.parse(attributes[attributeName] as string)
-        } catch (error) {
-          this.log.error('Failed to parse attribute value', {
-            attributeName,
-            attributeValue: attributes[attributeName],
-          })
-          throw error
-        }
-      }
-
       const highestPriorityPlatform =
         MemberAttributeService.getHighestPriorityPlatformForAttributes(
           Object.keys(attributes[attributeName]),
@@ -83,8 +71,16 @@ export default class MemberAttributeService extends LoggerBase {
         continue
       }
       if (typeof attributes[attributeName] !== 'object') {
-        attributes[attributeName] = {
-          custom: attributes[attributeName],
+        try {
+          attributes[attributeName] = JSON.parse(attributes[attributeName] as string)
+        } catch (error) {
+          this.log.error('Failed to parse attribute value', {
+            attributeName,
+            attributeValue: attributes[attributeName],
+          })
+          attributes[attributeName] = {
+            custom: attributes[attributeName],
+          }
         }
       }
 

--- a/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
@@ -30,6 +30,7 @@ export default class MemberAttributeService extends LoggerBase {
             attributeName,
             attributeValue: attributes[attributeName],
           })
+          throw error
         }
       }
 

--- a/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
@@ -78,6 +78,8 @@ export default class MemberAttributeService extends LoggerBase {
             attributeName,
             attributeValue: attributes[attributeName],
           })
+
+          // if we can't parse the value, probably it is a custom attribute
           attributes[attributeName] = {
             custom: attributes[attributeName],
           }

--- a/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
+++ b/services/apps/data_sink_worker/src/service/memberAttribute.service.ts
@@ -22,6 +22,17 @@ export default class MemberAttributeService extends LoggerBase {
     }
 
     for (const attributeName of Object.keys(attributes)) {
+      if (typeof attributes[attributeName] === 'string') {
+        try {
+          attributes[attributeName] = JSON.parse(attributes[attributeName] as string)
+        } catch (error) {
+          this.log.error('Failed to parse attribute value', {
+            attributeName,
+            attributeValue: attributes[attributeName],
+          })
+        }
+      }
+
       const highestPriorityPlatform =
         MemberAttributeService.getHighestPriorityPlatformForAttributes(
           Object.keys(attributes[attributeName]),


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4d1f468</samp>

Handle JSON string values for member attributes in data sink worker. Add parsing logic and error logging to `memberAttribute.service.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4d1f468</samp>

> _`value` is a string_
> _try to parse as JSON object_
> _log error in fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4d1f468</samp>

*  Add a condition to parse attribute values as JSON if they are strings ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1932/files?diff=unified&w=0#diff-6828f1aad25bb20986fb042b53a1ff112a0757880a36607870f26f85c79cb7b2R25-R35))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
