### PR TITLE
Improve org merge suggestions query

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1467,7 +1467,6 @@ class OrganizationRepository {
         FROM organizations org
         JOIN "organizationToMerge" otm ON org.id = otm."organizationId"
         JOIN "organizationSegments" os ON os."organizationId" = org.id
-        JOIN "organizationSegments" to_merge_segments on to_merge_segments."organizationId" = otm."toMergeId"
         LEFT JOIN "mergeActions" ma
           ON ma.type = :mergeActionType
           AND ma."tenantId" = :tenantId
@@ -1477,7 +1476,6 @@ class OrganizationRepository {
           )
         WHERE org."tenantId" = :tenantId
           AND os."segmentId" IN (:segmentIds)
-          AND to_merge_segments."segmentId" IN (:segmentIds)
           AND (ma.id IS NULL OR ma.state = :mergeActionStatus)
       ),
       

--- a/backend/src/middlewares/authMiddleware.ts
+++ b/backend/src/middlewares/authMiddleware.ts
@@ -38,6 +38,7 @@ export async function authMiddleware(req, res, next) {
 
     next()
   } catch (error) {
+    req.log.error(error, 'Error while finding user')
     await req.responseHandler.error(req, res, new Error401())
   }
 }


### PR DESCRIPTION
- Log auth errors
- Improve performance of org merge suggestions query
    - We don't need the second join on `organizationSegments`
    - Organizations from a segment can anyway be merged with orgs from other
      unrelated segments