### PR TITLE
init temporal search attribute

### DIFF
--- a/scripts/scaffold/temporal/Dockerfile
+++ b/scripts/scaffold/temporal/Dockerfile
@@ -7,4 +7,6 @@ ENV PATH /root/.temporalio/bin:$PATH
 
 EXPOSE 7233 8233
 
-ENTRYPOINT ["temporal", "server", "start-dev", "--ip", "0.0.0.0"]
+COPY ./entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/scripts/scaffold/temporal/entrypoint.sh
+++ b/scripts/scaffold/temporal/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+temporal server start-dev --ip 0.0.0.0 &
+
+# Function to check if Temporal is ready
+check_temporal_ready() {
+    # Execute the Temporal health check command
+    temporal operator cluster health
+
+    # Return the exit status of the health check command
+    return $?
+}
+
+# Wait for Temporal server to be ready
+echo "Waiting for Temporal server to be ready..."
+until check_temporal_ready; do
+    printf '.'
+    sleep 1
+done
+echo "Temporal server is ready."
+
+# Run Temporal setup command
+temporal operator search-attribute create --name TenantId --type Text --namespace default
+
+# Keep the container running after setup
+# (This could be tailing logs or just a sleep loop)
+tail -f /dev/null


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e56695</samp>

Added a custom entrypoint script for the Temporal service to enable a custom search attribute. Modified the Dockerfile to copy and use the script.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e56695</samp>

> _`Dockerfile` changed_
> _Copy and run `entrypoint.sh`_
> _Spring search attribute_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7e56695</samp>

* Copy and use custom entrypoint script for Temporal service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1943/files?diff=unified&w=0#diff-7f8cbbd355f6c4cd5656d2d8adc45f48ab5c8d1804356887e9b0dfa97dc27c4aL10-R12), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1943/files?diff=unified&w=0#diff-7fd5034a42c83504d5f88f4a689577f0d2ebf19373135a68af42025b308310d1R1-R27))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
