### PR TITLE
Bugfix/manual org changes overridden by enrichment c 2903

### DIFF
--- a/backend/src/api/organization/organizationUpdate.ts
+++ b/backend/src/api/organization/organizationUpdate.ts
@@ -21,7 +21,13 @@ import PermissionChecker from '../../services/user/permissionChecker'
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.organizationEdit)
 
-  const payload = await new OrganizationService(req).update(req.params.id, req.body, true)
+  const payload = await new OrganizationService(req).update(
+    req.params.id,
+    req.body,
+    true,
+    true,
+    true,
+  )
 
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/database/migrations/U1702035391__track-manual-org-changes.sql
+++ b/backend/src/database/migrations/U1702035391__track-manual-org-changes.sql
@@ -1,2 +1,2 @@
 alter table organizations
-    drop column "manuallyChanged";
+    drop column "manuallyChangedFields";

--- a/backend/src/database/migrations/U1702035391__track-manual-org-changes.sql
+++ b/backend/src/database/migrations/U1702035391__track-manual-org-changes.sql
@@ -1,0 +1,2 @@
+alter table organizations
+    drop column "manuallyChanged";

--- a/backend/src/database/migrations/V1702035391__track-manual-org-changes.sql
+++ b/backend/src/database/migrations/V1702035391__track-manual-org-changes.sql
@@ -1,2 +1,2 @@
 alter table organizations
-    add column "manuallyChanged" text[] null;
+    add column "manuallyChangedFields" text[] null;

--- a/backend/src/database/migrations/V1702035391__track-manual-org-changes.sql
+++ b/backend/src/database/migrations/V1702035391__track-manual-org-changes.sql
@@ -1,0 +1,2 @@
+alter table organizations
+    add column "manuallyChanged" text[] null;

--- a/backend/src/database/models/organization.ts
+++ b/backend/src/database/models/organization.ts
@@ -221,6 +221,11 @@ export default (sequelize) => {
         type: DataTypes.JSONB,
         allowNull: true,
       },
+      manuallyChanged: {
+        type: DataTypes.ARRAY(DataTypes.TEXT),
+        allowNull: true,
+        default: [],
+      },
     },
     {
       indexes: [

--- a/backend/src/database/models/organization.ts
+++ b/backend/src/database/models/organization.ts
@@ -221,7 +221,7 @@ export default (sequelize) => {
         type: DataTypes.JSONB,
         allowNull: true,
       },
-      manuallyChanged: {
+      manuallyChangedFields: {
         type: DataTypes.ARRAY(DataTypes.TEXT),
         allowNull: true,
         default: [],

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -1235,7 +1235,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
-        manuallyChangedFields: null,
+        manuallyChangedFields: [],
       }
 
       expect(organizationUpdated).toStrictEqual(organizationExpected)

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -227,7 +227,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       }
       expect(organizationCreated).toStrictEqual(expectedOrganizationCreated)
     })
@@ -308,7 +308,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       }
       expect(organizationCreated).toStrictEqual(expectedOrganizationCreated)
 
@@ -366,7 +366,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       }
       const organizationById = await OrganizationRepository.findById(
         organizationCreated.id,
@@ -1235,7 +1235,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       }
 
       expect(organizationUpdated).toStrictEqual(organizationExpected)

--- a/backend/src/database/repositories/__tests__/organizationRepository.test.ts
+++ b/backend/src/database/repositories/__tests__/organizationRepository.test.ts
@@ -227,6 +227,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
+        manuallyChanged: null,
       }
       expect(organizationCreated).toStrictEqual(expectedOrganizationCreated)
     })
@@ -307,6 +308,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
+        manuallyChanged: null,
       }
       expect(organizationCreated).toStrictEqual(expectedOrganizationCreated)
 
@@ -364,6 +366,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
+        manuallyChanged: null,
       }
       const organizationById = await OrganizationRepository.findById(
         organizationCreated.id,
@@ -1232,6 +1235,7 @@ describe('OrganizationRepository tests', () => {
         isTeamOrganization: false,
         attributes: {},
         weakIdentities: [],
+        manuallyChanged: null,
       }
 
       expect(organizationUpdated).toStrictEqual(organizationExpected)

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -606,15 +606,19 @@ class OrganizationRepository {
 
         // only check fields that are in the data object that will be updated
         if (column in data) {
-          if (record[column] !== null && (data[column] === null || data[column] === undefined)) {
-            // column was removed in the update -> will be set to null
+          if (
+            record[column] !== null &&
+            column in data &&
+            (data[column] === null || data[column] === undefined)
+          ) {
+            // column was removed in the update -> will be set to null by sequelize
             changed = true
           } else if (
             record[column] === null &&
             data[column] !== null &&
             data[column] !== undefined
           ) {
-            // column was null before now it's not
+            // column was null before now it's not anymore
             changed = true
           } else if (record[column] !== data[column]) {
             // column value has changed

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -593,7 +593,7 @@ describe('MemberService tests', () => {
         grossDeparturesByMonth: null,
         ultimateParent: null,
         immediateParent: null,
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       })
     })
 
@@ -687,7 +687,7 @@ describe('MemberService tests', () => {
         grossDeparturesByMonth: null,
         ultimateParent: null,
         immediateParent: null,
-        manuallyChanged: null,
+        manuallyChangedFields: null,
       })
     })
 
@@ -740,7 +740,7 @@ describe('MemberService tests', () => {
         emails: null,
         phoneNumbers: null,
         logo: null,
-        manuallyChanged: null,
+        manuallyChangedFields: null,
         memberOrganizations: {
           dateEnd: null,
           dateStart: null,

--- a/backend/src/services/__tests__/memberService.test.ts
+++ b/backend/src/services/__tests__/memberService.test.ts
@@ -593,6 +593,7 @@ describe('MemberService tests', () => {
         grossDeparturesByMonth: null,
         ultimateParent: null,
         immediateParent: null,
+        manuallyChanged: null,
       })
     })
 
@@ -686,6 +687,7 @@ describe('MemberService tests', () => {
         grossDeparturesByMonth: null,
         ultimateParent: null,
         immediateParent: null,
+        manuallyChanged: null,
       })
     })
 
@@ -738,6 +740,7 @@ describe('MemberService tests', () => {
         emails: null,
         phoneNumbers: null,
         logo: null,
+        manuallyChanged: null,
         memberOrganizations: {
           dateEnd: null,
           dateStart: null,

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -604,7 +604,13 @@ export default class OrganizationService extends LoggerBase {
     return OrganizationRepository.findOrganizationsWithMergeSuggestions(args, this.options)
   }
 
-  async update(id, data, overrideIdentities = false, syncToOpensearch = true) {
+  async update(
+    id,
+    data,
+    overrideIdentities = false,
+    syncToOpensearch = true,
+    manualChange = false,
+  ) {
     let tx
 
     try {
@@ -646,7 +652,13 @@ export default class OrganizationService extends LoggerBase {
         }
       }
 
-      const record = await OrganizationRepository.update(id, data, repoOptions, overrideIdentities)
+      const record = await OrganizationRepository.update(
+        id,
+        data,
+        repoOptions,
+        overrideIdentities,
+        manualChange,
+      )
 
       await SequelizeRepository.commitTransaction(tx)
 

--- a/services/apps/data_sink_worker/src/repo/organization.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/organization.repo.ts
@@ -452,7 +452,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
   public async update(id: string, data: Partial<IDbUpdateOrganizationData>): Promise<void> {
     // handle manuallyChanged
     const result = await this.db().oneOrNone(
-      `select id, "manuallyChanged" from organizations where id = $(id)`,
+      `select id, "manuallyChangedFields" from organizations where id = $(id)`,
       {
         id,
       },
@@ -460,8 +460,8 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
     if (!result) {
       throw new Error(`Organization with id ${id} not found!`)
     }
-    const manuallyChanged = result.manuallyChanged || []
-    for (const column of manuallyChanged) {
+    const manuallyChangedFields = result.manuallyChangedFields || []
+    for (const column of manuallyChangedFields) {
       if (column in data) {
         delete data[column]
       }

--- a/services/apps/data_sink_worker/src/repo/organization.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/organization.repo.ts
@@ -450,6 +450,23 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
   }
 
   public async update(id: string, data: Partial<IDbUpdateOrganizationData>): Promise<void> {
+    // handle manuallyChanged
+    const result = await this.db().oneOrNone(
+      `select id, "manuallyChanged" from organizations where id = $(id)`,
+      {
+        id,
+      },
+    )
+    if (!result) {
+      throw new Error(`Organization with id ${id} not found!`)
+    }
+    const manuallyChanged = result.manuallyChanged || []
+    for (const column of manuallyChanged) {
+      if (column in data) {
+        delete data[column]
+      }
+    }
+
     const keys = Object.keys(data)
     keys.push('updatedAt')
     // construct dynamic column set
@@ -458,6 +475,7 @@ export class OrganizationRepository extends RepositoryBase<OrganizationRepositor
         table: 'organizations',
       },
     })
+
     const updatedAt = new Date()
     const oneMinuteAgo = new Date(updatedAt.getTime() - 60 * 1000)
     const prepared = RepositoryBase.prepare(


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 474e1f8</samp>

This pull request implements a feature that allows users to manually edit organization data and track which fields have been changed. It adds a `manuallyChanged` attribute to the `Organization` model and the corresponding column to the `organizations` table in the database. It also updates the `OrganizationRepository` and `OrganizationService` classes and their tests to handle the new attribute and parameter. It modifies the `organizationUpdate` API method to accept additional parameters for manual changes. It includes two migration files to drop and add the `manuallyChanged` column.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 474e1f8</samp>

> _`update` method changed_
> _manual edits now tracked_
> _autumn migration_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 474e1f8</samp>

*  Add `manualChange` parameter to `OrganizationService.update` method to indicate whether the update is a manual change by the user or not ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-8a0b0b78667ca555dff0dfc355cfdb824a6564b56a5f119dde99feb34a568ce3L24-R30), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L607-R613), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L649-R661))
*  Modify `OrganizationRepository.update` method to handle the `manualChange` parameter and update the `manuallyChanged` attribute of the organization data accordingly ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL544-R634))
*  Add logic to `OrganizationRepository.update` method in `data_sink_worker` service to avoid overriding the fields that have been manually changed by the user ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853R453-R469), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853R478))
*  Replace the boolean `manuallyChanged` column in the `organizations` table with a text array column that stores the names of the fields that have been manually changed ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-9c5981227e09ab0ff14b25df46b49448db22808442d087293d269d5c2cd5b0efR1-R2), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-31a1eebc20ef76939fedc33d5223e5b1f95b2753e5989a5a3b10356bdd1b4ddeR1-R2))
*  Add the `manuallyChanged` attribute to the `Organization` model and the expected data in the test files ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-0532bedbaaab427bd1bee309432ab2d6ffae937793159b9d627b69e7feb94ac9R224-R228), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-e69ca09ed275be6a10b0299769fb625ba2c67299e0474e733b854c52b5569cbbR230), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-e69ca09ed275be6a10b0299769fb625ba2c67299e0474e733b854c52b5569cbbR311), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-e69ca09ed275be6a10b0299769fb625ba2c67299e0474e733b854c52b5569cbbR369), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-e69ca09ed275be6a10b0299769fb625ba2c67299e0474e733b854c52b5569cbbR1238), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-943ab6a52e8cbbfb336193ae971cefd732d6b86479d5146d864add1116161ac7R596), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-943ab6a52e8cbbfb336193ae971cefd732d6b86479d5146d864add1116161ac7R690), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-943ab6a52e8cbbfb336193ae971cefd732d6b86479d5146d864add1116161ac7R743))
*  Extract the `ORGANIZATION_UPDATE_COLUMNS` constant from the `OrganizationRepository.update` method and use it in both the `backend` and the `data_sink_worker` services ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-a52bcdecd97974bf17c43be28a61e4aeb39bfc9b38ff85ef4f9769279499b7ccL520-R577), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1944/files?diff=unified&w=0#diff-0621b348107cb770a4e97ac97eb6175f528e248853cd64ce4cb489fa07122853R478))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
