### PR TITLE
Support incident status in public status endpoint

### DIFF
--- a/frontend/src/modules/layout/components/system-status/system-status.vue
+++ b/frontend/src/modules/layout/components/system-status/system-status.vue
@@ -73,6 +73,10 @@ const StatusDisplay = {
     label: 'Under Maintenance',
     color: 'bg-gray-500',
   },
+  [Status.Incident]: {
+    label: 'Incident',
+    color: 'bg-yellow-500',
+  },
 } as const;
 
 const label = computed(() => {

--- a/frontend/src/modules/layout/types/SystemStatus.ts
+++ b/frontend/src/modules/layout/types/SystemStatus.ts
@@ -5,4 +5,5 @@ export enum Status {
   MajorOutage = 'major_outage',
   UnderMaintenance = 'under_maintenance', // currently not in use
   Unknown = 'unknown',
+  Incident = 'incident',
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1ce0d2</samp>

This pull request adds a new 'Incident' status option for the `system-status` component, which shows the current status of the crowd.dev platform. The new option is defined in the `Status` enum type and has a yellow background color.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1ce0d2</samp>

> _`Status` has new value_
> _`Incident` shows platform trouble_
> _Yellow warns of fall_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b1ce0d2</samp>

*  Add a new status option for the system status component to indicate an ongoing incident affecting the platform ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1945/files?diff=unified&w=0#diff-5de1fc72df18bea7998601f3fac6eb281fae3a9d708dccaba9042070b6fc6f78R76-R79), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1945/files?diff=unified&w=0#diff-7c08351d15685f6fbf6eb606e7cb1dbbdc441bbc2c3d79e409538838d07f6230R8))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
