### PR TITLE
Essential free plan cancelation banner

### DIFF
--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -118,6 +118,19 @@
               You can expect major improvements by Tuesday, Aug 15th. 🚧
             </div>
           </banner>
+          <banner
+            v-if="showUpgradeEssentialBanner"
+            variant="info"
+          >
+            <div
+              class="flex items-center justify-center grow text-sm"
+            >
+              crowd.dev's free plan ends on January 1st, 2024. Your access to this workspace will be revoked after.
+              <router-link class="ml-1 font-semibold" :to="{ name: 'settings', query: { activeTab: 'plans' } }">
+                Upgrade workspace
+              </router-link>
+            </div>
+          </banner>
         </div>
         <router-view />
       </el-main>
@@ -168,6 +181,7 @@ export default {
       showIntegrationsNeedReconnectAlert:
         'tenant/showIntegrationsNeedReconnectAlert',
       showOrganizationsAlertBanner: 'tenant/showOrganizationsAlertBanner',
+      showUpgradeEssentialBanner: 'tenant/showUpgradeEssentialBanner',
       showBanner: 'tenant/showBanner',
     }),
 

--- a/frontend/src/modules/layout/components/layout.vue
+++ b/frontend/src/modules/layout/components/layout.vue
@@ -120,14 +120,22 @@
           </banner>
           <banner
             v-if="showUpgradeEssentialBanner"
-            variant="info"
+            variant="alert"
           >
             <div
               class="flex items-center justify-center grow text-sm"
             >
-              crowd.dev's free plan ends on January 1st, 2024. Your access to this workspace will be revoked after.
-              <router-link class="ml-1 font-semibold" :to="{ name: 'settings', query: { activeTab: 'plans' } }">
-                Upgrade workspace
+              <p>
+                crowd.dev's free plan ends on <span class="font-semibold"> January 1st, 2024</span>.
+                Your access to this workspace will be revoked after.
+              </p>
+              <router-link :to="{ name: 'settings', query: { activeTab: 'plans' } }">
+                <el-button
+                  class="btn btn--sm btn--primary ml-4"
+                  :loading="loading"
+                >
+                  Upgrade workspace
+                </el-button>
               </router-link>
             </div>
           </banner>

--- a/frontend/src/modules/tenant/store/getters.js
+++ b/frontend/src/modules/tenant/store/getters.js
@@ -1,6 +1,7 @@
 import sharedGetters from '@/shared/store/getters';
 import { router } from '@/router';
 import moment from 'moment';
+import Plans from '@/security/plans';
 
 export default {
   ...sharedGetters(),
@@ -75,6 +76,18 @@ export default {
     return today.isSameOrBefore(limit, 'day');
   },
 
+  showUpgradeEssentialBanner: (
+    _state,
+    _getters,
+    _rootState,
+    rootGetters,
+  ) => {
+    const today = moment();
+    const limit = moment('2024-01-01').startOf('day');
+    const currentTenant = rootGetters['auth/currentTenant'];
+    return currentTenant.plan === Plans.values.essential && today.isBefore(limit);
+  },
+
   showBanner: (_state, getters) => (
     getters.showSampleDataAlert
       || getters.showIntegrationsErrorAlert
@@ -82,6 +95,7 @@ export default {
       || getters.showIntegrationsInProgressAlert
       || getters.showIntegrationsNeedReconnectAlert
       || getters.showOrganizationsAlertBanner
+      || getters.showUpgradeEssentialBanner
   ),
 
   limit: () => 40,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f6fda4</samp>

This pull request adds a new banner component to the frontend layout that encourages free and essential plan users to upgrade their workspace. It also adds a new Vuex getter to determine when to show the banner based on the plan and the expiration date.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f6fda4</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A banner bright and bold, to urge the free and frugal_
> _To upgrade their workspace, lest they lose their precious data_
> _And wander in the dark, like the shades of Erebus._

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5f6fda4</samp>

*  Add a banner component to the main layout template to inform free plan users of the upcoming end of the plan ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1950/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR121-R141), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1950/files?diff=unified&w=0#diff-d5286b5ea2e5319ce6019ee31bac75b95d2c6c188cd2d9fda171e5cd009d0f0bR192))
*  Import the Plans module to the tenant module getters to access the plan constants and values ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1950/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eR4))
*  Define a new getter `showUpgradeEssentialBanner` in the tenant module to check the current tenant's plan and date against the limit date of January 1st, 2024 ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1950/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eR79-R90))
*  Include the `showUpgradeEssentialBanner` getter in the `showBanner` getter logic to conditionally render the banner component in the `layout.vue` file ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1950/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eR98))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
