### PR TITLE
Trigger checks for paid Discord integrations

### DIFF
--- a/backend/src/database/repositories/integrationRepository.ts
+++ b/backend/src/database/repositories/integrationRepository.ts
@@ -258,6 +258,13 @@ class IntegrationRepository {
         status: 'done',
         platform,
       },
+      include: [
+        {
+          model: options.database.tenant,
+          as: 'tenant',
+          required: true,
+        },
+      ],
       limit: perPage,
       offset: (page - 1) * perPage,
       order: [['id', 'ASC']],

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -6,7 +6,7 @@ import {
   IntegrationStreamWorkerEmitter,
   DataSinkWorkerEmitter,
 } from '@crowd/sqs'
-import { IntegrationRunState, IntegrationType , TenantPlans } from '@crowd/types'
+import { IntegrationRunState, IntegrationType, TenantPlans } from '@crowd/types'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import MicroserviceRepository from '@/database/repositories/microserviceRepository'
 import IntegrationRepository from '@/database/repositories/integrationRepository'
@@ -213,8 +213,21 @@ export class IntegrationTickProcessor extends LoggerBase {
                 const chunkIndex = Math.min(Math.floor(rand), CHUNKS - 1)
                 const delay = chunkIndex * DELAY_BETWEEN_CHUNKS
 
+                if (
+                  newIntService.type === IntegrationType.DISCORD &&
+                  integration.tenant.plan === TenantPlans.Essential
+                ) {
+                  // not triggering discord integrations for essential plan, only paid plans
+                  logger.info(
+                    { integrationId: integration.id },
+                    'Not triggering new integration check for Discord for essential plan!',
+                  )
+                  // eslint-disable-next-line no-continue
+                  continue
+                }
+
                 // Divide integrations into chunks for Discord
-                if (newIntService.type === IntegrationType.DISCORD && integration.tenant.plan !== TenantPlans.Essential) {
+                if (newIntService.type === IntegrationType.DISCORD) {
                   setTimeout(async () => {
                     logger.info(
                       { integrationId: integration.id },

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -6,7 +6,7 @@ import {
   IntegrationStreamWorkerEmitter,
   DataSinkWorkerEmitter,
 } from '@crowd/sqs'
-import { IntegrationRunState, IntegrationType } from '@crowd/types'
+import { IntegrationRunState, IntegrationType , TenantPlans } from '@crowd/types'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import MicroserviceRepository from '@/database/repositories/microserviceRepository'
 import IntegrationRepository from '@/database/repositories/integrationRepository'
@@ -214,7 +214,7 @@ export class IntegrationTickProcessor extends LoggerBase {
                 const delay = chunkIndex * DELAY_BETWEEN_CHUNKS
 
                 // Divide integrations into chunks for Discord
-                if (newIntService.type === IntegrationType.DISCORD) {
+                if (newIntService.type === IntegrationType.DISCORD && integration.tenant.plan !== TenantPlans.Essential) {
                   setTimeout(async () => {
                     logger.info(
                       { integrationId: integration.id },

--- a/services/libs/integrations/src/integrations/discord/index.ts
+++ b/services/libs/integrations/src/integrations/discord/index.ts
@@ -9,6 +9,7 @@ import processWebhookStream from './processWebhookStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.DISCORD,
   memberAttributes: DISCORD_MEMBER_ATTRIBUTES,
+  checkEvery: 3 * 60,
   generateStreams,
   processStream,
   processData,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a84d</samp>

This pull request implements a premium feature for Discord integrations, which are checked every 3 minutes by the `IntegrationTickProcessor` class. It modifies the `integrationRepository` and the `discord` module to access and use the tenant's plan information.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a84d</samp>

> _`IntegrationTickProcessor` is the master of your fate_
> _It checks your plan and joins your models with `include`_
> _You want to use Discord but you have to pay the price_
> _Only premium tenants can unleash the power of `descriptor`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at a06a84d</samp>

*  Limit Discord integrations to premium plans by:
  - Adding `include` option to `IntegrationRepository` to join `tenant` model ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1951/files?diff=unified&w=0#diff-5b1c50661ca3f395a4ec888993b46eadd35b277a777e88e0e81e1f88461124a3R261-R267))
  - Importing `TenantPlans` enum from `@crowd/types` package ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1951/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L9-R9))
  - Adding condition to `IntegrationTickProcessor` to check integration type and tenant plan ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1951/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L217-R217))
* Set check interval for Discord integrations to 3 minutes by adding `checkEvery` property to `descriptor` object in `integrations/discord/index.ts` ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1951/files?diff=unified&w=0#diff-32a69dfcf219006b886b7a3583b9cd4f40d55372f2688f2655cbc4dab5c44ebdR12))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
