### PR TITLE
Improvement/test member enrichment with logs

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -421,7 +421,7 @@ class MemberRepository {
 
       const query = `
         INSERT INTO "memberToMerge" ("memberId", "toMergeId", "similarity", "createdAt", "updatedAt")
-        VALUES ${placeholders.join(', ')};
+        VALUES ${placeholders.join(', ')} on conflict do nothing;
       `
       try {
         await seq.query(query, {

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -384,7 +384,12 @@ export default class MemberEnrichmentService extends LoggerBase {
         }
       }
 
-      await searchSyncService.triggerMemberSync(this.options.currentTenant.id, result.id)
+      try {
+        await searchSyncService.triggerMemberSync(this.options.currentTenant.id, result.id)
+      }
+      catch(error) {
+        this.log.error(error, 'Failed to sync member')
+      }
 
       result = await memberService.findById(result.id, true, false)
       await SequelizeRepository.commitTransaction(transaction)

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -384,12 +384,7 @@ export default class MemberEnrichmentService extends LoggerBase {
         }
       }
 
-      try {
-        await searchSyncService.triggerMemberSync(this.options.currentTenant.id, result.id)
-      }
-      catch(error) {
-        this.log.error(error, 'Failed to sync member')
-      }
+      await searchSyncService.triggerMemberSync(this.options.currentTenant.id, result.id)
 
       result = await memberService.findById(result.id, true, false)
       await SequelizeRepository.commitTransaction(transaction)


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cdee997</samp>

This pull request improves the error handling and logging of the `memberEnrichmentService` and prevents duplicate records in the `memberToMerge` table. These changes enhance the reliability and performance of the premium member profile enrichment feature.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cdee997</samp>

> _We are the members of the merge_
> _We defy the duplicates and the errors_
> _We seek the data from beyond_
> _We enrich our profiles with the secrets_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cdee997</samp>

*  Prevent duplicate records and errors when inserting potential member matches into the `memberToMerge` table by adding `on conflict do nothing` clause to the SQL query ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1953/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL424-R424))
* Handle and log errors that might occur during the synchronization and enrichment of member data with external sources by adding try-catch blocks and log statements to the `memberEnrichmentService` class methods ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1953/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807L387-R391), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1953/files?diff=unified&w=0#diff-b83106cc7e05b9c0cbde32d3e0359c83630c0bb0a2a0257d97ee2a7bbf89f807R397))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
