### PR TITLE
Member find by id timeouts

### DIFF
--- a/backend/src/database/migrations/R__cubejs-materialized-views.sql
+++ b/backend/src/database/migrations/R__cubejs-materialized-views.sql
@@ -30,6 +30,10 @@ SELECT
         WHEN (a.sentiment->>'sentiment')::integer > 66 THEN 'positive'
         ELSE 'neutral'
     END::VARCHAR(8) AS "sentimentMood",
+    CASE 
+        WHEN (a.sentiment ->> 'sentiment'::text) IS NOT NULL THEN (a.sentiment ->> 'sentiment'::text)::double precision
+        ELSE NULL::double precision
+    END AS "sentiment",
     a."organizationId",
     a."segmentId",
     a."conversationId"

--- a/backend/src/database/migrations/R__cubejs-materialized-views.sql
+++ b/backend/src/database/migrations/R__cubejs-materialized-views.sql
@@ -30,10 +30,6 @@ SELECT
         WHEN (a.sentiment->>'sentiment')::integer > 66 THEN 'positive'
         ELSE 'neutral'
     END::VARCHAR(8) AS "sentimentMood",
-    CASE 
-        WHEN (a.sentiment ->> 'sentiment'::text) IS NOT NULL THEN (a.sentiment ->> 'sentiment'::text)::double precision
-        ELSE NULL::double precision
-    END AS "sentiment",
     a."organizationId",
     a."segmentId",
     a."conversationId"

--- a/backend/src/database/migrations/R__cubejs-materialized-views.sql
+++ b/backend/src/database/migrations/R__cubejs-materialized-views.sql
@@ -51,7 +51,6 @@ SELECT
 FROM organizations o
 JOIN "memberOrganizations" mo ON o.id = mo."organizationId"
 JOIN members m ON mo."memberId" = m.id
-JOIN activities a ON o.id = a."organizationId"
 GROUP BY o.id
 ;
 

--- a/backend/src/database/models/index.ts
+++ b/backend/src/database/models/index.ts
@@ -66,7 +66,7 @@ function models(queryTimeoutMilliseconds: number, databaseHostnameOverride = nul
       dialect: DB_CONFIG.dialect,
       dialectOptions: {
         application_name: SERVICE,
-        connectionTimeoutMillis: 5000,
+        connectionTimeoutMillis: 15000,
         query_timeout: queryTimeoutMilliseconds,
         idle_in_transaction_session_timeout: 10000,
       },

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -879,55 +879,43 @@ class MemberRepository {
       tenantId: currentTenant.id,
     }
 
+
+    if (segmentId) {
+      // we load data for a specific segment (can be leaf, parent or grand parent id)
+    
+      const dataFromOpensearch = (await this.findAndCountAllOpensearch({
+        filter: {
+          and: [
+            {
+              id: memberId
+            },
+          ]
+        },
+        limit: 1,
+        offset: 0,
+        segments: [segmentId],
+      }, options)).rows[0]
+
+      return {
+        activeDaysCount: dataFromOpensearch.activeDaysCount,
+        activityCount: dataFromOpensearch.activityCount,
+        activityTypes: dataFromOpensearch.activityTypes,
+        activeOn: dataFromOpensearch.activeOn,
+        averageSentiment: dataFromOpensearch.averageSentiment,
+        lastActive: dataFromOpensearch.lastActive,
+        memberId: dataFromOpensearch.id,
+        segmentId,
+      }
+    }
+
     // query for all leaf segment ids
-    let extraCTEs = `
+    const extraCTEs = `
       leaf_segment_ids AS (
         select id
         from segments
         where "tenantId" = :tenantId and "parentSlug" is not null and "grandparentSlug" is not null
       )
     `
-
-    if (segmentId) {
-      // we load data for a specific segment (can be leaf, parent or grand parent id)
-      replacements.segmentId = segmentId
-      extraCTEs = `
-        input_segment AS (
-          select
-            id,
-            slug,
-            "parentSlug",
-            "grandparentSlug"
-          from segments
-          where id = :segmentId
-            and "tenantId" = :tenantId
-        ),
-        segment_level AS (
-          select
-            case
-              when "parentSlug" is not null and "grandparentSlug" is not null
-                  then 'child'
-              when "parentSlug" is not null and "grandparentSlug" is null
-                  then 'parent'
-              when "parentSlug" is null and "grandparentSlug" is null
-                  then 'grandparent'
-              end as level,
-            id,
-            slug,
-            "parentSlug",
-            "grandparentSlug"
-          from input_segment
-        ),
-        leaf_segment_ids AS (
-          select s.id
-          from segments s
-          join segment_level sl on (sl.level = 'child' and s.id = sl.id)
-              or (sl.level = 'parent' and s."parentSlug" = sl.slug and s."grandparentSlug" is not null)
-              or (sl.level = 'grandparent' and s."grandparentSlug" = sl.slug)
-        )
-      `
-    }
-
     const query = `
       with ${extraCTEs}
         SELECT

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -932,21 +932,14 @@ class MemberRepository {
       with ${extraCTEs}
         SELECT
         a."memberId",
-        a."segmentId",
         count(a.id)::integer AS "activityCount",
         max(a.timestamp) AS "lastActive",
         array_agg(DISTINCT concat(a.platform, ':', a.type)) FILTER (WHERE a.platform IS NOT NULL) AS "activityTypes",
         array_agg(DISTINCT a.platform) FILTER (WHERE a.platform IS NOT NULL) AS "activeOn",
         count(DISTINCT a."timestamp"::date)::integer AS "activeDaysCount",
-        round(avg(
-            CASE WHEN (a.sentiment ->> 'sentiment'::text) IS NOT NULL THEN
-                (a.sentiment ->> 'sentiment'::text)::double precision
-            ELSE
-                NULL::double precision
-            END
-        )::numeric, 2):: float AS "averageSentiment"
+        round(avg(a.sentiment)::numeric, 2):: float AS "averageSentiment"
         FROM leaf_segment_ids lfs
-        join activities a on a."segmentId" = lfs.id
+        join mv_activities_cube a on a."segmentId" = lfs.id
         WHERE a."memberId" = :memberId
         and a."tenantId" = :tenantId
         GROUP BY a."memberId", a."segmentId"

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -942,7 +942,7 @@ class MemberRepository {
         join mv_activities_cube a on a."segmentId" = lfs.id
         WHERE a."memberId" = :memberId
         and a."tenantId" = :tenantId
-        GROUP BY a."memberId", a."segmentId"
+        GROUP BY a."memberId"
     `
 
     const data: ActivityAggregates[] = await seq.query(query, {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -421,7 +421,7 @@ class MemberRepository {
 
       const query = `
         INSERT INTO "memberToMerge" ("memberId", "toMergeId", "similarity", "createdAt", "updatedAt")
-        VALUES ${placeholders.join(', ')};
+        VALUES ${placeholders.join(', ')} ON CONFLICT DO NOTHING;
       `
       try {
         await seq.query(query, {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -899,13 +899,13 @@ class MemberRepository {
       }, options)).rows[0]
 
       return {
-        activeDaysCount: dataFromOpensearch.activeDaysCount,
-        activityCount: dataFromOpensearch.activityCount,
-        activityTypes: dataFromOpensearch.activityTypes,
-        activeOn: dataFromOpensearch.activeOn,
-        averageSentiment: dataFromOpensearch.averageSentiment,
-        lastActive: dataFromOpensearch.lastActive,
-        memberId: dataFromOpensearch.id,
+        activeDaysCount: dataFromOpensearch?.activeDaysCount || 0,
+        activityCount: dataFromOpensearch?.activityCount || 0,
+        activityTypes: dataFromOpensearch?.activityTypes || [],
+        activeOn: dataFromOpensearch?.activeOn || [],
+        averageSentiment: dataFromOpensearch?.averageSentiment || 0,
+        lastActive: dataFromOpensearch?.lastActive || null,
+        memberId,
         segmentId,
       }
     }

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -945,7 +945,7 @@ class MemberRepository {
                 NULL::double precision
             END
         )::numeric, 2):: float AS "averageSentiment"
-        FROM activities a
+        FROM mv_activities_cube a
         join leaf_segment_ids lfs on a."segmentId" = lfs.id
         WHERE a."memberId" = :memberId
         and a."tenantId" = :tenantId

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -887,7 +887,9 @@ class MemberRepository {
         filter: {
           and: [
             {
-              id: memberId
+              id: {
+                eq: memberId
+              }
             },
           ]
         },

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -1,7 +1,7 @@
 import { Error400 } from '@crowd/common'
 import { LoggerBase, logExecutionTime } from '@crowd/logging'
 import { WorkflowIdReusePolicy } from '@crowd/temporal'
-import { FeatureFlag, PlatformType, SyncMode, TemporalWorkflowId, SegmentData } from '@crowd/types'
+import { PlatformType, SyncMode, TemporalWorkflowId, SegmentData } from '@crowd/types'
 import { Blob } from 'buffer'
 import vader from 'crowd-sentiment'
 import { Transaction } from 'sequelize/types'

--- a/backend/src/services/segmentService.ts
+++ b/backend/src/services/segmentService.ts
@@ -189,7 +189,7 @@ export default class SegmentService extends LoggerBase {
   async queryProjectGroups(search: SegmentCriteria) {
     const result = await new SegmentRepository(this.options).queryProjectGroups(search)
 
-    const membersCountPerSegment = await MemberRepository.countMembersPerSegment(this.options)
+    const membersCountPerSegment = await MemberRepository.countMembersPerSegment(this.options, result.rows.map((s) => s.id))
     this.setMembersCount(result.rows, SegmentLevel.PROJECT_GROUP, membersCountPerSegment)
     return result
   }
@@ -457,7 +457,7 @@ export default class SegmentService extends LoggerBase {
       return
     }
 
-    const membersCountPerSegment = await MemberRepository.countMembersPerSegment(this.options)
+    const membersCountPerSegment = await MemberRepository.countMembersPerSegment(this.options, subprojectIds)
     this.setMembersCount(segments, level, membersCountPerSegment)
   }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99db436</samp>

This pull request improves the performance and functionality of the backend database and services, by using OpenSearch queries and materialized views for analytics, handling segment levels and key errors, and increasing the connection timeout. It also adds a new sentiment score column to the `mv_activities_cube` materialized view for better insights.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99db436</samp>

> _Oh we're the brave developers of the web_
> _We write the code that makes the data flow_
> _We tweak the queries and the views_
> _To speed up and improve our `mv_activities_cube`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99db436</samp>

*  Add and simplify sentiment score calculation for activities in `mv_activities_cube` materialized view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-23b6b1fdaba848ef8f3dbda6aa7e46bda8f734bd3471dd12a0aab65f5ea4046cR33-R36), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL941-R935))
*  Remove unnecessary join between `organizations` and `activities` tables in `mv_activities_cube` materialized view ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-23b6b1fdaba848ef8f3dbda6aa7e46bda8f734bd3471dd12a0aab65f5ea4046cL50))
*  Increase database connection timeout from 5000 to 15000 milliseconds ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-9ce5e52d0b259da42e2d77e9dbc11a9bbd7b38df687b9b50abe436fe15d5d734L69-R69))
*  Avoid duplicate key errors when inserting records into `memberToMerge` table ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL424-R424))
*  Use OpenSearch index instead of SQL tables to query and count members for segments and project groups ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL882-R914), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL1657-R1641), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-a34f023851ce907f2939409abc598adcfa809043b381eeb180000ecf4927c003L192-R192), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-a34f023851ce907f2939409abc598adcfa809043b381eeb180000ecf4927c003L460-R460))
*  Handle different segment levels and hierarchies when querying member activity data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL890-R924))
*  Remove unused `countMembersForSegments` method from `MemberRepository` class ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1955/files?diff=unified&w=0#diff-104433e3d1e0684596dd40f3f2c65b83799a74181ad8e7c74fc52560800a46fbL1732-L1750))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
