### PR TITLE
fix query error when checking for delayed results

### DIFF
--- a/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
@@ -2,6 +2,7 @@ import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
 import { IIntegrationResult, IntegrationResultState, TenantPlans } from '@crowd/types'
 import { IDelayedResults, IFailedResultData, IResultData } from './dataSink.data'
+import { distinct } from '@crowd/common'
 
 export default class DataSinkRepository extends RepositoryBase<DataSinkRepository> {
   constructor(dbStore: DbStore, parentLog: Logger) {
@@ -262,18 +263,15 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
     this.ensureTransactional()
 
     try {
-      const results = await this.db().any(
+      const resultData = await this.db().any(
         `
-        select r.id, 
-               r."tenantId", 
-               i.platform, 
-               run.onboarding
-        from 
-          integration.results r
+        select r.id,
+               r."tenantId",
+               i.platform,
+               r."runId"
+        from integration.results r
         inner join integrations i on r."integrationId" = i.id
-        left join integration.runs run on run.id = r."runId"
-        where r.state = $(delayedState)
-          and r."delayedUntil" < now()
+        where r.state = $(delayedState) and r."delayedUntil" < now()
         limit ${limit}
         for update skip locked;
         `,
@@ -282,7 +280,27 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
         },
       )
 
-      return results
+      const runIds = distinct(resultData.map((r) => r.runId))
+      if (runIds.length > 0) {
+        const runInfos = await this.db().any(
+          `
+        select id, onboarding
+        from integration.runs
+        where id in ($(runIds:csv))
+        `,
+          {
+            runIds,
+          },
+        )
+
+        for (const runInfo of runInfos) {
+          for (const result of resultData.filter((r) => r.runId === runInfo.id)) {
+            result.onboarding = runInfo.onboarding
+          }
+        }
+      }
+
+      return resultData
     } catch (err) {
       this.log.error(err, 'Failed to get delayed results!')
       throw err


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 80b7bd9</samp>

Optimizes the data sink worker query for delayed results and onboarding. Reduces the number of columns and rows fetched from the database in `dataSink.repo.ts`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 80b7bd9</samp>

> _To speed up the query and logic_
> _They imported a function `distinct`_
> _They selected less columns_
> _And fetched onboarding_
> _Only for the run ids that linked_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 80b7bd9</samp>

*  Import `distinct` function to get unique run ids from result data ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1956/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2R5))
*  Simplify query to get delayed results by selecting only necessary columns ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1956/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L265-R274))
*  Add logic to get onboarding information for each result by querying integration.runs table with distinct run ids and assigning onboarding value to matching results ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1956/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L285-R303))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
