### PR TITLE
use true for default value for onboarding when runId is null for inte…

### DIFF
--- a/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/dataSink.repo.ts
@@ -2,7 +2,7 @@ import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
 import { IIntegrationResult, IntegrationResultState, TenantPlans } from '@crowd/types'
 import { IDelayedResults, IFailedResultData, IResultData } from './dataSink.data'
-import { distinct } from '@crowd/common'
+import { distinct, singleOrDefault } from '@crowd/common'
 
 export default class DataSinkRepository extends RepositoryBase<DataSinkRepository> {
   constructor(dbStore: DbStore, parentLog: Logger) {
@@ -293,9 +293,12 @@ export default class DataSinkRepository extends RepositoryBase<DataSinkRepositor
           },
         )
 
-        for (const runInfo of runInfos) {
-          for (const result of resultData.filter((r) => r.runId === runInfo.id)) {
+        for (const result of resultData) {
+          const runInfo = singleOrDefault(runInfos, (r) => r.id === result.runId)
+          if (runInfo) {
             result.onboarding = runInfo.onboarding
+          } else {
+            result.onboarding = true
           }
         }
       }


### PR DESCRIPTION
…gration.results row

# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b9518f5</samp>

Refactored `dataSink.repo.ts` to enable filtering and prioritizing integration results by tenant and plan. Added an `onboarding` property to the results model.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b9518f5</samp>

> _To find and process results with ease_
> _We use a helper function, please_
> _It adds `onboarding` too_
> _To filter and prioritize for you_
> _This feature supports different tenants and plans with these_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b9518f5</samp>

*  Simplify and optimize the logic of finding the run info for each result in the data sink repository ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1957/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L5-R5), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1957/files?diff=unified&w=0#diff-f25773a6f91ffe16d0fb0a50cc67da49c54a529c754c94ccdfbcc23a0c1901a2L296-R301))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
