### PR TITLE
Add checks for paid Discord integrations

### DIFF
--- a/backend/src/database/repositories/integrationRepository.ts
+++ b/backend/src/database/repositories/integrationRepository.ts
@@ -258,7 +258,7 @@ class IntegrationRepository {
         status: 'done',
         platform,
       },
-       include: [
+      include: [
         {
           model: options.database.tenant,
           as: 'tenant',

--- a/backend/src/database/repositories/integrationRepository.ts
+++ b/backend/src/database/repositories/integrationRepository.ts
@@ -258,6 +258,13 @@ class IntegrationRepository {
         status: 'done',
         platform,
       },
+       include: [
+        {
+          model: options.database.tenant,
+          as: 'tenant',
+          required: true,
+        },
+      ],
       limit: perPage,
       offset: (page - 1) * perPage,
       order: [['id', 'ASC']],

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -6,7 +6,7 @@ import {
 } from '@crowd/common_services'
 import { INTEGRATION_SERVICES } from '@crowd/integrations'
 import { LoggerBase, getChildLogger } from '@crowd/logging'
-import { IntegrationType } from '@crowd/types'
+import { IntegrationType, TenantPlans } from '@crowd/types'
 import IntegrationRepository from '@/database/repositories/integrationRepository'
 import IntegrationRunRepository from '../../../database/repositories/integrationRunRepository'
 import { IServiceOptions } from '../../../services/IServiceOptions'
@@ -127,6 +127,19 @@ export class IntegrationTickProcessor extends LoggerBase {
             const rand = Math.random() * CHUNKS
             const chunkIndex = Math.min(Math.floor(rand), CHUNKS - 1)
             const delay = chunkIndex * DELAY_BETWEEN_CHUNKS
+
+            if (
+                  newIntService.type === IntegrationType.DISCORD &&
+                  integration.tenant.plan === TenantPlans.Essential
+                ) {
+                  // not triggering discord integrations for essential plan, only paid plans
+                  logger.info(
+                    { integrationId: integration.id },
+                    'Not triggering new integration check for Discord for essential plan!',
+                  )
+                  // eslint-disable-next-line no-continue
+                  continue
+                }
 
             // Divide integrations into chunks for Discord
             if (newIntService.type === IntegrationType.DISCORD) {

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -129,17 +129,17 @@ export class IntegrationTickProcessor extends LoggerBase {
             const delay = chunkIndex * DELAY_BETWEEN_CHUNKS
 
             if (
-                  newIntService.type === IntegrationType.DISCORD &&
-                  integration.tenant.plan === TenantPlans.Essential
-                ) {
-                  // not triggering discord integrations for essential plan, only paid plans
-                  logger.info(
-                    { integrationId: integration.id },
-                    'Not triggering new integration check for Discord for essential plan!',
-                  )
-                  // eslint-disable-next-line no-continue
-                  continue
-                }
+              newIntService.type === IntegrationType.DISCORD &&
+              integration.tenant.plan === TenantPlans.Essential
+            ) {
+              // not triggering discord integrations for essential plan, only paid plans
+              logger.info(
+                { integrationId: integration.id },
+                'Not triggering new integration check for Discord for essential plan!',
+              )
+              // eslint-disable-next-line no-continue
+              continue
+            }
 
             // Divide integrations into chunks for Discord
             if (newIntService.type === IntegrationType.DISCORD) {

--- a/services/libs/integrations/src/integrations/discord/index.ts
+++ b/services/libs/integrations/src/integrations/discord/index.ts
@@ -9,6 +9,7 @@ import processWebhookStream from './processWebhookStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.DISCORD,
   memberAttributes: DISCORD_MEMBER_ATTRIBUTES,
+  checkEvery: 3 * 60, // 3 hours
   generateStreams,
   processStream,
   processData,


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d371739</samp>

This pull request implements a new feature that restricts Discord integrations to paid plans only. It modifies the `integrationTickProcessor` service, the `IntegrationRepository` class, and the `descriptor` object for the Discord integration service to check and filter integrations by the tenant's plan.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d371739</samp>

> _`IntegrationRepository` with the `include` option_
> _Querying the tenants for their plan and their doom_
> _Discord integrations are restricted by the `checkEvery`_
> _Only the worthy can access the power of the `integrationTickProcessor`_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d371739</samp>

*  Add `include` option to `IntegrationRepository` class to query `tenant` model with `integration` model ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1961/files?diff=unified&w=0#diff-5b1c50661ca3f395a4ec888993b46eadd35b277a777e88e0e81e1f88461124a3R261-R267))
  - Importing `TenantPlans` enum from `@crowd/types` in `integrationTickProcessor` service ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1961/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73L9-R9))
  - Skipping Discord integration check if tenant's plan is `Essential` and logging the reason ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1961/files?diff=unified&w=0#diff-f68d85272a419f761c2d72615f7ca55a07315ebd6e91f75973f17dae350f3d73R131-R143))
  - Reducing the check frequency of Discord integration service to 3 hours ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1961/files?diff=unified&w=0#diff-32a69dfcf219006b886b7a3583b9cd4f40d55372f2688f2655cbc4dab5c44ebdR12))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
