### PR TITLE
Fix member copy and banner validation

### DIFF
--- a/frontend/src/modules/member/components/member-enrichment.vue
+++ b/frontend/src/modules/member/components/member-enrichment.vue
@@ -37,7 +37,7 @@
           class="btn btn--primary btn--full !h-8"
           :disabled="isEditLockedForSampleData"
           @click="onEnrichmentClick"
-        >Enrich member</el-button>
+        >Enrich contact</el-button>
         <el-button
           v-else
           class="btn btn--primary btn--full !h-8"

--- a/frontend/src/modules/tenant/store/getters.js
+++ b/frontend/src/modules/tenant/store/getters.js
@@ -2,6 +2,7 @@ import sharedGetters from '@/shared/store/getters';
 import { router } from '@/router';
 import moment from 'moment';
 import Plans from '@/security/plans';
+import config from '@/config';
 
 export default {
   ...sharedGetters(),
@@ -85,7 +86,8 @@ export default {
     const today = moment();
     const limit = moment('2024-01-01').startOf('day');
     const currentTenant = rootGetters['auth/currentTenant'];
-    return currentTenant.plan === Plans.values.essential && today.isBefore(limit);
+
+    return !config.isCommunityVersion && currentTenant.plan === Plans.values.essential && today.isBefore(limit);
   },
 
   showBanner: (_state, getters) => (


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ade7d3b</samp>

Added a feature flag to control the visibility of the `Enrich contact` button based on the plan and the date. Renamed the button to be consistent with the rest of the app.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ade7d3b</samp>

> _The button of doom has a new name_
> _But only the chosen ones can claim_
> _`isCommunityVersion` will seal your fate_
> _Enrich your contact before it's too late_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ade7d3b</samp>

*  Rename button label from "Enrich member" to "Enrich contact" for consistency ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1966/files?diff=unified&w=0#diff-a9cd6e2fd79f4e2e6a68f1b8cae4de9da1df9684d977d5fe19b311412b1bf72dL40-R40))
*  Import config module to access `isCommunityVersion` flag ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1966/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eR5))
*  Hide enrichment button in community version and for non-essential plan users after limit date ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1966/files?diff=unified&w=0#diff-54c60cb23895a3078b13209372fd59f08235360e53569fc6779613513495d69eL88-R90))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
