### PR TITLE
fixed ci deploy

### DIFF
--- a/.github/actions/deploy-service/action.yaml
+++ b/.github/actions/deploy-service/action.yaml
@@ -19,15 +19,10 @@ inputs:
     required: false
     default: 'false'
 
-  staging:
-    description: Is the service prioritized and deployed to staging?
+  cloud_env:
+    description: Which cloud environment are we deploying to?
     required: false
-    default: 'false'
-
-  lfx:
-    description: Is the service prioritized and deployed to lfx?
-    required: false
-    default: 'false'
+    default: 'default'
 
 runs:
   using: composite
@@ -46,7 +41,7 @@ runs:
       run: kubectl set image deployments/${{ inputs.service }}-dpl ${{ inputs.service }}=${{ inputs.image }}
 
     - name: Deploy image (prioritized - production)
-      if: inputs.prioritized == 'true' && inputs.lfx == 'false'
+      if: inputs.prioritized == 'true' && inputs.cloud_env == 'prod'
       shell: bash
       run: |
         kubectl set image deployments/${{ inputs.service }}-system-dpl ${{ inputs.service }}-system=${{ inputs.image }}
@@ -55,7 +50,7 @@ runs:
         kubectl set image deployments/${{ inputs.service }}-urgent-dpl ${{ inputs.service }}-urgent=${{ inputs.image }}
 
     - name: Deploy image (prioritized - lfx production)
-      if: inputs.prioritized == 'true' && inputs.lfx == 'true'
+      if: inputs.prioritized == 'true' && inputs.cloud_env == 'lfx_prod'
       shell: bash
       run: |
         kubectl set image deployments/${{ inputs.service }}-system-dpl ${{ inputs.service }}-system=${{ inputs.image }}
@@ -63,7 +58,12 @@ runs:
         kubectl set image deployments/${{ inputs.service }}-high-dpl ${{ inputs.service }}-high=${{ inputs.image }}
 
     - name: Deploy image (prioritized - staging)
-      if: inputs.prioritized == 'true' && inputs.staging == 'true'
+      if: inputs.prioritized == 'true' && inputs.cloud_env == 'staging'
+      shell: bash
+      run: kubectl set image deployments/${{ inputs.service }}-normal-dpl ${{ inputs.service }}-normal=${{ inputs.image }}
+
+    - name: Deploy image (prioritized - lfx staging)
+      if: inputs.prioritized == 'true' && inputs.cloud_env == 'lfx_staging'
       shell: bash
       run: kubectl set image deployments/${{ inputs.service }}-normal-dpl ${{ inputs.service }}-normal=${{ inputs.image }}
 

--- a/.github/workflows/lf-production-deploy-new.yaml
+++ b/.github/workflows/lf-production-deploy-new.yaml
@@ -208,7 +208,7 @@ jobs:
           service: search-sync-worker
           image: ${{ needs.build-and-push-search-sync-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-search-sync-api:
@@ -246,7 +246,7 @@ jobs:
           service: integration-sync-worker
           image: ${{ needs.build-and-push-integration-sync-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-webhook-api:

--- a/.github/workflows/lf-production-deploy-original.yaml
+++ b/.github/workflows/lf-production-deploy-original.yaml
@@ -237,7 +237,7 @@ jobs:
           service: nodejs-worker
           image: ${{ needs.build-and-push-backend.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-discord-ws:
@@ -293,7 +293,7 @@ jobs:
           service: integration-run-worker
           image: ${{ needs.build-and-push-integration-run-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-integration-stream-worker:
@@ -313,7 +313,7 @@ jobs:
           service: integration-stream-worker
           image: ${{ needs.build-and-push-integration-stream-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-integration-data-worker:
@@ -333,7 +333,7 @@ jobs:
           service: integration-data-worker
           image: ${{ needs.build-and-push-integration-data-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-data-sink-worker:
@@ -353,7 +353,7 @@ jobs:
           service: data-sink-worker
           image: ${{ needs.build-and-push-data-sink-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          lfx: true
+          cloud_env: lfx_prod
           prioritized: true
 
   deploy-frontend:

--- a/.github/workflows/lf-staging-deploy-backend.yaml
+++ b/.github/workflows/lf-staging-deploy-backend.yaml
@@ -76,7 +76,7 @@ jobs:
           service: nodejs-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true
 
   deploy-job-generator:

--- a/.github/workflows/lf-staging-deploy-data-sink-worker.yaml
+++ b/.github/workflows/lf-staging-deploy-data-sink-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: data-sink-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true

--- a/.github/workflows/lf-staging-deploy-integration-data-worker.yaml
+++ b/.github/workflows/lf-staging-deploy-integration-data-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-data-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true

--- a/.github/workflows/lf-staging-deploy-integration-run-worker.yaml
+++ b/.github/workflows/lf-staging-deploy-integration-run-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-run-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true

--- a/.github/workflows/lf-staging-deploy-integration-stream-worker.yaml
+++ b/.github/workflows/lf-staging-deploy-integration-stream-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-stream-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true

--- a/.github/workflows/lf-staging-deploy-search-sync-worker.yaml
+++ b/.github/workflows/lf-staging-deploy-search-sync-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: search-sync-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: lfx_staging
           prioritized: true

--- a/.github/workflows/production-deploy-new.yaml
+++ b/.github/workflows/production-deploy-new.yaml
@@ -208,6 +208,7 @@ jobs:
           service: search-sync-worker
           image: ${{ needs.build-and-push-search-sync-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-search-sync-api:
@@ -245,6 +246,7 @@ jobs:
           service: integration-sync-worker
           image: ${{ needs.build-and-push-integration-sync-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-webhook-api:

--- a/.github/workflows/production-deploy-original.yaml
+++ b/.github/workflows/production-deploy-original.yaml
@@ -237,6 +237,7 @@ jobs:
           service: nodejs-worker
           image: ${{ needs.build-and-push-backend.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-discord-ws:
@@ -292,6 +293,7 @@ jobs:
           service: integration-run-worker
           image: ${{ needs.build-and-push-integration-run-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-integration-stream-worker:
@@ -311,6 +313,7 @@ jobs:
           service: integration-stream-worker
           image: ${{ needs.build-and-push-integration-stream-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-integration-data-worker:
@@ -330,6 +333,7 @@ jobs:
           service: integration-data-worker
           image: ${{ needs.build-and-push-integration-data-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-data-sink-worker:
@@ -349,6 +353,7 @@ jobs:
           service: data-sink-worker
           image: ${{ needs.build-and-push-data-sink-worker.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
+          cloud_env: prod
           prioritized: true
 
   deploy-frontend:

--- a/.github/workflows/staging-deploy-backend.yaml
+++ b/.github/workflows/staging-deploy-backend.yaml
@@ -77,7 +77,7 @@ jobs:
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
           prioritized: true
-          staging: true
+          cloud_env: staging
 
   deploy-job-generator:
     needs: build-and-push

--- a/.github/workflows/staging-deploy-data-sink-worker.yaml
+++ b/.github/workflows/staging-deploy-data-sink-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: data-sink-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true

--- a/.github/workflows/staging-deploy-integration-data-worker.yaml
+++ b/.github/workflows/staging-deploy-integration-data-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-data-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true

--- a/.github/workflows/staging-deploy-integration-run-worker.yaml
+++ b/.github/workflows/staging-deploy-integration-run-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-run-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true

--- a/.github/workflows/staging-deploy-integration-stream-worker.yaml
+++ b/.github/workflows/staging-deploy-integration-stream-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-stream-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true

--- a/.github/workflows/staging-deploy-integration-sync-worker.yaml
+++ b/.github/workflows/staging-deploy-integration-sync-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: integration-sync-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true

--- a/.github/workflows/staging-deploy-search-sync-worker.yaml
+++ b/.github/workflows/staging-deploy-search-sync-worker.yaml
@@ -58,5 +58,5 @@ jobs:
           service: search-sync-worker
           image: ${{ needs.build-and-push.outputs.image }}
           cluster: ${{ env.CROWD_CLUSTER }}
-          staging: true
+          cloud_env: staging
           prioritized: true


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c460188</samp>

Refactored the `deploy-service` action to use a single `cloud_env` input parameter to specify the target environment for deploying the image. Updated various workflows that use the action to pass the appropriate `cloud_env` value for different services and environments. This simplifies the deployment logic and enables deploying to different clusters and namespaces.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c460188</samp>

> _We're deploying to the clouds of doom_
> _With `cloud_env` we seal our fate_
> _No matter what the cluster or the namespace_
> _We invoke the `deploy-service` gate_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c460188</samp>

*  Simplify the input parameters for the deploy-service action by replacing the boolean flags for staging and lfx with a single cloud_env parameter that can take values such as default, prod, lfx_prod, staging, lfx_staging, etc. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1968/files?diff=unified&w=0#diff-ccaa40e4bb696c52a10d75fa78a15a17627eedee23a2f9ac961ff3b3d7383f6aL22-R26))
*  Update the conditions for deploying the image to the production, lfx production, and staging environments to use the cloud_env parameter instead of the lfx and staging flags. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1968/files?diff=unified&w=0#diff-ccaa40e4bb696c52a10d75fa78a15a17627eedee23a2f9ac961ff3b3d7383f6aL49-R44), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1968/files?diff=unified&w=0#diff-ccaa40e4bb696c52a10d75fa78a15a17627eedee23a2f9ac961ff3b3d7383f6aL58-R53), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1968/files?diff=unified&w=0#diff-ccaa40e4bb696c52a10d75fa78a15a17627eedee23a2f9ac961ff3b3d7383f6aL66-R69))
*  Add a new step to deploy the image to the lfx staging environment with the corresponding cloud_env value. ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1968/files?diff=unified&w=0#diff-ccaa40e4bb696c52a10d75fa78a15a17627eedee23a2f9ac961ff3b3d7383f6aL66-R69))

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
