### PR TITLE
Fix identity display name in merge dialog

### DIFF
--- a/frontend/src/modules/organization/components/suggestions/organization-merge-suggestions-details.vue
+++ b/frontend/src/modules/organization/components/suggestions/organization-merge-suggestions-details.vue
@@ -243,6 +243,7 @@
               <app-platform :platform="identity.platform" />
               <span class="text-xs">
                 {{ getPlatformDetails(identity.platform)?.organization.handle(identity)
+                  ?? identity.name
                   ?? getPlatformDetails(identity.platform)?.name
                   ?? identity.platform }}</span>
             </div>


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0064247</samp>

Fix display of organization names in merge suggestions. Use `identity.name` as a fallback when `identity.displayName` is missing in `organization-merge-suggestions-details.vue`.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0064247</samp>

> _`identity.name`_
> _fallback for empty display_
> _autumn leaves merge_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 0064247</samp>

*  Add fallback value for identity name in organization merge suggestions details component ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1969/files?diff=unified&w=0#diff-a70a7f6b4373e8c9c09a6cc98f976a1d163ee5684a315379fe35982e3fcbbf48R246))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
