### PR TITLE
Add async feedback to organizations merge

### DIFF
--- a/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
+++ b/backend/src/serverless/microservices/nodejs/org-merge/orgMergeWorker.ts
@@ -4,7 +4,15 @@ import { REDIS_CONFIG } from '../../../../conf'
 import getUserContext from '../../../../database/utils/getUserContext'
 import OrganizationService from '../../../../services/organizationService'
 
-async function doNotifyFrontend({ log, success, tenantId, primaryOrgId, secondaryOrgId, original, toMerge }) {
+async function doNotifyFrontend({
+  log,
+  success,
+  tenantId,
+  primaryOrgId,
+  secondaryOrgId,
+  original,
+  toMerge,
+}) {
   const redis = await getRedisClient(REDIS_CONFIG, true)
   const apiPubSubEmitter = new RedisPubSubEmitter(
     'api-pubsub',
@@ -25,7 +33,7 @@ async function doNotifyFrontend({ log, success, tenantId, primaryOrgId, secondar
         primaryOrgId,
         secondaryOrgId,
         original,
-        toMerge
+        toMerge,
       }),
       undefined,
       tenantId,
@@ -64,7 +72,7 @@ async function orgMergeWorker(
       primaryOrgId,
       secondaryOrgId,
       original,
-      toMerge
+      toMerge,
     })
   }
 }

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -206,7 +206,12 @@ export default class OrganizationService extends LoggerBase {
       )
 
       this.options.log.info({ originalId, toMergeId }, 'Organizations merged!')
-      return { status: 200, mergedId: originalId, original: original.displayName, toMerge: toMerge.displayName }
+      return {
+        status: 200,
+        mergedId: originalId,
+        original: original.displayName,
+        toMerge: toMerge.displayName,
+      }
     } catch (err) {
       this.options.log.error(err, 'Error while merging organizations!', {
         originalId,

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -206,7 +206,7 @@ export default class OrganizationService extends LoggerBase {
       )
 
       this.options.log.info({ originalId, toMergeId }, 'Organizations merged!')
-      return { status: 200, mergedId: originalId }
+      return { status: 200, mergedId: originalId, original: original.displayName, toMerge: toMerge.displayName }
     } catch (err) {
       this.options.log.error(err, 'Error while merging organizations!', {
         originalId,

--- a/frontend/src/modules/organization/components/list/organization-list-toolbar.vue
+++ b/frontend/src/modules/organization/components/list/organization-list-toolbar.vue
@@ -111,6 +111,7 @@ const organizationStore = useOrganizationStore();
 const {
   selectedOrganizations,
   filters,
+  mergedOrganizations,
 } = storeToRefs(organizationStore);
 const { fetchOrganizations } = organizationStore;
 
@@ -175,17 +176,19 @@ const handleDoDestroyAllWithConfirm = () => ConfirmDialog({
 const handleMergeOrganizations = async () => {
   const [firstOrganization, secondOrganization] = selectedOrganizations.value;
 
-  Message.info(
-    null,
-    {
-      title: 'Organizations are being merged',
-    },
-  );
-
   OrganizationService.mergeOrganizations(firstOrganization.id, secondOrganization.id)
     .then(() => {
       Message.closeAll();
-      Message.success('Organizations merged successfuly');
+
+      organizationStore
+        .addMergedOrganizations(firstOrganization.id, secondOrganization.id);
+
+      const processesRunning = Object.keys(mergedOrganizations.value).length;
+
+      Message.info(null, {
+        title: 'Organizations merging in progress',
+        message: processesRunning > 1 ? `${processesRunning} processes running` : null,
+      });
 
       fetchOrganizations({ reload: true });
     })

--- a/frontend/src/modules/organization/components/organization-selection-dropdown.vue
+++ b/frontend/src/modules/organization/components/organization-selection-dropdown.vue
@@ -88,7 +88,6 @@ const fetchFn = async (query, limit) => {
   if (options.length !== filteredOptions.length) {
     filteredOptions.push({});
   }
-  console.log(filteredOptions);
 
   return filteredOptions;
 };

--- a/frontend/src/modules/organization/store/pinia/actions.ts
+++ b/frontend/src/modules/organization/store/pinia/actions.ts
@@ -20,11 +20,20 @@ export default {
         return Promise.reject(err);
       });
   },
+
   fetchOrganization(this: OrganizationState, id: string): Promise<Organization> {
     return OrganizationService.find(id)
       .then((organization: Organization) => {
         this.organization = organization;
         return Promise.resolve(organization);
       });
+  },
+
+  addMergedOrganizations(this: OrganizationState, primaryId: string, secondaryId: string) {
+    this.mergedOrganizations[primaryId] = secondaryId;
+  },
+
+  removeMergedOrganizations(this: OrganizationState, primaryId: string) {
+    delete this.mergedOrganizations[primaryId];
   },
 };

--- a/frontend/src/modules/organization/store/pinia/state.ts
+++ b/frontend/src/modules/organization/store/pinia/state.ts
@@ -9,6 +9,9 @@ export interface OrganizationState {
   organization: Organization | null;
   selectedOrganizations: Organization[];
   totalOrganizations: number;
+  mergedOrganizations: {
+    [key: string]: string;
+  }
 }
 
 const state: OrganizationState = {
@@ -20,6 +23,7 @@ const state: OrganizationState = {
   organization: null,
   selectedOrganizations: [],
   totalOrganizations: 0,
+  mergedOrganizations: {},
 };
 
 export default () => state;


### PR DESCRIPTION
# Changes proposed ✍️

### What
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ea0858c</samp>

This pull request adds a feature to allow users to merge multiple organizations into one in the frontend and backend. It updates the `orgMergeWorker` function to send the organization names to the frontend via the `org-merge` socket event. It also updates the frontend components and store modules to handle the socket event, display messages, and use the organization store state and actions. It also removes a debugging statement and improves the code formatting.
​
<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ea0858c</samp>

> _`org-merge` feature_
> _merging organizations_
> _autumn of cleanup_

### Why


### How
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ea0858c</samp>

*  Add `original` and `toMerge` parameters to `doNotifyFrontend` function and socket event `org-merge` payload to pass the display names of the original and merged organizations to the frontend ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bL7-R7), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR27-R28), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bR66-R67))
*  Modify `orgMergeWorker` function to get `original` and `toMerge` values from the response of `mergeSync` method and pass them to `doNotifyFrontend` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-f04834ad9fe6a99204916f860ff3b51cf03aec2ce285678ee97028666debf24bL45-R53))
*  Modify `mergeSync` method to return `original` and `toMerge` values along with the merge result ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-d06de70f55c91875884ab02d75e56977c1d82646913a7d693cbb7cb1a6f9ae79L209-R209))
*  Import `h` and `useOrganizationStore` modules in `auth-socket` module to create virtual DOM elements and access organization store state and actions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L2-R2))
*  Declare and assign `SocketEvents` constant to store the names of the socket events and use it instead of hard-coding the event names in `connectSocket` function ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L12-R25), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L39-R58), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L56-R67), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87L75-R86))
*  Add handler for `org-merge` socket event in `connectSocket` function to display a message to the user with the option to view the merged organization ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-32d58cce45e264c59c94cc5020b714e56adb3599b4dc5523516ca08ca605dc87R130-R196))
*  Replace `Message.success` call with `addMergedOrganizations` action and `Message.info` call in `mergeOrganizations` method of `organization-list-toolbar`, `organization-merge-dialog`, and `organization-merge-suggestions-page` components to store the ids of the merged organizations in the organization store state and display an info message that the merge is in progress ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-2846c11ee0e6f8358e4ae124a854248a56170abcca32e41f14ae2c22f482213dL178-R192), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dL122-R139), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-c3e340ad36925672ad5654918ab81af128ef6d444822078f1d8885b5d959869cL253-R280))
*  Replace `fetchOrganization` and `fetchOrganizations` calls with organization store actions in `mergeOrganizations` method of `organization-merge-dialog` component to use the store logic instead of the service logic ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dL129-R145), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dL137-R153))
*  Add `Message.closeAll` call in `mergeOrganizations` method of `organization-merge-dialog` component to close any previous messages before displaying the new one ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dR159))
*  Import `useOrganizationStore` and `storeToRefs` modules in `organization-list-toolbar`, `organization-merge-dialog`, and `organization-merge-suggestions-page` components to access organization store state and actions and convert the state to refs ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-2846c11ee0e6f8358e4ae124a854248a56170abcca32e41f14ae2c22f482213dR114), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dR75), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-c3e340ad36925672ad5654918ab81af128ef6d444822078f1d8885b5d959869cR142-R143))
*  Declare and assign `organizationStore` constant and destructure `mergedOrganizations` property in `organization-list-toolbar`, `organization-merge-dialog`, and `organization-merge-suggestions-page` components to access organization store state and actions ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-2846c11ee0e6f8358e4ae124a854248a56170abcca32e41f14ae2c22f482213dL178-R192), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-5cf950a293821279dec9c83cf42ebd77a54ce44a7dc81d006bfa41537d4edc0dL88-R92), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-c3e340ad36925672ad5654918ab81af128ef6d444822078f1d8885b5d959869cR149-R153))
*  Add `mergedOrganizations` property to `OrganizationState` interface and `state` function in `state` module to store the ids of the merged organizations ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-a565b1a2d8e4b80acff3ba3bd493341a656f351974ea79fb3b3471c09779ecb8R12-R14), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-a565b1a2d8e4b80acff3ba3bd493341a656f351974ea79fb3b3471c09779ecb8R26))
*  Add `addMergedOrganizations` and `removeMergedOrganizations` actions in `actions` module to update and remove the `mergedOrganizations` state property ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-34de31cb48d758f3b7c3784116aeb2031c39369c83620543c1aaf008d23fb6b6R31-R38))
*  Remove `console.log` statement in `organization-selection-dropdown` component to clean up the code ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-f1d6e78bb30333559d7be61d4b87b5691f7a45e63717e1a88908d32c0c5d1a64L91))
*  Add blank lines for code formatting in `organization-merge-suggestions-page` and `actions` modules to improve the readability of the code ([link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-c3e340ad36925672ad5654918ab81af128ef6d444822078f1d8885b5d959869cR255), [link](https://github.com/CrowdDotDev/crowd.dev/pull/1970/files?diff=unified&w=0#diff-34de31cb48d758f3b7c3784116aeb2031c39369c83620543c1aaf008d23fb6b6R23))

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
