### PR TITLE
Don't try to parse admin segments if user isn't authorized

### DIFF
--- a/backend/src/services/user/permissionChecker.ts
+++ b/backend/src/services/user/permissionChecker.ts
@@ -28,9 +28,9 @@ export default class PermissionChecker {
     this.language = language
     this.currentUser = currentUser
     this.currentSegments = currentSegments
-    this.adminSegments = currentUser.tenants.find(
-      (t) => t.tenantId === currentTenant.id,
-    )?.adminSegments
+    this.adminSegments = !currentUser
+      ? []
+      : currentUser.tenants.find((t) => t.tenantId === currentTenant.id)?.adminSegments
   }
 
   /**


### PR DESCRIPTION
- Sometimes `PermissionChecker` has this error where `currentUser` isn't defined
- This most likely happens when the user is not authorized at all
- In that situation there is no point in trying to get admin segments for the user anyway, so we skip this step