### PR TITLE
Fix missing members joined at data

### DIFF
--- a/backend/src/database/migrations/V1704365919__fix-member-joined-at.sql
+++ b/backend/src/database/migrations/V1704365919__fix-member-joined-at.sql
@@ -1,0 +1,36 @@
+DO $$
+DECLARE
+    _member_id UUID;
+    _first_acitivity TIMESTAMP;
+BEGIN
+    FOR _member_id IN
+        SELECT id
+        FROM members
+        WHERE EXTRACT(YEAR FROM "joinedAt") = 1970 -- those who have the wrong joinedAt
+          AND EXISTS ( -- yet have at least one activity with a non-1970 timestamp
+            SELECT 1
+            FROM activities a
+            WHERE a."memberId" = members.id
+              AND EXTRACT(YEAR FROM a.timestamp) != 1970
+        )
+    LOOP
+        RAISE NOTICE 'member_id: %', _member_id;
+
+        -- find the actual first non-1970 activity timestamp
+        SELECT MIN(a.timestamp) INTO _first_acitivity
+        FROM activities a
+        WHERE EXTRACT(YEAR FROM a.timestamp) != 1970
+          AND a."memberId" = _member_id;
+
+        IF _first_acitivity IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        RAISE NOTICE 'first_acitivity: %', _first_acitivity;
+
+        UPDATE members
+        SET "joinedAt" = _first_acitivity
+        WHERE id = _member_id;
+    END LOOP;
+END;
+$$;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -541,6 +541,12 @@ importers:
       lodash.uniqby:
         specifier: ^4.7.0
         version: 4.7.0
+      moment:
+        specifier: 2.29.4
+        version: 2.29.4
+      moment-timezone:
+        specifier: ^0.5.34
+        version: 0.5.43
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.18.14)(typescript@5.3.2)

--- a/services/apps/data_sink_worker/package.json
+++ b/services/apps/data_sink_worker/package.json
@@ -43,6 +43,8 @@
     "lodash.isequal": "^4.5.0",
     "lodash.mergewith": "^4.6.2",
     "lodash.uniqby": "^4.7.0",
+    "moment": "2.29.4",
+    "moment-timezone": "^0.5.34",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.4"

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -19,6 +19,7 @@ import {
 } from '@crowd/types'
 import mergeWith from 'lodash.mergewith'
 import isEqual from 'lodash.isequal'
+import moment from 'moment-timezone'
 import { IMemberCreateData, IMemberUpdateData } from './member.data'
 import MemberAttributeService from './memberAttribute.service'
 import IntegrationRepository from '../repo/integration.repo'
@@ -546,6 +547,15 @@ export default class MemberService extends LoggerBase {
     if (member.joinedAt) {
       const newDate = member.joinedAt
       const oldDate = new Date(dbMember.joinedAt)
+      // If either the new or the old date are earlier than 1970
+      // it means they come from an activity without timestamp
+      // and we want to keep the other one
+      if (moment(oldDate).subtract(5, 'days').unix() < 0) {
+        joinedAt = newDate.toISOString()
+      }
+      if (moment(newDate).unix() < 0) {
+        joinedAt = undefined
+      }
 
       if (oldDate <= newDate) {
         // we already have the oldest date in the db, so we don't need to update it


### PR DESCRIPTION
- When adding new activities for a member, avoid using 1970 activity timestamp as the new `joinedAt` of the member
- Fix existing members by changing their `joinedAt` to their earliest non-1970 activity timestamp if any