### PR TITLE
Improve find-existing-acitivty query in data-sink-worker

### DIFF
--- a/services/apps/data_sink_worker/src/repo/activity.repo.ts
+++ b/services/apps/data_sink_worker/src/repo/activity.repo.ts
@@ -103,6 +103,7 @@ export default class ActivityRepository extends RepositoryBase<ActivityRepositor
         and "segmentId" = $(segmentId)
         and "sourceId" = $(sourceId)
         and channel = $(channel)
+        and "deletedAt" IS NULL
       limit 1;
     `,
       {


### PR DESCRIPTION
This change makes it use:

    CREATE UNIQUE INDEX activities_tenant_segment_source_id_idx
    ON activities ("tenantId", "segmentId", "sourceId")
    WHERE ("deletedAt" IS NULL);

instead of:

    CREATE UNIQUE INDEX ix_unique_activities_tenantid_platform_type_sourceid_segmentid
    ON activities ("tenantId", platform, type, "sourceId", "segmentId");

