### PR TITLE
Fix my-project-groups query

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -541,6 +541,7 @@ class SegmentRepository extends RepositoryBase<
    */
   async queryProjectGroups(criteria: QueryData): Promise<PageData<SegmentData>> {
     let searchQuery = 'WHERE 1=1'
+    let segmentsSearchQuery = ''
 
     const replacements = {
       tenantId: this.currentTenant.id,
@@ -562,7 +563,7 @@ class SegmentRepository extends RepositoryBase<
       if (adminSegments.length === 0) {
         return { count: 0, rows: [], limit: criteria.limit, offset: criteria.offset }
       }
-      searchQuery += `AND s.id IN (:adminSegments)`
+      segmentsSearchQuery += `AND sp.id IN (:adminSegments)`
       replacements.adminSegments = adminSegments
     }
 
@@ -601,6 +602,7 @@ class SegmentRepository extends RepositoryBase<
                              AND sp."tenantId" = f."tenantId"
                   WHERE f."parentSlug" IS NULL
                     AND f."tenantId" = :tenantId
+                    ${segmentsSearchQuery}
                   GROUP BY f."id", p.id
               )
           SELECT


### PR DESCRIPTION
The `foundation` sub-query returns only project-groups, but admin segments only contain sub-projects. So it doesn't make much sense to filter the results of one with the other ones.

Instead we use admin segments to filter inside the sub-query, where we we still have access to sub-projects.

This way we still in the end return project-groups, but only those which include sub-projects, which the user can manage as a project-admin.
