### PR TITLE
API performance lf

### DIFF
--- a/backend/src/database/migrations/R__cubejs-materialized-views.sql
+++ b/backend/src/database/migrations/R__cubejs-materialized-views.sql
@@ -47,6 +47,7 @@ CREATE INDEX IF NOT EXISTS mv_activities_cube_timestamp ON mv_activities_cube (t
 CREATE INDEX IF NOT EXISTS mv_activities_cube_org_id ON mv_activities_cube ("organizationId");
 CREATE UNIQUE INDEX IF NOT EXISTS mv_activities_cube_id ON mv_activities_cube (id);
 CREATE INDEX IF NOT EXISTS mv_activities_cube_tenantId_timestamp_idx ON mv_activities_cube ("tenantId", "timestamp");
+CREATE INDEX mv_activities_cube_member_id_timestamp ON mv_activities_cube ("memberId", timestamp);
 
 
 -- Organizations

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -2246,7 +2246,7 @@ class MemberRepository {
             ) m ("memberId")
             JOIN activities a ON (a.id = (
                 SELECT id
-                FROM activities
+                FROM mv_activities_cube
                 WHERE "memberId" = m."memberId"::uuid
                 ORDER BY timestamp DESC
                 LIMIT 1


### PR DESCRIPTION
- Switch to using `mv_activities_cube` instead of `actitivies` table when retrieving last activities for each member in a list of members
- And create an index, which helps this query