### PR TITLE
Fix `Cannot read properties of null (reading 'id')`

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -606,7 +606,7 @@ class OrganizationRepository {
       })
 
       // ensure that it's not the same organization
-      if (existingOrg.id !== record.id) {
+      if (existingOrg && existingOrg.id !== record.id) {
         throw new Error409(options.language, 'organization.errors.websiteAlreadyExists')
       }
     }


### PR DESCRIPTION
The error happens when we have to move a website during org merging. Meaning, if we use the org with website as a secondary one. Note: we can only have one org with that website because of a unique constraint.

If you switch places and use the org with the website as primary, the merge goes through without an issue.

- `existingOrg` is undefined here, because there is no org with that webiste in the database
- there is no org with that website in the database, because prior to that we removed website from that org here: https://github.com/CrowdDotDev/crowd.dev/blob/46cbae424d17e81d4bebb053539bd8f5c1ef40e4/backend/src/services/organizationService.ts#L130-L132
- we needed to do that because we wouldn't be able to set a website on the second org while the first existed due to a unique constraint
