### PR TITLE
Improve `/membersToMerge` endpoint

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -257,24 +257,21 @@ class MemberRepository {
 
     const mems = await options.database.sequelize.query(
       `
-      select
-          mtm."memberId" AS id,
-          mtm."toMergeId",
-          count(*) over() AS total_count,
-          mtm.similarity
-      from
-          "memberToMerge" mtm
-      where exists (
-          select 1
-          from "memberSegments" ms
-          where ms."segmentId" in (:segmentIds) and ms."memberId" = mtm."memberId"
+        SELECT
+            DISTINCT
+            mtm."memberId" AS id,
+            mtm."toMergeId",
+            mtm.similarity,
+            mtm."activityEstimate"
+        FROM "memberToMerge" mtm
+        JOIN "memberSegments" ms ON ms."memberId" = mtm."memberId"
+        WHERE ms."segmentId" IN (:segmentIds)
           ${memberFilter}
-      )
-      ${similarityFilter}
-      order by ${order}
-      limit :limit
-      offset :offset;
-    `,
+          ${similarityFilter}
+        ORDER BY ${order}
+        LIMIT :limit
+        OFFSET :offset
+      `,
       {
         replacements: {
           segmentIds,
@@ -302,7 +299,27 @@ class MemberRepository {
         members: [i, memberToMergeResults[idx]],
         similarity: mems[idx].similarity,
       }))
-      return { rows: result, count: mems[0].total_count, limit, offset }
+
+      const totalCount = await options.database.sequelize.query(
+        `
+          SELECT
+              COUNT(DISTINCT mtm."memberId"::TEXT || mtm."toMergeId"::TEXT) AS count
+          FROM "memberToMerge" mtm
+          JOIN "memberSegments" ms ON ms."memberId" = mtm."memberId"
+          WHERE ms."segmentId" IN (:segmentIds)
+            ${memberFilter}
+            ${similarityFilter}
+        `,
+        {
+          replacements: {
+            segmentIds,
+            memberId,
+          },
+          type: QueryTypes.SELECT,
+        },
+      )
+
+      return { rows: result, count: totalCount[0].count, limit, offset }
     }
 
     return { rows: [{ members: [], similarity: 0 }], count: 0, limit, offset }


### PR DESCRIPTION
- Split one complex SQL query into two much simpler and faster ones