### PR TITLE
Retrieve the whole heirarchy for admin segments

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -853,10 +853,12 @@ class SegmentRepository extends RepositoryBase<
     const segments = await seq.query(
       `
         SELECT
-          id
-        FROM segments
-        WHERE "tenantId" = :tenantId
-          AND "sourceId" IN (:sourceIds)
+            DISTINCT UNNEST(ARRAY[s.id, s1.id, s2.id]) AS id
+        FROM segments s
+        JOIN segments s1 ON s1."parentSlug" = s.slug
+        JOIN segments s2 ON s2."parentSlug" = s1.slug
+        WHERE s.tenantId = :tenantId
+          AND s."sourceId" IN (:sourceIds)
       `,
       {
         replacements: { sourceIds, tenantId: this.options.currentTenant.id },


### PR DESCRIPTION
Starting from those which user is an admin of

- if a user is an admin of a project group, we include all projects and
  subprojects under that project group in admin segments
- if a user is an admin of a project, we include all subprojects
- if a user is an admin of a subproject, we only include that subproject