### PR TITLE
member_segments_mv, refreshing of the materialized view and usage in query for merge suggestions

### DIFF
--- a/backend/src/bin/jobs/mergeSuggestions.ts
+++ b/backend/src/bin/jobs/mergeSuggestions.ts
@@ -1,4 +1,4 @@
-import { timeout } from '@crowd/common'
+import { timeout, IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 import cronGenerator from 'cron-time-generator'
 import { getNodejsWorkerEmitter } from '@/serverless/utils/serviceSQS'
 import TenantService from '../../services/tenantService'
@@ -7,7 +7,8 @@ import { CrowdJob } from '../../types/jobTypes'
 const job: CrowdJob = {
   name: 'Merge suggestions',
   // every 12 hours
-  cronTime: cronGenerator.every(12).hours(),
+  cronTime:
+    IS_DEV_ENV || IS_TEST_ENV ? cronGenerator.every(2).minutes() : cronGenerator.every(12).hours(),
   onTrigger: async () => {
     const tenants = await TenantService._findAndCountAllForEveryUser({})
     const emitter = await getNodejsWorkerEmitter()

--- a/backend/src/bin/jobs/refreshMaterializedViews.ts
+++ b/backend/src/bin/jobs/refreshMaterializedViews.ts
@@ -1,26 +1,71 @@
 import cronGenerator from 'cron-time-generator'
-import SequelizeRepository from '../../database/repositories/sequelizeRepository'
+import { QueryTypes } from 'sequelize'
+import { Logger, getChildLogger, getServiceChildLogger, logExecutionTimeV2 } from '@crowd/logging'
+import { IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 import { CrowdJob } from '../../types/jobTypes'
+import { databaseInit } from '@/database/databaseConnection'
 
-let processingRefreshMemberAggregteMVs = false
+export const refreshMaterializedView = async (
+  view: string,
+  database: any,
+  log: Logger,
+): Promise<boolean> => {
+  log = getChildLogger('execution', log, {
+    view,
+  })
+  try {
+    const refreshQuery = `refresh materialized view concurrently "${view}"`
+    const runningQuery = await database.sequelize.query(
+      `
+        select 1
+        from pg_stat_activity
+        where query = :refreshQuery
+          and state != 'idle'
+          and pid != pg_backend_pid()
+      `,
+      {
+        replacements: {
+          refreshQuery,
+        },
+        type: QueryTypes.SELECT,
+        useMaster: true,
+      },
+    )
+
+    if (runningQuery.length > 0) {
+      log.warn(
+        `Materialized view will not be refreshed because there's already an ongoing refresh for it!`,
+      )
+      return false
+    }
+
+    log.info('Refreshing materialized view')
+    await logExecutionTimeV2(
+      () =>
+        database.sequelize.query(refreshQuery, {
+          useMaster: true,
+        }),
+      log,
+      `Refresh Materialized View ${view}`,
+    )
+
+    return true
+  } catch (err) {
+    log.error({ error: err }, 'Error while refreshing materialized view!')
+    return false
+  }
+}
 
 const job: CrowdJob = {
   name: 'Refresh Materialized View',
-  // every two hours
-  cronTime: cronGenerator.every(2).hours(),
+  cronTime:
+    IS_DEV_ENV || IS_TEST_ENV ? cronGenerator.every(1).minutes() : cronGenerator.every(2).hours(),
   onTrigger: async () => {
-    if (!processingRefreshMemberAggregteMVs) {
-      processingRefreshMemberAggregteMVs = true
-    } else {
-      return
-    }
-    const dbOptions = await SequelizeRepository.getDefaultIRepositoryOptions()
+    const database = await databaseInit(1000 * 60 * 15, true)
+    const log = getServiceChildLogger('RefreshMVJob')
 
-    await dbOptions.database.sequelize.query(
-      'refresh materialized view concurrently "memberActivityAggregatesMVs"',
-    )
-
-    processingRefreshMemberAggregteMVs = false
+    await refreshMaterializedView('memberActivityAggregatesMVs', database, log)
+    await refreshMaterializedView('member_segments_mv', database, log)
   },
 }
 

--- a/backend/src/bin/jobs/refreshMaterializedViewsForCube.ts
+++ b/backend/src/bin/jobs/refreshMaterializedViewsForCube.ts
@@ -1,23 +1,21 @@
-import { Logger, logExecutionTimeV2 } from '@crowd/logging'
+import { Logger, getServiceChildLogger } from '@crowd/logging'
 import { getTemporalClient } from '@crowd/temporal'
-import { QueryTypes } from 'sequelize'
 import { IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 import { CrowdJob } from '../../types/jobTypes'
 import { databaseInit } from '../../database/databaseConnection'
 import { TEMPORAL_CONFIG } from '@/conf'
-
-function createRefreshQuery(view: string) {
-  return `REFRESH MATERIALIZED VIEW CONCURRENTLY "${view}"`
-}
+import { refreshMaterializedView } from './refreshMaterializedViews'
 
 const job: CrowdJob = {
   name: 'Refresh Materialized View For Cube',
   cronTime: IS_DEV_ENV || IS_TEST_ENV ? '* * * * *' : '1,31 * * * *',
   onTrigger: async (log: Logger) => {
+    const refreshed = []
+
     try {
       // initialize database with 15 minutes query timeout
-      const forceNewDbInstance = true
-      const database = await databaseInit(1000 * 60 * 15, forceNewDbInstance)
+      const database = await databaseInit(1000 * 60 * 15, true)
+      const log = getServiceChildLogger('RefreshMVForCubeJob')
 
       const materializedViews = [
         'mv_members_cube',
@@ -27,57 +25,29 @@ const job: CrowdJob = {
       ]
 
       for (const view of materializedViews) {
-        const refreshQuery = createRefreshQuery(view)
-        const runningQuery = await database.sequelize.query(
-          `
-            SELECT 1
-            FROM pg_stat_activity
-            WHERE query = :refreshQuery
-              AND state != 'idle'
-              AND pid != pg_backend_pid()
-          `,
-          {
-            replacements: {
-              refreshQuery,
-            },
-            type: QueryTypes.SELECT,
-            useMaster: true,
-          },
-        )
-
-        if (runningQuery.length > 0) {
-          log.warn(
-            `Materialized views for cube will not be refreshed because there's already an ongoing refresh of ${view}!`,
-          )
-          return
+        const result = await refreshMaterializedView(view, database, log)
+        if (result) {
+          refreshed.push(view)
         }
-      }
-      for (const view of materializedViews) {
-        const refreshQuery = createRefreshQuery(view)
-        await logExecutionTimeV2(
-          () =>
-            database.sequelize.query(refreshQuery, {
-              useMaster: true,
-            }),
-          log,
-          `Refresh Materialized View ${view}`,
-        )
       }
     } catch (e) {
       log.error({ error: e }, `Error while refreshing materialized views!`)
     }
 
-    const temporal = await getTemporalClient(TEMPORAL_CONFIG)
+    if (refreshed.length > 0) {
+      log.info(`Refreshed [${refreshed.join(', ')}] materialized views! Triggering cube refresh!`)
+      const temporal = await getTemporalClient(TEMPORAL_CONFIG)
 
-    await temporal.workflow.start('spawnDashboardCacheRefreshForAllTenants', {
-      taskQueue: 'cache',
-      workflowId: `refreshAllTenants`,
-      retry: {
-        maximumAttempts: 10,
-      },
-      args: [],
-      searchAttributes: {},
-    })
+      await temporal.workflow.start('spawnDashboardCacheRefreshForAllTenants', {
+        taskQueue: 'cache',
+        workflowId: `refreshAllTenants`,
+        retry: {
+          maximumAttempts: 10,
+        },
+        args: [],
+        searchAttributes: {},
+      })
+    }
   },
 }
 

--- a/backend/src/database/migrations/R__member_segments_mv.sql
+++ b/backend/src/database/migrations/R__member_segments_mv.sql
@@ -1,0 +1,8 @@
+drop materialized view if exists member_segments_mv;
+
+create materialized view member_segments_mv as
+select distinct "memberId", "segmentId", "tenantId"
+from activities
+where "deletedAt" is null;
+
+create unique index ix_member_segments_memberid_segmentid on member_segments_mv ("memberId", "segmentId")

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -264,7 +264,7 @@ class MemberRepository {
             mtm.similarity,
             mtm."activityEstimate"
         FROM "memberToMerge" mtm
-        JOIN "memberSegments" ms ON ms."memberId" = mtm."memberId"
+        JOIN member_segments_mv ms ON ms."memberId" = mtm."memberId"
         WHERE ms."segmentId" IN (:segmentIds)
           ${memberFilter}
           ${similarityFilter}
@@ -305,7 +305,7 @@ class MemberRepository {
           SELECT
               COUNT(DISTINCT mtm."memberId"::TEXT || mtm."toMergeId"::TEXT) AS count
           FROM "memberToMerge" mtm
-          JOIN "memberSegments" ms ON ms."memberId" = mtm."memberId"
+          JOIN member_segments_mv ms ON ms."memberId" = mtm."memberId"
           WHERE ms."segmentId" IN (:segmentIds)
             ${memberFilter}
             ${similarityFilter}

--- a/services/apps/merge_suggestions_worker/src/schedules/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/schedules/memberMergeSuggestions.ts
@@ -2,18 +2,24 @@ import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/clien
 
 import { svc } from '../main'
 import { spawnSuggestionsForAllTenants } from 'workflows/spawnSuggestionsForAllTenants'
+import { IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 
 export const scheduleGenerateMemberMergeSuggestions = async () => {
   try {
     await svc.temporal.schedule.create({
       scheduleId: 'member-merge-suggestions',
-      spec: {
-        intervals: [
-          {
-            every: '2 hours',
-          },
-        ],
-      },
+      spec:
+        IS_DEV_ENV || IS_TEST_ENV
+          ? {
+              cronExpressions: ['*/2 * * * *'],
+            }
+          : {
+              intervals: [
+                {
+                  every: '2 hours',
+                },
+              ],
+            },
       policies: {
         overlap: ScheduleOverlapPolicy.BUFFER_ONE,
         catchupWindow: '1 minute',

--- a/services/apps/premium/members_enrichment_worker/src/schedules/getMembersToEnrich.ts
+++ b/services/apps/premium/members_enrichment_worker/src/schedules/getMembersToEnrich.ts
@@ -2,13 +2,14 @@ import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/clien
 
 import { svc } from '../main'
 import { getMembersToEnrich } from '../workflows'
+import { IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 
 export const scheduleMembersEnrichment = async () => {
   try {
     await svc.temporal.schedule.create({
       scheduleId: 'members-enrichment',
       spec: {
-        cronExpressions: ['*/30 * * * *'],
+        cronExpressions: IS_DEV_ENV || IS_TEST_ENV ? ['*/2 * * * *'] : ['*/30 * * * *'],
       },
       policies: {
         overlap: ScheduleOverlapPolicy.BUFFER_ONE,

--- a/services/apps/premium/organizations_enrichment_worker/src/schedules/organizationEnrichment.ts
+++ b/services/apps/premium/organizations_enrichment_worker/src/schedules/organizationEnrichment.ts
@@ -1,6 +1,7 @@
 import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/client'
 import { svc } from '../main'
 import { triggerTenantOrganizationEnrichment } from '../workflows'
+import { IS_DEV_ENV, IS_TEST_ENV } from '@crowd/common'
 
 export const scheduleOrganizationsEnrichment = async () => {
   try {
@@ -8,7 +9,7 @@ export const scheduleOrganizationsEnrichment = async () => {
       scheduleId: 'organizations-enrichment',
       spec: {
         // every hour (at minute 0)
-        cronExpressions: ['0 * * * *'],
+        cronExpressions: IS_DEV_ENV || IS_TEST_ENV ? ['*/2 * * * *'] : ['0 * * * *'],
       },
       policies: {
         overlap: ScheduleOverlapPolicy.BUFFER_ONE,


### PR DESCRIPTION
- Prepare a `member_segments_mv` materialized view that creates a proper `memberSegments` table (because this one has mistakes)
- make it refreshed every 2 hours
- use the view in the query where we fetch merge suggestions

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] ~Add screenshots to the PR description for relevant FE changes~
- [ ] ~New backend functionality has been unit-tested.~
- [ ] ~API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).~
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
