### PR TITLE
Active organizations endpoint using activity index, cubejs new members update

### DIFF
--- a/backend/src/api/organization/index.ts
+++ b/backend/src/api/organization/index.ts
@@ -14,6 +14,7 @@ export default (app) => {
     safeWrap(require('./organizationAutocomplete').default),
   )
   app.get(`/tenant/:tenantId/organization`, safeWrap(require('./organizationList').default))
+  app.get(`/tenant/:tenantId/organization/active`, safeWrap(require('./organizationActiveList').default))
   app.get(`/tenant/:tenantId/organization/:id`, safeWrap(require('./organizationFind').default))
 
   app.put(

--- a/backend/src/api/organization/index.ts
+++ b/backend/src/api/organization/index.ts
@@ -14,7 +14,10 @@ export default (app) => {
     safeWrap(require('./organizationAutocomplete').default),
   )
   app.get(`/tenant/:tenantId/organization`, safeWrap(require('./organizationList').default))
-  app.get(`/tenant/:tenantId/organization/active`, safeWrap(require('./organizationActiveList').default))
+  app.get(
+    `/tenant/:tenantId/organization/active`,
+    safeWrap(require('./organizationActiveList').default),
+  )
   app.get(`/tenant/:tenantId/organization/:id`, safeWrap(require('./organizationFind').default))
 
   app.put(

--- a/backend/src/api/organization/organizationActiveList.ts
+++ b/backend/src/api/organization/organizationActiveList.ts
@@ -1,0 +1,51 @@
+import { Error400 } from '@crowd/common'
+import { IActiveOrganizationFilter } from '../../database/repositories/types/organizationTypes'
+import Permissions from '../../security/permissions'
+import OrganizationService from '../../services/organizationService'
+import PermissionChecker from '../../services/user/permissionChecker'
+
+export default async (req, res) => {
+  new PermissionChecker(req).validateHas(Permissions.values.memberRead)
+
+  let offset = 0
+  if (req.query.offset) {
+    offset = parseInt(req.query.offset, 10)
+  }
+  let limit = 20
+  if (req.query.limit) {
+    limit = parseInt(req.query.limit, 10)
+  }
+
+  if (req.query.filter?.activityTimestampFrom === undefined) {
+    throw new Error400(req.language, 'errors.members.activeList.activityTimestampFrom')
+  }
+
+  if (req.query.filter?.activityTimestampTo === undefined) {
+    throw new Error400(req.language, 'errors.members.activeList.activityTimestampTo')
+  }
+
+  const filters: IActiveOrganizationFilter = {
+    platforms:
+      req.query.filter?.platforms !== undefined
+        ? req.query.filter?.platforms.split(',')
+        : undefined,
+    isTeamOrganization:
+      req.query.filter?.isTeamOrganization === undefined
+        ? undefined
+        : req.query.filter?.isTeamOrganization === 'true',
+    activityTimestampFrom: req.query.filter?.activityTimestampFrom,
+    activityTimestampTo: req.query.filter?.activityTimestampTo,
+  }
+
+  const orderBy = req.query.orderBy || 'activityCount_DESC'
+
+  const payload = await new OrganizationService(req).findAndCountActive(
+    filters,
+    offset,
+    limit,
+    orderBy,
+    req.query.segments,
+  )
+
+  await req.responseHandler.success(req, res, payload)
+}

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -2,7 +2,7 @@ import lodash, { chunk } from 'lodash'
 import { get as getLevenshteinDistance } from 'fast-levenshtein'
 import validator from 'validator'
 import { FieldTranslatorFactory, OpensearchQueryParser } from '@crowd/opensearch'
-import { Error404, Error409, PageData } from '@crowd/common'
+import { Error400, Error404, Error409, PageData } from '@crowd/common'
 import {
   FeatureFlag,
   IEnrichableOrganization,
@@ -11,6 +11,8 @@ import {
   IOrganizationMergeSuggestion,
   OpenSearchIndex,
   SegmentData,
+  SegmentProjectGroupNestedData,
+  SegmentProjectNestedData,
   SyncStatus,
 } from '@crowd/types'
 import Sequelize, { QueryTypes } from 'sequelize'
@@ -24,6 +26,7 @@ import OrganizationSyncRemoteRepository from './organizationSyncRemoteRepository
 import isFeatureEnabled from '@/feature-flags/isFeatureEnabled'
 import SegmentRepository from './segmentRepository'
 import { MergeActionType, MergeActionState } from './mergeActionsRepository'
+import { IActiveOrganizationData, IActiveOrganizationFilter } from './types/organizationTypes'
 
 const { Op } = Sequelize
 
@@ -2263,6 +2266,250 @@ class OrganizationRepository {
     )
 
     return { rows: translatedRows, count: countResponse.body.count, limit, offset }
+  }
+
+  static async findAndCountActiveOpensearch(
+    filter: IActiveOrganizationFilter,
+    limit: number,
+    offset: number,
+    orderBy: string,
+    options: IRepositoryOptions,
+    segments: string[] = [],
+  ): Promise<PageData<IActiveOrganizationData>> {
+    const tenant = SequelizeRepository.getCurrentTenant(options)
+
+    const segmentsEnabled = await isFeatureEnabled(FeatureFlag.SEGMENTS, options)
+
+    let originalSegment
+
+    if (segmentsEnabled) {
+      if (segments.length !== 1) {
+        throw new Error400(
+          `This operation can have exactly one segment. Found ${segments.length} segments.`,
+        )
+      }
+      originalSegment = segments[0]
+
+      const segmentRepository = new SegmentRepository(options)
+
+      const segment = await segmentRepository.findById(originalSegment)
+
+      if (segment === null) {
+        return {
+          rows: [],
+          count: 0,
+          limit,
+          offset,
+        }
+      }
+
+      if (SegmentRepository.isProjectGroup(segment)) {
+        segments = (segment as SegmentProjectGroupNestedData).projects.reduce((acc, p) => {
+          acc.push(...p.subprojects.map((sp) => sp.id))
+          return acc
+        }, [])
+      } else if (SegmentRepository.isProject(segment)) {
+        segments = (segment as SegmentProjectNestedData).subprojects.map((sp) => sp.id)
+      } else {
+        segments = [originalSegment]
+      }
+    } else {
+      originalSegment = (await new SegmentRepository(options).getDefaultSegment()).id
+    }
+
+    const activityPageSize = 10000
+    let activityOffset = 0
+
+    const activityQuery = {
+      query: {
+        bool: {
+          must: [
+            {
+              range: {
+                date_timestamp: {
+                  gte: filter.activityTimestampFrom,
+                  lte: filter.activityTimestampTo,
+                },
+              },
+            },
+            {
+              term: {
+                uuid_tenantId: tenant.id,
+              },
+            },
+          ],
+        },
+      },
+      aggs: {
+        group_by_organization: {
+          terms: {
+            field: 'uuid_organizationId',
+            size: 10000000,
+          },
+          aggs: {
+            activity_count: {
+              value_count: {
+                field: 'uuid_id',
+              },
+            },
+            active_days_count: {
+              cardinality: {
+                field: 'date_timestamp',
+                script: {
+                  source: "doc['date_timestamp'].value.toInstant().toEpochMilli()/86400000",
+                },
+              },
+            },
+            active_organizations_bucket_sort: {
+              bucket_sort: {
+                sort: [{ activity_count: { order: 'desc' } }],
+                size: activityPageSize,
+                from: activityOffset,
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    } as any
+
+    if (filter.platforms) {
+      const subQueries = filter.platforms.map((p) => ({ match_phrase: { keyword_platform: p } }))
+
+      activityQuery.query.bool.must.push({
+        bool: {
+          should: subQueries,
+        },
+      })
+    }
+
+    if (segmentsEnabled) {
+      const subQueries = segments.map((s) => ({ term: { uuid_segmentId: s } }))
+
+      activityQuery.query.bool.must.push({
+        bool: {
+          should: subQueries,
+        },
+      })
+    }
+
+    const direction = orderBy.split('_')[1].toLowerCase() === 'desc' ? 'desc' : 'asc'
+    if (orderBy.startsWith('activityCount')) {
+      activityQuery.aggs.group_by_organization.aggs.active_organizations_bucket_sort.bucket_sort.sort =
+        [{ activity_count: { order: direction } }]
+    } else if (orderBy.startsWith('activeDaysCount')) {
+      activityQuery.aggs.group_by_organization.aggs.active_organizations_bucket_sort.bucket_sort.sort =
+        [{ active_days_count: { order: direction } }]
+    } else {
+      throw new Error(`Invalid order by: ${orderBy}`)
+    }
+
+    const organizationIds = []
+    let organizationMap = {}
+    let activities
+
+    do {
+      activities = await options.opensearch.search({
+        index: OpenSearchIndex.ACTIVITIES,
+        body: activityQuery,
+      })
+
+      organizationIds.push(
+        ...activities.body.aggregations.group_by_organization.buckets.map((b) => b.key),
+      )
+
+      organizationMap = {
+        ...organizationMap,
+        ...activities.body.aggregations.group_by_organization.buckets.reduce((acc, b) => {
+          acc[b.key] = {
+            activityCount: b.activity_count,
+            activeDaysCount: b.active_days_count,
+          }
+
+          return acc
+        }, {}),
+      }
+
+      activityOffset += activityPageSize
+
+      // update page
+      activityQuery.aggs.group_by_organization.aggs.active_organizations_bucket_sort.bucket_sort.from =
+        activityOffset
+    } while (activities.body.aggregations.group_by_organization.buckets.length === activityPageSize)
+
+    if (organizationIds.length === 0) {
+      return {
+        rows: [],
+        count: 0,
+        limit,
+        offset,
+      }
+    }
+
+    const organizationQueryPayload = {
+      and: [
+        {
+          id: {
+            in: organizationIds,
+          },
+        },
+      ],
+    } as any
+
+    if (filter.isTeamOrganization === true) {
+      organizationQueryPayload.and.push({
+        isTeamOrganization: {
+          eq: true,
+        },
+      })
+    } else if (filter.isTeamOrganization === false) {
+      organizationQueryPayload.and.push({
+        isTeamOrganization: {
+          not: true,
+        },
+      })
+    }
+
+    // to retain the sort came from activity query
+    const customSortFunction = {
+      _script: {
+        type: 'number',
+        script: {
+          lang: 'painless',
+          source: `
+              def organizationId = doc['uuid_organizationId'].value;
+              return params.organizationIds.indexOf(organizationId);
+            `,
+          params: {
+            organizationIds: organizationIds.map((i) => `${i}`),
+          },
+        },
+        order: 'asc',
+      },
+    }
+
+    const organizations = await this.findAndCountAllOpensearch(
+      {
+        filter: organizationQueryPayload,
+        segments: [originalSegment],
+        countOnly: false,
+        limit,
+        offset,
+        customSortFunction,
+      },
+      options,
+    )
+
+    return {
+      rows: organizations.rows.map((o) => {
+        o.activityCount = organizationMap[o.id].activityCount.value
+        o.activeDaysCount = organizationMap[o.id].activeDaysCount.value
+        return o
+      }),
+      count: organizations.count,
+      offset,
+      limit,
+    }
   }
 
   static async findAndCountAll(

--- a/backend/src/database/repositories/types/organizationTypes.ts
+++ b/backend/src/database/repositories/types/organizationTypes.ts
@@ -1,0 +1,13 @@
+export interface IActiveOrganizationData {
+  id: string
+  displayName: string
+  activityCount: number
+  activeDaysCount: number
+}
+
+export interface IActiveOrganizationFilter {
+  platforms?: string[]
+  isTeamOrganization?: boolean
+  activityTimestampFrom: string
+  activityTimestampTo: string
+}

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -29,6 +29,7 @@ import {
 } from './helpers/mergeFunctions'
 import MemberOrganizationService from './memberOrganizationService'
 import SearchSyncService from './searchSyncService'
+import { IActiveOrganizationFilter } from '@/database/repositories/types/organizationTypes'
 
 export default class OrganizationService extends LoggerBase {
   options: IServiceOptions
@@ -752,6 +753,23 @@ export default class OrganizationService extends LoggerBase {
 
   async findAndCountAll(args) {
     return OrganizationRepository.findAndCountAll(args, this.options)
+  }
+
+  async findAndCountActive(
+    filters: IActiveOrganizationFilter,
+    offset: number,
+    limit: number,
+    orderBy: string,
+    segments: string[],
+  ) {
+    return OrganizationRepository.findAndCountActiveOpensearch(
+      filters,
+      limit,
+      offset,
+      orderBy,
+      this.options,
+      segments,
+    )
   }
 
   async findByUrl(url) {

--- a/services/libs/cubejs/src/app/schema/MemberIdentities.js
+++ b/services/libs/cubejs/src/app/schema/MemberIdentities.js
@@ -1,0 +1,25 @@
+cube('MemberIdentities', {
+  sql_table: '"memberIdentities"',
+
+  preAggregations: {},
+
+  joins: {
+    Members: {
+      sql: `${CUBE}."memberId" = ${Members}.id`,
+      relationship: 'belongsTo',
+    },
+  },
+
+  measures: {},
+
+  dimensions: {
+    platform: {
+      sql: `${CUBE}.platform`,
+      type: 'string',
+    },
+    username: {
+      sql: `${CUBE}.username`,
+      type: 'string',
+    },
+  },
+})

--- a/services/libs/cubejs/src/app/schema/Members.js
+++ b/services/libs/cubejs/src/app/schema/Members.js
@@ -21,6 +21,11 @@ cube('Members', {
       sql: `${CUBE}.id = ${MemberSegments}."memberId"`,
       relationship: 'belongsTo',
     },
+
+    MemberIdentities: {
+      sql: `${CUBE}.id = ${MemberIdentities}."memberId"`,
+      relationship: 'hasMany',
+    },
   },
 
   measures: {

--- a/services/libs/cubejs/src/enums.ts
+++ b/services/libs/cubejs/src/enums.ts
@@ -7,6 +7,7 @@ export enum CubeDimension {
   ACTIVITY_DATE = 'Activities.date',
   ACTIVITY_DATE_DAY = 'Activities.date.day',
   ACTIVITY_PLATFORM = 'Activities.platform',
+  MEMBER_IDENTITIES_PLATFORM = 'MemberIdentities.platform',
   ACTIVITY_TYPE = 'Activities.type',
   ACTIVITY_SENTIMENT_MOOD = 'Activities.sentimentMood',
   CONVERSATION_CREATED_AT = 'Conversations.createdat',

--- a/services/libs/cubejs/src/metrics/newMembers.ts
+++ b/services/libs/cubejs/src/metrics/newMembers.ts
@@ -41,7 +41,7 @@ export default async (
 
   if (filter.platform) {
     filters.push({
-      member: CubeDimension.ACTIVITY_PLATFORM,
+      member: CubeDimension.MEMBER_IDENTITIES_PLATFORM,
       operator: 'equals',
       values: [filter.platform],
     })

--- a/services/libs/opensearch/src/repo/activity.data.ts
+++ b/services/libs/opensearch/src/repo/activity.data.ts
@@ -22,4 +22,5 @@ export interface IDbActivitySyncData {
   username: string
   objectMemberId: string | null
   objectMemberUsername: string | null
+  organizationId: string | null
 }

--- a/services/libs/opensearch/src/repo/activity.repo.ts
+++ b/services/libs/opensearch/src/repo/activity.repo.ts
@@ -32,7 +32,8 @@ export class ActivityRepository extends RepositoryBase<ActivityRepository> {
             "parentId",
             username,
             "objectMemberId",
-            "objectMemberUsername"
+            "objectMemberUsername",
+            "organizationId"
       from activities where id in ($(activityIds:csv)) and "deletedAt" is null
     `,
       {

--- a/services/libs/opensearch/src/repo/activity.repo.ts
+++ b/services/libs/opensearch/src/repo/activity.repo.ts
@@ -20,7 +20,6 @@ export class ActivityRepository extends RepositoryBase<ActivityRepository> {
             score,
             "sourceId",
             "sourceParentId",
-            attributes,
             channel,
             body,
             title,

--- a/services/libs/opensearch/src/service/activity.sync.service.ts
+++ b/services/libs/opensearch/src/service/activity.sync.service.ts
@@ -273,7 +273,6 @@ export class ActivitySyncService {
     p.int_score = data.score ?? 0
     p.keyword_sourceId = data.sourceId
     p.keyword_sourceParentId = data.sourceParentId
-    p.string_attributes = data.attributes ? JSON.stringify(data.attributes) : '{}'
     p.keyword_channel = data.channel
     p.string_body = trimUtf8ToMaxByteLength(data.body, ActivitySyncService.MAX_BYTE_LENGTH)
     p.string_title = data.title

--- a/services/libs/opensearch/src/service/activity.sync.service.ts
+++ b/services/libs/opensearch/src/service/activity.sync.service.ts
@@ -286,6 +286,7 @@ export class ActivitySyncService {
     p.string_username = data.username
     p.uuid_objectMemberId = data.objectMemberId
     p.string_objectMemberUsername = data.objectMemberUsername
+    p.uuid_organizationId = data.organizationId
 
     return p
   }

--- a/services/libs/opensearch/src/service/init.service.ts
+++ b/services/libs/opensearch/src/service/init.service.ts
@@ -296,6 +296,7 @@ export class InitService {
       username: 'Test Member',
       objectMemberId: '4ea4c0f7-fdf8-448c-99ff-e03d0df95358',
       objectMemberUsername: 'Test Member2',
+      organizationId: '2badb0e5-e21b-4955-aba7-d52ef66bae59',
     }
 
     const prepared = ActivitySyncService.prefixData(fakeActivity)


### PR DESCRIPTION
- new organization/active endpoint that gets active organizations using activity index and org index from opensearch
- adds memberIdentity.platform filtering support to member cubes in cubejs

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
