### PR TITLE
Fix datadog logging

### DIFF
--- a/services/libs/logging/src/logger.ts
+++ b/services/libs/logging/src/logger.ts
@@ -24,6 +24,10 @@ export const getServiceLogger = (): Logger => {
   }
 
   serviceLoggerInstance = Bunyan.createLogger(options)
+  if (!IS_DEV_ENV && !IS_TEST_ENV) {
+    delete serviceLoggerInstance.fields.hostname
+  }
+
   return serviceLoggerInstance
 }
 


### PR DESCRIPTION
- Bunyan, when writing logs in json, always includes `hostname` as a field
- Bunyan takes the value for that field from the os (you can check it either in `HOSTNAME` env variable, or running the `hostname` command)
- On kubernetes hostname in a container resolves to the pod name
- Datadog, when receiving logs, tries to match `hostname` field to a name of any host it knows about. If `hostname` field isn't present in logs, it tries to derive it from a kubernetes node, which these logs came from
- When `hostname` in logs doesn't match any of the hosts Datadog knows about, Datadog won't assign any extra tags, which those hosts already have
- This was creating a problem, when we assigned tags such as `account:crowd` and `cluster_name:crowd-kube-production` to nodes, which weren't propagating to logs coming from these nodes
- Without this tag propagation it's impossible to tell which kubernetes cluster the logs came from
- To fix that, we just make Bunyan to stop populating `hostname` field in json logs, allowing Datadog to do its magic