### PR TITLE
Fix blank merge dialog in organizations

### DIFF
--- a/frontend/src/modules/member/components/member-merge-dialog.vue
+++ b/frontend/src/modules/member/components/member-merge-dialog.vue
@@ -19,7 +19,7 @@
           </div>
           <div class="w-1/2 px-3">
             <app-member-selection-dropdown
-              v-if="memberToMerge === null"
+              v-if="!memberToMerge"
               :id="props.modelValue?.id"
               v-model="memberToMerge"
               style="margin-right: 5px"

--- a/frontend/src/modules/organization/components/organization-merge-dialog.vue
+++ b/frontend/src/modules/organization/components/organization-merge-dialog.vue
@@ -19,7 +19,7 @@
           </div>
           <div class="w-1/2 px-3">
             <app-organization-selection-dropdown
-              v-if="organizationToMerge === null"
+              v-if="!organizationToMerge"
               :id="props.modelValue?.id"
               v-model="organizationToMerge"
               style="margin-right: 5px"
@@ -94,7 +94,7 @@ const organizationStore = useOrganizationStore();
 const originalOrganizationPrimary = ref(true);
 const sendingMerge = ref(false);
 
-const organizationToMerge = ref();
+const organizationToMerge = ref(null);
 
 const isModalOpen = computed({
   get() {


### PR DESCRIPTION
# Changes proposed ✍️

### What
- On organizations profile page, if user opened Merge dialog, the right side would be blank.

### How
- Fixed by rendering the organization selection dropdown if the organization didn't exist. Before it was failing because we were validating if `organization === null` instead of `!organization`. And organization initially was undefined.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
