### PR TITLE
Datadog rum userid

### DIFF
--- a/frontend/src/modules/auth/store/auth.actions.ts
+++ b/frontend/src/modules/auth/store/auth.actions.ts
@@ -7,6 +7,7 @@ import { disconnectSocket, connectSocket, isSocketConnected } from '@/modules/au
 import identify from '@/shared/monitoring/identify';
 import { watch } from 'vue';
 import config from '@/config';
+import { setRumUser } from '@/utils/datadog/rum';
 
 export default {
   init() {
@@ -28,10 +29,10 @@ export default {
     if (!lfxHeader || lfxHeader.authuser) {
       return;
     }
-    Auth0Service.getUser()
-      .then((user) => {
-        lfxHeader.authuser = user;
-      });
+    Auth0Service.getUser().then((user) => {
+      setRumUser(user.nickname);
+      lfxHeader.authuser = user;
+    });
   },
   silentLogin() {
     Auth0Service.getTokenSilently()

--- a/frontend/src/modules/auth/types/User.type.ts
+++ b/frontend/src/modules/auth/types/User.type.ts
@@ -12,6 +12,7 @@ export interface User {
   id: string;
   importHash: string | null;
   lastName: string;
+  login: string | null;
   phoneNumber: string | null;
   provider: string;
   tenants: TenantUser[];

--- a/frontend/src/utils/datadog/rum.js
+++ b/frontend/src/utils/datadog/rum.js
@@ -18,3 +18,7 @@ export function initRUM() {
     defaultPrivacyLevel: 'mask-user-input',
   });
 }
+
+export function setRumUser(id) {
+  datadogRum.setUser({ id });
+}


### PR DESCRIPTION
With datadog we can already track sessions and replay them in datadog
Now we want to know which user these sessions belong to
For that we:
- Extract a login from auth0 provider id, which looks like this `auth0|misha`
- Send it to frontend
- And configure it with datadog