### PR TITLE
Syncing primary member to opensearch again after moving activities completes

### DIFF
--- a/services/apps/entity_merging_worker/src/workflows/all.ts
+++ b/services/apps/entity_merging_worker/src/workflows/all.ts
@@ -29,6 +29,7 @@ export async function finishMemberMerging(
 ): Promise<void> {
   await moveActivitiesBetweenMembers(primaryId, secondaryId, tenantId)
   await recalculateActivityAffiliationsOfMemberAsync(primaryId, tenantId)
+  await syncMember(primaryId, secondaryId)
   await deleteMember(secondaryId)
   await setMergeActionState(primaryId, secondaryId, tenantId, 'merged' as MergeActionState)
 }


### PR DESCRIPTION
More in linear task

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
