### PR TITLE
Org merging segments

### DIFF
--- a/backend/src/api/organization/organizationMerge.ts
+++ b/backend/src/api/organization/organizationMerge.ts
@@ -8,13 +8,15 @@ export default async (req, res) => {
 
   const primaryOrgId = req.params.organizationId
   const secondaryOrgId = req.body.organizationToMerge
+  const segmentId = req.body.segments[0]
 
   const requestPayload = {
     primary: primaryOrgId,
     secondary: secondaryOrgId,
+    segmentId,
   }
 
-  await new OrganizationService(req).mergeSync(primaryOrgId, secondaryOrgId)
+  await new OrganizationService(req).mergeSync(primaryOrgId, secondaryOrgId, segmentId)
 
   track('Merge organizations', requestPayload, { ...req })
 

--- a/backend/src/bin/jobs/refreshMaterializedViews.ts
+++ b/backend/src/bin/jobs/refreshMaterializedViews.ts
@@ -65,6 +65,7 @@ const job: CrowdJob = {
       await refreshMaterializedView('memberActivityAggregatesMVs', database, log)
     }
     await refreshMaterializedView('member_segments_mv', database, log)
+    await refreshMaterializedView('organization_segments_mv', database, log)
   },
 }
 

--- a/backend/src/database/migrations/R__organization_segments_mv.sql
+++ b/backend/src/database/migrations/R__organization_segments_mv.sql
@@ -1,0 +1,9 @@
+DROP MATERIALIZED VIEW IF EXISTS organization_segments_mv;
+
+CREATE MATERIALIZED VIEW organization_segments_mv AS
+SELECT DISTINCT "organizationId", "segmentId", "tenantId"
+FROM activities
+WHERE "deletedAt" IS NULL;
+
+CREATE UNIQUE INDEX ix_organization_segments_orgid_segmentid ON organization_segments_mv ("organizationId", "segmentId");
+CREATE INDEX ix_organization_segments_segmentid ON organization_segments_mv ("segmentId");

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1198,7 +1198,8 @@ class OrganizationRepository {
           otm."similarity"
         FROM organizations org
         JOIN "organizationToMerge" otm ON org.id = otm."organizationId"
-        JOIN "organization_segments_mv" os ON os."organizationId" = org.id
+        JOIN "organization_segments_mv" os1 ON os1."organizationId" = org.id
+        JOIN "organization_segments_mv" os2 ON os2."organizationId" = otm."toMergeId"
         LEFT JOIN "mergeActions" ma
           ON ma.type = :mergeActionType
           AND ma."tenantId" = :tenantId
@@ -1207,7 +1208,8 @@ class OrganizationRepository {
             OR (ma."primaryId" = otm."toMergeId" AND ma."secondaryId" = org.id)
           )
         WHERE org."tenantId" = :tenantId
-          AND os."segmentId" IN (:segmentIds)
+          AND os1."segmentId" IN (:segmentIds)
+          AND os2."segmentId" IN (:segmentIds)
           AND (ma.id IS NULL OR ma.state = :mergeActionStatus)
           ${organizationFilter}
       ),

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1198,7 +1198,7 @@ class OrganizationRepository {
           otm."similarity"
         FROM organizations org
         JOIN "organizationToMerge" otm ON org.id = otm."organizationId"
-        JOIN "organizationSegments" os ON os."organizationId" = org.id
+        JOIN "organization_segments_mv" os ON os."organizationId" = org.id
         LEFT JOIN "mergeActions" ma
           ON ma.type = :mergeActionType
           AND ma."tenantId" = :tenantId

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -389,7 +389,7 @@ export default class OrganizationService extends LoggerBase {
     }
   }
 
-  async mergeSync(originalId, toMergeId) {
+  async mergeSync(originalId, toMergeId, segmentId) {
     this.options.log.info({ originalId, toMergeId }, 'Merging organizations!')
 
     const removeExtraFields = (organization: IOrganization): IOrganization =>
@@ -422,7 +422,11 @@ export default class OrganizationService extends LoggerBase {
           const backup = {
             primary: {
               ...lodash.pick(
-                await OrganizationRepository.findByIdOpensearch(originalId, this.options),
+                await OrganizationRepository.findByIdOpensearch(
+                  originalId,
+                  this.options,
+                  segmentId,
+                ),
                 OrganizationService.ORGANIZATION_MERGE_FIELDS,
               ),
               identities: await OrganizationRepository.getIdentities([originalId], this.options),

--- a/frontend/src/modules/organization/organization-service.js
+++ b/frontend/src/modules/organization/organization-service.js
@@ -1,5 +1,6 @@
 import authAxios from '@/shared/axios/auth-axios';
 import { AuthService } from '@/modules/auth/services/auth.service';
+import { router } from '@/router';
 
 export class OrganizationService {
   static async update(id, data, segments) {
@@ -41,6 +42,7 @@ export class OrganizationService {
       `/tenant/${tenantId}/organization/${organizationToKeepId}/merge`,
       {
         organizationToMerge: organizationToMergeId,
+        segments: [router.currentRoute.value.query.projectGroup],
       },
     );
 


### PR DESCRIPTION
1. When generating org merge suggestions:
    - instead of using `organizationSegments` table we use the new `organization_segments_mv` materialized view, which is based on the `activities` table.
    - we make sure both organizations belong to the project group (otherwise we can't merge them)
2. When merging orgs from frontend, instead of passing the whole list of subprojects to the backend, we only pass project group id. This way we ensure we definitely find both orgs by id in opensearch.