### PR TITLE
Faster dockerfiles

### DIFF
--- a/scripts/services/docker/Dockerfile.automations_worker
+++ b/scripts/services/docker/Dockerfile.automations_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.backend
+++ b/scripts/services/docker/Dockerfile.backend
@@ -4,6 +4,8 @@ WORKDIR /usr/crowd/app
 RUN corepack enable && apk add --update --no-cache python3 build-base && ln -sf python3 /usr/bin/python &&  python3 -m venv .venv && source .venv/bin/activate && python3 -m ensurepip && pip3 install --no-cache --upgrade pip setuptools
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./backend ./backend
 COPY ./services/libs ./services/libs
 RUN pnpm i --frozen-lockfile

--- a/scripts/services/docker/Dockerfile.cache_worker
+++ b/scripts/services/docker/Dockerfile.cache_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.data_sink_worker
+++ b/scripts/services/docker/Dockerfile.data_sink_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.emails_worker
+++ b/scripts/services/docker/Dockerfile.emails_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.entity_merging_worker
+++ b/scripts/services/docker/Dockerfile.entity_merging_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.exports_worker
+++ b/scripts/services/docker/Dockerfile.exports_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.integration_run_worker
+++ b/scripts/services/docker/Dockerfile.integration_run_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.integration_stream_worker
+++ b/scripts/services/docker/Dockerfile.integration_stream_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.integration_sync_worker
+++ b/scripts/services/docker/Dockerfile.integration_sync_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.members_enrichment_worker
+++ b/scripts/services/docker/Dockerfile.members_enrichment_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 
@@ -12,7 +16,7 @@ FROM node:20-bookworm-slim as runner
 WORKDIR /usr/crowd/app
 RUN corepack enable && apt update && apt install -y ca-certificates --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/crowd/app/node_modules ./node_modules  
+COPY --from=builder /usr/crowd/app/node_modules ./node_modules
 COPY --from=builder /usr/crowd/app/services/libs ./services/libs
 COPY --from=builder /usr/crowd/app/services/archetypes/ ./services/archetypes
 COPY --from=builder /usr/crowd/app/services/apps/premium/members_enrichment_worker/ ./services/apps/premium/members_enrichment_worker

--- a/scripts/services/docker/Dockerfile.merge_suggestions_worker
+++ b/scripts/services/docker/Dockerfile.merge_suggestions_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.organizations_enrichment_worker
+++ b/scripts/services/docker/Dockerfile.organizations_enrichment_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.profiles_worker
+++ b/scripts/services/docker/Dockerfile.profiles_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.script_executor_worker
+++ b/scripts/services/docker/Dockerfile.script_executor_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.search_sync_api
+++ b/scripts/services/docker/Dockerfile.search_sync_api
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.search_sync_worker
+++ b/scripts/services/docker/Dockerfile.search_sync_worker
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 

--- a/scripts/services/docker/Dockerfile.webhook_api
+++ b/scripts/services/docker/Dockerfile.webhook_api
@@ -1,9 +1,13 @@
 FROM node:20-alpine as builder
 
+RUN apk add --no-cache python3 make g++
+
 WORKDIR /usr/crowd/app
 RUN corepack enable
 
 COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
 COPY ./services ./services
 RUN pnpm i --frozen-lockfile
 


### PR DESCRIPTION
Download pnpm dependencies from just a pnpm lockfile, even before copying everything else.
This way we cache the slowest/heaviest layer without depending on the code.
No need to wait for a complete `pnpm install` whenever you change a single line of code.