### PR TITLE
Update groupsio integration data structure

### DIFF
--- a/backend/src/serverless/integrations/usecases/groupsio/types.ts
+++ b/backend/src/serverless/integrations/usecases/groupsio/types.ts
@@ -3,7 +3,7 @@ export interface GroupsioIntegrationData {
   token: string
   tokenExpiry: string
   password: string
-  groupNames: GroupName[]
+  groups: GroupDetails[]
 }
 
 export interface GroupsioGetToken {
@@ -15,6 +15,12 @@ export interface GroupsioGetToken {
 export interface GroupsioVerifyGroup {
   groupName: GroupName
   cookie: string
+}
+
+export interface GroupDetails {
+  id: number
+  slug: string
+  name: string
 }
 
 export type GroupName = string

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -1710,6 +1710,20 @@ export default class IntegrationService {
     // user should update them every time thety change something
 
     try {
+      for (const group of integrationData.groups) {
+        const config: AxiosRequestConfig = {
+          method: 'get',
+          url: `https://groups.io/api/v1/getgroup?group_name=${encodeURIComponent(group.slug)}`,
+          headers: {
+            'Content-Type': 'application/json',
+            Cookie: integrationData.token,
+          },
+        }
+
+        const response = await axios(config)
+        group.id = response.data.id
+        group.name = response.data.nice_group_name
+      }
       this.options.log.info('Creating Groups.io integration!')
       const encryptedPassword = encryptData(integrationData.password)
       integration = await this.createOrUpdate(
@@ -1720,7 +1734,7 @@ export default class IntegrationService {
             token: integrationData.token,
             tokenExpiry: integrationData.tokenExpiry,
             password: encryptedPassword,
-            groups: integrationData.groupNames,
+            groups: integrationData.groups,
             updateMemberAttributes: true,
           },
           status: 'in-progress',

--- a/frontend/src/integrations/groupsio/components/groupsio-connect-drawer.vue
+++ b/frontend/src/integrations/groupsio/components/groupsio-connect-drawer.vue
@@ -124,7 +124,7 @@
           <app-array-input
             v-for="(_, ii) of form.groups"
             :key="ii"
-            v-model="form.groups[ii]"
+            v-model="form.groups[ii].slug"
             placeholder="crowd-test"
             :validation-function="validateGroup"
             :disabled="!isAPIConnectionValid"
@@ -202,7 +202,9 @@ const form = reactive({
   email: '',
   password: '',
   twoFactorCode: '',
-  groups: [''],
+  groups: [{
+    slug: '',
+  }],
   groupsValidationState: [null],
 });
 
@@ -239,7 +241,7 @@ const rules = computed(() => {
 });
 
 const addGroup = () => {
-  form.groups.push('');
+  form.groups.push({});
 };
 
 const removeGroup = (index) => {
@@ -323,7 +325,7 @@ const handleCancel = () => {
     form.email = '';
     form.password = '';
     form.twoFactorCode = '';
-    form.groups = [''];
+    form.groups = [{}];
     form.groupsValidationState = new Array(form.groups.length).fill(true);
     cookie.value = '';
     isAPIConnectionValid.value = false;
@@ -334,7 +336,7 @@ const handleCancel = () => {
     form.email = props.integration?.settings?.email;
     form.password = '';
     form.twoFactorCode = '';
-    form.groups = props?.integration?.settings?.groups ? [...props.integration.settings.groups] : [''];
+    form.groups = props?.integration?.settings?.groups ? [...props.integration.settings.groups] : [{}];
     form.groupsValidationState = new Array(form.groups.length).fill(true);
     cookie.value = props.integration?.settings?.token;
     isAPIConnectionValid.value = true;
@@ -364,7 +366,7 @@ const connect = async () => {
     token: cookie.value,
     tokenExpiry: cookieExpiry.value,
     password: form.password,
-    groupNames: form.groups,
+    groups: form.groups,
     isUpdate: !!props.integration.settings?.email,
   })
     .then(() => {

--- a/frontend/src/modules/integration/integration-service.js
+++ b/frontend/src/modules/integration/integration-service.js
@@ -418,7 +418,7 @@ export class IntegrationService {
     return response.data.isWebhooksReceived;
   }
 
-  static async groupsioConnect(email, token, tokenExpiry, password, groupNames) {
+  static async groupsioConnect(email, token, tokenExpiry, password, groups) {
     const tenantId = AuthService.getTenantId();
 
     const response = await authAxios.post(
@@ -428,7 +428,7 @@ export class IntegrationService {
         token,
         tokenExpiry,
         password,
-        groupNames,
+        groups,
         ...getSegments(),
       },
     );

--- a/frontend/src/modules/integration/integration-store.js
+++ b/frontend/src/modules/integration/integration-store.js
@@ -628,10 +628,10 @@ export default {
     async doGroupsioConnect(
       { commit },
       {
-        email, token, tokenExpiry, password, groupNames, isUpdate,
+        email, token, tokenExpiry, password, groups, isUpdate,
       },
     ) {
-      console.log('doGroupsioConnect', email, token, groupNames, isUpdate);
+      console.log('doGroupsioConnect', email, token, groups, isUpdate);
 
       try {
         commit('CREATE_STARTED');
@@ -641,7 +641,7 @@ export default {
           token,
           tokenExpiry,
           password,
-          groupNames,
+          groups,
         );
 
         commit('CREATE_SUCCESS', integration);

--- a/services/libs/integrations/src/integrations/groupsio/generateStreams.ts
+++ b/services/libs/integrations/src/integrations/groupsio/generateStreams.ts
@@ -32,9 +32,9 @@ const handler: GenerateStreamsHandler = async (ctx) => {
     // because we need to know who the members are before we can start parsing
     // messages don't have enough information to create members
     await ctx.publishStream<GroupsioGroupMembersStreamMetadata>(
-      `${GroupsioStreamType.GROUP_MEMBERS}:${group}`,
+      `${GroupsioStreamType.GROUP_MEMBERS}:${group.slug}`,
       {
-        group,
+        group: group.slug,
         page: null,
       },
     )
@@ -43,7 +43,7 @@ const handler: GenerateStreamsHandler = async (ctx) => {
       await ctx.publishStream<GroupsioPastGroupMembersStreamMetadata>(
         `${GroupsioStreamType.PAST_GROUP_MEMBERS}:${group}`,
         {
-          group,
+          group: group.slug,
           page: null,
         },
       )

--- a/services/libs/integrations/src/integrations/groupsio/types.ts
+++ b/services/libs/integrations/src/integrations/groupsio/types.ts
@@ -80,7 +80,13 @@ export interface GroupsioPublishData<T> {
 export interface GroupsioIntegrationSettings {
   email: string
   token: string
-  groups: GroupName[]
+  groups: GroupDetails[]
+}
+
+export interface GroupDetails {
+  id: number
+  name: string
+  slug: string
 }
 
 export interface ActivityLog {


### PR DESCRIPTION
# Changes proposed ✍️

### What
We need to change the groupsio integration structure to include more data (group id) as described in https://github.com/CrowdDotDev/linux-foundation-support/issues/773
​
Here's an example of how it looks like when run locally

```
{
  "email": "[redacted]",
  "token": "[redacted]",
  "groups": [
    {
      "id": 112739,
      "name": "SONiC | sonic-community",
      "slug": "lf-sonic-foundation+sonic-community"
    },
    {
      "id": 107077,
      "name": "SONiC | sonic-outreach",
      "slug": "lf-sonic-foundation+sonic-outreach"
    },
    {
      "id": 118579,
      "name": "SONiC | sonic-smartswitch",
      "slug": "lf-sonic-foundation+sonic-smartswitch"
    },
    {
      "id": 107075,
      "name": "SONiC | sonic-tsc",
      "slug": "lf-sonic-foundation+sonic-tsc"
    }
  ],
  "password": "[redacted]",
  "tokenExpiry": "2024-06-19 13:50:07.077 +00:00",
  "updateMemberAttributes": false
}
```

