### PR TITLE
Improve member merge/unmerge

### DIFF
--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -1,3 +1,4 @@
+import os from 'os'
 import { SERVICE } from '@crowd/common'
 import { getUnleashClient } from '@crowd/feature-flags'
 import { getServiceLogger } from '@crowd/logging'
@@ -94,6 +95,11 @@ setImmediate(async () => {
       level: 'trace',
     }),
   )
+
+  app.use((req, res, next) => {
+    res.setHeader('X-Hostname', os.hostname())
+    next()
+  })
 
   app.use((req, res, next) => {
     // this middleware fixes the issue with logging and datadog

--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -97,6 +97,11 @@ setImmediate(async () => {
   )
 
   app.use((req, res, next) => {
+    req.profileSql = req.headers['x-profile-sql'] === 'true'
+    next()
+  })
+
+  app.use((req, res, next) => {
     res.setHeader('X-Hostname', os.hostname())
     next()
   })

--- a/backend/src/api/member/memberFind.ts
+++ b/backend/src/api/member/memberFind.ts
@@ -38,7 +38,7 @@ export default async (req, res) => {
   if (await isFeatureEnabled(FeatureFlag.SERVE_PROFILES_OPENSEARCH, req)) {
     payload = await new MemberService(req).findByIdOpensearch(req.params.id, segmentId)
   } else {
-    payload = await new MemberService(req).findById(req.params.id, true, true, segmentId)
+    payload = await new MemberService(req).findById(req.params.id, { segmentId })
   }
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/api/member/memberUpdate.ts
+++ b/backend/src/api/member/memberUpdate.ts
@@ -24,7 +24,10 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.memberEdit)
 
   const member = await new MemberService(req).findById(req.params.id)
-  const payload = await new MemberService(req).update(req.params.id, req.body, true, true)
+  const payload = await new MemberService(req).update(req.params.id, req.body, {
+    syncToOpensearch: true,
+    manualChange: true,
+  })
 
   const differentTagIds = lodash.difference(
     payload.tags.map((t) => t.id),

--- a/backend/src/bin/scripts/merge-duplicated-members.ts
+++ b/backend/src/bin/scripts/merge-duplicated-members.ts
@@ -155,7 +155,9 @@ async function check(): Promise<number> {
 
         const allMembers = []
         for (const id of data.all_ids) {
-          const member = await MemberRepository.findById(id, txOptions)
+          const member = await MemberRepository.findById(id, txOptions, {
+            doPopulateRelations: false,
+          })
           allMembers.push(member)
         }
 

--- a/backend/src/bin/scripts/merge-members.ts
+++ b/backend/src/bin/scripts/merge-members.ts
@@ -64,11 +64,15 @@ if (parameters.help || !parameters.originalId || !parameters.targetId) {
 
     const options = await SequelizeRepository.getDefaultIRepositoryOptions()
 
-    const originalMember = await MemberRepository.findById(originalId, options, true, true, true)
+    const originalMember = await MemberRepository.findById(originalId, options, {
+      ignoreTenant: true,
+    })
     options.currentTenant = { id: originalMember.tenantId }
 
     for (const targetId of targetIds) {
-      const targetMember = await MemberRepository.findById(targetId, options, true, true, true)
+      const targetMember = await MemberRepository.findById(targetId, options, {
+        ignoreTenant: true,
+      })
 
       if (originalMember.tenantId !== targetMember.tenantId) {
         log.error(

--- a/backend/src/database/databaseConnection.ts
+++ b/backend/src/database/databaseConnection.ts
@@ -9,9 +9,10 @@ export async function databaseInit(
   queryTimeoutMilliseconds: number = 60000,
   forceNewInstance: boolean = false,
   databaseHostnameOverride: string = null,
+  profileQueries: boolean = false,
 ) {
-  if (forceNewInstance) {
-    return models(queryTimeoutMilliseconds, databaseHostnameOverride)
+  if (profileQueries || forceNewInstance) {
+    return models(queryTimeoutMilliseconds, databaseHostnameOverride, profileQueries)
   }
 
   if (!cached) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -596,8 +596,6 @@ class MemberRepository {
     const toMergeMember = await this.findById(toMergeId, options, returnPlain)
 
     await member.removeToMerge(toMergeMember, { transaction })
-
-    return this.findById(id, options)
   }
 
   static async addNoMerge(id, toMergeId, options: IRepositoryOptions) {
@@ -610,8 +608,6 @@ class MemberRepository {
     const toMergeMember = await this.findById(toMergeId, options, returnPlain)
 
     await member.addNoMerge(toMergeMember, { transaction })
-
-    return this.findById(id, options)
   }
 
   static async removeNoMerge(id, toMergeId, options: IRepositoryOptions) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -812,8 +812,13 @@ class MemberRepository {
     id,
     data,
     options: IRepositoryOptions,
-    doPopulateRelations = true,
-    manualChange = false,
+    {
+      doPopulateRelations = true,
+      manualChange = false,
+    }: {
+      doPopulateRelations?: boolean
+      manualChange?: boolean
+    } = {},
   ) {
     const currentUser = SequelizeRepository.getCurrentUser(options)
 

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -190,7 +190,7 @@ class MemberRepository {
 
     await this._createAuditLog(AuditLogRepository.CREATE, record, data, options)
 
-    return this.findById(record.id, options, true, doPopulateRelations)
+    return this.findById(record.id, options, { doPopulateRelations })
   }
 
   static async includeMemberToSegments(memberId: string, options: IRepositoryOptions) {
@@ -1173,7 +1173,7 @@ class MemberRepository {
 
     await this._createAuditLog(AuditLogRepository.UPDATE, record, data, options)
 
-    return this.findById(record.id, options, true, doPopulateRelations)
+    return this.findById(record.id, options, { doPopulateRelations })
   }
 
   static async destroy(id, options: IRepositoryOptions, force = false) {
@@ -1182,7 +1182,7 @@ class MemberRepository {
     const currentTenant = SequelizeRepository.getCurrentTenant(options)
 
     await MemberRepository.excludeMembersFromSegments([id], { ...options, transaction })
-    const member = await this.findById(id, options, true, false)
+    const member = await this.findById(id, options, { doPopulateRelations: false })
 
     // if member doesn't belong to any other segment anymore, remove it
     if (member.segments.length === 0) {
@@ -1496,11 +1496,19 @@ class MemberRepository {
   static async findById(
     id,
     options: IRepositoryOptions,
-    returnPlain = true,
-    doPopulateRelations = true,
-    ignoreTenant = false,
-    segmentId?: string,
-    newIdentities?: boolean,
+    {
+      returnPlain = true,
+      doPopulateRelations = true,
+      ignoreTenant = false,
+      segmentId,
+      newIdentities,
+    }: {
+      returnPlain?: boolean
+      doPopulateRelations?: boolean
+      ignoreTenant?: boolean
+      segmentId?: string
+      newIdentities?: boolean
+    } = {},
   ) {
     const transaction = SequelizeRepository.getTransaction(options)
 

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -610,20 +610,6 @@ class MemberRepository {
     await member.addNoMerge(toMergeMember, { transaction })
   }
 
-  static async removeNoMerge(id, toMergeId, options: IRepositoryOptions) {
-    const transaction = SequelizeRepository.getTransaction(options)
-
-    const returnPlain = false
-
-    const member = await this.findById(id, options, returnPlain)
-
-    const toMergeMember = await this.findById(toMergeId, options, returnPlain)
-
-    await member.removeNoMerge(toMergeMember, { transaction })
-
-    return this.findById(id, options)
-  }
-
   static async memberExists(
     username,
     platform,

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -1433,7 +1433,7 @@ class MemberRepository {
              "integrationId",
              "createdAt",
              "updatedAt"
-      from "memberIdentities" 
+      from "memberIdentities"
       where "memberId" in (:memberIds)
       order by "createdAt" asc;
     `

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -36,6 +36,7 @@ import {
 } from '@crowd/data-access-layer/src/member_identities'
 import { FieldTranslatorFactory, OpensearchQueryParser } from '@crowd/opensearch'
 import { findManyLfxMemberships } from '@crowd/data-access-layer/src/lfx_memberships'
+import { addMemberNoMerge, removeMemberToMerge } from '@crowd/data-access-layer/src/member_merge'
 import { KUBE_MODE, SERVICE } from '@/conf'
 import { ServiceType } from '../../conf/configTypes'
 import isFeatureEnabled from '../../feature-flags/isFeatureEnabled'
@@ -588,26 +589,16 @@ class MemberRepository {
 
   static async removeToMerge(id, toMergeId, options: IRepositoryOptions) {
     const transaction = SequelizeRepository.getTransaction(options)
+    const qx = SequelizeRepository.getQueryExecutor(options, transaction)
 
-    const returnPlain = false
-
-    const member = await this.findById(id, options, returnPlain)
-
-    const toMergeMember = await this.findById(toMergeId, options, returnPlain)
-
-    await member.removeToMerge(toMergeMember, { transaction })
+    await removeMemberToMerge(qx, id, toMergeId)
   }
 
   static async addNoMerge(id, toMergeId, options: IRepositoryOptions) {
     const transaction = SequelizeRepository.getTransaction(options)
+    const qx = SequelizeRepository.getQueryExecutor(options, transaction)
 
-    const returnPlain = false
-
-    const member = await this.findById(id, options, returnPlain)
-
-    const toMergeMember = await this.findById(toMergeId, options, returnPlain)
-
-    await member.addNoMerge(toMergeMember, { transaction })
+    await addMemberNoMerge(qx, id, toMergeId)
   }
 
   static async memberExists(

--- a/backend/src/database/repositories/tenantRepository.ts
+++ b/backend/src/database/repositories/tenantRepository.ts
@@ -453,7 +453,10 @@ class TenantRepository {
 
   static async getAvailablePlatforms(id, options: IRepositoryOptions) {
     const query = `
-        select distinct platform from "memberIdentities" where "tenantId" = :tenantId
+      SELECT platform
+      FROM "memberIdentities"
+      WHERE "tenantId" = :tenantId
+      GROUP BY 1
     `
     const parameters: any = {
       tenantId: id,

--- a/backend/src/middlewares/databaseMiddleware.ts
+++ b/backend/src/middlewares/databaseMiddleware.ts
@@ -5,7 +5,8 @@ const log = getServiceLogger()
 
 export async function databaseMiddleware(req, res, next) {
   try {
-    const database = await databaseInit()
+    const profileQueries = req.headers['x-profile-sql'] === 'true'
+    const database = await databaseInit(undefined, undefined, undefined, profileQueries)
     req.database = database
   } catch (error) {
     log.error(error, 'Database connection error!')

--- a/backend/src/middlewares/databaseMiddleware.ts
+++ b/backend/src/middlewares/databaseMiddleware.ts
@@ -5,7 +5,7 @@ const log = getServiceLogger()
 
 export async function databaseMiddleware(req, res, next) {
   try {
-    const profileQueries = req.headers['x-profile-sql'] === 'true'
+    const profileQueries = !!req.profileSql
     const database = await databaseInit(undefined, undefined, undefined, profileQueries)
     req.database = database
   } catch (error) {

--- a/backend/src/services/IServiceOptions.ts
+++ b/backend/src/services/IServiceOptions.ts
@@ -17,4 +17,5 @@ export interface IServiceOptions {
   unleash?: Unleash
   temporal: TemporalClient
   productDb: DbConnection
+  profileSql?: boolean
 }

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -144,7 +144,9 @@ export default class ActivityService extends LoggerBase {
             // we have some custom platform types in db that are not in enum
             !Object.values(PlatformType).includes(data.platform))
         ) {
-          const { displayName } = await MemberRepository.findById(data.member, repositoryOptions)
+          const { displayName } = await MemberRepository.findById(data.member, repositoryOptions, {
+            doPopulateRelations: false,
+          })
           // Get the first key of the username object as a string
           data.username = displayName
         }

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -685,7 +685,11 @@ export default class IntegrationService {
         transaction,
       })
 
-      member = await MemberRepository.findById(payload.memberId, { ...this.options, transaction })
+      member = await MemberRepository.findById(
+        payload.memberId,
+        { ...this.options, transaction },
+        { doPopulateRelations: false },
+      )
 
       const memberSyncRemoteRepo = new MemberSyncRemoteRepository({ ...this.options, transaction })
 

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1807,7 +1807,18 @@ export default class MemberService extends LoggerBase {
     }
   }
 
-  async findById(id, returnPlain = true, doPopulateRelations = true, segmentId?: string) {
+  async findById(
+    id,
+    {
+      returnPlain = true,
+      doPopulateRelations = true,
+      segmentId,
+    }: {
+      returnPlain?: boolean
+      doPopulateRelations?: boolean
+      segmentId?: string
+    } = {},
+  ) {
     return MemberRepository.findById(id, this.options, {
       returnPlain,
       doPopulateRelations,

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -635,7 +635,9 @@ export default class MemberService extends LoggerBase {
     delete payload.secondary.organizations
 
     try {
-      const member = await MemberRepository.findById(memberId, this.options)
+      const member = await MemberRepository.findById(memberId, this.options, {
+        doPopulateRelations: 'no-activity-aggregates',
+      })
 
       const repoOptions: IRepositoryOptions =
         await SequelizeRepository.createTransactionalRepositoryOptions(this.options)
@@ -822,7 +824,9 @@ export default class MemberService extends LoggerBase {
     const relationships = ['tags', 'notes', 'tasks', 'identities', 'affiliations']
 
     try {
-      const member = await MemberRepository.findById(memberId, this.options)
+      const member = await MemberRepository.findById(memberId, this.options, {
+        doPopulateRelations: 'no-activity-aggregates',
+      })
 
       member.memberOrganizations = await MemberOrganizationRepository.findMemberRoles(
         memberId,
@@ -1436,7 +1440,9 @@ export default class MemberService extends LoggerBase {
   }
 
   async findGithub(memberId) {
-    const memberIdentities = (await MemberRepository.findById(memberId, this.options)).username
+    const memberIdentities = (
+      await MemberRepository.findById(memberId, this.options, { doPopulateRelations: false })
+    ).username
     const axios = require('axios')
     // GitHub allows a maximum of 5 parameters
     const identities = Object.values(memberIdentities).flat().slice(0, 5)

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1808,14 +1808,11 @@ export default class MemberService extends LoggerBase {
   }
 
   async findById(id, returnPlain = true, doPopulateRelations = true, segmentId?: string) {
-    return MemberRepository.findById(
-      id,
-      this.options,
+    return MemberRepository.findById(id, this.options, {
       returnPlain,
       doPopulateRelations,
-      false,
       segmentId,
-    )
+    })
   }
 
   async findAllAutocomplete(data) {

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1283,7 +1283,7 @@ export default class MemberService extends LoggerBase {
 
           // Update original member
           const txService = new MemberService(repoOptions as IServiceOptions)
-          await txService.update(originalId, captureNewState({ primary: toUpdate }), false)
+          await txService.update(originalId, captureNewState({ primary: toUpdate }), { syncToOpensearch: false })
 
           // update members that belong to source organization to destination org
           const memberOrganizationService = new MemberOrganizationService(repoOptions)
@@ -1543,7 +1543,14 @@ export default class MemberService extends LoggerBase {
     }
   }
 
-  async update(id, data, syncToOpensearch = true, manualChange = false) {
+  async update(
+    id,
+    data,
+    {
+      syncToOpensearch = true,
+      manualChange = false,
+    }: { syncToOpensearch?: boolean; manualChange?: boolean } = {},
+  ) {
     let transaction
     const searchSyncService = new SearchSyncService(
       this.options,

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1174,8 +1174,12 @@ export default class MemberService extends LoggerBase {
       await captureApiChange(
         this.options,
         memberMergeAction(originalId, async (captureOldState, captureNewState) => {
-          const original = await MemberRepository.findById(originalId, this.options)
-          const toMerge = await MemberRepository.findById(toMergeId, this.options)
+          const original = await MemberRepository.findById(originalId, this.options, {
+            doPopulateRelations: 'no-activity-aggregates',
+          })
+          const toMerge = await MemberRepository.findById(toMergeId, this.options, {
+            doPopulateRelations: 'no-activity-aggregates',
+          })
 
           captureOldState({
             primary: original,

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1162,7 +1162,7 @@ export default class MemberService extends LoggerBase {
     let tx
 
     try {
-      await captureApiChange(
+      const { original, toMerge } = await captureApiChange(
         this.options,
         memberMergeAction(originalId, async (captureOldState, captureNewState) => {
           const original = await MemberRepository.findById(originalId, this.options, {
@@ -1297,7 +1297,7 @@ export default class MemberService extends LoggerBase {
           })
 
           await SequelizeRepository.commitTransaction(tx)
-          return null
+          return { original, toMerge }
         }),
       )
 
@@ -1307,7 +1307,14 @@ export default class MemberService extends LoggerBase {
         retry: {
           maximumAttempts: 10,
         },
-        args: [originalId, toMergeId, this.options.currentTenant.id],
+        args: [
+          originalId,
+          toMergeId,
+          original.displayName,
+          toMerge.displayName,
+          this.options.currentTenant.id,
+          this.options.currentUser.id,
+        ],
         searchAttributes: {
           TenantId: [this.options.currentTenant.id],
         },

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1283,7 +1283,10 @@ export default class MemberService extends LoggerBase {
 
           // Update original member
           const txService = new MemberService(repoOptions as IServiceOptions)
-          await txService.update(originalId, captureNewState({ primary: toUpdate }), { syncToOpensearch: false })
+          await txService.update(originalId, captureNewState({ primary: toUpdate }), {
+            syncToOpensearch: false,
+            doPopulateRelations: false,
+          })
 
           // update members that belong to source organization to destination org
           const memberOrganizationService = new MemberOrganizationService(repoOptions)
@@ -1549,7 +1552,12 @@ export default class MemberService extends LoggerBase {
     {
       syncToOpensearch = true,
       manualChange = false,
-    }: { syncToOpensearch?: boolean; manualChange?: boolean } = {},
+      doPopulateRelations = true,
+    }: {
+      syncToOpensearch?: boolean
+      manualChange?: boolean
+      doPopulateRelations?: boolean
+    } = {},
   ) {
     let transaction
     const searchSyncService = new SearchSyncService(
@@ -1701,7 +1709,10 @@ export default class MemberService extends LoggerBase {
             )
           }
 
-          const record = await MemberRepository.update(id, data, repoOptions, { manualChange })
+          const record = await MemberRepository.update(id, data, repoOptions, {
+            manualChange,
+            doPopulateRelations,
+          })
 
           return record
         }),

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -441,7 +441,7 @@ export default class MemberService extends LoggerBase {
         data.organizations = lodash.uniqBy(organizations, 'id')
       }
 
-      const fillRelations = false
+      const doPopulateRelations = false
 
       let record
       if (existing) {
@@ -462,7 +462,7 @@ export default class MemberService extends LoggerBase {
             ...this.options,
             transaction,
           },
-          fillRelations,
+          { doPopulateRelations },
         )
       } else {
         // It is important to call it with doPopulateRelations=false
@@ -477,7 +477,7 @@ export default class MemberService extends LoggerBase {
             ...this.options,
             transaction,
           },
-          fillRelations,
+          doPopulateRelations,
         )
 
         telemetryTrack(
@@ -770,7 +770,9 @@ export default class MemberService extends LoggerBase {
       delete payload.primary.affiliations
 
       // update rest of the primary member fields
-      await MemberRepository.update(memberId, payload.primary, repoOptions, false, false)
+      await MemberRepository.update(memberId, payload.primary, repoOptions, {
+        doPopulateRelations: false,
+      })
 
       // trigger entity-merging-worker to move activities in the background
       await SequelizeRepository.commitTransaction(tx)
@@ -1688,7 +1690,7 @@ export default class MemberService extends LoggerBase {
             )
           }
 
-          const record = await MemberRepository.update(id, data, repoOptions, true, manualChange)
+          const record = await MemberRepository.update(id, data, repoOptions, { manualChange })
 
           return record
         }),

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -321,7 +321,7 @@ export default class MemberEnrichmentService extends LoggerBase {
             {
               displayName: `${enrichmentData.first_name} ${enrichmentData.last_name}`,
             },
-            false,
+            { syncToOpensearch: false },
           )
         }
       }

--- a/backend/src/services/premium/enrichment/memberEnrichmentService.ts
+++ b/backend/src/services/premium/enrichment/memberEnrichmentService.ts
@@ -237,7 +237,10 @@ export default class MemberEnrichmentService extends LoggerBase {
 
       // Create an instance of the MemberService and use it to look up the member
       const memberService = new MemberService(this.options)
-      const member = await memberService.findById(memberId, false, false)
+      const member = await memberService.findById(memberId, {
+        returnPlain: false,
+        doPopulateRelations: false,
+      })
 
       // If the member's GitHub handle or email address is not available, throw an error
       if (!member.username[PlatformType.GITHUB] && member.emails.length === 0) {

--- a/backend/src/services/searchSyncService.ts
+++ b/backend/src/services/searchSyncService.ts
@@ -1,4 +1,4 @@
-import { LoggerBase } from '@crowd/logging'
+import { LoggerBase, logExecutionTimeV2 } from '@crowd/logging'
 import { SearchSyncApiClient } from '@crowd/opensearch'
 import { FeatureFlag, SyncMode } from '@crowd/types'
 import { SearchSyncWorkerEmitter } from '@crowd/common_services'
@@ -46,11 +46,22 @@ export default class SearchSyncService extends LoggerBase {
     throw new Error(`Unknown mode ${this.mode} !`)
   }
 
+  private async logExecutionTime<T>(process: () => Promise<T>, name: string): Promise<T> {
+    if (this.options.profileSql) {
+      return logExecutionTimeV2(process, this.options.log, name)
+    }
+
+    return process()
+  }
+
   async triggerMemberSync(tenantId: string, memberId: string) {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
-      await client.triggerMemberSync(memberId)
+      await this.logExecutionTime(
+        () => client.triggerMemberSync(memberId),
+        `triggerMemberSync: tenant:${tenantId}, member:${memberId}`,
+      )
     } else if (client instanceof SearchSyncWorkerEmitter) {
       await client.triggerMemberSync(tenantId, memberId, false)
     } else {
@@ -72,7 +83,10 @@ export default class SearchSyncService extends LoggerBase {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient || client instanceof SearchSyncWorkerEmitter) {
-      await client.triggerOrganizationMembersSync(tenantId, organizationId, false)
+      await this.logExecutionTime(
+        () => client.triggerOrganizationMembersSync(tenantId, organizationId, false),
+        `triggerOrganizationMembersSync: tenant:${tenantId}, organization:${organizationId}`,
+      )
     } else {
       throw new Error('Unexpected search client type!')
     }
@@ -82,7 +96,10 @@ export default class SearchSyncService extends LoggerBase {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
-      await client.triggerRemoveMember(memberId)
+      await this.logExecutionTime(
+        () => client.triggerRemoveMember(memberId),
+        `triggerRemoveMember: tenant:${tenantId}, member:${memberId}`,
+      )
     } else if (client instanceof SearchSyncWorkerEmitter) {
       await client.triggerRemoveMember(tenantId, memberId, false)
     } else {
@@ -104,7 +121,10 @@ export default class SearchSyncService extends LoggerBase {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
-      await client.triggerActivitySync(activityId)
+      await this.logExecutionTime(
+        () => client.triggerActivitySync(activityId),
+        `triggerActivitySync: tenant:${tenantId}, activity:${activityId}`,
+      )
     } else if (client instanceof SearchSyncWorkerEmitter) {
       await client.triggerActivitySync(tenantId, activityId, false)
     } else {
@@ -158,7 +178,10 @@ export default class SearchSyncService extends LoggerBase {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
-      await client.triggerOrganizationSync(organizationId)
+      await this.logExecutionTime(
+        () => client.triggerOrganizationSync(organizationId),
+        `triggerOrganizationSync: tenant:${tenantId}, organization:${organizationId}`,
+      )
     } else if (client instanceof SearchSyncWorkerEmitter) {
       await client.triggerOrganizationSync(tenantId, organizationId, false)
     } else {
@@ -180,7 +203,10 @@ export default class SearchSyncService extends LoggerBase {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
-      await client.triggerRemoveOrganization(organizationId)
+      await this.logExecutionTime(
+        () => client.triggerRemoveOrganization(organizationId),
+        `triggerRemoveOrganization: tenant:${tenantId}, organization:${organizationId}`,
+      )
     } else if (client instanceof SearchSyncWorkerEmitter) {
       await client.triggerRemoveOrganization(tenantId, organizationId, false)
     } else {

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -97,7 +97,6 @@ import pluralize from 'pluralize';
 import { getExportMax, showExportDialog, showExportLimitDialog } from '@/modules/member/member-export-limit';
 import AppBulkEditAttributePopover from '@/modules/member/components/bulk/bulk-edit-attribute-popover.vue';
 import AppTagPopover from '@/modules/tag/components/tag-popover.vue';
-import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import useMemberMergeMessage from '@/shared/modules/merge/config/useMemberMergeMessage';
 import { useAuthStore } from '@/modules/auth/store/auth.store';
 import usePermissions from '@/shared/modules/permissions/helpers/usePermissions';
@@ -117,9 +116,6 @@ const { getUser } = authStore;
 const memberStore = useMemberStore();
 const { selectedMembers, filters } = storeToRefs(memberStore);
 const { fetchMembers } = memberStore;
-
-const lsSegmentsStore = useLfSegmentsStore();
-const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
 
 const { hasPermission } = usePermissions();
 
@@ -152,19 +148,19 @@ const markAsTeamMemberOptions = computed(() => {
 const handleMergeMembers = async () => {
   const [firstMember, secondMember] = selectedMembers.value;
 
-  const { loadingMessage, successMessage, apiErrorMessage } = useMemberMergeMessage;
+  const { loadingMessage, apiErrorMessage } = useMemberMergeMessage;
 
   loadingMessage();
 
   return MemberService.merge(firstMember, secondMember)
     .then(() => {
-      successMessage({
-        primaryMember: firstMember,
-        secondaryMember: secondMember,
-        selectedProjectGroupId: selectedProjectGroup.value?.id,
-      });
-
-      fetchMembers({ reload: true });
+      Message.closeAll();
+      Message.info(
+        'We’re finalizing contributor merging. We will let you know once the process is completed.',
+        {
+          title: 'Contributors merging in progress',
+        },
+      );
     })
     .catch((error) => {
       apiErrorMessage({ error });

--- a/frontend/src/modules/member/components/member-merge-dialog.vue
+++ b/frontend/src/modules/member/components/member-merge-dialog.vue
@@ -66,8 +66,8 @@
 import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { MemberService } from '@/modules/member/member-service';
+import Message from '@/shared/message/message';
 import { mapActions } from '@/shared/vuex/vuex.helpers';
-import { useMemberStore } from '@/modules/member/store/pinia';
 import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import useMemberMergeMessage from '@/shared/modules/merge/config/useMemberMergeMessage';
@@ -96,9 +96,6 @@ const router = useRouter();
 
 const lsSegmentsStore = useLfSegmentsStore();
 const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
-
-const memberStore = useMemberStore();
-const { fetchMembers } = memberStore;
 
 const { doFind } = mapActions('member');
 
@@ -140,7 +137,7 @@ const mergeSuggestion = () => {
   const primaryMember = originalMemberPrimary.value ? props.modelValue : memberToMerge.value;
   const secondaryMember = originalMemberPrimary.value ? memberToMerge.value : props.modelValue;
 
-  const { loadingMessage, successMessage, apiErrorMessage } = useMemberMergeMessage;
+  const { loadingMessage, apiErrorMessage } = useMemberMergeMessage;
 
   loadingMessage();
 
@@ -154,15 +151,16 @@ const mergeSuggestion = () => {
 
   MemberService.merge(primaryMember, secondaryMember)
     .then(() => {
+      Message.closeAll();
+      Message.info(
+        'We’re finalizing contributor merging. We will let you know once the process is completed.',
+        {
+          title: 'Contributors merging in progress',
+        },
+      );
       emit('update:modelValue', null);
 
       if (route.name === 'memberView') {
-        successMessage({
-          primaryMember,
-          secondaryMember,
-          selectedProjectGroupId: selectedProjectGroup.value?.id,
-        });
-
         doFind({
           id: primaryMember.id,
           segments: [selectedProjectGroup.value?.id],
@@ -173,14 +171,6 @@ const mergeSuggestion = () => {
             },
           });
         });
-      } else if (route.name === 'member') {
-        successMessage({
-          primaryMember,
-          secondaryMember,
-          selectedProjectGroupId: selectedProjectGroup.value?.id,
-        });
-
-        fetchMembers({ reload: true });
       }
       emit('update:modelValue', null);
     })

--- a/frontend/src/modules/member/components/member-merge-suggestions.vue
+++ b/frontend/src/modules/member/components/member-merge-suggestions.vue
@@ -140,8 +140,6 @@ import {
 import Message from '@/shared/message/message';
 import AppLoading from '@/shared/loading/loading-placeholder.vue';
 import AppMemberMergeSuggestionsDetails from '@/modules/member/components/suggestions/member-merge-suggestions-details.vue';
-import { storeToRefs } from 'pinia';
-import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { merge } from 'lodash';
 import useMemberMergeMessage from '@/shared/modules/merge/config/useMemberMergeMessage';
 import LfButton from '@/ui-kit/button/Button.vue';
@@ -164,9 +162,6 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['reload']);
-
-const lsSegmentsStore = useLfSegmentsStore();
-const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
 
 const { trackEvent } = useProductTracking();
 
@@ -283,7 +278,7 @@ const mergeSuggestion = () => {
   const primaryMember = membersToMerge.value.members[primary.value];
   const secondaryMember = membersToMerge.value.members[(primary.value + 1) % 2];
 
-  const { loadingMessage, successMessage, apiErrorMessage } = useMemberMergeMessage;
+  const { loadingMessage, apiErrorMessage } = useMemberMergeMessage;
 
   loadingMessage();
 
@@ -297,13 +292,14 @@ const mergeSuggestion = () => {
 
   MemberService.merge(primaryMember, secondaryMember)
     .then(() => {
+      Message.closeAll();
+      Message.info(
+        'We’re finalizing contributor merging. We will let you know once the process is completed.',
+        {
+          title: 'Contributors merging in progress',
+        },
+      );
       primary.value = 0;
-
-      successMessage({
-        primaryMember,
-        secondaryMember,
-        selectedProjectGroupId: selectedProjectGroup.value?.id,
-      });
 
       const nextIndex = offset.value >= (count.value - 1) ? Math.max(count.value - 2, 0) : offset.value;
       fetch(nextIndex);

--- a/frontend/src/modules/member/components/member-unmerge-dialog.vue
+++ b/frontend/src/modules/member/components/member-unmerge-dialog.vue
@@ -338,7 +338,7 @@ const unmerge = () => {
   MemberService.unmerge(props.modelValue?.id, preview.value)
     .then(() => {
       Message.info(
-        'We’re syncing all activities of the unmerged contributor. We will let you know once the process is completed.',
+        'We’re finalizing contributor unmerging. We will let you know once the process is completed.',
         {
           title: 'Contributors unmerging in progress',
         },

--- a/frontend/src/modules/member/pages/member-merge-suggestions-page.vue
+++ b/frontend/src/modules/member/pages/member-merge-suggestions-page.vue
@@ -282,17 +282,19 @@ const merge = (suggestion: any) => {
   const secondaryMember = suggestion.members[1];
   sending.value = `${primaryMember.id}:${secondaryMember.id}`;
 
-  const { loadingMessage, successMessage } = useMemberMergeMessage;
+  const { loadingMessage } = useMemberMergeMessage;
 
   loadingMessage();
 
   MemberService.merge(primaryMember, secondaryMember)
     .then(() => {
-      successMessage({
-        primaryMember,
-        secondaryMember,
-        selectedProjectGroupId: selectedProjectGroup.value?.id as string,
-      });
+      Message.closeAll();
+      Message.info(
+        'We’re finalizing contributor merging. We will let you know once the process is completed.',
+        {
+          title: 'Contributors merging in progress',
+        },
+      );
     })
     .finally(() => {
       reload();

--- a/frontend/src/shared/axios/auth-axios.js
+++ b/frontend/src/shared/axios/auth-axios.js
@@ -106,6 +106,10 @@ authAxios.interceptors.request.use(
       setOptions.headers.Authorization = `Bearer ${token}`;
     }
 
+    if (localStorage.getItem('profile-sql') === '1') {
+      setOptions.headers['x-profile-sql'] = 'true';
+    }
+
     setOptions.headers['Accept-Language'] = getLanguageCode();
 
     return setOptions;

--- a/services/apps/entity_merging_worker/src/activities.ts
+++ b/services/apps/entity_merging_worker/src/activities.ts
@@ -4,6 +4,7 @@ export {
   moveActivitiesWithIdentityToAnotherMember,
   recalculateActivityAffiliationsOfMemberAsync,
   syncMember,
+  notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
 } from './activities/members'
 

--- a/services/apps/entity_merging_worker/src/activities.ts
+++ b/services/apps/entity_merging_worker/src/activities.ts
@@ -6,6 +6,7 @@ export {
   syncMember,
   notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
+  syncRemoveMember,
 } from './activities/members'
 
 export {

--- a/services/apps/entity_merging_worker/src/activities/members.ts
+++ b/services/apps/entity_merging_worker/src/activities/members.ts
@@ -122,6 +122,13 @@ export async function syncMember(memberId: string, secondaryMemberId: string): P
   }
 }
 
+export async function syncRemoveMember(memberId: string): Promise<void> {
+  const syncApi = new SearchSyncApiClient({
+    baseUrl: process.env['CROWD_SEARCH_SYNC_API_URL'],
+  })
+  await syncApi.triggerRemoveMember(memberId)
+}
+
 export async function notifyFrontendMemberMergeSuccessful(
   primaryId: string,
   secondaryId: string,

--- a/services/apps/entity_merging_worker/src/activities/members.ts
+++ b/services/apps/entity_merging_worker/src/activities/members.ts
@@ -122,6 +122,42 @@ export async function syncMember(memberId: string, secondaryMemberId: string): P
   }
 }
 
+export async function notifyFrontendMemberMergeSuccessful(
+  primaryId: string,
+  secondaryId: string,
+  primaryDisplayName: string,
+  secondaryDisplayName: string,
+  tenantId: string,
+  userId: string,
+): Promise<void> {
+  const emitter = new RedisPubSubEmitter(
+    'api-pubsub',
+    svc.redis,
+    (err) => {
+      svc.log.error({ err }, 'Error in api-ws emitter!')
+    },
+    svc.log,
+  )
+
+  emitter.emit(
+    'user',
+    new ApiWebsocketMessage(
+      'member-merge',
+      JSON.stringify({
+        success: true,
+        tenantId,
+        userId,
+        primaryId,
+        secondaryId,
+        primaryDisplayName,
+        secondaryDisplayName,
+      }),
+      undefined,
+      tenantId,
+    ),
+  )
+}
+
 export async function notifyFrontendMemberUnmergeSuccessful(
   primaryId: string,
   secondaryId: string,

--- a/services/apps/entity_merging_worker/src/workflows/all.ts
+++ b/services/apps/entity_merging_worker/src/workflows/all.ts
@@ -18,6 +18,7 @@ const {
   syncOrganization,
   notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
+  syncRemoveMember,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '15 minutes',
 })
@@ -33,6 +34,7 @@ export async function finishMemberMerging(
   await moveActivitiesBetweenMembers(primaryId, secondaryId, tenantId)
   await recalculateActivityAffiliationsOfMemberAsync(primaryId, tenantId)
   await syncMember(primaryId, secondaryId)
+  await syncRemoveMember(secondaryId)
   await deleteMember(secondaryId)
   await setMergeActionState(primaryId, secondaryId, tenantId, 'merged' as MergeActionState)
   await notifyFrontendMemberMergeSuccessful(

--- a/services/apps/entity_merging_worker/src/workflows/all.ts
+++ b/services/apps/entity_merging_worker/src/workflows/all.ts
@@ -16,6 +16,7 @@ const {
   setMergeActionState,
   syncMember,
   syncOrganization,
+  notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '15 minutes',
@@ -24,13 +25,24 @@ const {
 export async function finishMemberMerging(
   primaryId: string,
   secondaryId: string,
+  primaryDisplayName: string,
+  secondaryDisplayName: string,
   tenantId: string,
+  userId: string,
 ): Promise<void> {
   await moveActivitiesBetweenMembers(primaryId, secondaryId, tenantId)
   await recalculateActivityAffiliationsOfMemberAsync(primaryId, tenantId)
   await syncMember(primaryId, secondaryId)
   await deleteMember(secondaryId)
   await setMergeActionState(primaryId, secondaryId, tenantId, 'merged' as MergeActionState)
+  await notifyFrontendMemberMergeSuccessful(
+    primaryId,
+    secondaryId,
+    primaryDisplayName,
+    secondaryDisplayName,
+    tenantId,
+    userId,
+  )
 }
 
 export async function finishMemberUnmerging(

--- a/services/libs/data-access-layer/src/member_merge/index.ts
+++ b/services/libs/data-access-layer/src/member_merge/index.ts
@@ -1,0 +1,36 @@
+import { QueryExecutor } from '../queryExecutor'
+
+export async function removeMemberToMerge(
+  qx: QueryExecutor,
+  memberId: string,
+  toMergeId: string,
+): Promise<void> {
+  await qx.result(
+    `
+      DELETE FROM "memberToMerge"
+      WHERE "memberId" = $(memberId)
+        AND "toMergeId" = $(toMergeId)
+    `,
+    {
+      memberId,
+      toMergeId,
+    },
+  )
+}
+
+export async function addMemberNoMerge(
+  qx: QueryExecutor,
+  memberId: string,
+  noMergeId: string,
+): Promise<void> {
+  await qx.result(
+    `
+      INSERT INTO "memberNoMerge" ("memberId", "noMergeId")
+      VALUES ($(memberId), $(noMergeId))
+    `,
+    {
+      memberId,
+      noMergeId,
+    },
+  )
+}


### PR DESCRIPTION
- Allow logging execution time of SQL queries and search-sync-api requests in backend with a custom header `x-profile-sql: true`
- Return pod name on the backend in the header `x-hostname`, so you can immediately go look for these profile logs on the right pod 
- Pass `x-profile-sql: true` header to API requests from frontend when there is a local storage entry `profile-sql=1`
- Optimize some calls to `MemberRepository.findById()` to avoid unnecessarily populating relations, and sometimes populating them, but without activity aggregates (which for some members take extra 20s)