### PR TITLE
Kafka Oracle SASL auth

### DIFF
--- a/backend/config/custom-environment-variables.json
+++ b/backend/config/custom-environment-variables.json
@@ -27,7 +27,8 @@
       }
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "s3": {

--- a/services/apps/data_sink_worker/config/custom-environment-variables.json
+++ b/services/apps/data_sink_worker/config/custom-environment-variables.json
@@ -16,7 +16,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "sentiment": {

--- a/services/apps/integration_run_worker/config/custom-environment-variables.json
+++ b/services/apps/integration_run_worker/config/custom-environment-variables.json
@@ -16,7 +16,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "redis": {

--- a/services/apps/integration_stream_worker/config/custom-environment-variables.json
+++ b/services/apps/integration_stream_worker/config/custom-environment-variables.json
@@ -16,7 +16,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "redis": {

--- a/services/apps/integration_sync_worker/config/custom-environment-variables.json
+++ b/services/apps/integration_sync_worker/config/custom-environment-variables.json
@@ -20,7 +20,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "redis": {

--- a/services/apps/search_sync_worker/config/custom-environment-variables.json
+++ b/services/apps/search_sync_worker/config/custom-environment-variables.json
@@ -20,7 +20,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "redis": {

--- a/services/apps/webhook_api/config/custom-environment-variables.json
+++ b/services/apps/webhook_api/config/custom-environment-variables.json
@@ -16,7 +16,8 @@
       "secretAccessKey": "CROWD_SQS_AWS_SECRET_ACCESS_KEY"
     },
     "kafka": {
-      "brokers": "CROWD_KAFKA_BROKERS"
+      "brokers": "CROWD_KAFKA_BROKERS",
+      "extra": "CROWD_KAFKA_EXTRA"
     }
   },
   "unleash": {

--- a/services/libs/queue/src/factory.ts
+++ b/services/libs/queue/src/factory.ts
@@ -19,6 +19,7 @@ export class QueueFactory {
             initialRetryTime: 100,
             retries: 8,
           },
+          ...(kafkaConfig.extra ? JSON.parse(kafkaConfig.extra) : {}),
         })
         return new KafkaQueueService(kafkaClient, log)
       default:

--- a/services/libs/queue/src/vendors/kafka/config.ts
+++ b/services/libs/queue/src/vendors/kafka/config.ts
@@ -3,27 +3,27 @@ import { IKafkaConfig } from './types'
 
 export const INTEGRATION_RUN_WORKER_QUEUE_SETTINGS: IKafkaConfig = {
   name: CrowdQueue.INTEGRATION_RUN_WORKER,
-  partitionCount: 10,
+  partitionCount: 2,
 }
 
 export const INTEGRATION_STREAM_WORKER_QUEUE_SETTINGS: IKafkaConfig = {
   name: CrowdQueue.INTEGRATION_STREAM_WORKER,
-  partitionCount: 10,
+  partitionCount: 2,
 }
 
 export const DATA_SINK_WORKER_QUEUE_SETTINGS: IKafkaConfig = {
   name: CrowdQueue.DATA_SINK_WORKER,
-  partitionCount: 10,
+  partitionCount: 2,
 }
 
 export const SEARCH_SYNC_WORKER_QUEUE_SETTINGS: IKafkaConfig = {
   name: CrowdQueue.SEARCH_SYNC_WORKER,
-  partitionCount: 10,
+  partitionCount: 2,
 }
 
 export const INTEGRATION_SYNC_WORKER_QUEUE_SETTINGS: IKafkaConfig = {
   name: CrowdQueue.INTEGRATION_SYNC_WORKER,
-  partitionCount: 10,
+  partitionCount: 2,
 }
 
 export const configMap = {

--- a/services/libs/queue/src/vendors/kafka/types.ts
+++ b/services/libs/queue/src/vendors/kafka/types.ts
@@ -7,6 +7,7 @@ export interface IKafkaConfig extends IQueueConfig {
 export interface IKafkaClientConfig {
   brokers: string
   clientId: string
+  extra?: string
 }
 
 export interface IKafkaQueueStartOptions {


### PR DESCRIPTION
# Allow configuring extra Kafka client parameters for Oracle SASL auth

Oracle Streaming Services requires authentication when accessing it through Kafka interface. This auth is done via SSL with user and pass credentials.

It looks like this ([see here](https://kafka.js.org/docs/configuration#sasl)):
```
new Kafka({
  clientId: 'my-app',
  brokers: ['kafka1:9092', 'kafka2:9092'],
  // authenticationTimeout: 10000,
  // reauthenticationThreshold: 10000,
  ssl: true,
  sasl: {
    mechanism: 'plain', // scram-sha-256 or scram-sha-512
    username: 'my-username',
    password: 'my-password'
  },
})
```

To make this auth (and maybe more other potential things possible) we introduce a new `CROWD_KAFKA_EXTRA` env variable, which will contain a stringified JSON with extra arguments, like so:
```
CROWD_KAFKA_EXTRA='{"ssl":true,"sasl":{"mechanism":"plain","username":"my-username","password":"my-password"}}'
```
