### PR TITLE
Improve search sync perf

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -2331,22 +2331,23 @@ class MemberRepository {
     const withSearch = !!search
     let searchCTE = ''
     let searchJoin = ''
+    let searchFilter = '1=1'
 
     if (withSearch) {
       search = search.toLowerCase()
       searchCTE = `
-      ,  
+      ,
       member_search AS (
           SELECT
-            "memberId"
+            DISTINCT "memberId"
           FROM "memberIdentities" mi
-          join members m on m.id = mi."memberId"
-          where (verified and lower("value") like '%${search}%') or 
-          lower(m."displayName") like '%${search}%' 
-          GROUP BY 1
+          where (verified and lower("value") like '%${search}%')
         )
       `
-      searchJoin = ` JOIN member_search ms ON ms."memberId" = m.id `
+      searchJoin = ` LEFT JOIN member_search ms ON ms."memberId" = m.id `
+      searchFilter = `
+        (ms."memberId" IS NOT NULL OR lower(m."displayName") like '%${search}%')
+       `
     }
 
     const createQuery = (fields) => `
@@ -2371,6 +2372,7 @@ class MemberRepository {
       ${searchJoin}
       WHERE m."tenantId" = $(tenantId)
         AND (${filterString})
+        AND (${searchFilter})
     `
 
     if (countOnly) {

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -196,7 +196,9 @@ export default class ActivityService extends LoggerBase {
       await SequelizeRepository.commitTransaction(transaction)
 
       if (fireSync) {
-        await searchSyncService.triggerMemberSync(this.options.currentTenant.id, record.memberId)
+        await searchSyncService.triggerMemberSync(this.options.currentTenant.id, record.memberId, {
+          withAggs: true,
+        })
         await searchSyncService.triggerActivitySync(this.options.currentTenant.id, record.id)
       }
 
@@ -608,7 +610,9 @@ export default class ActivityService extends LoggerBase {
       await SequelizeRepository.commitTransaction(transaction)
 
       await searchSyncService.triggerActivitySync(this.options.currentTenant.id, record.id)
-      await searchSyncService.triggerMemberSync(this.options.currentTenant.id, record.memberId)
+      await searchSyncService.triggerMemberSync(this.options.currentTenant.id, record.memberId, {
+        withAggs: true,
+      })
       return record
     } catch (error) {
       if (error.name && error.name.includes('Sequelize')) {

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -769,7 +769,9 @@ export default class IntegrationService {
     const searchSyncService = new SearchSyncService(this.options)
 
     // send it to opensearch because in member.update we bypass while passing transactions
-    await searchSyncService.triggerMemberSync(this.options.currentTenant.id, member.id)
+    await searchSyncService.triggerMemberSync(this.options.currentTenant.id, member.id, {
+      withAggs: true,
+    })
   }
 
   async hubspotStopSyncOrganization(payload: IHubspotManualSyncPayload) {

--- a/backend/src/services/searchSyncService.ts
+++ b/backend/src/services/searchSyncService.ts
@@ -54,12 +54,12 @@ export default class SearchSyncService extends LoggerBase {
     return process()
   }
 
-  async triggerMemberSync(tenantId: string, memberId: string) {
+  async triggerMemberSync(tenantId: string, memberId: string, opts: { withAggs?: boolean } = {}) {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {
       await this.logExecutionTime(
-        () => client.triggerMemberSync(memberId),
+        () => client.triggerMemberSync(memberId, opts),
         `triggerMemberSync: tenant:${tenantId}, member:${memberId}`,
       )
     } else if (client instanceof SearchSyncWorkerEmitter) {

--- a/services/apps/search_sync_api/src/routes/member.ts
+++ b/services/apps/search_sync_api/src/routes/member.ts
@@ -15,10 +15,10 @@ router.post(
       req.log,
     )
 
-    const { memberId } = req.body
+    const { memberId, withAggs } = req.body
     try {
       req.log.trace(`Calling memberSyncService.syncMembers for ${memberId}`)
-      await memberSyncService.syncMembers(memberId)
+      await memberSyncService.syncMembers(memberId, { withAggs })
       res.sendStatus(200)
     } catch (error) {
       req.log.error(error)

--- a/services/libs/data-access-layer/src/activities/index.ts
+++ b/services/libs/data-access-layer/src/activities/index.ts
@@ -1,24 +1,31 @@
+import { SegmentType } from '@crowd/types'
 import { IMemberSegmentAggregates } from '../members/types'
 import { IDbOrganizationAggregateData } from '../organizations'
 import { QueryExecutor } from '../queryExecutor'
 
+function groupByField(segmentType: SegmentType) {
+  switch (segmentType) {
+    case SegmentType.SUB_PROJECT:
+      return 's.id'
+    case SegmentType.PROJECT:
+      return 's."parentId"'
+    case SegmentType.PROJECT_GROUP:
+      return 's."grandparentId"'
+  }
+
+  throw new Error(`Invalid segment type: ${segmentType}`)
+}
+
 export async function getOrgAggregates(
   qx: QueryExecutor,
   organizationId: string,
+  groupBy: SegmentType,
 ): Promise<IDbOrganizationAggregateData[]> {
   return qx.select(
     `
-      WITH
-        segments_with_children AS (
-          SELECT
-              UNNEST(ARRAY["id", "parentId", "grandparentId"]) AS segment_id,
-              s.id AS subproject
-          FROM segments s
-          WHERE type = 'subproject'
-        )
       SELECT
           o."id" AS "organizationId",
-          s.segment_id AS "segmentId",
+          ${groupByField(groupBy)} AS "segmentId",
           o."tenantId",
           COALESCE(MIN(a.timestamp), '1970-01-01') AS "joinedAt",
           MAX(a.timestamp) AS "lastActive",
@@ -28,9 +35,9 @@ export async function getOrgAggregates(
           COALESCE(ROUND(AVG(a.score)), 0) AS "avgContributorEngagement"
       FROM activities a
       JOIN organizations o ON o."id" = a."organizationId"
-      JOIN segments_with_children s ON s.subproject = a."segmentId"
+      JOIN segments s ON s.id = a."segmentId"
       WHERE a."organizationId" = $(organizationId)
-      GROUP BY o."id", s.segment_id, o."tenantId"
+      GROUP BY 1, 2, 3
     `,
     {
       organizationId,
@@ -41,20 +48,13 @@ export async function getOrgAggregates(
 export async function getMemberAggregates(
   qx: QueryExecutor,
   memberId: string,
+  groupBy: SegmentType,
 ): Promise<IMemberSegmentAggregates[]> {
   return qx.select(
     `
-      WITH
-          segments_with_children AS (
-            SELECT
-              UNNEST(ARRAY["id", "parentId", "grandparentId"]) AS segment_id,
-              s.id AS subproject
-            FROM segments s
-            WHERE type = 'subproject'
-          )
       SELECT
           m."id" AS "memberId",
-          s.segment_id AS "segmentId",
+          ${groupByField(groupBy)} AS "segmentId",
           m."tenantId",
           COUNT(DISTINCT a.id) AS "activityCount",
           MAX(a.timestamp) AS "lastActive",
@@ -63,9 +63,9 @@ export async function getMemberAggregates(
           ROUND(AVG((a.sentiment ->> 'sentiment')::NUMERIC(5, 2)), 2) AS "averageSentiment"
       FROM activities a
       JOIN members m ON m."id" = a."memberId"
-      JOIN segments_with_children s ON s.subproject = a."segmentId"
+      JOIN segments s ON s.id = a."segmentId"
       WHERE a."memberId" = $(memberId)
-      GROUP BY m."id", s.segment_id, m."tenantId"
+      GROUP BY 1, 2, 3
     `,
     {
       memberId,

--- a/services/libs/opensearch/src/apiClient.ts
+++ b/services/libs/opensearch/src/apiClient.ts
@@ -12,13 +12,17 @@ export class SearchSyncApiClient {
     })
   }
 
-  public async triggerMemberSync(memberId: string): Promise<void> {
+  public async triggerMemberSync(
+    memberId: string,
+    opts: { withAggs?: boolean } = {},
+  ): Promise<void> {
     if (!memberId) {
       throw new Error('memberId is required!')
     }
 
     await this.searchSyncApi.post('/sync/members', {
       memberId,
+      ...opts,
     })
   }
 

--- a/services/libs/opensearch/src/service/member.sync.service.ts
+++ b/services/libs/opensearch/src/service/member.sync.service.ts
@@ -336,7 +336,10 @@ export class MemberSyncService {
     )
   }
 
-  public async syncMembers(memberId: string): Promise<IMemberSyncResult> {
+  public async syncMembers(
+    memberId: string,
+    opts: { withAggs?: boolean } = {},
+  ): Promise<IMemberSyncResult> {
     const syncMemberAggregates = async (memberId) => {
       let documentsIndexed = 0
       let memberData: IMemberSegmentAggregates[] = []
@@ -374,7 +377,12 @@ export class MemberSyncService {
       }
     }
 
-    const syncResults = await syncMemberAggregates(memberId)
+    const syncResults = opts.withAggs
+      ? await syncMemberAggregates(memberId)
+      : {
+          membersSynced: 0,
+          documentsIndexed: 0,
+        }
 
     const syncMembersToOpensearchForMergeSuggestions = async (memberId) => {
       const qx = repoQx(this.memberRepo)

--- a/services/libs/opensearch/src/service/member.sync.service.ts
+++ b/services/libs/opensearch/src/service/member.sync.service.ts
@@ -9,6 +9,7 @@ import {
   IMemberOrganization,
   IMemberWithAggregatesForMergeSuggestions,
   MemberAttributeType,
+  SegmentType,
 } from '@crowd/types'
 import { IndexedEntityType } from '../repo/indexing.data'
 import { IndexingRepository } from '../repo/indexing.repo'
@@ -338,10 +339,12 @@ export class MemberSyncService {
   public async syncMembers(memberId: string): Promise<IMemberSyncResult> {
     const syncMemberAggregates = async (memberId) => {
       let documentsIndexed = 0
-      let memberData: IMemberSegmentAggregates[]
+      let memberData: IMemberSegmentAggregates[] = []
       try {
         const qx = repoQx(this.memberRepo)
-        memberData = await getMemberAggregates(qx, memberId)
+        for (const type of Object.values(SegmentType)) {
+          memberData = memberData.concat(await getMemberAggregates(qx, memberId, type))
+        }
       } catch (e) {
         this.log.error(e, 'Failed to get organization aggregates!')
         throw e

--- a/services/libs/opensearch/src/service/organization.sync.service.ts
+++ b/services/libs/opensearch/src/service/organization.sync.service.ts
@@ -18,6 +18,7 @@ import {
   IOrganizationFullAggregatesOpensearch,
   OpenSearchIndex,
   OrganizationIdentityType,
+  SegmentType,
 } from '@crowd/types'
 import { IndexedEntityType } from '../repo/indexing.data'
 import { IndexingRepository } from '../repo/indexing.repo'
@@ -313,10 +314,12 @@ export class OrganizationSyncService {
       let documentsIndexed = 0
       const organizationIdsToIndex = []
       for (const organizationId of organizationIds) {
-        let orgData: IDbOrganizationAggregateData[]
+        let orgData: IDbOrganizationAggregateData[] = []
         try {
           const qx = repoQx(this.orgRepo)
-          orgData = await getOrgAggregates(qx, organizationId)
+          for (const type of Object.values(SegmentType)) {
+            orgData = orgData.concat(await getOrgAggregates(qx, organizationId, type))
+          }
         } catch (e) {
           this.log.error(e, 'Failed to get organization aggregates!')
           throw e


### PR DESCRIPTION
1. Tried to improve the aggregates fetching queries themselves by breaking them down into 3 smaller ones — one for each segment level (subproject, project, project group).
2. Recalculate members aggregates only when activities change. No need to recalculate member aggregates when we change member profile