### PR TITLE
Improve performance of searching members by name

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -2331,22 +2331,23 @@ class MemberRepository {
     const withSearch = !!search
     let searchCTE = ''
     let searchJoin = ''
+    let searchFilter = '1=1'
 
     if (withSearch) {
       search = search.toLowerCase()
       searchCTE = `
-      ,  
+      ,
       member_search AS (
           SELECT
-            "memberId"
+            DISTINCT "memberId"
           FROM "memberIdentities" mi
-          join members m on m.id = mi."memberId"
-          where (verified and lower("value") like '%${search}%') or 
-          lower(m."displayName") like '%${search}%' 
-          GROUP BY 1
+          where (verified and lower("value") like '%${search}%')
         )
       `
-      searchJoin = ` JOIN member_search ms ON ms."memberId" = m.id `
+      searchJoin = ` LEFT JOIN member_search ms ON ms."memberId" = m.id `
+      searchFilter = `
+        (ms."memberId" IS NOT NULL OR lower(m."displayName") like '%${search}%')
+       `
     }
 
     const createQuery = (fields) => `
@@ -2371,6 +2372,7 @@ class MemberRepository {
       ${searchJoin}
       WHERE m."tenantId" = $(tenantId)
         AND (${filterString})
+        AND (${searchFilter})
     `
 
     if (countOnly) {


### PR DESCRIPTION
Split filtering on search value to avoid double seq-scan on `members` table