### PR TITLE
adjust the findById endpoint to show an org across all segments

### DIFF
--- a/backend/src/api/organization/organizationFind.ts
+++ b/backend/src/api/organization/organizationFind.ts
@@ -21,14 +21,6 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.organizationRead)
 
   const segmentId = req.query.segmentId
-  if (!segmentId) {
-    await req.responseHandler.error(req, res, {
-      code: 400,
-      message: 'Segment ID is required',
-    })
-    return
-  }
-
   const payload = await new OrganizationService(req).findById(req.params.id, segmentId)
 
   await req.responseHandler.success(req, res, payload)

--- a/backend/src/database/migrations/U1723620708__makeSegmentNullableInOrgSegmentsAgg.sql
+++ b/backend/src/database/migrations/U1723620708__makeSegmentNullableInOrgSegmentsAgg.sql
@@ -1,0 +1,1 @@
+alter table "organizationSegmentsAgg" alter column "segmentId" set not null;

--- a/backend/src/database/migrations/V1723620708__makeSegmentNullableInOrgSegmentsAgg.sql
+++ b/backend/src/database/migrations/V1723620708__makeSegmentNullableInOrgSegmentsAgg.sql
@@ -1,0 +1,1 @@
+alter table "organizationSegmentsAgg" alter column "segmentId" drop not null;

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1716,7 +1716,7 @@ class OrganizationRepository {
       limit,
       offset,
       segmentId,
-      tenantId: options.currentTenant.id
+      tenantId: options.currentTenant.id,
     }
 
     const filterString = RawQueryParser.parseFilters(

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1216,6 +1216,7 @@ class OrganizationRepository {
         offset: 0,
         segmentId,
         include: {
+          aggregates: true,
           attributes: true,
           lfxMemberships: true,
           identities: true,
@@ -1233,6 +1234,7 @@ class OrganizationRepository {
           limit: 1,
           offset: 0,
           include: {
+            aggregates: false,
             attributes: true,
             lfxMemberships: true,
             identities: true,
@@ -1681,6 +1683,7 @@ class OrganizationRepository {
         segments: false,
         attributes: false,
       } as {
+        aggregates: boolean
         identities?: boolean
         lfxMemberships?: boolean
         segments?: boolean
@@ -1693,10 +1696,10 @@ class OrganizationRepository {
 
     const qx = SequelizeRepository.getQueryExecutor(options, transaction)
 
-    const withAggregates = !!segmentId
-    let segment
-    if (withAggregates) {
-      segment = await new SegmentRepository(options).findById(segmentId)
+    const withAggregates = include.aggregates
+
+    if (segmentId) {
+      const segment = await new SegmentRepository(options).findById(segmentId)
 
       if (segment === null) {
         options.log.info('No segment found for organization')
@@ -1712,8 +1715,8 @@ class OrganizationRepository {
     const params = {
       limit,
       offset,
-      tenantId: options.currentTenant.id,
-      segmentId: segment?.id,
+      segmentId,
+      tenantId: options.currentTenant.id
     }
 
     const filterString = RawQueryParser.parseFilters(
@@ -1744,7 +1747,9 @@ class OrganizationRepository {
       FROM organizations o
       ${
         withAggregates
-          ? ` JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND osa."segmentId" = $(segmentId)`
+          ? ` JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND ${
+              segmentId ? `osa."segmentId" = $(segmentId)` : `osa."segmentId" IS NULL`
+            }`
           : ''
       }
       WHERE 1=1

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -1043,7 +1043,7 @@ export default class OrganizationService extends LoggerBase {
           'tags',
           'logo',
         ],
-        include: { identities: true, lfxMemberships: true },
+        include: { aggregates: true, identities: true, lfxMemberships: true },
       },
       this.options,
     )
@@ -1059,7 +1059,7 @@ export default class OrganizationService extends LoggerBase {
         offset,
         segmentId: undefined,
         fields: ['id', 'displayName', 'isTeamOrganization'],
-        include: { identities: true, segments: true, lfxMemberships: true },
+        include: { aggregates: false, identities: true, segments: true, lfxMemberships: true },
       },
       this.options,
     )

--- a/services/libs/data-access-layer/src/organizations/types.ts
+++ b/services/libs/data-access-layer/src/organizations/types.ts
@@ -64,7 +64,7 @@ export interface IDbOrgAttributeInput {
 
 export interface IDbOrganizationAggregateData {
   organizationId: string
-  segmentId: string
+  segmentId?: string
   tenantId: string
 
   joinedAt: string

--- a/services/libs/types/src/segments.ts
+++ b/services/libs/types/src/segments.ts
@@ -86,6 +86,7 @@ export enum SegmentType {
   PROJECT_GROUP = 'projectGroup',
   PROJECT = 'project',
   SUB_PROJECT = 'subproject',
+  NO_SEGMENT = 'noSegment',
 }
 
 export interface SegmentCriteria extends SearchCriteria {


### PR DESCRIPTION
# Changes proposed ✍️

The current behavior of the organization.findById endpoint is that if no segmentId is passed, it returns data (aggregates) across all segments.