### PR TITLE
Cascade on dropping `membersGlobalActivityCount` for dependent mvs

### DIFF
--- a/backend/src/database/migrations/R__memberEnrichmentMaterializedViews.sql
+++ b/backend/src/database/migrations/R__memberEnrichmentMaterializedViews.sql
@@ -1,5 +1,5 @@
 -- global member activity counts
-drop materialized view if exists "membersGlobalActivityCount";
+drop materialized view if exists "membersGlobalActivityCount" cascade;
 create materialized view "membersGlobalActivityCount" as
 select msa."memberId",
     sum(msa."activityCount") AS total_count
@@ -415,9 +415,11 @@ progai_hit_count_among_attempted as (
 select
     (select count from progai_enrichable_members) as "enrichableMembers",
     (select count from attempted_to_enrich_among_progai_enrichable_members) as "attemptedToEnrich",
-    round((select count from attempted_to_enrich_among_progai_enrichable_members)::numeric / (select count from progai_enrichable_members)::numeric * 100, 2) as progress,
+    case when (select count from progai_enrichable_members)::numeric = 0 then 0 else 
+    round((select count from attempted_to_enrich_among_progai_enrichable_members)::numeric / (select count from progai_enrichable_members)::numeric * 100, 2) end as progress,
     (select count from progai_hit_count_among_attempted) as "hitCount",
-    round((select count from progai_hit_count_among_attempted)::numeric / (select count from attempted_to_enrich_among_progai_enrichable_members)::numeric * 100, 2) as "hitRate";
+    case when (select count from attempted_to_enrich_among_progai_enrichable_members)::numeric = 0 then 0 else 
+    round((select count from progai_hit_count_among_attempted)::numeric / (select count from attempted_to_enrich_among_progai_enrichable_members)::numeric * 100, 2) end as "hitRate";
 
 -- member enrichment monitoring (progai-linkedin)
 drop materialized view if exists "memberEnrichmentMonitoringProgaiLinkedin";


### PR DESCRIPTION
# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new materialized views for enhanced member enrichment monitoring, including total counts and specific data sources.
- **Bug Fixes**
	- Improved error handling in calculations to prevent division by zero in member enrichment metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->