### PR TITLE
Don't display the "Find GitHub" option if the contributor already has a GitHub identity

### DIFF
--- a/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
+++ b/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
@@ -7,7 +7,11 @@
     <lf-icon-old name="link-unlink" />
     Unmerge profile
   </lf-dropdown-item>
-  <lf-dropdown-item v-if="hasPermission(LfPermission.memberEdit) && !hasGithubIdentity" :disabled="!!props.contributor.username?.github" @click="emit('findGithub')">
+  <lf-dropdown-item 
+    v-if="hasPermission(LfPermission.memberEdit) && !hasGithubIdentity"
+    :disabled="!!props.contributor.username?.github"
+    @click="emit('findGithub')"
+  >
     <lf-icon-old name="github-fill" />
     Find GitHub
   </lf-dropdown-item>

--- a/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
+++ b/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
@@ -7,7 +7,7 @@
     <lf-icon-old name="link-unlink" />
     Unmerge profile
   </lf-dropdown-item>
-  <lf-dropdown-item v-if="hasPermission(LfPermission.memberEdit)" :disabled="!!props.contributor.username?.github" @click="emit('findGithub')">
+  <lf-dropdown-item v-if="hasPermission(LfPermission.memberEdit) && !hasGithubIdentity" :disabled="!!props.contributor.username?.github" @click="emit('findGithub')">
     <lf-icon-old name="github-fill" />
     Find GitHub
   </lf-dropdown-item>
@@ -46,7 +46,7 @@ import { MemberService } from '@/modules/member/member-service';
 import { doManualAction } from '@/shared/helpers/manualAction.helpers';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
 import AppMemberUnmergeDialog from '@/modules/member/components/member-unmerge-dialog.vue';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import useContributorHelpers from '@/modules/contributor/helpers/contributor.helpers';
 import { Contributor } from '@/modules/contributor/types/Contributor';
 import { useContributorStore } from '@/modules/contributor/store/contributor.store';
@@ -65,6 +65,7 @@ const { isTeamMember, isBot, isMasked } = useContributorHelpers();
 const { updateContributorAttributes } = useContributorStore();
 
 const unmerge = ref<Contributor | null>(null);
+const hasGithubIdentity = computed(() => (!!props.contributor.identities?.find((identity) => identity.platform === 'github')));
 
 const markTeamMember = (teamMember: boolean) => {
   trackEvent({

--- a/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
+++ b/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
@@ -65,7 +65,7 @@ const { isTeamMember, isBot, isMasked } = useContributorHelpers();
 const { updateContributorAttributes } = useContributorStore();
 
 const unmerge = ref<Contributor | null>(null);
-const hasGithubIdentity = computed(() => (!!props.contributor.identities?.find((identity) => identity.platform === 'github')));
+const hasGithubIdentity = computed(() => (props.contributor.identities?.some((identity) => identity.platform === 'github')));
 
 const markTeamMember = (teamMember: boolean) => {
   trackEvent({

--- a/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
+++ b/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
@@ -7,7 +7,7 @@
     <lf-icon-old name="link-unlink" />
     Unmerge profile
   </lf-dropdown-item>
-  <lf-dropdown-item 
+  <lf-dropdown-item
     v-if="hasPermission(LfPermission.memberEdit) && !hasGithubIdentity"
     :disabled="!!props.contributor.username?.github"
     @click="emit('findGithub')"


### PR DESCRIPTION
# Changes proposed ✍️
Don't display the "Find GitHub" option if the contributor already has a GitHub identity
![image](https://github.com/user-attachments/assets/31448e7a-74ce-454f-8259-48b96a11df0e)

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced dropdown functionality to conditionally display the "Find GitHub" option based on the contributor's GitHub identity.
  
- **Bug Fixes**
	- Improved logic for determining the visibility of the "Find GitHub" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->