### PR TITLE
Active on identities popover doesn't have a maximum height

### DIFF
--- a/frontend/src/modules/organization/components/details/header/organization-details-header-profiles.vue
+++ b/frontend/src/modules/organization/components/details/header/organization-details-header-profiles.vue
@@ -41,7 +41,7 @@
       <div
         v-if="idents.length > 1"
         class="absolute w-58 top-full left-1/2 -translate-x-1/2 bg-white flex flex-col gap-1 p-1 shadow platform-popover
-         transition z-30 rounded-md border border-gray-100 mt-2"
+         transition z-30 rounded-md border border-gray-100 mt-2 overflow-y-auto overflow-x-hidden max-h-72"
       >
         <div class="absolute -top-2 h-2 w-full left-0" />
         <a


### PR DESCRIPTION
# Changes proposed ✍️

Active on identities popover doesn't have a maximum height

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
