### PR TITLE
Bugfix/lfx 1960 work history glitch

### DIFF
--- a/frontend/src/modules/contributor/components/details/work-history/contributor-details-work-history-item.vue
+++ b/frontend/src/modules/contributor/components/details/work-history/contributor-details-work-history-item.vue
@@ -3,7 +3,7 @@
     @mouseover="hovered = true"
     @mouseleave="hovered = false"
   >
-    <div class="flex">
+    <div class="flex min-h-7">
       <div class="flex flex-auto flex-col overflow-hidden">
         <div v-if="props.organization?.memberOrganizations?.title" class="text-small text-gray-900 mb-1.5 flex items-center gap-1.5">
           <lf-svg name="id-card" class="h-4 w-4 text-gray-400" />

--- a/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
+++ b/frontend/src/modules/contributor/components/shared/contributor-dropdown.vue
@@ -44,7 +44,7 @@ import { useRoute, useRouter } from 'vue-router';
 import { MemberService } from '@/modules/member/member-service';
 import { doManualAction } from '@/shared/helpers/manualAction.helpers';
 import ConfirmDialog from '@/shared/dialog/confirm-dialog';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import useContributorHelpers from '@/modules/contributor/helpers/contributor.helpers';
 import { Contributor } from '@/modules/contributor/types/Contributor';
 import { useContributorStore } from '@/modules/contributor/store/contributor.store';

--- a/frontend/src/shared/modules/report-issue/config/type/identity/type-identity.vue
+++ b/frontend/src/shared/modules/report-issue/config/type/identity/type-identity.vue
@@ -2,7 +2,7 @@
   <div class="flex items-center">
     <div>
       <lf-tooltip v-if="props.attribute.type === 'email'" content="Email" placement="top-start">
-        <lf-icon name="mail-line" :size="20" />
+        <app-platform-icon platform="emails" size="small" />
       </lf-tooltip>
       <lf-tooltip v-else-if="platform(props.attribute.platform)" placement="top-start" :content="platform(props.attribute.platform).name">
         <img
@@ -19,7 +19,7 @@
         />
       </lf-tooltip>
     </div>
-    <p class="text-medium pl-2">
+    <p class="text-medium pl-2 max-w-60 truncate" :title="props.attribute.value">
       {{ props.attribute.value }}
     </p>
   </div>
@@ -31,6 +31,7 @@ import { OrganizationIdentity } from '@/modules/organization/types/Organization'
 import LfTooltip from '@/ui-kit/tooltip/Tooltip.vue';
 import LfIcon from '@/ui-kit/icon/Icon.vue';
 import { CrowdIntegrations } from '@/integrations/integrations-config';
+import AppPlatformIcon from '@/shared/modules/platform/components/platform-icon.vue';
 
 const props = defineProps<{
   attribute: ContributorIdentity | OrganizationIdentity

--- a/frontend/src/ui-kit/timeline/Timeline.vue
+++ b/frontend/src/ui-kit/timeline/Timeline.vue
@@ -2,7 +2,7 @@
   <div
     v-for="group in props.groups"
     :key="group.label"
-    class="c-timeline"
+    :class="['c-timeline', group.items.length > 1 ? '' : 'c-single-item']"
     @mouseover="emit('onGroupHover', group)"
     @mouseleave="emit('onGroupHover', null)"
   >

--- a/frontend/src/ui-kit/timeline/timeline.scss
+++ b/frontend/src/ui-kit/timeline/timeline.scss
@@ -3,9 +3,16 @@
   &__group-label {
     @apply flex items-center font-semibold text-medium leading-6 mb-1 truncate text-black hover:text-primary-500 transition block w-full overflow-hidden;
   }
-  // &__border {
-  //   @apply w-px h-full bg-gray-200;
-  // }
+
+  &.c-single-item {
+    ::v-deep .c-timeline__item {
+      .c-timeline__item-content {
+        &::before {
+          @apply invisible;
+        }
+      }
+    }
+  }
 
   ::v-deep .c-timeline__item {
     @apply relative mb-4;
@@ -36,5 +43,3 @@
     }
   }
 }
-
-


### PR DESCRIPTION
# Changes proposed ✍️

### What
- Fix UI glitch when hovering work history timeline that has "unknown" value
- Fix UI issue on the report identity issue modal

## Tickets
[LFX-1960](https://linear.app/lfx/issue/LFX-1960/ui-glitches-on-work-history-display)
[LFX-1961](https://linear.app/lfx/issue/LFX-1961/fix-overflow-and-icon-display-of-the-identity-on-report-issue-modal)

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **UI Improvements**
  - Enhanced timeline component to handle single-item groups with improved styling
  - Updated contributor dropdown and identity type display
  - Refined visual representation of work history items

- **Minor Changes**
  - Removed unused Vue import in contributor dropdown
  - Updated email type icon and attribute display
  - Added truncation and tooltip for long attribute values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->