### PR TITLE
Bugfix/cm 1959 integration loading

### DIFF
--- a/frontend/src/modules/admin/modules/integration/components/integration-list-item.vue
+++ b/frontend/src/modules/admin/modules/integration/components/integration-list-item.vue
@@ -47,13 +47,16 @@
           <div v-else-if="hasError">
             {{ props.config.name }} integration failed to connect due to an API error.
           </div>
-          <component
-            :is="props.config.connectedParamsComponent"
-            v-else-if="isComplete && props.config.connectedParamsComponent"
-            :integration="integration"
-            :segment-id="route.params.id"
-            :grandparent-id="route.params.grandparentId"
-          />
+          <div v-else-if="isComplete && props.config.connectedParamsComponent">
+            <div v-if="loadingFetch" v-loading="true" class="min-w-8 min-h-6" />
+            <component
+              :is="props.config.connectedParamsComponent"
+              v-else
+              :integration="integration"
+              :segment-id="route.params.id"
+              :grandparent-id="route.params.grandparentId"
+            />
+          </div>
           <component
             :is="props.config.statusComponent"
             v-else-if="!isComplete && props.config.statusComponent"
@@ -125,7 +128,7 @@ const props = defineProps<{
 const route = useRoute();
 
 const { doDestroy } = mapActions('integration');
-const { findByPlatform } = mapGetters('integration');
+const { findByPlatform, loadingFetch } = mapGetters('integration');
 
 const { trackEvent } = useProductTracking();
 

--- a/frontend/src/modules/admin/modules/integration/components/integration-list-item.vue
+++ b/frontend/src/modules/admin/modules/integration/components/integration-list-item.vue
@@ -47,16 +47,15 @@
           <div v-else-if="hasError">
             {{ props.config.name }} integration failed to connect due to an API error.
           </div>
-          <div v-else-if="isComplete && props.config.connectedParamsComponent">
-            <div v-if="loadingFetch" v-loading="true" class="min-w-8 min-h-6" />
-            <component
-              :is="props.config.connectedParamsComponent"
-              v-else
-              :integration="integration"
-              :segment-id="route.params.id"
-              :grandparent-id="route.params.grandparentId"
-            />
-          </div>
+
+          <component
+            :is="props.config.connectedParamsComponent"
+            v-else-if="isComplete && props.config.connectedParamsComponent"
+            :integration="integration"
+            :segment-id="route.params.id"
+            :grandparent-id="route.params.grandparentId"
+          />
+
           <component
             :is="props.config.statusComponent"
             v-else-if="!isComplete && props.config.statusComponent"
@@ -128,7 +127,7 @@ const props = defineProps<{
 const route = useRoute();
 
 const { doDestroy } = mapActions('integration');
-const { findByPlatform, loadingFetch } = mapGetters('integration');
+const { findByPlatform } = mapGetters('integration');
 
 const { trackEvent } = useProductTracking();
 

--- a/frontend/src/modules/admin/modules/integration/pages/integration-list.page.vue
+++ b/frontend/src/modules/admin/modules/integration/pages/integration-list.page.vue
@@ -57,8 +57,8 @@
       </section>
     </div>
 
-    <section>
-      <app-integration-progress-wrapper :segments="[route.params.id]">
+    <section v-loading="loadingFetch">
+      <app-integration-progress-wrapper v-if="!loadingFetch" :segments="[route.params.id]">
         <template #default="{ progress, progressError }">
           <div v-if="platformsByStatus.length > 0" class="flex flex-col gap-6">
             <lf-integration-list-item
@@ -100,7 +100,7 @@ const route = useRoute();
 
 const { findSubProject } = useLfSegmentsStore();
 const { doFetch } = mapActions('integration');
-const { array } = mapGetters('integration');
+const { array, loadingFetch } = mapGetters('integration');
 
 const { id, grandparentId } = route.params;
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
Added loading state to the integrations list component to prevent it from rendering until all the integrations data are loaded.

### Why
This is causing a bug on the integrations list page that displays previous integration list instead of the current segment being viewed.

### Ticket
https://linear.app/lfx/issue/CM-1959/issue-with-integrations-loading-status

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced integration list item component with conditional rendering of connected parameters and status components
  - Added loading state for integration progress section

- **Improvements**
  - Improved component flexibility to display relevant information based on integration state
  - Implemented loading indicator while fetching integration data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->