### PR TITLE
Combine activity moving and affiliation recalculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,5 +4,6 @@
   },
   "devDependencies": {
     "husky": "^9.1.7"
-  }
+  },
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,9 @@ importers:
       '@crowd/opensearch':
         specifier: workspace:*
         version: link:../../libs/opensearch
+      '@crowd/queue':
+        specifier: workspace:*
+        version: link:../../libs/queue
       '@crowd/redis':
         specifier: workspace:*
         version: link:../../libs/redis

--- a/services/apps/entity_merging_worker/package.json
+++ b/services/apps/entity_merging_worker/package.json
@@ -18,6 +18,7 @@
     "@crowd/opensearch": "workspace:*",
     "@crowd/redis": "workspace:*",
     "@crowd/types": "workspace:*",
+    "@crowd/queue": "workspace:*",
     "@temporalio/workflow": "~1.11.1",
     "tsx": "^4.7.1",
     "typescript": "^5.6.3"

--- a/services/apps/entity_merging_worker/src/activities.ts
+++ b/services/apps/entity_merging_worker/src/activities.ts
@@ -1,6 +1,5 @@
 export {
   deleteMember,
-  moveActivitiesBetweenMembers,
   moveActivitiesWithIdentityToAnotherMember,
   recalculateActivityAffiliationsOfMemberAsync,
   syncMember,

--- a/services/apps/entity_merging_worker/src/activities.ts
+++ b/services/apps/entity_merging_worker/src/activities.ts
@@ -6,6 +6,8 @@ export {
   notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
   syncRemoveMember,
+  finishMemberMergingUpdateActivities,
+  finishMemberUnmergingUpdateActivities,
 } from './activities/members'
 
 export {

--- a/services/apps/entity_merging_worker/src/activities/members.ts
+++ b/services/apps/entity_merging_worker/src/activities/members.ts
@@ -6,7 +6,6 @@ import {
   deleteMemberSegments,
   findMemberById,
   getIdentitiesWithActivity,
-  moveActivitiesToNewMember,
   moveIdentityActivitiesToNewMember,
 } from '@crowd/data-access-layer/src/old/apps/entity_merging_worker'
 import { dbStoreQx } from '@crowd/data-access-layer/src/queryExecutor'
@@ -26,19 +25,6 @@ export async function deleteMember(memberId: string): Promise<void> {
   const qx = dbStoreQx(svc.postgres.writer)
   await cleanupMemberAggregates(qx, memberId)
   await cleanupMember(svc.postgres.writer, memberId)
-}
-
-export async function moveActivitiesBetweenMembers(
-  primaryId: string,
-  secondaryId: string,
-  tenantId: string,
-): Promise<void> {
-  const memberExists = await findMemberById(svc.postgres.writer, primaryId, tenantId)
-
-  if (!memberExists) {
-    return
-  }
-  await moveActivitiesToNewMember(svc.questdbSQL, svc.queue, primaryId, secondaryId, tenantId)
 }
 
 export async function moveActivitiesWithIdentityToAnotherMember(

--- a/services/apps/entity_merging_worker/src/workflows/all.ts
+++ b/services/apps/entity_merging_worker/src/workflows/all.ts
@@ -1,24 +1,8 @@
 import { proxyActivities } from '@temporalio/workflow'
 
-import { updateActivities } from '@crowd/data-access-layer/src/activities/update'
-import { DbStore } from '@crowd/data-access-layer/src/database'
-import { DbConnOrTx } from '@crowd/data-access-layer/src/database'
-import { IDbActivityCreateData } from '@crowd/data-access-layer/src/old/apps/data_sink_worker/repo/activity.data'
-import {
-  figureOutNewOrgId,
-  prepareMemberAffiliationsUpdate,
-} from '@crowd/data-access-layer/src/old/apps/profiles_worker'
-import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
-import { IQueue } from '@crowd/queue'
-import {
-  IMemberIdentity,
-  MemberIdentityType,
-  MergeActionState,
-  MergeActionStep,
-} from '@crowd/types'
+import { IMemberIdentity, MergeActionState, MergeActionStep } from '@crowd/types'
 
 import * as activities from '../activities'
-import { svc } from '../main'
 
 const {
   deleteMember,
@@ -34,33 +18,11 @@ const {
   notifyFrontendMemberMergeSuccessful,
   notifyFrontendMemberUnmergeSuccessful,
   syncRemoveMember,
+  finishMemberMergingUpdateActivities,
+  finishMemberUnmergingUpdateActivities,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '60 minutes',
 })
-
-async function finishMemberMergingUpdateActivities(
-  pgDb: DbStore,
-  qDb: DbConnOrTx,
-  queueClient: IQueue,
-  memberId: string,
-  newMemberId: string,
-) {
-  const qx = pgpQx(pgDb.connection())
-  const { orgCases } = await prepareMemberAffiliationsUpdate(qx, memberId)
-
-  await updateActivities(
-    qDb,
-    queueClient,
-    [
-      async () => ({ memberId: newMemberId }),
-      async (activity) => ({ organizationId: figureOutNewOrgId(activity, orgCases) }),
-    ],
-    `"memberId" = $(memberId)`,
-    {
-      memberId,
-    },
-  )
-}
 
 export async function finishMemberMerging(
   primaryId: string,
@@ -74,13 +36,7 @@ export async function finishMemberMerging(
     step: MergeActionStep.MERGE_ASYNC_STARTED,
   })
 
-  await finishMemberMergingUpdateActivities(
-    svc.postgres.reader,
-    svc.questdbSQL,
-    svc.queue,
-    primaryId,
-    secondaryId,
-  )
+  await finishMemberMergingUpdateActivities(primaryId, secondaryId)
 
   await syncMember(primaryId)
   await syncRemoveMember(secondaryId)
@@ -99,56 +55,6 @@ export async function finishMemberMerging(
   )
 }
 
-function moveByIdentities({
-  activity,
-  identities,
-  newMemberId,
-}: {
-  activity: IDbActivityCreateData
-  identities: IMemberIdentity[]
-  newMemberId: string
-}): Partial<IDbActivityCreateData> {
-  const { platform, username } = activity
-  const activityMatches = identities.some(
-    (i) =>
-      i.type === MemberIdentityType.USERNAME && i.platform === platform && i.value === username,
-  )
-
-  return activityMatches ? { memberId: newMemberId } : {}
-}
-
-export async function finishMemberUnmergingUpdateActivities({
-  pgDb,
-  qDb,
-  queueClient,
-  memberId,
-  newMemberId,
-  identities,
-}: {
-  pgDb: DbStore
-  qDb: DbConnOrTx
-  queueClient: IQueue
-  memberId: string
-  newMemberId: string
-  identities: IMemberIdentity[]
-}) {
-  const qx = pgpQx(pgDb.connection())
-  const { orgCases } = await prepareMemberAffiliationsUpdate(qx, memberId)
-
-  await updateActivities(
-    qDb,
-    queueClient,
-    [
-      async (activity) => moveByIdentities({ activity, identities, newMemberId }),
-      async (activity) => ({
-        organizationId: figureOutNewOrgId(activity, orgCases),
-      }),
-    ],
-    `"memberId" = $(memberId)`,
-    { memberId },
-  )
-}
-
 export async function finishMemberUnmerging(
   primaryId: string,
   secondaryId: string,
@@ -163,9 +69,6 @@ export async function finishMemberUnmerging(
   })
 
   await finishMemberUnmergingUpdateActivities({
-    pgDb: svc.postgres.reader,
-    qDb: svc.questdbSQL,
-    queueClient: svc.queue,
     memberId: primaryId,
     newMemberId: secondaryId,
     identities,

--- a/services/libs/data-access-layer/src/old/apps/entity_merging_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/entity_merging_worker/index.ts
@@ -40,25 +40,6 @@ export async function findMemberById(db: DbStore, primaryId: string, tenantId: s
   )
 }
 
-export async function moveActivitiesToNewMember(
-  qdb: DbConnOrTx,
-  queueClient: IQueue,
-  primaryId: string,
-  secondaryId: string,
-  tenantId: string,
-) {
-  await updateActivities(
-    qdb,
-    queueClient,
-    async () => ({ memberId: primaryId }),
-    `"memberId" = $(memberId) AND "tenantId" = $(tenantId)`,
-    {
-      memberId: secondaryId,
-      tenantId,
-    },
-  )
-}
-
 export async function updateMergeActionState(
   db: DbStore,
   primaryId: string,

--- a/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash'
-import QueryStream from 'pg-query-stream'
 
 import { getDefaultTenantId, getLongestDateRange } from '@crowd/common'
 import { DbConnOrTx, DbStore } from '@crowd/database'
@@ -7,9 +6,9 @@ import { getServiceChildLogger } from '@crowd/logging'
 import { IQueue } from '@crowd/queue'
 import { IMemberOrganization } from '@crowd/types'
 
-import { insertActivities } from '../../../activities'
+import { updateActivities } from '../../../activities/update'
 import { findMemberAffiliations } from '../../../member_segment_affiliations'
-import { formatQuery, pgpQx } from '../../../queryExecutor'
+import { QueryExecutor, pgpQx } from '../../../queryExecutor'
 import { IDbActivityCreateData } from '../data_sink_worker/repo/activity.data'
 
 import { IAffiliationsLastCheckedAt, IMemberId } from './types'
@@ -17,13 +16,24 @@ import { IAffiliationsLastCheckedAt, IMemberId } from './types'
 const logger = getServiceChildLogger('profiles_worker')
 const tenantId = getDefaultTenantId()
 
-export async function runMemberAffiliationsUpdate(
-  pgDb: DbStore,
-  qDb: DbConnOrTx,
-  queueClient: IQueue,
-  memberId: string,
-) {
-  const qx = pgpQx(pgDb.connection())
+type Condition = {
+  when: string[]
+  orgId: string
+  matches: (activity: IDbActivityCreateData) => boolean
+}
+
+type MemberOrganizationWithOverrides = IMemberOrganization & {
+  isPrimaryWorkExperience: boolean
+  memberCount: number
+}
+
+type TimelineItem = {
+  organizationId: string
+  isPrimaryWorkExperience: boolean
+  withDates?: boolean
+}
+
+export async function prepareMemberAffiliationsUpdate(qx: QueryExecutor, memberId: string) {
   const tsBetween = (start: string, end: string) => {
     return `timestamp BETWEEN '${start}' AND '${end}'`
   }
@@ -40,23 +50,6 @@ export async function runMemberAffiliationsUpdate(
       return tsBetween(start, end)
     }
     return tsAfter(start)
-  }
-
-  type Condition = {
-    when: string[]
-    orgId: string
-    matches: (activity: IDbActivityCreateData) => boolean
-  }
-
-  type MemberOrganizationWithOverrides = IMemberOrganization & {
-    isPrimaryWorkExperience: boolean
-    memberCount: number
-  }
-
-  type TimelineItem = {
-    organizationId: string
-    isPrimaryWorkExperience: boolean
-    withDates?: boolean
   }
 
   const condition = ({ when, orgId }: Condition) => {
@@ -313,40 +306,44 @@ export async function runMemberAffiliationsUpdate(
     fullCase = `${nullableOrg(fallbackOrganizationId)}`
   }
 
-  async function insertIfMatches(activity: IDbActivityCreateData) {
-    activity.organizationId = null
+  return { orgCases, fullCase }
+}
 
-    if (orgCases.length > 0) {
-      for (const condition of orgCases) {
-        if (condition.matches(activity)) {
-          activity.organizationId = condition.orgId
-          break
-        }
+export function figureOutNewOrgId(activity: IDbActivityCreateData, orgCases: Condition[]) {
+  if (orgCases.length > 0) {
+    for (const condition of orgCases) {
+      if (condition.matches(activity)) {
+        return condition.orgId
       }
     }
-
-    await insertActivities(queueClient, [activity], true)
   }
 
-  const qs = new QueryStream(
-    formatQuery(
-      `
-        SELECT *
-        FROM activities
-        WHERE "memberId" = $(memberId)
-          AND COALESCE("organizationId", cast('00000000-0000-0000-0000-000000000000' as uuid)) != COALESCE(
-            ${fullCase},
-            cast('00000000-0000-0000-0000-000000000000' as uuid)
-          )
-      `,
-      { memberId },
-    ),
+  return null
+}
+
+export async function runMemberAffiliationsUpdate(
+  pgDb: DbStore,
+  qDb: DbConnOrTx,
+  queueClient: IQueue,
+  memberId: string,
+) {
+  const qx = pgpQx(pgDb.connection())
+
+  const { orgCases, fullCase } = await prepareMemberAffiliationsUpdate(qx, memberId)
+
+  const { processed, duration } = await updateActivities(
+    qDb,
+    queueClient,
+    async (activity) => ({ organizationId: figureOutNewOrgId(activity, orgCases) }),
+    `
+      "memberId" = $(memberId)
+      AND COALESCE("organizationId", cast('00000000-0000-0000-0000-000000000000' as uuid)) != COALESCE(
+        ${fullCase},
+        cast('00000000-0000-0000-0000-000000000000' as uuid)
+      )
+    `,
+    { memberId },
   )
-  const { processed, duration } = await qDb.stream(qs, async (stream) => {
-    for await (const activity of stream) {
-      await insertIfMatches(activity as unknown as IDbActivityCreateData)
-    }
-  })
 
   logger.info(`Updated ${processed} activities in ${duration}ms`)
 }


### PR DESCRIPTION
Since those two operations depend on each other, but they're both async, how it was before was incorrect. Now we combine them into one operation