### PR TITLE
Remove redundant identity uniqueness check in member merge

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -543,8 +543,7 @@ class MemberRepository {
     const tenant = SequelizeRepository.getCurrentTenant(options)
 
     for (const i of identitiesToMove) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { rowCount } = await moveToNewMember(qx, {
+      await moveToNewMember(qx, {
         tenantId: tenant.id,
         oldMemberId: fromMemberId,
         newMemberId: toMemberId,
@@ -552,10 +551,6 @@ class MemberRepository {
         value: i.value,
         type: i.type,
       })
-
-      if (rowCount !== 1) {
-        throw new Error('One row should be updated!')
-      }
     }
 
     if (identitiesToUpdate.length > 0) {


### PR DESCRIPTION
Remove application-level uniqueness check for verified identities in moveIdentitiesBetweenMembers since it's already enforced by database unique index uix_memberIdentities_platform_value_type_tenantId_verified. This fixes the error when merging members with duplicate unverified identities.
