### PR TITLE
fix: explicit `withAggs` in syncMember to avoid empty opts

### DIFF
--- a/backend/src/services/searchSyncService.ts
+++ b/backend/src/services/searchSyncService.ts
@@ -48,7 +48,7 @@ export default class SearchSyncService extends LoggerBase {
     return process()
   }
 
-  async triggerMemberSync(tenantId: string, memberId: string, opts: { withAggs?: boolean } = {}) {
+  async triggerMemberSync(tenantId: string, memberId: string, opts?: { withAggs?: boolean }) {
     const client = await this.getSearchSyncClient()
 
     if (client instanceof SearchSyncApiClient) {

--- a/services/apps/entity_merging_worker/src/activities/members.ts
+++ b/services/apps/entity_merging_worker/src/activities/members.ts
@@ -106,7 +106,7 @@ export async function syncMember(memberId: string): Promise<void> {
     baseUrl: process.env['CROWD_SEARCH_SYNC_API_URL'],
   })
 
-  await syncApi.triggerMemberSync(memberId)
+  await syncApi.triggerMemberSync(memberId, { withAggs: true })
 }
 
 export async function syncRemoveMember(memberId: string): Promise<void> {

--- a/services/libs/opensearch/src/apiClient.ts
+++ b/services/libs/opensearch/src/apiClient.ts
@@ -13,10 +13,7 @@ export class SearchSyncApiClient {
     })
   }
 
-  public async triggerMemberSync(
-    memberId: string,
-    opts: { withAggs?: boolean } = {},
-  ): Promise<void> {
+  public async triggerMemberSync(memberId: string, opts?: { withAggs?: boolean }): Promise<void> {
     if (!memberId) {
       throw new Error('memberId is required!')
     }

--- a/services/libs/opensearch/src/service/member.sync.service.ts
+++ b/services/libs/opensearch/src/service/member.sync.service.ts
@@ -383,8 +383,6 @@ export class MemberSyncService {
   ): Promise<IMemberSyncResult> {
     const qx = repoQx(this.memberRepo)
 
-    this.log.info('opts withAggs', { withAggs: opts.withAggs })
-
     const syncMemberAggregates = async (memberId) => {
       if (opts.syncFrom) {
         const lastSyncDate = await findLastSyncDate(qx, memberId)

--- a/services/libs/opensearch/src/service/member.sync.service.ts
+++ b/services/libs/opensearch/src/service/member.sync.service.ts
@@ -383,6 +383,8 @@ export class MemberSyncService {
   ): Promise<IMemberSyncResult> {
     const qx = repoQx(this.memberRepo)
 
+    this.log.info('opts withAggs', { withAggs: opts.withAggs })
+
     const syncMemberAggregates = async (memberId) => {
       if (opts.syncFrom) {
         const lastSyncDate = await findLastSyncDate(qx, memberId)


### PR DESCRIPTION
# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
