### PR TITLE
Remove limit from update statement

### DIFF
--- a/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
@@ -440,8 +440,7 @@ export async function updateAffiliationsLastCheckedAt(db: DbStore): Promise<void
   try {
     await db.connection().any(
       `
-        update tenants set "affiliationsLastCheckedAt" = now()
-        limit 1
+        update tenants set "affiliationsLastCheckedAt" = now();
       `,
     )
   } catch (err) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
Temporal workflows were getting stuck because PostgreSQL's LIMIT clause is not valid in an UPDATE statement in this context.

### Changes
Removed limit from statement. Currently, we have 2 tenants, one for LF and one for Loki. This statement will now update both entries which is ok because Loki tenant is only used for authentication.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
