### PR TITLE
Add `query-stream` config and error propagation 

### DIFF
--- a/services/libs/data-access-layer/src/activities/ilp.ts
+++ b/services/libs/data-access-layer/src/activities/ilp.ts
@@ -53,6 +53,13 @@ export async function insertActivities(
   const emitter = new QueueEmitter(queueClient, ACTIVITIES_QUEUE_SETTINGS, logger)
 
   for (const row of toInsert) {
+    logger.debug(
+      {
+        activityId: row.id,
+        queue: ACTIVITIES_QUEUE_SETTINGS.name,
+      },
+      'Dispatching activity to queue!',
+    )
     await emitter.sendMessage(generateUUIDv4(), row, generateUUIDv4())
   }
   telemetry.increment('questdb.insert_activity', activities.length)

--- a/services/libs/data-access-layer/src/activities/update.ts
+++ b/services/libs/data-access-layer/src/activities/update.ts
@@ -19,7 +19,10 @@ export async function streamActivities(
   params?: Record<string, unknown>,
 ): Promise<{ processed: number; duration: number }> {
   const whereClause = formatQuery(where, params)
-  const qs = new QueryStream(`SELECT * FROM activities WHERE ${whereClause}`)
+  const qs = new QueryStream(`SELECT * FROM activities WHERE ${whereClause}`, [], {
+    batchSize: 1000,
+    highWaterMark: 250,
+  })
 
   const t = timer(logger, `query activities with ${whereClause}`)
 
@@ -35,16 +38,19 @@ export async function streamActivities(
 
     qdb
       .stream(qs, async (stream) => {
-        for await (const item of stream) {
-          t.end()
+        try {
+          for await (const item of stream) {
+            t.end()
 
-          const activity = item as unknown as IDbActivityCreateData
+            const activity = item as unknown as IDbActivityCreateData
+            await onActivity(activity)
+          }
 
-          await onActivity(activity)
+          processedAllRows = true
+          tryFinish()
+        } catch (error) {
+          reject(error)
         }
-
-        processedAllRows = true
-        tryFinish()
       })
       .then((res) => {
         streamResult = res


### PR DESCRIPTION
# Changes proposed ✍️

- Explicitly added `batchSize` and `highWaterMark` options to pg-query-stream for performance.
- Fix stream error handling to propagate failures to Temporal workflows, enabling proper retries.