### PR TITLE
fix: resolve project to sub-project segments in member and org queries

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1569,7 +1569,7 @@ class OrganizationRepository {
 
     let segments = []
     if (segmentId) {
-      const segment = (await findSegmentById(optionsQx(options), segmentId))
+      const segment = await findSegmentById(optionsQx(options), segmentId)
 
       if (segment === null) {
         options.log.info('No segment found for organization')

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1619,7 +1619,7 @@ class OrganizationRepository {
       FROM organizations o
       ${
         withAggregates
-          ? ` INNER JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND osa."segmentId" IN ($(segments)::UUID[])`
+          ? ` INNER JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND osa."segmentId" IN ($(segments:csv))`
           : ` LEFT JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND osa."segmentId" IS NULL`
       }
       WHERE 1=1

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -234,7 +234,7 @@ export async function queryMembersAdvanced(
       FROM members m
       ${
         withAggregates
-          ? ` INNER JOIN "memberSegmentsAgg" msa ON msa."memberId" = m.id AND msa."segmentId" IN ($(segments)::UUID[])`
+          ? ` INNER JOIN "memberSegmentsAgg" msa ON msa."memberId" = m.id AND msa."segmentId" IN ($(segments:csv))`
           : ''
       }
       LEFT JOIN member_orgs mo ON mo."memberId" = m.id

--- a/services/libs/data-access-layer/src/segments/index.ts
+++ b/services/libs/data-access-layer/src/segments/index.ts
@@ -2,7 +2,13 @@ import lodash from 'lodash'
 import cloneDeep from 'lodash.clonedeep'
 
 import { DEFAULT_ACTIVITY_TYPE_SETTINGS } from '@crowd/integrations'
-import { ActivityTypeSettings, SegmentData, SegmentRawData } from '@crowd/types'
+import {
+  ActivityTypeSettings,
+  SegmentData,
+  SegmentProjectGroupNestedData,
+  SegmentProjectNestedData,
+  SegmentRawData,
+} from '@crowd/types'
 
 import { QueryExecutor } from '../queryExecutor'
 
@@ -166,4 +172,18 @@ export function populateSegmentRelations(record: SegmentRawData): SegmentData {
   }
 
   return segmentData
+}
+
+export function getSegmentSubprojectIds(segment: SegmentData): string[] {
+  if (isSegmentProjectGroup(segment)) {
+    return ((segment as SegmentProjectGroupNestedData).projects || []).flatMap((p) =>
+      p.subprojects ? p.subprojects.map((sp) => sp.id) : [],
+    )
+  }
+
+  if (isSegmentProject(segment)) {
+    return (segment as SegmentProjectNestedData).subprojects.map((sp) => sp.id)
+  }
+
+  return [segment.id]
 }


### PR DESCRIPTION
# Changes proposed ✍️

Modified member queries to automatically resolve project/group segment Ids to their relevant sub-project segment Ids, ensuring members are returned regardless of which level of segment ID is provided.