### PR TITLE
Remove updatedAt check when getting integrations data

### DIFF
--- a/services/libs/data-access-layer/src/old/apps/integration_run_worker/integrationRun.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/integration_run_worker/integrationRun.repo.ts
@@ -1,9 +1,7 @@
-import moment from 'moment'
-
 import { DEFAULT_TENANT_ID } from '@crowd/common'
 import { DbStore, RepositoryBase } from '@crowd/database'
 import { Logger } from '@crowd/logging'
-import { IntegrationRunState, IntegrationStreamState, IntegrationType } from '@crowd/types'
+import { IntegrationRunState, IntegrationStreamState } from '@crowd/types'
 
 import {
   IGenerateStreamsData,
@@ -88,13 +86,6 @@ export default class IntegrationRunRepository extends RepositoryBase<Integration
     )
 
     if (!results) {
-      return null
-    }
-
-    if (
-      results.type === IntegrationType.GITHUB &&
-      moment(results.updatedAt).isBefore(moment('2024-12-19'))
-    ) {
       return null
     }
 


### PR DESCRIPTION
# Changes proposed ✍️
This piece of code:
```
    if (
      results.type === IntegrationType.GITHUB &&
      moment(results.updatedAt).isBefore(moment('2024-12-19'))
    ) {
      return null
    }
```
was added [in this commit (commit even mentions "revert me:", since it was a temporary optimization)](https://github.com/CrowdDotDev/crowd.dev/pull/2723) because of the GitHub Archive implementation. This was added to prevent any historical onboardings with archive for old integrations. Since the GitHub Archive is no longer active, this no longer makes sense -> This is actually preventing to re-onboard some of the older integrations to get missing data back.



## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
