### PR TITLE
fix: prevent empty secondaryIdentities when unmerging email

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1094,7 +1094,7 @@ export default class MemberService extends LoggerBase {
         })
 
         // exclude the original identity to avoid duplicates
-        secondaryIdentities = allEmailIdentities.filter((i) => i.id !== identity.id)
+        secondaryIdentities = lodash.uniqBy([...allEmailIdentities, identity], (i) => i.id)
       }
 
       // Ensure primary member retains at least one identity


### PR DESCRIPTION
# Bugfix 🐞

Unmerging an email identity sometimes failed because the code excluded the selected identity if it was the only match, resulting in no identities being removed.

This fix ensures the selected identity is always included in the unmerge, preventing empty extractions.