### PR TITLE
fix: always expand currentSegments to subproject IDs for merge suggestions

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -299,20 +299,14 @@ class MemberRepository {
     args: IFetchMemberMergeSuggestionArgs,
     options: IRepositoryOptions,
   ) {
-    let segmentIds: string[]
-
     const HIGH_CONFIDENCE_LOWER_BOUND = 0.9
     const MEDIUM_CONFIDENCE_LOWER_BOUND = 0.7
 
-    if (args.filter?.projectIds) {
-      segmentIds = (
-        await new SegmentRepository(options).getSegmentSubprojects(args.filter.projectIds)
-      ).map((s) => s.id)
-    } else if (args.filter?.subprojectIds) {
-      segmentIds = args.filter.subprojectIds
-    } else {
-      segmentIds = SequelizeRepository.getSegmentIds(options)
-    }
+    const currentSegments = SequelizeRepository.getSegmentIds(options)
+
+    const segmentIds = (
+      await new SegmentRepository(options).getSegmentSubprojects(currentSegments)
+    ).map((s) => s.id)
 
     let similarityFilter = ''
     const similarityConditions = []

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -880,17 +880,10 @@ class OrganizationRepository {
     const HIGH_CONFIDENCE_LOWER_BOUND = 0.9
     const MEDIUM_CONFIDENCE_LOWER_BOUND = 0.7
 
-    let segmentIds: string[]
-
-    if (args.filter?.projectIds) {
-      segmentIds = (
-        await new SegmentRepository(options).getSegmentSubprojects(args.filter.projectIds)
-      ).map((s) => s.id)
-    } else if (args.filter?.subprojectIds) {
-      segmentIds = args.filter.subprojectIds
-    } else {
-      segmentIds = SequelizeRepository.getSegmentIds(options)
-    }
+    const currentSegments = SequelizeRepository.getSegmentIds(options)
+    const segmentIds = (
+      await new SegmentRepository(options).getSegmentSubprojects(currentSegments)
+    ).map((s) => s.id)
 
     let similarityFilter = ''
     const similarityConditions = []


### PR DESCRIPTION
# Changes proposed ✍️

With recent changes, the frontend now sends only project group IDs (not subproject IDs) to the merge suggestions endpoint, expecting the backend to resolve and expand these to subproject IDs. However, since the legacy filter structure is no longer used in the frontend, the backend was defaulting to using the provided segment IDs directly. This caused queries with project group IDs to return no results.

The backend now always expands `currentSegments` (project group IDs) to their corresponding subproject IDs before querying, ensuring merge suggestions are returned correctly with the new frontend behavior.
