### PR TITLE
feat: jira integration

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -16,7 +16,8 @@ import {
 import {
   NangoIntegration,
   connectNangoIntegration,
-  createNangoIntegration,
+  createNangoConnection,
+  createNangoGithubConnection,
   deleteNangoConnection,
   getNangoConnectionData,
   getNangoConnections,
@@ -65,7 +66,6 @@ import { encryptData } from '../utils/crypto'
 
 import { IServiceOptions } from './IServiceOptions'
 import { getGithubInstallationToken } from './helpers/githubToken'
-import { jiraIntegrationData } from '../types/jiraTypes'
 
 const discordToken = DISCORD_CONFIG.token || DISCORD_CONFIG.token2
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -23,7 +23,6 @@ import {
   getNangoConnections,
   setNangoMetadata,
   startNangoSync,
-  getNangoCloudSessionToken,
 } from '@crowd/nango'
 import { RedisCache } from '@crowd/redis'
 import { Edition, PlatformType } from '@crowd/types'
@@ -1690,7 +1689,6 @@ export default class IntegrationService {
         return { jiraIntegrationType, nangoPayload }
       }
 
-      const data = await getNangoCloudSessionToken()
       const { jiraIntegrationType, nangoPayload } = constructNangoConnectionPayload(integrationData)
       this.options.log.info(
         `jira integration type determined: ${jiraIntegrationType}, starting nango connection...`,

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -22,7 +22,6 @@ import {
   getNangoConnections,
   setNangoMetadata,
   startNangoSync,
-  getNangoCloudSessionToken,
 } from '@crowd/nango'
 import { RedisCache } from '@crowd/redis'
 import { Edition, PlatformType } from '@crowd/types'
@@ -1690,7 +1689,6 @@ export default class IntegrationService {
         return { jiraIntegrationType, nangoPayload }
       }
 
-      const data = await getNangoCloudSessionToken()
       const { jiraIntegrationType, nangoPayload } = constructNangoConnectionPayload(integrationData)
       this.options.log.info(
         `jira integration type determined: ${jiraIntegrationType}, starting nango connection...`,

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -15,9 +15,9 @@ import {
 } from '@crowd/common'
 import {
   NangoIntegration,
+  connectNangoIntegration,
   createNangoConnection,
   createNangoGithubConnection,
-  connectNangoIntegration,
   deleteNangoConnection,
   getNangoConnectionData,
   getNangoConnections,
@@ -61,10 +61,11 @@ import {
 import { getOrganizations } from '../serverless/integrations/usecases/linkedin/getOrganizations'
 import getToken from '../serverless/integrations/usecases/nango/getToken'
 import { getIntegrationRunWorkerEmitter } from '../serverless/utils/queueService'
+import { JiraIntegrationData } from '../types/jiraTypes'
 import { encryptData } from '../utils/crypto'
+
 import { IServiceOptions } from './IServiceOptions'
 import { getGithubInstallationToken } from './helpers/githubToken'
-import { JiraIntegrationData } from '../types/jiraTypes'
 
 const discordToken = DISCORD_CONFIG.token || DISCORD_CONFIG.token2
 
@@ -1681,7 +1682,7 @@ export default class IntegrationService {
             baseUrl,
           },
           credentials: {
-            apiKey: integrationData.personalAccessToken
+            apiKey: integrationData.personalAccessToken,
           },
         }
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -1682,7 +1682,7 @@ export default class IntegrationService {
             baseUrl,
           },
           credentials: {
-            apiKey: integrationData.personalAccessToken
+            apiKey: integrationData.personalAccessToken,
           },
         }
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -18,6 +18,7 @@ import {
   connectNangoIntegration,
   createNangoConnection,
   createNangoGithubConnection,
+  connectNangoIntegration,
   deleteNangoConnection,
   getNangoConnectionData,
   getNangoConnections,
@@ -62,7 +63,6 @@ import { getOrganizations } from '../serverless/integrations/usecases/linkedin/g
 import getToken from '../serverless/integrations/usecases/nango/getToken'
 import { getIntegrationRunWorkerEmitter } from '../serverless/utils/queueService'
 import { encryptData } from '../utils/crypto'
-
 import { IServiceOptions } from './IServiceOptions'
 import { getGithubInstallationToken } from './helpers/githubToken'
 import { jiraIntegrationData } from '../types/jiraTypes'
@@ -1703,6 +1703,7 @@ export default class IntegrationService {
 
       integration = await this.createOrUpdate(
         {
+          id: connectionId,
           platform: PlatformType.JIRA,
           settings: {
             url: integrationData.url,
@@ -1713,6 +1714,7 @@ export default class IntegrationService {
                 : null,
               apiToken: integrationData.apiToken ? encryptData(integrationData.apiToken) : null,
             },
+            nangoIntegrationName: jiraIntegrationType,
             projects: integrationData.projects.map((project) => project.toUpperCase()),
           },
           status: 'done',

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -64,7 +64,7 @@ import { getIntegrationRunWorkerEmitter } from '../serverless/utils/queueService
 import { encryptData } from '../utils/crypto'
 import { IServiceOptions } from './IServiceOptions'
 import { getGithubInstallationToken } from './helpers/githubToken'
-import { jiraIntegrationData } from '../types/jiraTypes'
+import { JiraIntegrationData } from '../types/jiraTypes'
 
 const discordToken = DISCORD_CONFIG.token || DISCORD_CONFIG.token2
 
@@ -1628,13 +1628,13 @@ export default class IntegrationService {
    * 2. Jira Data Center (PAT): Requires URL and optionally a Personal Access Token
    * 3. Jira Data Center (basic auth): Requires URL, username, and password (API key)
    */
-  async jiraConnectOrUpdate(integrationData: jiraIntegrationData) {
+  async jiraConnectOrUpdate(integrationData: JiraIntegrationData) {
     const transaction = await SequelizeRepository.createTransaction(this.options)
     let integration: any
     let connectionId: string
     try {
       const constructNangoConnectionPayload = (
-        integrationData: jiraIntegrationData,
+        integrationData: JiraIntegrationData,
       ): Record<string, any> => {
         let jiraIntegrationType: NangoIntegration
         // nangoPayload is different for each integration

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -23,6 +23,7 @@ import {
   getNangoConnections,
   setNangoMetadata,
   startNangoSync,
+  getNangoCloudSessionToken,
 } from '@crowd/nango'
 import { RedisCache } from '@crowd/redis'
 import { Edition, PlatformType } from '@crowd/types'
@@ -1682,19 +1683,20 @@ export default class IntegrationService {
             baseUrl,
           },
           credentials: {
-            apiKey: integrationData.personalAccessToken,
+            apiKey: integrationData.personalAccessToken
           },
         }
 
         return { jiraIntegrationType, nangoPayload }
       }
 
+      const data = await getNangoCloudSessionToken()
       const { jiraIntegrationType, nangoPayload } = constructNangoConnectionPayload(integrationData)
       this.options.log.info(
         `jira integration type determined: ${jiraIntegrationType}, starting nango connection...`,
       )
       connectionId = await connectNangoIntegration(jiraIntegrationType, nangoPayload)
-      
+
       if (integrationData.projects && integrationData.projects.length > 0) {
         await setNangoMetadata(jiraIntegrationType, connectionId, {
           projectIdsToSync: integrationData.projects.map((project) => project.toUpperCase()),

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -66,6 +66,7 @@ import { encryptData } from '../utils/crypto'
 
 import { IServiceOptions } from './IServiceOptions'
 import { getGithubInstallationToken } from './helpers/githubToken'
+import { jiraIntegrationData } from '../types/jiraTypes'
 
 const discordToken = DISCORD_CONFIG.token || DISCORD_CONFIG.token2
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -15,7 +15,6 @@ import {
 } from '@crowd/common'
 import {
   NangoIntegration,
-  connectNangoIntegration,
   createNangoConnection,
   createNangoGithubConnection,
   connectNangoIntegration,

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -61,7 +61,6 @@ import {
 import { getOrganizations } from '../serverless/integrations/usecases/linkedin/getOrganizations'
 import getToken from '../serverless/integrations/usecases/nango/getToken'
 import { getIntegrationRunWorkerEmitter } from '../serverless/utils/queueService'
-import { jiraIntegrationData } from '../types/jiraTypes'
 import { encryptData } from '../utils/crypto'
 
 import { IServiceOptions } from './IServiceOptions'
@@ -1695,7 +1694,7 @@ export default class IntegrationService {
         `jira integration type determined: ${jiraIntegrationType}, starting nango connection...`,
       )
       connectionId = await connectNangoIntegration(jiraIntegrationType, nangoPayload)
-
+      
       if (integrationData.projects && integrationData.projects.length > 0) {
         await setNangoMetadata(jiraIntegrationType, connectionId, {
           projectIdsToSync: integrationData.projects.map((project) => project.toUpperCase()),

--- a/backend/src/types/jiraTypes.ts
+++ b/backend/src/types/jiraTypes.ts
@@ -1,0 +1,7 @@
+export interface jiraIntegrationData {
+	url: string;
+	username?: string;
+	personalAccessToken?: string;
+	apiToken?: string;
+	projects?: string[];
+  };

--- a/backend/src/types/jiraTypes.ts
+++ b/backend/src/types/jiraTypes.ts
@@ -1,4 +1,4 @@
-export interface jiraIntegrationData {
+export interface JiraIntegrationData {
   url: string
   username?: string
   personalAccessToken?: string

--- a/backend/src/types/jiraTypes.ts
+++ b/backend/src/types/jiraTypes.ts
@@ -1,7 +1,7 @@
 export interface jiraIntegrationData {
-	url: string;
-	username?: string;
-	personalAccessToken?: string;
-	apiToken?: string;
-	projects?: string[];
-  };
+  url: string
+  username?: string
+  personalAccessToken?: string
+  apiToken?: string
+  projects?: string[]
+}

--- a/frontend/src/config/integrations/jira/components/jira-connect.vue
+++ b/frontend/src/config/integrations/jira/components/jira-connect.vue
@@ -1,18 +1,14 @@
 <template>
-  <lf-tooltip
-    placement="top"
-    content-class="!max-w-76 !p-3 !text-start"
-    content="These integrations are temporarily disabled. Please contact the CM team for further questions."
-  >
-    <lf-button
-      :disabled="true"
-      type="secondary"
-      @click="isJiraSettingsDrawerVisible = true"
-    >
+  <div class="flex items-center gap-4">
+    <!--      <lf-button type="secondary-ghost" @click="isDetailsModalOpen = true">-->
+    <!--        <lf-icon name="circle-info" type="regular" />-->
+    <!--        Details-->
+    <!--      </lf-button>-->
+    <lf-button type="secondary" @click="isJiraSettingsDrawerVisible = true">
       <lf-icon name="link-simple" />
       <slot>Connect</slot>
     </lf-button>
-  </lf-tooltip>
+  </div>
   <lf-jira-settings-drawer
     v-if="isJiraSettingsDrawerVisible"
     v-model="isJiraSettingsDrawerVisible"
@@ -26,7 +22,6 @@
 import { defineProps, ref } from 'vue';
 import LfIcon from '@/ui-kit/icon/Icon.vue';
 import LfButton from '@/ui-kit/button/Button.vue';
-import LfTooltip from '@/ui-kit/tooltip/Tooltip.vue';
 import LfJiraSettingsDrawer from '@/config/integrations/jira/components/jira-settings-drawer.vue';
 
 const props = defineProps<{

--- a/frontend/src/modules/integration/integration-store.js
+++ b/frontend/src/modules/integration/integration-store.js
@@ -807,7 +807,6 @@ export default {
         });
       } catch (error) {
         Errors.handle(error);
-        Message.error('Something went wrong. Please try again later.');
         commit('CREATE_ERROR');
       }
     },

--- a/frontend/src/modules/lf/layout/components/lf-banners.vue
+++ b/frontend/src/modules/lf/layout/components/lf-banners.vue
@@ -127,16 +127,16 @@
           </router-link>
         </div>
       </banner>
-      <!-- TODO: Remove this banner once Jira and Confluence integrations are back up -->
+      <!-- TODO: Remove this banner once Confluence integrations is back up -->
       <banner
         variant="alert"
       >
         <div
           class="flex flex-wrap items-center justify-center grow text-sm py-2"
         >
-          <span class="font-semibold">Temporary Disruption of Confluence and Jira Integrations</span>
-          <span>&nbsp;Confluence and Jira integrations are currently stopped.
-            The team is actively working on bringing the integrations back and restore full functionality.</span>
+          <span class="font-semibold">Temporary Disruption of Confluence Integration</span>
+          <span>&nbsp;Confluence integration is currently stopped.
+            The team is actively working on bringing the integration back and restore full functionality.</span>
         </div>
       </banner>
     </div>

--- a/services/apps/cron_service/src/jobs/nangoConnectionCleanup.job.ts
+++ b/services/apps/cron_service/src/jobs/nangoConnectionCleanup.job.ts
@@ -29,10 +29,9 @@ const job: IJobDefinition = {
     await initNangoCloudClient()
     const dbConnection = await getDbConnection(READ_DB_CONFIG(), 3, 0)
 
-    const allIntegrations = await fetchNangoIntegrationData(
-      pgpQx(dbConnection),
-      ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform),
-    )
+    const allIntegrations = await fetchNangoIntegrationData(pgpQx(dbConnection), [
+      ...new Set(ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform)),
+    ])
 
     const nangoConnections = await getNangoConnections()
 

--- a/services/apps/cron_service/src/jobs/nangoMonitoring.job.ts
+++ b/services/apps/cron_service/src/jobs/nangoMonitoring.job.ts
@@ -34,10 +34,9 @@ const job: IJobDefinition = {
     await initNangoCloudClient()
     const dbConnection = await getDbConnection(READ_DB_CONFIG(), 3, 0)
 
-    const allIntegrations = await fetchNangoIntegrationData(
-      pgpQx(dbConnection),
-      ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform),
-    )
+    const allIntegrations = await fetchNangoIntegrationData(pgpQx(dbConnection), [
+      ...new Set(ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform)),
+    ])
 
     const nangoConnections = await getNangoConnections()
 
@@ -75,7 +74,9 @@ const job: IJobDefinition = {
           ctx.log.warn(`${int.platform} integration with id "${int.id}" is not connected to Nango!`)
         } else {
           const results = await getNangoConnectionStatus(
-            int.platform as NangoIntegration,
+            int.platform == PlatformType.JIRA
+              ? (int.settings.nangoIntegrationName as NangoIntegration)
+              : (int.platform as NangoIntegration),
             nangoConnection.connection_id,
           )
 

--- a/services/apps/cron_service/src/jobs/nangoTrigger.job.ts
+++ b/services/apps/cron_service/src/jobs/nangoTrigger.job.ts
@@ -28,15 +28,14 @@ const job: IJobDefinition = {
 
     const dbConnection = await getDbConnection(READ_DB_CONFIG(), 3, 0)
 
-    const integrationsToTrigger = await fetchNangoIntegrationData(
-      pgpQx(dbConnection),
-      ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform),
-    )
+    const integrationsToTrigger = await fetchNangoIntegrationData(pgpQx(dbConnection), [
+      ...new Set(ALL_NANGO_INTEGRATIONS.map(nangoIntegrationToPlatform)),
+    ])
 
     for (const int of integrationsToTrigger) {
       const { id, settings } = int
 
-      const platform = platformToNangoIntegration(int.platform as PlatformType)
+      const platform = platformToNangoIntegration(int.platform as PlatformType, settings)
 
       if (platform === NangoIntegration.GITHUB && !settings.nangoMapping) {
         // ignore non-nango github integrations

--- a/services/apps/nango_worker/src/bin/full-resync.ts
+++ b/services/apps/nango_worker/src/bin/full-resync.ts
@@ -30,7 +30,10 @@ setImmediate(async () => {
     )
 
     if (integration) {
-      const nangoIntegration = platformToNangoIntegration(integration.platform as PlatformType)
+      const nangoIntegration = platformToNangoIntegration(
+        integration.platform as PlatformType,
+        integration.settings,
+      )
 
       try {
         const toTrigger: string[] = []

--- a/services/apps/nango_worker/src/bin/trigger-onboarding-for-model.ts
+++ b/services/apps/nango_worker/src/bin/trigger-onboarding-for-model.ts
@@ -34,7 +34,10 @@ setImmediate(async () => {
       log.info(
         `Triggering nango integration check for integrationId '${integrationId}' and connectionId '${connectionId}'!`,
       )
-      const providerConfigKey = platformToNangoIntegration(integration.platform as PlatformType)
+      const providerConfigKey = platformToNangoIntegration(
+        integration.platform as PlatformType,
+        integration.settings,
+      )
 
       await dbConnection.none(
         `

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -152,6 +152,9 @@ const en = {
     git: {
       noIntegration: 'The Git integration is not configured.',
     },
+    jira: {
+      invalidUrl: 'The URL provided is invalid. Please enter a valid URL format such as https://example.com or https://example.atlassian.net',
+    },
     alreadyExists: '{0}',
   },
 

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -153,7 +153,8 @@ const en = {
       noIntegration: 'The Git integration is not configured.',
     },
     jira: {
-      invalidUrl: 'The URL provided is invalid. Please enter a valid URL format such as https://example.com or https://example.atlassian.net',
+      invalidUrl:
+        'The URL provided is invalid. Please enter a valid URL format such as https://example.com or https://example.atlassian.net',
     },
     alreadyExists: '{0}',
   },

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -155,6 +155,8 @@ const en = {
     jira: {
       invalidUrl:
         'The URL provided is invalid. Please enter a valid URL format such as https://example.com or https://example.atlassian.net',
+      invalidCredentials:
+        'The given credentials were found to be invalid. Please check the credentials and try again',
     },
     alreadyExists: '{0}',
   },

--- a/services/libs/nango/src/client.ts
+++ b/services/libs/nango/src/client.ts
@@ -177,6 +177,27 @@ export const createNangoGithubConnection = async (
   }
 }
 
+export const connectNangoIntegration = async (
+  integration: NangoIntegration,
+  params: any,
+): Promise<string> => {
+  ensureBackendClient()
+
+  log.info({ params, integration }, 'Creating a nango connection...')
+  const data = await getNangoCloudSessionToken()
+
+  if (!frontendModule) {
+    frontendModule = await import('@nangohq/frontend')
+  }
+
+  const frontendClient = new frontendModule.default({
+    connectSessionToken: data.token,
+  }) as Nango
+
+  const result = await frontendClient.auth(integration, params)
+  return result.connectionId
+}
+
 export const createNangoConnection = async (
   integration: NangoIntegration,
   params: any,

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -94,26 +94,26 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {
     models: {
-      ISSUES: "Issue",
-      ISSUE_COMMENT: "IssueComment",
-      ISSUE_ATTACHMENTS: "IssueAttachment"
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
     syncs: {
-      ISSUES: "issues",
-      ISSUE_COMMENT: "issue-comments",
-      ISSUE_ATTACHMENTS: "issue-attachments"
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_API_KEY]: {
     models: {
-      ISSUES: "Issue",
-      ISSUE_COMMENT: "IssueComment",
-      ISSUE_ATTACHMENTS: "IssueAttachment"
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
     syncs: {
-      ISSUES: "issues",
-      ISSUE_COMMENT: "issue-comments",
-      ISSUE_ATTACHMENTS: "issue-attachments"
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
     },
   },
 } as const satisfies IntegrationConfig

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -5,7 +5,7 @@ export enum NangoIntegration {
   GERRIT = 'gerrit',
   JIRA_CLOUD_BASIC = 'jira-basic',
   JIRA_DATA_CENTER_API_KEY = 'jira-data-center-api-key',
-  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic'
+  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic',
   GITHUB = 'github',
 }
 
@@ -72,14 +72,14 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_CLOUD_BASIC]: {
     models: {
-      ISSUES: "Issue",
-      ISSUE_COMMENT: "IssueComment",
-      ISSUE_ATTACHMENTS: "IssueAttachment"
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
     syncs: {
-      ISSUES: "issues",
-      ISSUE_COMMENT: "issue-comments",
-      ISSUE_ATTACHMENTS: "issue-attachments"
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -72,14 +72,14 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_CLOUD_BASIC]: {
     models: {
-      ISSUES: "Issue",
-      ISSUE_COMMENT: "IssueComment",
-      ISSUE_ATTACHMENTS: "IssueAttachment"
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
     syncs: {
-      ISSUES: "issues",
-      ISSUE_COMMENT: "issue-comments",
-      ISSUE_ATTACHMENTS: "issue-attachments"
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -6,7 +6,7 @@ export enum NangoIntegration {
   GITHUB = 'github',
   JIRA_CLOUD_BASIC = 'jira-basic',
   JIRA_DATA_CENTER_API_KEY = 'jira-data-center-api-key',
-  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic'
+  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic',
 }
 
 export const ALL_NANGO_INTEGRATIONS = Object.values(NangoIntegration)
@@ -17,17 +17,27 @@ export const nangoIntegrationToPlatform = (integration: NangoIntegration): Platf
       return PlatformType.GERRIT
     case NangoIntegration.GITHUB:
       return PlatformType.GITHUB_NANGO
+    case NangoIntegration.JIRA_CLOUD_BASIC:
+    case NangoIntegration.JIRA_DATA_CENTER_API_KEY:
+    case NangoIntegration.JIRA_DATA_CENTER_BASIC:
+      return PlatformType.JIRA
     default:
       throw new Error('Unknown integration')
   }
 }
 
-export const platformToNangoIntegration = (platform: PlatformType): NangoIntegration => {
+export const platformToNangoIntegration = (
+  platform: PlatformType,
+  platformSetting: any,
+): NangoIntegration => {
   switch (platform) {
     case PlatformType.GERRIT:
       return NangoIntegration.GERRIT
     case PlatformType.GITHUB_NANGO:
       return NangoIntegration.GITHUB
+    case PlatformType.JIRA:
+      // nango has multiple Jira integrations based on auth method
+      return platformSetting.nangoIntegrationName
     default:
       throw new Error('Unknown platform')
   }

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -83,12 +83,28 @@ export const NANGO_INTEGRATION_CONFIG = {
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {
-    models: {},
-    syncs: {},
+    models: {
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
+    },
+    syncs: {
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
+    },
   },
   [NangoIntegration.JIRA_DATA_CENTER_API_KEY]: {
-    models: {},
-    syncs: {},
+    models: {
+      ISSUES: 'Issue',
+      ISSUE_COMMENT: 'IssueComment',
+      ISSUE_ATTACHMENTS: 'IssueAttachment',
+    },
+    syncs: {
+      ISSUES: 'issues',
+      ISSUE_COMMENT: 'issue-comments',
+      ISSUE_ATTACHMENTS: 'issue-attachments',
+    },
   },
 } as const satisfies IntegrationConfig
 

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -82,7 +82,7 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_CLOUD_BASIC]: {
     models: {
-      ISSUES: 'Issue',
+      ISSUES: 'Issues',
       ISSUE_COMMENT: 'IssueComment',
       ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
@@ -94,7 +94,7 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {
     models: {
-      ISSUES: 'Issue',
+      ISSUES: 'Issues',
       ISSUE_COMMENT: 'IssueComment',
       ISSUE_ATTACHMENTS: 'IssueAttachment',
     },
@@ -106,7 +106,7 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_DATA_CENTER_API_KEY]: {
     models: {
-      ISSUES: 'Issue',
+      ISSUES: 'Issues',
       ISSUE_COMMENT: 'IssueComment',
       ISSUE_ATTACHMENTS: 'IssueAttachment',
     },

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -3,10 +3,10 @@ import { PlatformType } from '@crowd/types'
 
 export enum NangoIntegration {
   GERRIT = 'gerrit',
+  GITHUB = 'github',
   JIRA_CLOUD_BASIC = 'jira-basic',
   JIRA_DATA_CENTER_API_KEY = 'jira-data-center-api-key',
-  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic',
-  GITHUB = 'github',
+  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic'
 }
 
 export const ALL_NANGO_INTEGRATIONS = Object.values(NangoIntegration)
@@ -72,38 +72,38 @@ export const NANGO_INTEGRATION_CONFIG = {
   },
   [NangoIntegration.JIRA_CLOUD_BASIC]: {
     models: {
-      ISSUES: 'Issue',
-      ISSUE_COMMENT: 'IssueComment',
-      ISSUE_ATTACHMENTS: 'IssueAttachment',
+      ISSUES: "Issue",
+      ISSUE_COMMENT: "IssueComment",
+      ISSUE_ATTACHMENTS: "IssueAttachment"
     },
     syncs: {
-      ISSUES: 'issues',
-      ISSUE_COMMENT: 'issue-comments',
-      ISSUE_ATTACHMENTS: 'issue-attachments',
+      ISSUES: "issues",
+      ISSUE_COMMENT: "issue-comments",
+      ISSUE_ATTACHMENTS: "issue-attachments"
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {
     models: {
-      ISSUES: 'Issue',
-      ISSUE_COMMENT: 'IssueComment',
-      ISSUE_ATTACHMENTS: 'IssueAttachment',
+      ISSUES: "Issue",
+      ISSUE_COMMENT: "IssueComment",
+      ISSUE_ATTACHMENTS: "IssueAttachment"
     },
     syncs: {
-      ISSUES: 'issues',
-      ISSUE_COMMENT: 'issue-comments',
-      ISSUE_ATTACHMENTS: 'issue-attachments',
+      ISSUES: "issues",
+      ISSUE_COMMENT: "issue-comments",
+      ISSUE_ATTACHMENTS: "issue-attachments"
     },
   },
   [NangoIntegration.JIRA_DATA_CENTER_API_KEY]: {
     models: {
-      ISSUES: 'Issue',
-      ISSUE_COMMENT: 'IssueComment',
-      ISSUE_ATTACHMENTS: 'IssueAttachment',
+      ISSUES: "Issue",
+      ISSUE_COMMENT: "IssueComment",
+      ISSUE_ATTACHMENTS: "IssueAttachment"
     },
     syncs: {
-      ISSUES: 'issues',
-      ISSUE_COMMENT: 'issue-comments',
-      ISSUE_ATTACHMENTS: 'issue-attachments',
+      ISSUES: "issues",
+      ISSUE_COMMENT: "issue-comments",
+      ISSUE_ATTACHMENTS: "issue-attachments"
     },
   },
 } as const satisfies IntegrationConfig

--- a/services/libs/nango/src/types.ts
+++ b/services/libs/nango/src/types.ts
@@ -3,7 +3,9 @@ import { PlatformType } from '@crowd/types'
 
 export enum NangoIntegration {
   GERRIT = 'gerrit',
-  // JIRA = 'jira',
+  JIRA_CLOUD_BASIC = 'jira-basic',
+  JIRA_DATA_CENTER_API_KEY = 'jira-data-center-api-key',
+  JIRA_DATA_CENTER_BASIC = 'jira-data-center-basic'
   GITHUB = 'github',
 }
 
@@ -68,10 +70,26 @@ export const NANGO_INTEGRATION_CONFIG = {
       STARS: 'stars',
     },
   },
-  // [NangoIntegration.JIRA]: {
-  //   models: {},
-  //   syncs: {},
-  // },
+  [NangoIntegration.JIRA_CLOUD_BASIC]: {
+    models: {
+      ISSUES: "Issue",
+      ISSUE_COMMENT: "IssueComment",
+      ISSUE_ATTACHMENTS: "IssueAttachment"
+    },
+    syncs: {
+      ISSUES: "issues",
+      ISSUE_COMMENT: "issue-comments",
+      ISSUE_ATTACHMENTS: "issue-attachments"
+    },
+  },
+  [NangoIntegration.JIRA_DATA_CENTER_BASIC]: {
+    models: {},
+    syncs: {},
+  },
+  [NangoIntegration.JIRA_DATA_CENTER_API_KEY]: {
+    models: {},
+    syncs: {},
+  },
 } as const satisfies IntegrationConfig
 
 export type IntegrationConfig = {


### PR DESCRIPTION
# Changes proposed ✍️

### What
Migrate Jira migration to Nango

### Why
The current Jira implementation is broken

### How
**BACKEND** (@skwowet & @epipav please check backend changes): 

Preparing API to use nango for Jira, using their 3 integrations:
1. jira-basic (Cloud)
2. jira-data-center-basic
3. jira-data-center-api-key

PS: I had to adjust some core functions to support the mapping between our Jira and Nango's Jira. This is because Nango treats each auth flow as a separate integration, while we have a single Jira integration that supports all those auth methods.

**FRONTEND** (@Sameh16 & @gaspergrom please check frontend changes):

1. Enable Jira to allow new connections (I just reverted the old implementation before disabling Jira)
2. Remove Jira from the warning message in the banner and keep Confluence only 


## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
