### PR TITLE
Fix org merge suggestions exceeding OpenSearch clause limit

### DIFF
--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -173,7 +173,7 @@ export async function getOrganizationMergeSuggestions(
   )
 
   // limit to prevent exceeding OpenSearch's maxClauseCount (1024)
-  for (const identity of identities.slice(0, 140)) {
+  for (const identity of identities.slice(0, 120)) {
     if (identity.value.length > 0) {
       // weak identity search
       identitiesShould.push({


### PR DESCRIPTION
Merge suggestion queries failed when combining many identity matches (should clause) with numerous exclusion IDs (must_not clause using individual terms).

Solution: Consolidate all excluded IDs (source org + noMergeIds) into a single terms query within the must_not clause. This drastically reduces clause count and fixes the error.