### PR TITLE
fix: collection update

### DIFF
--- a/frontend/src/modules/admin/modules/collections/components/lf-collection-add.vue
+++ b/frontend/src/modules/admin/modules/collections/components/lf-collection-add.vue
@@ -298,7 +298,7 @@ const fetchCategories = (query: string) => {
     groupType: form.type || undefined,
   })
     .then((res) => {
-      form.categoryId = !form.categoryId ? (props.collection?.categoryId || '') : form.categoryId;
+      form.categoryId = !form.categoryId ? (props.collection?.categoryId || null) : form.categoryId;
       categories.value = res.rows;
     });
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
Since we are now not forcing a category to be added when we create a collection, the default value should be `null` and not `''`. DB won't accept this value since it requires a uuid.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
