### PR TITLE
fix(oganizations): correct logic for lfxMembership filter

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1514,7 +1514,7 @@ class OrganizationRepository {
     index: number,
     filterName: string,
   ) {
-    const lfxFilterObj = Object.assign(filtersArray[filterName][index])
+    const lfxFilterObj = Object.assign(filtersArray[filterName][index])?.lfxMembership
     filtersArray[filterName].splice(index, 1)
 
     if (filtersArray[filterName].length === 0)


### PR DESCRIPTION
# Changes proposed ✍️
Return the value of `lfxMembership` filter instead of the parent object, so that SQL query is constructed properly
 
### What
copilot:summary
​
copilot:poem

### Why
[The logic responsible for building the query](https://github.com/CrowdDotDev/crowd.dev/blob/f9e8ba6992c4f67a76aa344665b40a93a106e86f/backend/src/database/repositories/organizationRepository.ts#L1599) is expecting the filter value and not the object 

### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
