### PR TITLE
feat: on TinyBird, when sorting collections by "starred", sort them also by "projectCount"

### DIFF
--- a/services/libs/tinybird/datasources/insightsProjects.datasource
+++ b/services/libs/tinybird/datasources/insightsProjects.datasource
@@ -14,7 +14,7 @@ SCHEMA >
     `twitter` String `json:$.record.twitter` DEFAULT '',
     `widgets` Array(String) `json:$.record.widgets[:]` DEFAULT [],
     `repositories` Array(String) `json:$.record.repositories[:]` DEFAULT [],
-    `enable` UInt8 `json:$.record.enable` DEFAULT 1,
+    `enabled` UInt8 `json:$.record.enabled` DEFAULT 1,
     `isLF` UInt8 `json:$.record.isLF` DEFAULT 0,
     `keywords` Array(String) `json:$.record.keywords[:]` DEFAULT []
 

--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -102,6 +102,14 @@ SQL >
                 description="Order by direction. ASC or DESC",
                 required=False,
             ) == 'ASC' %} ASC
-            {% else %} DESC
+            {% else %}
+                DESC
+                {% if String(
+                    orderByName,
+                    'starred',
+                    description="When starred sorting is selected, also sort by projectCount.",
+                    required=False,
+                ) == 'starred' %} , projectCount DESC
+                {% end %}
             {% end %}
     {% end %}

--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -41,7 +41,7 @@ SQL >
     SELECT collectionsInsightsProjects.collectionId, insightsProjects_filtered.*
     from insightsProjects_filtered
     join
-        collectionsInsightsProjects
+        collectionsInsightsProjects final
         on collectionsInsightsProjects.insightsProjectId = insightsProjects_filtered.id
     where
         (collectionsInsightsProjects.collectionId in (select id from collections_paginated))

--- a/services/libs/tinybird/pipes/insightsProjects_filtered.pipe
+++ b/services/libs/tinybird/pipes/insightsProjects_filtered.pipe
@@ -32,7 +32,7 @@ SQL >
     left join collection_info on collection_info.insightsProjectId = insightsProjects.id
     left join segmentsAggregatedMV on segmentsAggregatedMV.segmentId = insightsProjects.segmentId
     where
-        insightsProjects.enable = 1
+        insightsProjects.enabled = 1
         {% if defined(slug) %}
             AND insightsProjects.slug
             = {{ String(slug, description="Filter collection by slug", required=False) }}

--- a/services/libs/tinybird/pipes/segments_filtered.pipe
+++ b/services/libs/tinybird/pipes/segments_filtered.pipe
@@ -4,7 +4,7 @@ SQL >
     SELECT "segmentId" as id, repositories
     FROM insightsProjects FINAL
     where
-        insightsProjects.enable
+        insightsProjects.enabled
         {% if defined(project) %}
             AND slug = {{ String(project, description="Filter by project slug", required=True) }}
         {% else %} AND false


### PR DESCRIPTION
On TinyBird, when sorting collections by "starred", we also want to sort them by "projectCount".

This is just a quick fix for now. Ideally we would allow sorting on multiple fields but we will tackle that later if and when the need arises.