### PR TITLE
feat: on TinyBird, when sorting collections by "starred", sort them also by "projectCount"

### DIFF
--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -102,6 +102,14 @@ SQL >
                 description="Order by direction. ASC or DESC",
                 required=False,
             ) == 'ASC' %} ASC
-            {% else %} DESC
+            {% else %}
+                DESC
+                {% if String(
+                    orderByName,
+                    'starred',
+                    description="When starred sorting is selected, also sort by projectCount.",
+                    required=False,
+                ) == 'starred' %} , projectCount DESC
+                {% end %}
             {% end %}
     {% end %}

--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -109,7 +109,7 @@ SQL >
                     'starred',
                     description="When starred sorting is selected, also sort by projectCount.",
                     required=False,
-                ) == 'starred' %} , projectCount DESC
+                ) == 'starred' %}, projectCount DESC
                 {% end %}
             {% end %}
     {% end %}


### PR DESCRIPTION
[Ticket in Linear](https://linear.app/lfx/issue/INS-469/refactor-display-of-collections-and-insights-projects).

On TinyBird, when sorting collections by "starred", we also want to sort them by "projectCount".

This is just a quick fix for now. Ideally we would allow sorting on multiple fields but we will tackle that later if and when the need arises.