### PR TITLE
fix: update status code for merge errors

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -1106,7 +1106,7 @@ export default class MemberService extends LoggerBase {
       )
 
       if (primaryIdentities.length === 0) {
-        throw new Error(`Original member only has one identity, cannot extract it!`)
+        throw new Error400(this.options.language, 'merge.errors.noIdentities')
       }
 
       const secondaryActivityCount = 0
@@ -1252,7 +1252,7 @@ export default class MemberService extends LoggerBase {
       mergeAction?.state === MergeActionState.IN_PROGRESS ||
       mergeAction?.state === MergeActionState.PENDING
     ) {
-      throw new Error409(this.options.language, 'merge.errors.multipleMerge', mergeAction?.state)
+      throw new Error409(this.options.language, 'merge.errors.multiple', mergeAction?.state)
     }
 
     let tx

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -6,7 +6,7 @@ import {
   organizationMergeAction,
   organizationUnmergeAction,
 } from '@crowd/audit-logs'
-import { Error409, websiteNormalizer } from '@crowd/common'
+import { Error409, websiteNormalizer, Error400 } from '@crowd/common'
 import { hasLfxMembership } from '@crowd/data-access-layer/src/lfx_memberships'
 import { findMergeAction } from '@crowd/data-access-layer/src/mergeActions/repo'
 import { findOrgAttributes, upsertOrgIdentities } from '@crowd/data-access-layer/src/organizations'
@@ -459,7 +459,7 @@ export default class OrganizationService extends LoggerBase {
       mergeAction?.state === MergeActionState.IN_PROGRESS ||
       mergeAction?.state === MergeActionState.PENDING
     ) {
-      throw new Error409(this.options.language, 'merge.errors.multipleMerge', mergeAction?.state)
+      throw new Error409(this.options.language, 'merge.errors.multiple', mergeAction?.state)
     }
 
     try {
@@ -489,8 +489,9 @@ export default class OrganizationService extends LoggerBase {
               mergedId: originalId,
             }
           }
+
           if (toMergeWithLfxMembership) {
-            throw new Error('Cannot merge LFX membership organization as a secondary one!')
+            throw new Error400(this.options.language, 'merge.errors.mergeLfxSecondary')
           }
 
           this.log.info({ originalId, toMergeId }, '[Merge Organizations] - Found organizations! ')

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -6,7 +6,7 @@ import {
   organizationMergeAction,
   organizationUnmergeAction,
 } from '@crowd/audit-logs'
-import { Error409, websiteNormalizer, Error400 } from '@crowd/common'
+import { Error400, Error409, websiteNormalizer } from '@crowd/common'
 import { hasLfxMembership } from '@crowd/data-access-layer/src/lfx_memberships'
 import { findMergeAction } from '@crowd/data-access-layer/src/mergeActions/repo'
 import { findOrgAttributes, upsertOrgIdentities } from '@crowd/data-access-layer/src/organizations'

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -165,7 +165,9 @@ const en = {
 
   merge: {
     errors: {
-      multipleMerge: 'Cannot merge suggestions - found existing merge with {0} state',
+      multiple: 'Cannot merge suggestions - found existing merge with {0} state',
+      lfxSecondary: 'Cannot merge LFX membership organization as a secondary one!',
+      noIdentities: 'Original member only has one identity, cannot extract it!',
     },
   },
 

--- a/services/libs/data-access-layer/src/categories/index.ts
+++ b/services/libs/data-access-layer/src/categories/index.ts
@@ -465,11 +465,11 @@ export async function listCategories(
   }[]
 > {
   return qx.select(
-    `          SELECT c.id, c.name, cg.id as "categoryGroupId", cg.name as "categoryGroupName"
+    `          SELECT c.id, c.name, cg.id as "categoryGroupId", cg.name as "categoryGroupName", cg.type as "categoryGroupType"
                    FROM "categories" c
                             JOIN "categoryGroups" cg ON c."categoryGroupId" = cg.id
                    WHERE c.name ILIKE $(query)
-                     AND COALESCE($(groupType), type) = type
+                     AND COALESCE($(groupType), cg.type) = cg.type
                    ORDER BY cg.name
                     LIMIT $(limit)
           OFFSET $(offset)


### PR DESCRIPTION
# Changes proposed ✍️

Return 400 Bad Request when, 
- attempting to merge an LFX membership organization as a secondary.
- no primary identities exist during member merges.