### PR TITLE
fix(security): mask password in data dog sessions

### DIFF
--- a/frontend/src/config/integrations/groupsio/components/groupsio-settings-drawer.vue
+++ b/frontend/src/config/integrations/groupsio/components/groupsio-settings-drawer.vue
@@ -54,6 +54,7 @@
           <el-input
             ref="focus"
             v-model="form.password"
+            :type="'password'"
             @blur="onBlurPassword()"
           >
             <template #suffix>
@@ -262,9 +263,9 @@
 import {
   ref, reactive, onMounted, computed,
 } from 'vue';
-import groupsio from '@/config/integrations/groupsio/config';
 import { required, email } from '@vuelidate/validators';
 import useVuelidate from '@vuelidate/core';
+import groupsio from '@/config/integrations/groupsio/config';
 import AppDrawer from '@/shared/drawer/drawer.vue';
 import { mapActions } from '@/shared/vuex/vuex.helpers';
 import AppFormItem from '@/shared/form/form-item.vue';


### PR DESCRIPTION
# Changes proposed ✍️

Set `input` type to `"password"` to ensure automatic masking of sensitive user input during session replay, in compliance with Datadog's privacy defaults.

**From Datadog Docs:**

> “Input elements of type password, email, and tel… are always masked.”

https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/#privacy-restrictions