### PR TITLE
chore: improve search results to not return non-onboarded proejcts

### DIFF
--- a/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
+++ b/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
@@ -23,6 +23,11 @@ SQL >
         insightsProjects_filtered.slug as "projectSlug",
         insightsProjects_filtered.name
     from insightsProjects_filtered
+    where
+        not (
+            insightsProjects_filtered."organizationCount" = 0
+            and insightsProjects_filtered."contributorCount" = 0
+        )
     order by insightsProjects_filtered.contributorCount desc
     limit {{ Integer(limit, 10, description="Limit number of records for each type", required=False) }}
     union all


### PR DESCRIPTION
# Changes proposed ✍️

### What
Improvement on this PR is to stop showing projects that are not yet onboarded on the Search dropdown.
To know if the project is not onboarded I'm using the same flags as we are using on the Nuxt side, which is wether or not the projects has `organizationCount` and `contributorCount`.

### Why
https://linear.app/lfx/issue/INS-531/hide-non-onboarded-projects-from-search-results

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
