### PR TITLE
chore: reduce batch size in display aggs workflows

### DIFF
--- a/services/apps/profiles_worker/src/workflows/member/refreshMemberDisplayAggregates.ts
+++ b/services/apps/profiles_worker/src/workflows/member/refreshMemberDisplayAggregates.ts
@@ -10,7 +10,7 @@ const {
   getMemberDisplayAggregates,
   setMemberDisplayAggregates,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '30 minutes',
+  startToCloseTimeout: '45 minutes',
 })
 
 /*
@@ -36,7 +36,7 @@ const {
 export async function refreshMemberDisplayAggregates(
   args: IRefreshDisplayAggregatesArgs,
 ): Promise<void> {
-  const BATCH_SIZE = 250
+  const BATCH_SIZE = 100
 
   const lastUuid: string = args.lastUuid ?? null
   let lastSyncedAt: string = args.lastSyncedAt ?? null

--- a/services/apps/profiles_worker/src/workflows/organization/refreshOrganizationDisplayAggregates.ts
+++ b/services/apps/profiles_worker/src/workflows/organization/refreshOrganizationDisplayAggregates.ts
@@ -10,7 +10,7 @@ const {
   getOrganizationDisplayAggregates,
   setOrganizationDisplayAggregates,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '30 minutes',
+  startToCloseTimeout: '45 minutes',
 })
 
 /*
@@ -37,7 +37,7 @@ const {
 export async function refreshOrganizationDisplayAggregates(
   args: IRefreshDisplayAggregatesArgs,
 ): Promise<void> {
-  const BATCH_SIZE = 250
+  const BATCH_SIZE = 100
 
   const lastUuid: string = args.lastUuid ?? null
   let lastSyncedAt: string = args.lastSyncedAt ?? null


### PR DESCRIPTION
To prevent workflow execution timeouts