### PR TITLE
fix(organization): throw 400 error for single identity extraction

### DIFF
--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -163,7 +163,10 @@ export default class OrganizationService extends LoggerBase {
       )
 
       if (primaryIdentities.length === 0) {
-        throw new Error(`Original organization only has one identity, cannot extract it!`)
+        throw new Error400(
+          this.options.language,
+          'organization.unmerge.errors.cannotExtractSingleIdentity',
+        )
       }
 
       let secondaryMemberCount: number

--- a/services/libs/common/src/i18n/en.ts
+++ b/services/libs/common/src/i18n/en.ts
@@ -166,6 +166,14 @@ const en = {
       invalid2FA: 'Invalid Two-factor authentication code',
     },
     alreadyExists: '{0}',
+    organization: {
+      unmerge: {
+        errors: {
+          cannotExtractSingleIdentity:
+            'Original organization only has one identity, cannot extract it!',
+        },
+      },
+    },
   },
 
   merge: {


### PR DESCRIPTION
# Changes proposed ✍️

Throw 400 error code instead of 500 on organization single identity extraction.