### PR TITLE
fix: add missing filter for contributions in a materialized view

### DIFF
--- a/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
+++ b/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
@@ -8,4 +8,5 @@ SQL >
         countDistinctState(memberId) AS contributorCount,
         countDistinctState(organizationId) AS organizationCount
     FROM activities_with_relations_sorted_deduplicated_ds
+    WHERE isContribution = true
     GROUP BY segmentId


### PR DESCRIPTION
[Ticket in Linear](https://linear.app/lfx/issue/INS-530/wrong-definition-of-contributor-and-orgs).

We were missing a filter for `isContribution` in one of our pipes / materialised views, which inflated the number of contibutors by a huge amount. This adds the missing restriction in the TinyBird pipe.