### PR TITLE
fix: preserve manually changed member attributes

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -604,6 +604,22 @@ export default class MemberService extends LoggerBase {
     let attributes: Record<string, unknown> | undefined
     if (member.attributes) {
       const temp = mergeWith({}, dbMember.attributes, member.attributes)
+
+      const manuallyChangedFields: string[] = dbMember.manuallyChangedFields || []
+      if (manuallyChangedFields.length > 0) {
+        const attrColumn = 'attributes'
+        const manuallyChangedAttributes = (dbMember.manuallyChangedFields || [])
+          .filter((f) => f.startsWith(attrColumn))
+          .map((f) => f.substring(attrColumn.length))
+
+        // Preserve manually changed attributes
+        for (const key of manuallyChangedAttributes) {
+          if (dbMember.attributes[key] !== undefined) {
+            temp[key] = dbMember.attributes[key]
+          }
+        }
+      }
+
       if (!isEqual(temp, dbMember.attributes)) {
         attributes = temp
       }

--- a/services/libs/data-access-layer/src/old/apps/data_sink_worker/repo/member.data.ts
+++ b/services/libs/data-access-layer/src/old/apps/data_sink_worker/repo/member.data.ts
@@ -7,6 +7,7 @@ export interface IDbMember {
   joinedAt: string
   attributes: Record<string, unknown>
   reach: Partial<Record<PlatformType | 'total', number>>
+  manuallyChangedFields?: string[]
 }
 
 let getMemberColumnSet: DbColumnSet
@@ -14,7 +15,7 @@ export function getSelectMemberColumnSet(instance: DbInstance): DbColumnSet {
   if (getMemberColumnSet) return getMemberColumnSet
 
   getMemberColumnSet = new instance.helpers.ColumnSet(
-    ['id', 'score', 'joinedAt', 'reach', 'attributes', 'displayName'],
+    ['id', 'score', 'joinedAt', 'reach', 'attributes', 'displayName', 'manuallyChangedFields'],
     {
       table: {
         table: 'members',


### PR DESCRIPTION
# Changes proposed ✍️

Manually updated member attributes (e.g., isBot) were being unintentionally overwritten by incoming activity data. This caused manually flagged bot members to lose their isBot status.

This update ensures that manual changes always take precedence over automated updates, aligning with the expected behavior of the member profile system.
