### PR TITLE
chore: restore bot profiles via script

### DIFF
--- a/services/apps/script_executor_worker/src/activities.ts
+++ b/services/apps/script_executor_worker/src/activities.ts
@@ -50,6 +50,10 @@ import {
   resetIndexedIdentities,
 } from './activities/populate-activity-relations'
 import { getUnprocessedLLMApprovedSuggestions } from './activities/process-llm-verified-merges'
+import {
+  getMembersManuallyMarkedAsBots,
+  updateMemberAttributesAndManuallyChangedFields,
+} from './activities/restore-bot-profiles'
 import { deleteIndexedEntities } from './activities/sync/entity-index'
 import { getMembersForSync, syncMembersBatch } from './activities/sync/member'
 import { getOrganizationsForSync, syncOrganizationsBatch } from './activities/sync/organization'
@@ -98,4 +102,6 @@ export {
   calculateMemberAffiliations,
   getUnprocessedLLMApprovedSuggestions,
   getWorkflowsCount,
+  getMembersManuallyMarkedAsBots,
+  updateMemberAttributesAndManuallyChangedFields,
 }

--- a/services/apps/script_executor_worker/src/activities/restore-bot-profiles.ts
+++ b/services/apps/script_executor_worker/src/activities/restore-bot-profiles.ts
@@ -1,0 +1,24 @@
+import MemberRepository from '@crowd/data-access-layer/src/old/apps/script_executor_worker/member.repo'
+import { IAttributes, IMember } from '@crowd/types'
+
+import { svc } from '../main'
+
+export async function getMembersManuallyMarkedAsBots(
+  limit: number,
+): Promise<Pick<IMember, 'id' | 'attributes' | 'manuallyChangedFields'>[]> {
+  const memberRepo = new MemberRepository(svc.postgres.reader.connection(), svc.log)
+  return memberRepo.getMembersManuallyMarkedAsBots(limit)
+}
+
+export async function updateMemberAttributesAndManuallyChangedFields(
+  memberId: string,
+  attributes: IAttributes,
+  manuallyChangedFields: string[],
+): Promise<void> {
+  const memberRepo = new MemberRepository(svc.postgres.writer.connection(), svc.log)
+  return memberRepo.updateMemberAttributesAndManuallyChangedFields(
+    memberId,
+    attributes,
+    manuallyChangedFields,
+  )
+}

--- a/services/apps/script_executor_worker/src/workflows.ts
+++ b/services/apps/script_executor_worker/src/workflows.ts
@@ -8,6 +8,7 @@ import { fixActivityForiegnKeys } from './workflows/fixActivityForiegnKeys'
 import { fixOrgIdentitiesWithWrongUrls } from './workflows/fixOrgIdentitiesWithWrongUrls'
 import { populateActivityRelations } from './workflows/populateActivityRelations'
 import { processLLMVerifiedMerges } from './workflows/processLLMVerifiedMerges'
+import { restoreBotProfiles } from './workflows/restoreBotProfiles'
 import { syncMembers } from './workflows/sync/members'
 import { syncOrganizations } from './workflows/sync/organizations'
 
@@ -24,4 +25,5 @@ export {
   cleanupOrganizations,
   fixActivityForiegnKeys,
   processLLMVerifiedMerges,
+  restoreBotProfiles,
 }

--- a/services/apps/script_executor_worker/src/workflows/restoreBotProfiles.ts
+++ b/services/apps/script_executor_worker/src/workflows/restoreBotProfiles.ts
@@ -1,0 +1,48 @@
+import { continueAsNew, proxyActivities } from '@temporalio/workflow'
+import { log } from '@temporalio/workflow'
+
+import * as activities from '../activities'
+import { IScriptBatchTestArgs } from '../types'
+
+const { getMembersManuallyMarkedAsBots, updateMemberAttributesAndManuallyChangedFields } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: '30 minutes',
+    retry: { maximumAttempts: 3, backoffCoefficient: 3 },
+  })
+
+export async function restoreBotProfiles(args: IScriptBatchTestArgs): Promise<void> {
+  const BATCH_SIZE = args.batchSize ?? 200
+
+  const botMembers = await getMembersManuallyMarkedAsBots(BATCH_SIZE)
+
+  if (botMembers.length === 0) {
+    console.log('No more bot members to restore!')
+    return
+  }
+
+  for (const member of botMembers) {
+    if (args.testRun) {
+      log.info(`Restoring bot profile for member ${member.id}`, {
+        attributes: member.attributes,
+        manuallyChangedFields: member.manuallyChangedFields,
+      })
+    }
+
+    member.manuallyChangedFields = [...new Set(member.manuallyChangedFields)]
+    member.attributes.isBot.default = 'true'
+
+    await updateMemberAttributesAndManuallyChangedFields(
+      member.id,
+      member.attributes,
+      member.manuallyChangedFields,
+    )
+  }
+
+  if (args.testRun) {
+    console.log('Test run completed - stopping after first batch!')
+    return
+  }
+
+  // Continue as new for the next batch
+  await continueAsNew<typeof restoreBotProfiles>(args)
+}

--- a/services/libs/types/src/attributes.ts
+++ b/services/libs/types/src/attributes.ts
@@ -1,4 +1,3 @@
 export interface IAttributes {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: Record<string, any>
+  [key: string]: Record<string, unknown>
 }

--- a/services/libs/types/src/members.ts
+++ b/services/libs/types/src/members.ts
@@ -74,6 +74,7 @@ export interface IMember {
   location?: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   contributions?: any
+  manuallyChangedFields?: string[]
 }
 
 export interface MemberIdentity {


### PR DESCRIPTION
# Changes proposed ✍️

This script fixes an issue where bot profiles were incorrectly overwritten by new data. It:  
- Updates the `isBot.default` attribute to `'true'` for affected members.  
- Deduplicates the `manuallyChangedFields` array.  
- Processes members in batches (default: 200) for safety.  
