### PR TITLE
fix: the interval to calculate `reviewedAt` portion in merge lead time widget

### DIFF
--- a/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
@@ -8,9 +8,9 @@ SQL >
     %
     select
         round(avg(dateDiff('second', prf.openedAt, prf.mergedAt))) AS openedToMergedSeconds,
-        round(avg(dateDiff('second', prf.openedAt, prf.assignedAt))) AS openedToReviewAssignedSeconds,
+        round(avg(dateDiff('second', prf.openedAt, prf.reviewRequestedAt))) AS openedToReviewAssignedSeconds,
         round(
-            avg(dateDiff('second', prf.assignedAt, prf.reviewedAt))
+            avg(dateDiff('second', prf.reviewRequestedAt, prf.reviewedAt))
         ) AS reviewAssignedToFirstReviewSeconds,
         round(avg(dateDiff('second', prf.reviewedAt, prf.approvedAt))) AS firstReviewToApprovedSeconds,
         round(avg(dateDiff('second', prf.approvedAt, prf.mergedAt))) AS approvedToMergedSeconds


### PR DESCRIPTION
This PR fixes the wrong interval calculation for `openedToReviewAssignedSeconds` and `reviewAssignedToFirstReviewSeconds`. Before it was using the `assignedAt` field, but this field is for assigning the PR to someone, instead we should have been using  `reviewRequestedAt` which keeps the first review request time

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
