### PR TITLE
fix: coalesce negative time differences to zero when calculating `reviewAssignedToFirstReviewSeconds`

### DIFF
--- a/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
@@ -12,7 +12,7 @@ SQL >
             avg(dateDiff('second', prf.openedAt, prf.reviewRequestedAt))
         ) AS openedToReviewAssignedSeconds,
         round(
-            avg(dateDiff('second', prf.reviewRequestedAt, prf.reviewedAt))
+            avg(max2(dateDiff('second', prf.reviewRequestedAt, prf.reviewedAt), 0))
         ) AS reviewAssignedToFirstReviewSeconds,
         round(avg(dateDiff('second', prf.reviewedAt, prf.approvedAt))) AS firstReviewToApprovedSeconds,
         round(avg(dateDiff('second', prf.approvedAt, prf.mergedAt))) AS approvedToMergedSeconds


### PR DESCRIPTION
Since in some PRs review requests can come **after** someone reviews a pr, we should handle negative time differences between `reviewAssiged` -> `reviewFirstReviewed`, by attributing 0 to such cases instead of negative values when calculating average

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
