### PR TITLE
fix: remove tenant id from args

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -815,7 +815,6 @@ export default class MemberService extends LoggerBase {
           payload.secondary.identities,
           member.displayName,
           secondaryMember.displayName,
-          this.options.currentTenant.id,
           this.options.currentUser.id,
         ],
         searchAttributes: {
@@ -1421,7 +1420,6 @@ export default class MemberService extends LoggerBase {
           toMergeId,
           original.displayName,
           toMerge.displayName,
-          this.options.currentTenant.id,
           this.options.currentUser.id,
           doNotDeleteSecondaryMember,
         ],


### PR DESCRIPTION
# Changes proposed ✍️

### What
Remove tenantId from merge/unmerge workflow args. Because of this `doNotDeleteSecondaryMember` was not being set to false for all user operations.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
