### PR TITLE
fix: hardcoded isLF for insightsProjects

### DIFF
--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -214,9 +214,11 @@ export class CollectionService extends LoggerBase {
 
       const slug = getCleanString(project.name).replace(/\s+/g, '-')
 
+      const segment = project.segmentId ? await findSegmentById(qx, project.segmentId) : null
+
       const createdProject = await createInsightsProject(qx, {
         ...project,
-        isLF: false,
+        isLF: segment?.isLF ?? false,
         slug,
       })
 
@@ -362,6 +364,13 @@ export class CollectionService extends LoggerBase {
   async updateInsightsProject(id: string, project: Partial<ICreateInsightsProject>) {
     return SequelizeRepository.withTx(this.options, async (tx) => {
       const qx = SequelizeRepository.getQueryExecutor(this.options, tx)
+
+      // If segmentId is being updated, fetch the new segment's isLF value
+      if (project.segmentId) {
+        const segment = await findSegmentById(qx, project.segmentId)
+        project.isLF = segment?.isLF ?? false
+      }
+
       await updateInsightsProject(qx, id, project)
 
       if (project.collections) {


### PR DESCRIPTION
# Changes proposed ✍️

### What
insightsProjects.isLF was being hardcoded. This should inherit the corresponding segments.isLF.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
