### PR TITLE
fix: query to find groupsio integration based on group name

### DIFF
--- a/services/apps/webhook_api/src/routes/groupsio.ts
+++ b/services/apps/webhook_api/src/routes/groupsio.ts
@@ -33,12 +33,12 @@ export const installGroupsIoRoutes = async (app: express.Express) => {
           event,
           data,
         })
-
+        req.log.info({ integrationId: integration.id }, 'Trigerring Webhook Processing!')
         await req.emitters.integrationStreamWorker.triggerWebhookProcessing(
           integration.platform,
           result,
         )
-
+        req.log.info({ integrationId: integration.id }, 'Webhook processed!')
         res.sendStatus(204)
       } else {
         req.log.error({ event, groupName }, 'No integration found for incoming Groups.io Webhook!')

--- a/services/libs/data-access-layer/src/old/apps/webhook_api/webhooks.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/webhook_api/webhooks.repo.ts
@@ -64,7 +64,10 @@ export class WebhooksRepository extends RepositoryBase<WebhooksRepository> {
       `
       select id, platform from integrations
       where platform = $(platform) and "deletedAt" is null
-      and settings -> 'groups' ? $(groupName)
+      and exists (
+        select 1 from jsonb_array_elements(settings -> 'groups') as group_item
+        where group_item ->> 'slug' = $(groupName)
+      )
       `,
       {
         platform: PlatformType.GROUPSIO,


### PR DESCRIPTION
# Changes proposed ✍️
Fix query

### What
The query responsible for finding Groupsio integrations (upon webhook trigger) uses an outdated structure of settings.
outdated structure: `["group1", "group2", "group3"]`
current structure: `[
  { "id": "id1", "slug": "groupName1", "name": "Group One" },
  { "id": "id2", "slug": "groupName2", "name": "Group Two" }
]`

_PS: the groupName is stored in the slug_ 


### Why
groupsio integrations aren't receiving any updates

### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
