### PR TITLE
fix: payload sent to triggerIntegrationRun

### DIFF
--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -140,7 +140,6 @@ export class IntegrationTickProcessor extends LoggerBase {
                   } minutes!`,
                 )
                 await emitter.triggerIntegrationRun(
-                  integration.tenantId,
                   integration.platform,
                   integration.id,
                   false,
@@ -149,7 +148,6 @@ export class IntegrationTickProcessor extends LoggerBase {
             } else {
               logger.info({ integrationId: integration.id }, 'Triggering new integration check!')
               await emitter.triggerIntegrationRun(
-                integration.tenantId,
                 integration.platform,
                 integration.id,
                 false,

--- a/backend/src/serverless/integrations/services/integrationTickProcessor.ts
+++ b/backend/src/serverless/integrations/services/integrationTickProcessor.ts
@@ -139,19 +139,11 @@ export class IntegrationTickProcessor extends LoggerBase {
                     delay / 60 / 1000
                   } minutes!`,
                 )
-                await emitter.triggerIntegrationRun(
-                  integration.platform,
-                  integration.id,
-                  false,
-                )
+                await emitter.triggerIntegrationRun(integration.platform, integration.id, false)
               }, delay)
             } else {
               logger.info({ integrationId: integration.id }, 'Triggering new integration check!')
-              await emitter.triggerIntegrationRun(
-                integration.platform,
-                integration.id,
-                false,
-              )
+              await emitter.triggerIntegrationRun(integration.platform, integration.id, false)
             }
           } else {
             logger.info({ integrationId: integration.id }, 'Existing run found, skipping!')


### PR DESCRIPTION
# Changes proposed ✍️
Fix payload sent to `triggerIntegrationRun`

### What
integration_run_worker doesn't trigger **any integration runs** failing with: 
`{"message":"invalid input syntax for type uuid: \"hackernews\"","name":"error","stack":"error: invalid input syntax for type uuid: \"hackernews\"\n    at Parser.parseErrorMessage ...`
Due to the invalid payload sent from `IntegrationTickProcessor` 

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
