### PR TITLE
fix: use segmentId instead of tenantId to get linkedIn tokens from nango [CM-335]

### DIFF
--- a/backend/src/api/integration/helpers/linkedinConnect.ts
+++ b/backend/src/api/integration/helpers/linkedinConnect.ts
@@ -4,6 +4,7 @@ import PermissionChecker from '../../../services/user/permissionChecker'
 
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.tenantEdit)
-  const payload = await new IntegrationService(req).linkedinConnect()
+  const segmentId = req.body.segments[0]
+  const payload = await new IntegrationService(req).linkedinConnect(segmentId)
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
 import lodash from 'lodash'
 import moment from 'moment'
 
-import { DEFAULT_TENANT_ID, EDITION, Error400, Error404, Error542 } from '@crowd/common'
+import { EDITION, Error400, Error404, Error542 } from '@crowd/common'
 import {
   NangoIntegration,
   connectNangoIntegration,
@@ -846,8 +846,8 @@ export default class IntegrationService {
     throw new Error404(this.options.language, 'errors.linkedin.cantOnboardWrongStatus')
   }
 
-  async linkedinConnect() {
-    const nangoId = `${DEFAULT_TENANT_ID}-${PlatformType.LINKEDIN}`
+  async linkedinConnect(segmentId: string) {
+    const nangoId = `${segmentId}-${PlatformType.LINKEDIN}`
 
     let token: string
     try {


### PR DESCRIPTION
# Changes proposed ✍️
Use `segmentId` instead of `tenantId` to get LinkedIn tokens from nango

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
