### PR TITLE
feat: extend `activityRelations` with additional columns

### DIFF
--- a/backend/src/database/migrations/V1750680190__extend_activityRelations.sql
+++ b/backend/src/database/migrations/V1750680190__extend_activityRelations.sql
@@ -1,0 +1,5 @@
+-- extend activityRelations table with sourceId, type, and timestamp columns
+alter table "activityRelations" 
+add column "sourceId" varchar(150) not null,
+add column "type" varchar(50) not null,
+add column "timestamp" timestamp with time zone not null;

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -1178,6 +1178,9 @@ export default class ActivityService extends LoggerBase {
           platform: a.payload.platform,
           username: a.payload.username,
           objectMemberUsername: a.payload.objectMemberUsername,
+          sourceId: a.payload.sourceId,
+          type: a.payload.type,
+          timestamp: a.payload.timestamp,
         }
       }),
     )

--- a/services/apps/script_executor_worker/src/activities/populate-activity-relations/index.ts
+++ b/services/apps/script_executor_worker/src/activities/populate-activity-relations/index.ts
@@ -75,6 +75,9 @@ export async function createRelations(activitiesRedisKey): Promise<void> {
         objectMemberUsername: activity.objectMemberUsername,
         organizationId: activity.organizationId,
         parentId: activity.parentId,
+        sourceId: activity.sourceId,
+        type: activity.type,
+        timestamp: activity.timestamp,
       }
     })
     await createOrUpdateRelations(pgpQx(svc.postgres.writer.connection()), payload)

--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -1527,6 +1527,9 @@ export async function createOrUpdateRelations(
     const platformParam = `platform_${index++}`
     const usernameParam = `username_${index++}`
     const objectMemberUsernameParam = `objectMemberUsername_${index++}`
+    const sourceIdParam = `sourceId_${index++}`
+    const typeParam = `type_${index++}`
+    const timestampParam = `timestamp_${index++}`
 
     params[activityIdParam] = data.activityId
     params[memberIdParam] = data.memberId
@@ -1538,6 +1541,9 @@ export async function createOrUpdateRelations(
     params[platformParam] = data.platform
     params[usernameParam] = data.username
     params[objectMemberUsernameParam] = data.objectMemberUsername ?? null
+    params[sourceIdParam] = data.sourceId ?? null
+    params[typeParam] = data.type ?? null
+    params[timestampParam] = data.timestamp ?? null
 
     valueList.push(
       `
@@ -1552,6 +1558,9 @@ export async function createOrUpdateRelations(
           $(${platformParam}), 
           $(${usernameParam}), 
           $(${objectMemberUsernameParam}), 
+          $(${sourceIdParam}), 
+          $(${typeParam}), 
+          $(${timestampParam}), 
           now(), 
           now()
         )`,
@@ -1571,6 +1580,9 @@ export async function createOrUpdateRelations(
             "platform",
             "username",
             "objectMemberUsername",
+            "sourceId",
+            "type",
+            "timestamp",
             "createdAt", 
             "updatedAt")
     VALUES ${valueList.join(',')}
@@ -1584,7 +1596,10 @@ export async function createOrUpdateRelations(
         "organizationId" = EXCLUDED."organizationId",
         "platform" = EXCLUDED."platform",
         "username" = EXCLUDED."username",
-        "objectMemberUsername" = EXCLUDED."objectMemberUsername";
+        "objectMemberUsername" = EXCLUDED."objectMemberUsername",
+        "sourceId" = EXCLUDED."sourceId",
+        "type" = EXCLUDED."type",
+        "timestamp" = EXCLUDED."timestamp";
 
     `,
     params,
@@ -1723,6 +1738,8 @@ export interface IActivityRelationsCreateData {
   platform: string
   username: string
   objectMemberUsername?: string
+  sourceId: string
+  type: string
 }
 
 export async function getActivityRelationsSortedByTimestamp(

--- a/services/libs/data-access-layer/src/old/apps/data_sink_worker/repo/activity.data.ts
+++ b/services/libs/data-access-layer/src/old/apps/data_sink_worker/repo/activity.data.ts
@@ -72,6 +72,9 @@ export interface IActivityRelationCreateOrUpdateData {
   platform: string
   username: string
   objectMemberUsername?: string
+  sourceId: string
+  type: string
+  timestamp: string
 }
 
 export interface IActivityRelationUpdateById {


### PR DESCRIPTION
# Changes proposed ✍️

I have added the migration to introduce new columns to the `activityRelations` schema, and also updated the existing populateActivityRelations workflow to backfill data from questdb for these new columns.

Once the backfill is finished, will open a new PR that includes the following:
- migration script to fix dups in relations
	- keep only the row with the latest `updatedAt` for each (timestamp, platform, sourceId, segmentId) group
- set the sorting key as w/e is in questdb `timestamp, platform, sourceId, segmentId` (we can't add `channel` as key here since we don't have the col in the schema)
- add relevant indexes on `activityRelations` for affiliations and clean up if any redundant indexes