### PR TITLE
fix: disabled update settings button

### DIFF
--- a/frontend/src/config/integrations/github-nango/components/settings/github-settings-drawer.vue
+++ b/frontend/src/config/integrations/github-nango/components/settings/github-settings-drawer.vue
@@ -58,7 +58,6 @@
             :disabled="
               $v.$invalid
                 || !repositories.length
-                || props.integration?.status === 'in-progress'
             "
             @click="connect()"
           >


### PR DESCRIPTION
# Changes proposed ✍️

Remove disabled button when integration is in progress. There isn't a limitation on github nango to update the settings.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
