### PR TITLE
fix: don't initialise QuestDB automatically

### DIFF
--- a/services/libs/data-access-layer/src/conversations/ilp.ts
+++ b/services/libs/data-access-layer/src/conversations/ilp.ts
@@ -17,7 +17,9 @@ export async function insertConversations(
   const now = Date.now()
 
   if (conversations.length > 0) {
-    ilp = getClientILP()
+    if (!ilp) {
+      ilp = getClientILP()
+    }
 
     for (const conversation of conversations) {
       const id = conversation.id || generateUUIDv4()

--- a/services/libs/data-access-layer/src/conversations/ilp.ts
+++ b/services/libs/data-access-layer/src/conversations/ilp.ts
@@ -8,7 +8,7 @@ import { IDbConversationCreateData } from '../old/apps/data_sink_worker/repo/con
 
 const log = getServiceChildLogger('data-access-layer/conversations/ilp.ts')
 
-const ilp: Sender = getClientILP()
+let ilp: Sender
 export async function insertConversations(
   conversations: IDbConversationCreateData[],
   update = false,
@@ -17,6 +17,8 @@ export async function insertConversations(
   const now = Date.now()
 
   if (conversations.length > 0) {
+    ilp = getClientILP()
+
     for (const conversation of conversations) {
       const id = conversation.id || generateUUIDv4()
       ids.push(id)


### PR DESCRIPTION
Due to a top-level variable being initialised in the data access layer, it was being executed immediately when the code was imported, which was causing issues when QuestDB was not in use.

This moves the variable initialistion to inside the function that uses it, so we don't have the above problem.
