### PR TITLE
feat: reflect integrations on insights

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -927,14 +927,12 @@ class SegmentRepository extends RepositoryBase<
 
     const result = await this.options.database.sequelize.query(
       `
-       select
+      select
          r.url as url
        from
         "githubRepos" r
-       left join "integrations" i on r."integrationId" = i.id
        where r."segmentId" = :segmentId
        and r."tenantId" = :tenantId
-       and (i.id is null or i."segmentId" != :segmentId)
        order by r.url
       `,
       {

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -415,27 +415,24 @@ export class CollectionService extends LoggerBase {
         }
       }
 
+      // Add mapped repositories to GitHub platform
+      const segmentRepository = new SegmentRepository(this.options)
+      const mappedRepos = await segmentRepository.getMappedRepos(segmentId)
+
+      for (const repo of mappedRepos) {
+        const url = repo.url
+        try {
+          const parsedUrl = new URL(url)
+          if (parsedUrl.hostname === 'github.com') {
+            const label = parsedUrl.pathname.slice(1) // removes leading '/'
+            addToResult(PlatformType.GITHUB, url, label)
+          }
+        } catch (err) {
+          // Do nothing
+        }
+      }
+
       for (const i of integrations) {
-        if (i.platform === PlatformType.GITHUB) {
-          for (const org of (i.settings as any).orgs) {
-            for (const repo of org.repos) {
-              const label = `${org.name}/${repo.name}`
-              const fullUrl = `https://github.com/${label}`
-              addToResult(i.platform, fullUrl, label)
-            }
-          }
-        }
-
-        if (i.platform === PlatformType.GITHUB_NANGO) {
-          for (const org of (i.settings as any).orgs) {
-            for (const repo of org.repos) {
-              const label = `${org.name}/${repo.name}`
-              const fullUrl = `https://github.com/${label}`
-              addToResult(PlatformType.GITHUB, fullUrl, label)
-            }
-          }
-        }
-
         if (i.platform === PlatformType.GIT) {
           for (const r of (i.settings as any).remotes) {
             try {
@@ -469,23 +466,6 @@ export class CollectionService extends LoggerBase {
           for (const r of (i.settings as any).remote.repos) {
             addToResult(i.platform, r, r)
           }
-        }
-      }
-
-      // Add mapped repositories to GitHub platform
-      const segmentRepository = new SegmentRepository(this.options)
-      const mappedRepos = await segmentRepository.getMappedRepos(segmentId)
-
-      for (const repo of mappedRepos) {
-        const url = repo.url
-        try {
-          const parsedUrl = new URL(url)
-          if (parsedUrl.hostname === 'github.com') {
-            const label = parsedUrl.pathname.slice(1) // removes leading '/'
-            addToResult(PlatformType.GITHUB, url, label)
-          }
-        } catch (err) {
-          // Do nothing
         }
       }
 

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -450,7 +450,7 @@ export class CollectionService extends LoggerBase {
 
               addToResult(i.platform, r, label)
             } catch {
-              console.warn(`Invalid URL in remotes: ${r}`)
+              this.options.log.warn(`Invalid URL in remotes: ${r}`)
             }
           }
         }

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -517,7 +517,7 @@ export class CollectionService extends LoggerBase {
         description,
         github,
         logoUrl,
-        name,
+        name: segment.name,
         topics,
         twitter,
         website,

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -592,14 +592,4 @@ export class CollectionService extends LoggerBase {
 
     return result
   }
-
-  async cleanInsightsProjectsById(id: string) {
-    const qx = SequelizeRepository.getQueryExecutor(this.options)
-    const result = await updateInsightsProject(qx, id, {
-      widgets: [],
-      repositories: [],
-    })
-
-    return result
-  }
 }

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -438,13 +438,20 @@ export class CollectionService extends LoggerBase {
 
         if (i.platform === PlatformType.GIT) {
           for (const r of (i.settings as any).remotes) {
-            let label = r
-            if (r.includes('https://gitlab.com/')) {
-              label = r.replace('https://gitlab.com/', '')
-            } else if (r.includes('https://github.com/')) {
-              label = r.replace('https://github.com/', '')
+            try {
+              const url = new URL(r)
+              let label = r
+
+              if (url.hostname === 'gitlab.com') {
+                label = url.pathname.slice(1) 
+              } else if (url.hostname === 'github.com') {
+                label = url.pathname.slice(1)
+              }
+
+              addToResult(i.platform, r, label)
+            } catch {
+              console.warn(`Invalid URL in remotes: ${r}`)
             }
-            addToResult(i.platform, r, label)
           }
         }
 

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -27,6 +27,7 @@ import { fetchIntegrationsForSegment } from '@crowd/data-access-layer/src/integr
 import { OrganizationField, findOrgById, queryOrgs } from '@crowd/data-access-layer/src/orgs'
 import { QueryFilter } from '@crowd/data-access-layer/src/query'
 import { findSegmentById } from '@crowd/data-access-layer/src/segments'
+import { QueryResult } from '@crowd/data-access-layer/src/utils'
 import { GithubIntegrationSettings } from '@crowd/integrations'
 import { LoggerBase } from '@crowd/logging'
 import { DEFAULT_WIDGET_VALUES, PlatformType, Widgets } from '@crowd/types'
@@ -578,13 +579,25 @@ export class CollectionService extends LoggerBase {
     }
   }
 
-  async findInsightsProjectsBySegmentId(segmentId: string): Promise<any> {
+  async findInsightsProjectsBySegmentId(
+    segmentId: string,
+  ): Promise<QueryResult<InsightsProjectField>[]> {
     const qx = SequelizeRepository.getQueryExecutor(this.options)
     const result = await queryInsightsProjects(qx, {
       filter: {
         segmentId: { eq: segmentId },
       },
       fields: Object.values(InsightsProjectField),
+    })
+
+    return result
+  }
+
+  async cleanInsightsProjectsById(id: string) {
+    const qx = SequelizeRepository.getQueryExecutor(this.options)
+    const result = await updateInsightsProject(qx, id, {
+      widgets: [],
+      repositories: [],
     })
 
     return result

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -577,4 +577,16 @@ export class CollectionService extends LoggerBase {
       widgets: [...widgets],
     }
   }
+
+  async findInsightsProjectsBySegmentId(segmentId: string): Promise<any> {
+    const qx = SequelizeRepository.getQueryExecutor(this.options)
+    const result = await queryInsightsProjects(qx, {
+      filter: {
+        segmentId: { eq: segmentId },
+      },
+      fields: Object.values(InsightsProjectField),
+    })
+
+    return result
+  }
 }

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -443,7 +443,7 @@ export class CollectionService extends LoggerBase {
               let label = r
 
               if (url.hostname === 'gitlab.com') {
-                label = url.pathname.slice(1) 
+                label = url.pathname.slice(1)
               } else if (url.hostname === 'github.com') {
                 label = url.pathname.slice(1)
               }

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -323,7 +323,10 @@ export default class IntegrationService {
               }
             }
 
-            if (integration.platform === PlatformType.GITHUB) {
+            if (
+              integration.platform === PlatformType.GITHUB ||
+              integration.platform === PlatformType.GITHUB_NANGO
+            ) {
               // soft delete github repos
               await GithubReposRepository.delete(integration.id, {
                 ...this.options,

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -178,18 +178,9 @@ export default class IntegrationService {
 
     if (platforms.some(IntegrationService.isCodePlatform)) {
       const repositories = await collectionService.findRepositoriesForSegment(segmentId)
-
-
-      // data.repositories = Object.entries(repositories).flatMap(([platform, entries]) =>
-      //   entries.map((entry) => ({
-      //     platform,
-      //     url: entry.url,
-      //   })),
-      // )
-
-      // @ts-ignore
-      data.repositories = [...new Set(Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)))]
-
+      data.repositories = [
+        ...new Set(Object.values(repositories).flatMap((entries) => entries.map((e) => e.url))),
+      ]
     }
 
     if (platforms.includes(PlatformType.GITHUB)) {
@@ -247,7 +238,7 @@ export default class IntegrationService {
 
             if (integration?.segmentId) {
               console.log(`Cleaning insights project for integration ${integration.id}...`)
-              
+
               const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
                 integration.segmentId,
               )
@@ -256,7 +247,6 @@ export default class IntegrationService {
                 await collectionService.cleanInsightsProjectsById(insightsProject.id)
               }
               console.log(`data cleaned ${integration.id}...`)
-
             }
           } catch (err) {
             throw new Error404()

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -237,16 +237,16 @@ export default class IntegrationService {
             integration = await this.findById(id)
 
             if (integration?.segmentId) {
-              console.log(`Cleaning insights project for integration ${integration.id}...`)
-
               const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
                 integration.segmentId,
               )
 
               if (insightsProject) {
-                await collectionService.cleanInsightsProjectsById(insightsProject.id)
+                await collectionService.updateInsightsProject(insightsProject.id, {
+                  repositories: [],
+                  widgets: [],
+                })
               }
-              console.log(`data cleaned ${integration.id}...`)
             }
           } catch (err) {
             throw new Error404()

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -152,7 +152,7 @@ export default class IntegrationService {
         transaction,
       })
 
-      const collectionService = new CollectionService(this.options)
+      const collectionService = new CollectionService({ ...this.options, transaction })
 
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
@@ -225,7 +225,7 @@ export default class IntegrationService {
         transaction,
       })
 
-      const collectionService = new CollectionService(this.options)
+      const collectionService = new CollectionService({ ...this.options, transaction })
 
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
@@ -360,16 +360,14 @@ export default class IntegrationService {
 
       const { widgets } = await collectionService.findSegmentsWidgetsById(segmentId)
 
-      const repositories = [
-        ...new Set<string>(
-          insightsProject.repositories.filter((repo: string) => !toRemoveRepo.has(repo)),
-        ),
-      ]
+      const insightsRepo = insightsProject.repositories ?? []
 
-      await collectionService.updateInsightsProject(insightsProject.id, {
-        widgets,
-        repositories,
-      })
+      const filteredRepos = insightsRepo.filter((repo) => !toRemoveRepo.has(repo))
+
+      // remove duplicates
+      const repositories = [...new Set<string>(filteredRepos)]
+
+      await collectionService.updateInsightsProject(insightsProject.id, { widgets, repositories })
 
       await SequelizeRepository.commitTransaction(transaction)
     } catch (error) {

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -190,6 +190,7 @@ export default class IntegrationService {
     transaction: Transaction
   }) {
     const collectionService = new CollectionService({ ...this.options, transaction })
+    const segmentRepository = new SegmentRepository({ ...this.options, transaction })
 
     const data: Partial<ICreateInsightsProject> = {}
     const { widgets } = await collectionService.findSegmentsWidgetsById(segmentId)
@@ -197,8 +198,12 @@ export default class IntegrationService {
 
     if (IntegrationService.isCodePlatform(platform)) {
       const repositories = await collectionService.findRepositoriesForSegment(segmentId)
+      const mappedRepositories = await segmentRepository.getMappedRepos(segmentId)
       data.repositories = [
-        ...new Set(Object.values(repositories).flatMap((entries) => entries.map((e) => e.url))),
+        ...new Set([
+          ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
+          ...mappedRepositories.map((repo) => repo.url),
+        ]),
       ]
     }
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -190,7 +190,6 @@ export default class IntegrationService {
     transaction: Transaction
   }) {
     const collectionService = new CollectionService({ ...this.options, transaction })
-    const segmentRepository = new SegmentRepository({ ...this.options, transaction })
 
     const data: Partial<ICreateInsightsProject> = {}
     const { widgets } = await collectionService.findSegmentsWidgetsById(segmentId)

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -179,12 +179,17 @@ export default class IntegrationService {
     if (platforms.some(IntegrationService.isCodePlatform)) {
       const repositories = await collectionService.findRepositoriesForSegment(segmentId)
 
-      data.repositories = Object.entries(repositories).flatMap(([platform, entries]) =>
-        entries.map((entry) => ({
-          platform,
-          url: entry.url,
-        })),
-      )
+
+      // data.repositories = Object.entries(repositories).flatMap(([platform, entries]) =>
+      //   entries.map((entry) => ({
+      //     platform,
+      //     url: entry.url,
+      //   })),
+      // )
+
+      // @ts-ignore
+      data.repositories = [...new Set(Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)))]
+
     }
 
     if (platforms.includes(PlatformType.GITHUB)) {
@@ -241,6 +246,8 @@ export default class IntegrationService {
             integration = await this.findById(id)
 
             if (integration?.segmentId) {
+              console.log(`Cleaning insights project for integration ${integration.id}...`)
+              
               const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
                 integration.segmentId,
               )
@@ -248,6 +255,8 @@ export default class IntegrationService {
               if (insightsProject) {
                 await collectionService.cleanInsightsProjectsById(insightsProject.id)
               }
+              console.log(`data cleaned ${integration.id}...`)
+
             }
           } catch (err) {
             throw new Error404()

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -198,11 +198,9 @@ export default class IntegrationService {
 
     if (IntegrationService.isCodePlatform(platform)) {
       const repositories = await collectionService.findRepositoriesForSegment(segmentId)
-      const mappedRepositories = await segmentRepository.getMappedRepos(segmentId)
       data.repositories = [
         ...new Set([
           ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
-          ...mappedRepositories.map((repo) => repo.url),
         ]),
       ]
     }

--- a/backend/src/services/segmentService.ts
+++ b/backend/src/services/segmentService.ts
@@ -1,4 +1,8 @@
+import { Transaction } from 'sequelize'
+
 import { Error400, validateNonLfSlug } from '@crowd/common'
+import { QueryExecutor } from '@crowd/data-access-layer'
+import { ICreateInsightsProject, findBySlug } from '@crowd/data-access-layer/src/collections'
 import {
   buildSegmentActivityTypes,
   isSegmentSubproject,
@@ -20,6 +24,7 @@ import SegmentRepository from '../database/repositories/segmentRepository'
 import SequelizeRepository from '../database/repositories/sequelizeRepository'
 
 import { IServiceOptions } from './IServiceOptions'
+import { CollectionService } from './collectionService'
 
 interface UnnestedActivityTypes {
   [key: string]: any
@@ -73,12 +78,22 @@ export default class SegmentService extends LoggerBase {
     }
 
     const transaction = await SequelizeRepository.createTransaction(this.options)
+    const qx = SequelizeRepository.getQueryExecutor(this.options, transaction)
+
+    const collectionService = new CollectionService({ ...this.options, transaction })
+    const segmentRepository = new SegmentRepository({ ...this.options, transaction })
 
     try {
-      const segmentRepository = new SegmentRepository({ ...this.options, transaction })
-
       // create project group
       const projectGroup = await segmentRepository.create(data)
+
+      await collectionService.createCollection({
+        name: data.name,
+        categoryId: null,
+        description: '',
+        slug: data.slug,
+        starred: data.isLF ?? false,
+      })
 
       // create project counterpart
       const project = await segmentRepository.create({
@@ -89,15 +104,19 @@ export default class SegmentService extends LoggerBase {
       })
 
       // create subproject counterpart
-      await segmentRepository.create({
-        ...data,
-        parentSlug: data.slug,
-        grandparentSlug: data.slug,
-        parentName: data.name,
-        grandparentName: data.name,
-        parentId: project.id,
-        grandparentId: projectGroup.id,
-      })
+      await this.createSubprojectInternal(
+        {
+          ...data,
+          parentSlug: data.slug,
+          grandparentSlug: data.slug,
+          parentName: data.name,
+          grandparentName: data.name,
+          parentId: project.id,
+          grandparentId: projectGroup.id,
+        },
+        qx,
+        transaction,
+      )
 
       await SequelizeRepository.commitTransaction(transaction)
 
@@ -118,6 +137,7 @@ export default class SegmentService extends LoggerBase {
       throw new Error('Missing parentSlug. Projects must belong to a project group.')
     }
     const transaction = await SequelizeRepository.createTransaction(this.options)
+    const qx = SequelizeRepository.getQueryExecutor(this.options, transaction)
 
     const segmentRepository = new SegmentRepository({ ...this.options, transaction })
 
@@ -136,16 +156,20 @@ export default class SegmentService extends LoggerBase {
       const project = await segmentRepository.create({ ...data, parentId: parent.id })
 
       // create subproject counterpart
-      await segmentRepository.create({
-        ...data,
-        parentSlug: data.slug,
-        grandparentSlug: data.parentSlug,
-        name: data.name,
-        parentName: data.name,
-        grandparentName: parent.name,
-        parentId: project.id,
-        grandparentId: parent.id,
-      })
+      await this.createSubprojectInternal(
+        {
+          ...data,
+          parentSlug: data.slug,
+          grandparentSlug: data.parentSlug,
+          name: data.name,
+          parentName: data.name,
+          grandparentName: parent.name,
+          parentId: project.id,
+          grandparentId: parent.id,
+        },
+        qx,
+        transaction,
+      )
 
       await SequelizeRepository.commitTransaction(transaction)
 
@@ -157,6 +181,17 @@ export default class SegmentService extends LoggerBase {
   }
 
   async createSubproject(data: SegmentData): Promise<SegmentData> {
+    return SequelizeRepository.withTx(this.options, async (tx) => {
+      const qx = SequelizeRepository.getQueryExecutor(this.options, tx)
+      return this.createSubprojectInternal(data, qx, tx)
+    })
+  }
+
+  async createSubprojectInternal(
+    data: SegmentData,
+    qx: QueryExecutor,
+    transaction: Transaction,
+  ): Promise<SegmentData> {
     if (!data.parentSlug) {
       throw new Error('Missing parentSlug. Subprojects must belong to a project.')
     }
@@ -164,44 +199,54 @@ export default class SegmentService extends LoggerBase {
     if (!data.grandparentSlug) {
       throw new Error('Missing grandparentSlug. Subprojects must belong to a project group.')
     }
-    const transaction = await SequelizeRepository.createTransaction(this.options)
 
-    try {
-      const segmentRepository = new SegmentRepository({
-        ...this.options,
-        transaction,
-      })
+    const segmentRepository = new SegmentRepository({ ...this.options, transaction })
+    const collectionService = new CollectionService({ ...this.options, transaction })
 
-      const parent = await segmentRepository.findBySlug(data.parentSlug, SegmentLevel.PROJECT)
-
-      if (parent === null) {
-        throw new Error(`Project ${data.parentSlug} does not exist.`)
-      }
-      if (parent.isLF === false) data.slug = validateNonLfSlug(data.slug)
-
-      const grandparent = await segmentRepository.findBySlug(
-        data.grandparentSlug,
-        SegmentLevel.PROJECT_GROUP,
-      )
-
-      if (grandparent === null) {
-        throw new Error(`Project group ${data.parentSlug} does not exist.`)
-      }
-
-      const subproject = await segmentRepository.create({
-        ...data,
-        parentId: parent.id,
-        grandparentId: grandparent.id,
-        isLF: parent.isLF,
-      })
-
-      await SequelizeRepository.commitTransaction(transaction)
-
-      return subproject
-    } catch (error) {
-      await SequelizeRepository.rollbackTransaction(transaction)
-      throw error
+    const parent = await segmentRepository.findBySlug(data.parentSlug, SegmentLevel.PROJECT)
+    if (!parent) {
+      throw new Error(`Project ${data.parentSlug} does not exist.`)
     }
+
+    if (parent.isLF === false) {
+      data.slug = validateNonLfSlug(data.slug)
+    }
+
+    const grandparent = await segmentRepository.findBySlug(
+      data.grandparentSlug,
+      SegmentLevel.PROJECT_GROUP,
+    )
+    if (!grandparent) {
+      throw new Error(`Project group ${data.grandparentSlug} does not exist.`)
+    }
+
+    const subproject = await segmentRepository.create({
+      ...data,
+      parentId: parent.id,
+      grandparentId: grandparent.id,
+      isLF: parent.isLF,
+    })
+
+    const collections = await findBySlug(qx, data.grandparentSlug)
+
+    const [existingProject] = await collectionService.findInsightsProjectsByName(subproject.name)
+
+    const projectData: Partial<ICreateInsightsProject> = {
+      segmentId: subproject.id,
+      name: subproject.name,
+      slug: subproject.slug,
+      ...(parent.isLF && { collections: collections.map((c) => c.id), starred: false }),
+    }
+
+    const mustUpdateProject = existingProject && !existingProject.segmentId
+
+    if (mustUpdateProject) {
+      await collectionService.updateInsightsProject(existingProject.id, projectData)
+    } else {
+      await collectionService.createInsightsProject(projectData)
+    }
+
+    return subproject
   }
 
   async findById(id) {

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -49,10 +49,12 @@ export interface IInsightsProject {
   linkedin: string
   twitter: string
   widgets: string[]
-  repositories: {
-    platform: string
-    url: string
-  }[]
+  repositories:
+    | {
+        platform: string
+        url: string
+      }[]
+    | string[]
 }
 
 export interface ICreateInsightsProject extends IInsightsProject {

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -11,10 +11,10 @@ import {
 import { QueryOptions } from '../utils'
 
 export interface ICreateCollection {
-  name: string
-  description?: string
   categoryId: string
-  slug: string
+  description?: string
+  name: string
+  slug?: string
   starred: boolean
 }
 
@@ -59,6 +59,7 @@ export interface IInsightsProject {
 
 export interface ICreateInsightsProject extends IInsightsProject {
   collections: string[]
+  starred?: boolean
 }
 
 export interface ICollectionInsightProject {
@@ -71,13 +72,14 @@ export interface ICollectionInsightProject {
 }
 
 export enum CollectionField {
-  ID = 'id',
-  NAME = 'name',
-  DESCRIPTION = 'description',
   CATEGORY_ID = 'categoryId',
   CREATED_AT = 'createdAt',
-  UPDATED_AT = 'updatedAt',
+  DESCRIPTION = 'description',
+  ID = 'id',
+  NAME = 'name',
+  SLUG = 'slug',
   STARRED = 'starred',
+  UPDATED_AT = 'updatedAt',
 }
 
 export async function queryCollections<T extends CollectionField>(
@@ -158,7 +160,10 @@ export async function queryInsightsProjects<T extends InsightsProjectField>(
   return queryTable(qx, 'insightsProjects', Object.values(InsightsProjectField), opts)
 }
 
-export async function createInsightsProject(qx: QueryExecutor, insightProject: IInsightsProject) {
+export async function createInsightsProject(
+  qx: QueryExecutor,
+  insightProject: Partial<IInsightsProject>,
+) {
   return qx.selectOne(
     prepareInsert(
       'insightsProjects',
@@ -278,4 +283,14 @@ function prepareProject(project: Partial<ICreateInsightsProject>) {
     ...project,
   }
   return toUpdate
+}
+
+export async function findBySlug(qx: QueryExecutor, slug: string) {
+  const collections = await queryCollections(qx, {
+    filter: {
+      slug: { eq: slug },
+    },
+    fields: Object.values(CollectionField),
+  })
+  return collections
 }

--- a/services/libs/data-access-layer/src/query.ts
+++ b/services/libs/data-access-layer/src/query.ts
@@ -1,35 +1,35 @@
 enum Operator {
   AND = 'and',
-  OR = 'or',
-  NOT = 'not',
-  LIKE = 'like',
-  NOT_LIKE = 'notLike',
   EQ = 'eq',
-  NE = 'ne',
+  FIELD = 'field',
   GT = 'gt',
   GTE = 'gte',
-  LTE = 'lte',
-  LT = 'lt',
   IN = 'in',
-  NOT_IN = 'notIn',
   IS = 'is',
   IS_NULL = 'isNull',
-  FIELD = 'field',
+  LIKE = 'like',
+  LT = 'lt',
+  LTE = 'lte',
+  NE = 'ne',
+  NOT = 'not',
+  NOT_IN = 'notIn',
+  NOT_LIKE = 'notLike',
+  OR = 'or',
   VALUE = 'value',
 }
 
 type ANY_LITERAL = string | number | boolean
 
+type EQ = { [Operator.EQ]: ANY_LITERAL }
 type GT = { [Operator.GT]: ANY_LITERAL }
 type GTE = { [Operator.GTE]: ANY_LITERAL }
+type IN = { [Operator.IN]: ANY_LITERAL[] }
+type LIKE = { [Operator.LIKE]: string }
 type LT = { [Operator.LT]: ANY_LITERAL }
 type LTE = { [Operator.LTE]: ANY_LITERAL }
-type EQ = { [Operator.EQ]: ANY_LITERAL }
 type NE = { [Operator.NE]: ANY_LITERAL }
-type LIKE = { [Operator.LIKE]: string }
-type NOT_LIKE = { [Operator.NOT_LIKE]: string }
-type IN = { [Operator.IN]: ANY_LITERAL[] }
 type NOT_IN = { [Operator.NOT_IN]: ANY_LITERAL[] }
+type NOT_LIKE = { [Operator.NOT_LIKE]: string }
 
 type ANY_OPERATOR = GT | GTE | LT | LTE | EQ | NE | LIKE | NOT_LIKE | IN | NOT_IN | NOT
 

--- a/services/libs/types/src/enums/platforms.ts
+++ b/services/libs/types/src/enums/platforms.ts
@@ -31,6 +31,13 @@ export enum PlatformType {
   OTHER = 'other',
 }
 
+export type CodePlatform =
+  | PlatformType.GITHUB
+  | PlatformType.GITHUB_NANGO
+  | PlatformType.GITLAB
+  | PlatformType.GIT
+  | PlatformType.GERRIT;
+
 export const ALL_PLATFORM_TYPES = Object.keys(PlatformType) as PlatformType[]
 
 export enum IntegrationType {

--- a/services/libs/types/src/enums/platforms.ts
+++ b/services/libs/types/src/enums/platforms.ts
@@ -36,7 +36,7 @@ export type CodePlatform =
   | PlatformType.GITHUB_NANGO
   | PlatformType.GITLAB
   | PlatformType.GIT
-  | PlatformType.GERRIT;
+  | PlatformType.GERRIT
 
 export const ALL_PLATFORM_TYPES = Object.keys(PlatformType) as PlatformType[]
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
Whenever an integration is created, updated, or disconnected, we want to reflect those changes on the corresponding insightsProject, if one exists.

### How
1. A new function `findInsightsProjectsBySegmentId` has been added to retrieve the relevant `insightsProject` associated with a given segment ID.
2. A static method `isCodePlatform` has been introduced to determine whether a platform is a code platform.
3. The integration create/update callbacks now include logic to update the associated insightsProject.
4. On the destroyAll callback remove repositories and plugins from the insightsProject.

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
