### PR TITLE
fix: adjust popover width and max height for better display of emails and identities

### DIFF
--- a/frontend/src/modules/member/components/list/columns/member-list-emails.vue
+++ b/frontend/src/modules/member/components/list/columns/member-list-emails.vue
@@ -48,9 +48,8 @@
     <el-popover
       v-if="distinctEmails?.length > 3"
       placement="top"
-      :width="400"
       trigger="hover"
-      popper-class="support-popover"
+      popper-class="support-popover max-h-100 overflow-y-auto !w-auto"
     >
       <template #reference>
         <span

--- a/frontend/src/shared/modules/identities/components/identities-horizontal-list.vue
+++ b/frontend/src/shared/modules/identities/components/identities-horizontal-list.vue
@@ -38,7 +38,7 @@
       </slot>
     </template>
 
-    <div class="overflow-y-auto overflow-x-hidden max-h-72">
+    <div class="overflow-y-auto overflow-x-hidden max-h-100">
       <div class="text-xs text-gray-400 font-semibold mb-3 px-5">
         Identities
       </div>


### PR DESCRIPTION

# Changes proposed ✍️

### What
This pull request focuses on improving the styling and usability of components by adjusting CSS class properties for better layout and scrolling behavior.

### Styling and Usability Improvements:

* [`frontend/src/modules/member/components/list/columns/member-list-emails.vue`](diffhunk://#diff-46f73e0f9ad875648edbab6ab67d658cd4419f0781e50071831d75844b97ee7eL51-R52): Updated the `popper-class` property of the `el-popover` component to include `max-h-100`, `overflow-y-auto`, and `!w-auto` for improved scrolling and layout consistency. Removed the unused `width` property.

* [`frontend/src/shared/modules/identities/components/identities-horizontal-list.vue`](diffhunk://#diff-48e8ca27094c132b0c5ba57291867363a89af22c8be4de4b1e6775c77fba8092L41-R41): Changed the `max-h-72` class to `max-h-100` in a container to allow for a taller maximum height, enhancing the display of content within the scrollable area.

### Why


### How
copilot:walkthrough

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
