### PR TITLE
fix: affiliations conflict resolve when multiple dated and conflicting work experiences exist

### DIFF
--- a/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
@@ -106,8 +106,7 @@ export async function prepareMemberAffiliationsUpdate(qx: QueryExecutor, memberI
       const withDates = orgs.filter((row) => !!row.dateStart)
       if (withDates.length === 1) {
         return withDates[0]
-      }
-      else if (withDates.length > 1) {
+      } else if (withDates.length > 1) {
         // only consider work experiences with dates for the next steps, if there are more than one
         // and ignore ones without dates
         orgs = withDates

--- a/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
@@ -58,7 +58,7 @@ export async function prepareMemberAffiliationsUpdate(qx: QueryExecutor, memberI
   const nullableOrg = (orgId: string) => (orgId ? `cast('${orgId}' as uuid)` : 'NULL')
 
   const isDateInInterval = (date: Date, start: Date | null, end: Date | null) => {
-    return (!start || date >= start) && (!end || date < end)
+    return (!start || date >= start) && (!end || date <= end)
   }
 
   const findOrgsWithRolesInDate = (

--- a/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/profiles_worker/index.ts
@@ -58,7 +58,7 @@ export async function prepareMemberAffiliationsUpdate(qx: QueryExecutor, memberI
   const nullableOrg = (orgId: string) => (orgId ? `cast('${orgId}' as uuid)` : 'NULL')
 
   const isDateInInterval = (date: Date, start: Date | null, end: Date | null) => {
-    return (!start || date >= start) && (!end || date <= end)
+    return (!start || date >= start) && (!end || date < end)
   }
 
   const findOrgsWithRolesInDate = (
@@ -105,8 +105,12 @@ export async function prepareMemberAffiliationsUpdate(qx: QueryExecutor, memberI
       // 1. favor the one with dates if there's only one
       const withDates = orgs.filter((row) => !!row.dateStart)
       if (withDates.length === 1) {
-        // there can be one primary work exp with intersecting date ranges
         return withDates[0]
+      }
+      else if (withDates.length > 1) {
+        // only consider work experiences with dates for the next steps, if there are more than one
+        // and ignore ones without dates
+        orgs = withDates
       }
 
       // 2. get the two orgs with the most members, and return the one with the most members if there's no draw


### PR DESCRIPTION
When multiple dated work experiences exist, the affiliations algorithm previously continued processing using all work experiences — including those without dates — which caused undated entries to be treated with the same weight as dated ones in subsequent steps.

Now, in such cases, we proceed with the next steps using **only** work experiences that have dates.

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [x] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
