### PR TITLE
feat: improve github insights api [CM-2420]

### DIFF
--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -526,20 +526,21 @@ export class CollectionService extends LoggerBase {
             mainOrg.name,
             settings.orgs[0].repos[0].name,
           )
-        : await GithubIntegrationService.findOrgDetails(mainOrg.name)
+        : {
+            ...(await GithubIntegrationService.findOrgDetails(mainOrg.name)),
+            topics: mainOrg.topics,
+          }
 
       if (!details) {
         return null
       }
-
-      const topics = await GithubIntegrationService.findTopics(mainOrg.name, mainOrg.repos)
 
       return {
         description: mainOrg.description,
         github: details.github,
         logoUrl: details.logoUrl,
         name: segment.name,
-        topics,
+        topics: details.topics,
         twitter: details.twitter,
         website: details.website,
       }

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -111,13 +111,13 @@ export class CollectionService extends LoggerBase {
       })
       const projects = connections.length
         ? await queryInsightsProjects(qx, {
-          filter: {
-            id: {
-              in: connections.map((c) => c.insightsProjectId),
+            filter: {
+              id: {
+                in: connections.map((c) => c.insightsProjectId),
+              },
             },
-          },
-          fields: Object.values(InsightsProjectField),
-        })
+            fields: Object.values(InsightsProjectField),
+          })
         : []
 
       return {
@@ -176,11 +176,11 @@ export class CollectionService extends LoggerBase {
     const projects =
       connections.length > 0
         ? await queryInsightsProjects(qx, {
-          filter: {
-            id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
-          },
-          fields: Object.values(InsightsProjectField),
-        })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
+            },
+            fields: Object.values(InsightsProjectField),
+          })
         : []
 
     const total = await countCollections(qx, filter)
@@ -262,20 +262,20 @@ export class CollectionService extends LoggerBase {
       const segment = project.segmentId ? await findSegmentById(qx, project.segmentId) : null
       const organization = project.organizationId
         ? await findOrgById(qx, project.organizationId, [
-          OrganizationField.ID,
-          OrganizationField.DISPLAY_NAME,
-          OrganizationField.LOGO,
-        ])
+            OrganizationField.ID,
+            OrganizationField.DISPLAY_NAME,
+            OrganizationField.LOGO,
+          ])
         : null
 
       const collections =
         connections.length > 0
           ? await queryCollections(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.collectionId)) },
-            },
-            fields: Object.values(CollectionField),
-          })
+              filter: {
+                id: { in: uniq(connections.map((c) => c.collectionId)) },
+              },
+              fields: Object.values(CollectionField),
+            })
           : []
 
       return {
@@ -337,11 +337,11 @@ export class CollectionService extends LoggerBase {
     const collections =
       connections.length > 0
         ? await queryCollections(qx, {
-          filter: {
-            id: { in: uniq(connections.map((c) => c.collectionId)) },
-          },
-          fields: Object.values(CollectionField),
-        })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.collectionId)) },
+            },
+            fields: Object.values(CollectionField),
+          })
         : []
 
     const total = await countInsightsProjects(qx, filter)

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -111,13 +111,13 @@ export class CollectionService extends LoggerBase {
       })
       const projects = connections.length
         ? await queryInsightsProjects(qx, {
-            filter: {
-              id: {
-                in: connections.map((c) => c.insightsProjectId),
-              },
+          filter: {
+            id: {
+              in: connections.map((c) => c.insightsProjectId),
             },
-            fields: Object.values(InsightsProjectField),
-          })
+          },
+          fields: Object.values(InsightsProjectField),
+        })
         : []
 
       return {
@@ -176,11 +176,11 @@ export class CollectionService extends LoggerBase {
     const projects =
       connections.length > 0
         ? await queryInsightsProjects(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
-            },
-            fields: Object.values(InsightsProjectField),
-          })
+          filter: {
+            id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
+          },
+          fields: Object.values(InsightsProjectField),
+        })
         : []
 
     const total = await countCollections(qx, filter)
@@ -262,20 +262,20 @@ export class CollectionService extends LoggerBase {
       const segment = project.segmentId ? await findSegmentById(qx, project.segmentId) : null
       const organization = project.organizationId
         ? await findOrgById(qx, project.organizationId, [
-            OrganizationField.ID,
-            OrganizationField.DISPLAY_NAME,
-            OrganizationField.LOGO,
-          ])
+          OrganizationField.ID,
+          OrganizationField.DISPLAY_NAME,
+          OrganizationField.LOGO,
+        ])
         : null
 
       const collections =
         connections.length > 0
           ? await queryCollections(qx, {
-              filter: {
-                id: { in: uniq(connections.map((c) => c.collectionId)) },
-              },
-              fields: Object.values(CollectionField),
-            })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.collectionId)) },
+            },
+            fields: Object.values(CollectionField),
+          })
           : []
 
       return {
@@ -337,11 +337,11 @@ export class CollectionService extends LoggerBase {
     const collections =
       connections.length > 0
         ? await queryCollections(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.collectionId)) },
-            },
-            fields: Object.values(CollectionField),
-          })
+          filter: {
+            id: { in: uniq(connections.map((c) => c.collectionId)) },
+          },
+          fields: Object.values(CollectionField),
+        })
         : []
 
     const total = await countInsightsProjects(qx, filter)
@@ -501,7 +501,7 @@ export class CollectionService extends LoggerBase {
         return null
       }
 
-      const { description, name, repos } = mainOrg
+      const { description, name } = mainOrg
 
       const orgDetail = await GithubIntegrationService.findOrgDetail(name)
 
@@ -511,7 +511,7 @@ export class CollectionService extends LoggerBase {
 
       const { logoUrl, github, website, twitter } = orgDetail
 
-      const topics = await GithubIntegrationService.findOrgTopics(name, repos)
+      const topics = await GithubIntegrationService.findOrgTopics(name, [github])
 
       return {
         description,

--- a/backend/src/services/githubIntegrationService.ts
+++ b/backend/src/services/githubIntegrationService.ts
@@ -14,7 +14,7 @@ import { getGithubInstallationToken } from './helpers/githubToken'
 const githubMaxSearchResult = 1000
 
 export default class GithubIntegrationService {
-  constructor(private readonly options: IServiceOptions) { }
+  constructor(private readonly options: IServiceOptions) {}
 
   public async findGithubRepos(
     query: string,

--- a/backend/src/services/githubIntegrationService.ts
+++ b/backend/src/services/githubIntegrationService.ts
@@ -172,6 +172,7 @@ export default class GithubIntegrationService {
         github: data.html_url,
         logoUrl: data.owner.avatar_url,
         name: data.name,
+        topics: data.topics || null,
         twitter: null,
         website: data.homepage || null,
       }
@@ -213,20 +214,22 @@ export default class GithubIntegrationService {
   ): Promise<
     GithubIntegrationSettings['orgs'][number] & {
       description: string
+      topics: string[]
     }
   > {
     const prompt = `
-    Given the following array of organizations:
-      ${orgs.map((org) => `organization name: ${org.name} organization url: ${org.url}`).join('\n')}
+      Given the following array of organizations:
+        ${orgs.map((org) => `organization name: ${org.name} organization url: ${org.url}`).join('\n')}
 
-      project name: "${projectName}"
+        project name: "${projectName}"
 
-      Analyze the project’s content (e.g., README, code, metadata), along with the organization info (name and URL), to:
+        Analyze the project’s content (e.g., README, code, metadata), along with the organization info (name and URL), to:
 
-      1. Identify which organization from the array is the main one associated with the project. Return null if none is a clear match.
-      2. Generate a neutral, objective description of what the project does.
+        1. Identify which organization from the array is the main one associated with the project. Return null if none is a clear match.
+        2. Generate a neutral, objective description of what the project does.
+        3. List up to 5 relevant topics that characterize the matched organization’s domain, technology, or focus (based on repository metadata, documentation, and the organization's own site). If no relevant topics are found, return an empty array.
 
-      Use all available information to infer the description, with this priority:
+      Use all available information to infer the description and topics, with this priority:
 
       - First, use information from the organization URL, if available, as the most authoritative source — **unless the organization has exactly one repository**.
       - If an organization has exactly one repository, prioritize all available content from that repository (e.g., README, description, code, metadata) over the organization's URL or name.
@@ -238,13 +241,19 @@ export default class GithubIntegrationService {
         - Still generate the description as usual, but if the organization has only one repository, prioritize that repository’s content for the description.
       - If the array has more than one organization, and one of them has exactly one repository, treat that repository as the primary signal for association and description — but only if its content is relevant and non-generic.
 
+      IMPORTANT:
+      - Output MUST be a single valid JSON object or the literal value 'null'.
+      - DO NOT return any explanation, reasoning, markdown, formatting, headings, or text before or after the JSON.
+      - DO NOT say "Here is the result", "Answer:", "Based on analysis", or anything else — ONLY return raw JSON.
+
       Return:
       - If no match is found: null
-      - If a match is found: {description: string; index: number}
-
-      Output ONLY valid JSON.
-      Do NOT return any text, explanation, or formatting outside of the JSON.
-
+      - If a match is found:
+        {
+          "description": string,
+          "index": number,
+          "topics": string[]
+        }
     `
 
     const llmService = new LlmService(
@@ -259,17 +268,20 @@ export default class GithubIntegrationService {
     const { result } = await llmService.findMainGithubOrganization<{
       description: string
       index: number
+      topics: string[]
     }>(prompt)
 
     if (
       typeof result === 'object' &&
       result !== null &&
       typeof result.description === 'string' &&
-      typeof result.index === 'number'
+      typeof result.index === 'number' &&
+      typeof result.topics === 'object'
     ) {
       return {
         ...orgs[result.index],
         description: result.description,
+        topics: result.topics,
       }
     }
 

--- a/backend/src/services/githubIntegrationService.ts
+++ b/backend/src/services/githubIntegrationService.ts
@@ -121,7 +121,7 @@ export default class GithubIntegrationService {
     }))
   }
 
-  public static async findOrgDetail(org: string) {
+  public static async findOrgDetails(org: string) {
     const auth = await getGithubInstallationToken()
     const logger = getServiceLogger()
 
@@ -151,7 +151,7 @@ export default class GithubIntegrationService {
     }
   }
 
-  public static async findRepoDetail(org: string, repo: string) {
+  public static async findRepoDetails(org: string, repo: string) {
     const auth = await getGithubInstallationToken()
     const logger = getServiceLogger()
 
@@ -181,7 +181,7 @@ export default class GithubIntegrationService {
     }
   }
 
-  public static async findOrgTopics(org: string, repos: { name: string }[]) {
+  public static async findTopics(org: string, repos: { name: string }[]) {
     const auth = await getGithubInstallationToken()
     const logger = getServiceLogger()
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -212,11 +212,11 @@ export default class IntegrationService {
       if (githubInsights) {
         data.description = githubInsights.description
         data.github = githubInsights.github
+        data.keywords = githubInsights.topics
         data.logoUrl = githubInsights.logoUrl
         data.name = githubInsights.name
         data.twitter = githubInsights.twitter
         data.website = githubInsights.website
-        data.keywords = githubInsights.topics
       }
     }
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -216,6 +216,7 @@ export default class IntegrationService {
         data.name = githubInsights.name
         data.twitter = githubInsights.twitter
         data.website = githubInsights.website
+        data.keywords = githubInsights.topics
       }
     }
 


### PR DESCRIPTION
# Changes proposed ✍️

### What
we want to improve the accuracy of the github static insights api.

### How
1. Improve the prompt for getting the info, if the organization has just one repo gets all the data from there.
2. Improve the topics, we a re not getting the data from all the organization but just from the `insightsProjects.github` url

Closes [CM-2420](https://linear.app/lfx/issue/CM-2420/improvements-on-projects-automatic-creation)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [x] add ref to linear task