### PR TITLE
fix: missed one spot when renaming the slug column

### DIFF
--- a/services/libs/tinybird/datasources/searchVolume.datasource
+++ b/services/libs/tinybird/datasources/searchVolume.datasource
@@ -8,5 +8,5 @@ SCHEMA >
 
 ENGINE ReplacingMergeTree
 ENGINE_PARTITION_KEY toYear(dataTimestamp)
-ENGINE_SORTING_KEY slug, dataTimestamp
+ENGINE_SORTING_KEY project, dataTimestamp
 ENGINE_VER updatedAt


### PR DESCRIPTION
I missed one spot in the Tinybird pipe when renaming the slug column to project.