### PR TITLE
fix: fix a date type mismatch in the search volume pipe and data source

### DIFF
--- a/services/libs/tinybird/datasources/searchVolume.datasource
+++ b/services/libs/tinybird/datasources/searchVolume.datasource
@@ -2,9 +2,9 @@ SCHEMA >
     `id` UInt64 `json:$.record.id`,
     `insightsProjectId` UUID `json:$.record.insights_project_id`,
     `project` String `json:$.record.project`,
-    `dataTimestamp` DateTime64(3) `json:$.record.data_timestamp`,
+    `dataTimestamp` Date `json:$.record.data_timestamp`,
     `volume` UInt64 `json:$.record.volume`,
-    `updatedAt` DateTime64(3) `json:$.record.updated_at`
+    `updatedAt` DateTime64(1) `json:$.record.updated_at`
 
 ENGINE ReplacingMergeTree
 ENGINE_PARTITION_KEY toYear(dataTimestamp)

--- a/services/libs/tinybird/pipes/search_volume.pipe
+++ b/services/libs/tinybird/pipes/search_volume.pipe
@@ -14,7 +14,7 @@ SQL >
     WHERE
         insightsProjectId = toUUID((select insightsProjectId from segments_filtered))
         {% if defined(startDate) %}
-            AND searchVolume.dataTimestamp
+            AND toDateTime(searchVolume.dataTimestamp)
             >= {{
                 DateTime(
                     startDate,
@@ -24,7 +24,7 @@ SQL >
             }}
         {% end %}
         {% if defined(endDate) %}
-            AND searchVolume.dataTimestamp
+            AND toDateTime(searchVolume.dataTimestamp)
             <= {{
                 DateTime(
                     endDate,


### PR DESCRIPTION
The pipe was not returning any data due to a type mismatch in one of the date fields.