### PR TITLE
fix: add transaction for the github nango connect

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -746,19 +746,21 @@ export default class IntegrationService {
         // create github mapping - this also creates git integration
         await txService.mapGithubRepos(integrationId, mapping, false)
 
-        integration = await txService.createOrUpdate({
-          id: integrationId,
-          platform: PlatformType.GITHUB_NANGO,
-          settings: {
-            ...settings,
-            ...(integration.settings.nangoMapping
-              ? {
-                  nangoMapping: integration.settings.nangoMapping,
-                }
-              : {}),
+        integration = await txService.createOrUpdate(
+          {
+            id: integrationId,
+            platform: PlatformType.GITHUB_NANGO,
+            settings: {
+              ...settings,
+              ...(integration.settings.nangoMapping
+                ? {
+                    nangoMapping: integration.settings.nangoMapping,
+                  }
+                : {}),
+            },
           },
           transaction,
-        })
+        )
       }
 
       await SequelizeRepository.commitTransaction(transaction)


### PR DESCRIPTION
# Changes proposed ✍️

### What:
In some cases we were getting `undefined` as transaction in the `createOrUpdate` function.
For this reason we were getting error for finalizing the transactions

### Why:
We were not passing the `transaction` param in the `githubNangoConnect`



