### PR TITLE
fix: do nothing an conflict when assigning automatic categorization

### DIFF
--- a/services/apps/categorization_worker/src/activities/activities.ts
+++ b/services/apps/categorization_worker/src/activities/activities.ts
@@ -283,21 +283,14 @@ export async function connectProjectAndCollection(
   collectionIds: string[],
   insightsProjectId: string,
 ) {
-  try {
-    svc.log.info(
-      `updating the collections: ${collectionIds} with the project: ${insightsProjectId}`,
-    )
-    await connectProjectsAndCollections(
-      dbStoreQx(svc.postgres.writer),
-      collectionIds.map((collectionId) => ({
-        insightsProjectId,
-        collectionId,
-        starred: false,
-      })),
-    )
-  } catch (error) {
-    svc.log.warn(
-      `There was an errore updating the project: ${insightsProjectId} with one of the collections: ${JSON.stringify(collectionIds)}`,
-    )
-  }
+  svc.log.info(`updating the collections: ${collectionIds} with the project: ${insightsProjectId}`)
+  await connectProjectsAndCollections(
+    dbStoreQx(svc.postgres.writer),
+    collectionIds.map((collectionId) => ({
+      insightsProjectId,
+      collectionId,
+      starred: false,
+    })),
+    'DO NOTHING',
+  )
 }

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -201,6 +201,7 @@ export async function connectProjectsAndCollections(
     collectionId: string
     starred: boolean
   }[],
+  onConflict?: string,
 ) {
   if (connections.length === 0) {
     return
@@ -211,6 +212,7 @@ export async function connectProjectsAndCollections(
       'collectionsInsightsProjects',
       ['collectionId', 'insightsProjectId', 'starred'],
       connections,
+      onConflict ?? null,
     ),
   )
 }


### PR DESCRIPTION
# Changes Proposed ✍️

### What
Added the `DO NOTHING` clause to the `onConflict` handler when automatically assigning a collection to a project.

### Why
In production, we observed frequent errors like the following:

```
level":"ERROR","err":{"message":"duplicate key value violates unique constraint \"collectionsInsightsProjects_collectionId_insightsProjectId_key
```

These errors indicate that some collections are already assigned to the target project, causing the operation to fail due to a uniqueness violation.

### How
The `onConflict` option is now used to avoid throwing an error when the collection is already assigned — we simply do nothing in that case.


## Checklist ✅
- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.