### PR TITLE
fix: use insights project id as primary key for the repositories

### DIFF
--- a/backend/src/database/migrations/V1753798343__revert_primary_key_segment_repositories.sql
+++ b/backend/src/database/migrations/V1753798343__revert_primary_key_segment_repositories.sql
@@ -1,0 +1,11 @@
+-- 1. Drop the current primary key
+ALTER TABLE "segmentRepositories"
+DROP CONSTRAINT "segmentRepositories_pkey";
+
+-- 2. Add the new primary key
+ALTER TABLE "segmentRepositories"
+ADD CONSTRAINT "segmentRepositories_pkey" PRIMARY KEY ("repository", "insightsProjectId");
+
+-- 3. Drop the NOT NULL constraint on segmentId
+ALTER TABLE "segmentRepositories"
+ALTER COLUMN "segmentId" DROP NOT NULL;

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -389,11 +389,15 @@ export class CollectionService extends LoggerBase {
 
       const repositories = CollectionService.normalizeRepositories(project.repositories)
 
-      await upsertSegmentRepositories(qx, { insightsProjectId, repositories, segmentId })
+      await upsertSegmentRepositories(qx, {
+        insightsProjectId,
+        repositories,
+        segmentId,
+      })
 
       await deleteMissingSegmentRepositories(qx, {
         repositories,
-        segmentId,
+        insightsProjectId,
       })
 
       if (project.collections) {

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -312,9 +312,9 @@ export async function upsertSegmentRepositories(
     repositories,
     segmentId,
   }: {
-    insightsProjectId?: string
+    insightsProjectId: string
     repositories: string[]
-    segmentId: string
+    segmentId?: string
   },
 ) {
   if (repositories.length === 0) {
@@ -332,7 +332,7 @@ export async function upsertSegmentRepositories(
       'segmentRepositories',
       ['insightsProjectId', 'repository', 'segmentId'],
       data,
-      '("repository", "segmentId") DO NOTHING',
+      '("repository", "insightsProjectId") DO NOTHING',
     ),
   )
 }
@@ -340,19 +340,19 @@ export async function upsertSegmentRepositories(
 export async function deleteMissingSegmentRepositories(
   qx: QueryExecutor,
   {
+    insightsProjectId,
     repositories,
-    segmentId,
   }: {
+    insightsProjectId: string
     repositories: string[]
-    segmentId: string
   },
 ) {
   return qx.result(
     `
     DELETE FROM "segmentRepositories"
-    WHERE "segmentId" = '${segmentId}'
+    WHERE "insightsProjectId" = '${insightsProjectId}'
       AND ${repositories.length > 0 ? `"repository" != ALL(ARRAY[${repositories.map((repo) => `'${repo}'`).join(', ')}])` : 'TRUE'};
     `,
-    { segmentId, repositories },
+    { insightsProjectId, repositories },
   )
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What:
we want to use the `insisghtProject.id` as primary key on the `segmentRepositories` table.

### Why:
at the moment we have lots of insightsProjects whiche do not have the `segmentId` valorized, this could lead to unconsistent data

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
