### PR TITLE
fix: stuck integration runs preventing new ones [CM-2460]

### DIFF
--- a/backend/src/database/repositories/integrationRunRepository.ts
+++ b/backend/src/database/repositories/integrationRunRepository.ts
@@ -10,10 +10,6 @@ import { IntegrationStreamState } from '../../types/integrationStreamTypes'
 import { IRepositoryOptions } from './IRepositoryOptions'
 import { RepositoryBase } from './repositoryBase'
 
-export interface IStreamService {
-  continueProcessingRunStreams(runId: string): Promise<void>
-}
-
 export default class IntegrationRunRepository extends RepositoryBase<
   IntegrationRun,
   string,

--- a/backend/src/database/repositories/integrationRunRepository.ts
+++ b/backend/src/database/repositories/integrationRunRepository.ts
@@ -160,6 +160,7 @@ export default class IntegrationRunRepository extends RepositoryBase<
     select id
     from integration.runs
     where state in (:delayedState, :processingState, :pendingState) and ${condition}
+    and "createdAt" > NOW() - INTERVAL '24 hours'
     order by "createdAt" desc
     limit 1
     `


### PR DESCRIPTION
This pull request includes a single change to the `IntegrationRunRepository` class, adding a condition to filter integration runs created within the last 24 hours.

* [`backend/src/database/repositories/integrationRunRepository.ts`](diffhunk://#diff-e85e54a5f618a5ad94f26e63df6459198d0d61bdbc36613e1057045bd69704d4R163): Updated the SQL query to include a condition that ensures only integration runs with a `createdAt` timestamp within the last 24 hours are selected.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
