### PR TITLE
chore: disable SERP and CrustData member enrichment sources

### DIFF
--- a/services/apps/members_enrichment_worker/src/sources/progai-linkedin-scraper/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/progai-linkedin-scraper/service.ts
@@ -105,7 +105,10 @@ export default class EnrichmentServiceProgAILinkedinScraper
   private async getDataUsingLinkedinHandle(
     handle: string,
   ): Promise<IMemberEnrichmentDataProgAI | null> {
-    const url = `${process.env['CROWD_ENRICHMENT_PROGAI_URL']}/get_profile`
+    let response: IMemberEnrichmentDataProgAIResponse
+
+    try {
+      const url = `${process.env['CROWD_ENRICHMENT_PROGAI_URL']}/get_profile`
     const config = {
       method: 'get',
       url,
@@ -115,9 +118,19 @@ export default class EnrichmentServiceProgAILinkedinScraper
         api_key: process.env['CROWD_ENRICHMENT_PROGAI_API_KEY'],
       },
       headers: {},
+      validateStatus: function (status) {
+        return (status >= 200 && status < 300) || status === 404 || status === 422
+      },
     }
 
-    const response: IMemberEnrichmentDataProgAIResponse = (await axios(config)).data
+      response = (await axios(config)).data
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        this.log.warn(
+          `Axios error occurred while getting ProgAI data: ${err.response?.status} - ${err.response?.statusText}`,
+        )
+      }
+    }
 
     return response?.profile || null
   }

--- a/services/apps/members_enrichment_worker/src/sources/progai-linkedin-scraper/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/progai-linkedin-scraper/service.ts
@@ -109,19 +109,19 @@ export default class EnrichmentServiceProgAILinkedinScraper
 
     try {
       const url = `${process.env['CROWD_ENRICHMENT_PROGAI_URL']}/get_profile`
-    const config = {
-      method: 'get',
-      url,
-      params: {
-        linkedin_url: `https://linkedin.com/in/${handle}`,
-        with_emails: true,
-        api_key: process.env['CROWD_ENRICHMENT_PROGAI_API_KEY'],
-      },
-      headers: {},
-      validateStatus: function (status) {
-        return (status >= 200 && status < 300) || status === 404 || status === 422
-      },
-    }
+      const config = {
+        method: 'get',
+        url,
+        params: {
+          linkedin_url: `https://linkedin.com/in/${handle}`,
+          with_emails: true,
+          api_key: process.env['CROWD_ENRICHMENT_PROGAI_API_KEY'],
+        },
+        headers: {},
+        validateStatus: function (status) {
+          return (status >= 200 && status < 300) || status === 404 || status === 422
+        },
+      }
 
       response = (await axios(config)).data
     } catch (err) {

--- a/services/apps/members_enrichment_worker/src/workflows/enrichMember.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/enrichMember.ts
@@ -24,11 +24,11 @@ const {
   hasRemainingCredits,
   getMemberById,
 } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '1 minute',
+  startToCloseTimeout: '5 minutes',
   retry: {
-    initialInterval: '5s',
+    initialInterval: '60s',
     backoffCoefficient: 2.0,
-    maximumInterval: '30s',
+    maximumInterval: '5 minutes',
     maximumAttempts: 4,
   },
 })

--- a/services/apps/members_enrichment_worker/src/workflows/getMembersToEnrich.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/getMembersToEnrich.ts
@@ -22,9 +22,7 @@ export async function getMembersToEnrich(): Promise<void> {
   const sources = [
     MemberEnrichmentSource.PROGAI,
     MemberEnrichmentSource.CLEARBIT,
-    MemberEnrichmentSource.SERP,
     MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER,
-    MemberEnrichmentSource.CRUSTDATA,
   ]
 
   const members = await getEnrichableMembers(QUERY_FOR_ENRICHABLE_MEMBERS_PER_RUN, sources)
@@ -52,8 +50,8 @@ export async function getMembersToEnrich(): Promise<void> {
           retry: {
             backoffCoefficient: 2,
             maximumAttempts: 10,
-            initialInterval: 2 * 1000,
-            maximumInterval: 30 * 1000,
+            initialInterval: '60s',
+            maximumInterval: '5 minutes',
           },
           args: [member, sources],
         })


### PR DESCRIPTION
# Changes proposed ✍️

- Update Temporal retry config to handle rate limiting (1min --> 5min intervals)
- Remove SERP and CrustData from enrichment sources list
- Add error handling for ProgAI LinkedIn scraper
- Keep existing cache processing logic intact
