### PR TITLE
fix: update conflict handling in `createOrUpdateRelations` to use dedup constraint

### DIFF
--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -1222,7 +1222,7 @@ export async function createOrUpdateRelations(
             "updatedAt")
     VALUES ${valueList.join(',')}
 
-    ON CONFLICT ("activityId") 
+    ON CONFLICT ON CONSTRAINT "ix_unique_activity_relations_dedup_key"
     DO UPDATE 
     SET 
         "updatedAt" = EXCLUDED."updatedAt",
@@ -1243,7 +1243,6 @@ export async function createOrUpdateRelations(
         "score" = EXCLUDED."score",
         "isContribution" = EXCLUDED."isContribution",
         "pullRequestReviewState" = EXCLUDED."pullRequestReviewState";
-
     `,
     params,
   )


### PR DESCRIPTION
# Changes proposed ✍️

Change conflict target to the 6-key dedup constraint to convert conflicts into updates and eliminate the 23505 flood