### PR TITLE
fix: update segment repositories table

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -921,7 +921,7 @@ class SegmentRepository extends RepositoryBase<
     return result[0].segment_name as string
   }
 
-  async getMappedRepos(segmentId: string) {
+  async getGithubMappedRepos(segmentId: string) {
     const transaction = SequelizeRepository.getTransaction(this.options)
     const tenantId = this.options.currentTenant.id
 
@@ -931,6 +931,34 @@ class SegmentRepository extends RepositoryBase<
          r.url as url
        from
         "githubRepos" r
+       where r."segmentId" = :segmentId
+       and r."tenantId" = :tenantId
+       and r."deletedAt" is null
+       order by r.url
+      `,
+      {
+        replacements: {
+          segmentId,
+          tenantId,
+        },
+        type: QueryTypes.SELECT,
+        transaction,
+      },
+    )
+
+    return result
+  }
+
+  async getGitlabMappedRepos(segmentId: string) {
+    const transaction = SequelizeRepository.getTransaction(this.options)
+    const tenantId = this.options.currentTenant.id
+
+    const result = await this.options.database.sequelize.query(
+      `
+      select
+         r.url as url
+       from
+        "gitlabRepos" r
        where r."segmentId" = :segmentId
        and r."tenantId" = :tenantId
        and r."deletedAt" is null

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -23,7 +23,7 @@ import {
   queryInsightsProjects,
   updateCollection,
   updateInsightsProject,
-  upsertSegmentRepositories,
+  insertSegmentRepositories,
 } from '@crowd/data-access-layer/src/collections'
 import { fetchIntegrationsForSegment } from '@crowd/data-access-layer/src/integrations'
 import { OrganizationField, findOrgById, queryOrgs } from '@crowd/data-access-layer/src/orgs'
@@ -113,13 +113,13 @@ export class CollectionService extends LoggerBase {
       })
       const projects = connections.length
         ? await queryInsightsProjects(qx, {
-            filter: {
-              id: {
-                in: connections.map((c) => c.insightsProjectId),
-              },
+          filter: {
+            id: {
+              in: connections.map((c) => c.insightsProjectId),
             },
-            fields: Object.values(InsightsProjectField),
-          })
+          },
+          fields: Object.values(InsightsProjectField),
+        })
         : []
 
       return {
@@ -178,11 +178,11 @@ export class CollectionService extends LoggerBase {
     const projects =
       connections.length > 0
         ? await queryInsightsProjects(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
-            },
-            fields: Object.values(InsightsProjectField),
-          })
+          filter: {
+            id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
+          },
+          fields: Object.values(InsightsProjectField),
+        })
         : []
 
     const total = await countCollections(qx, filter)
@@ -264,20 +264,20 @@ export class CollectionService extends LoggerBase {
       const segment = project.segmentId ? await findSegmentById(qx, project.segmentId) : null
       const organization = project.organizationId
         ? await findOrgById(qx, project.organizationId, [
-            OrganizationField.ID,
-            OrganizationField.DISPLAY_NAME,
-            OrganizationField.LOGO,
-          ])
+          OrganizationField.ID,
+          OrganizationField.DISPLAY_NAME,
+          OrganizationField.LOGO,
+        ])
         : null
 
       const collections =
         connections.length > 0
           ? await queryCollections(qx, {
-              filter: {
-                id: { in: uniq(connections.map((c) => c.collectionId)) },
-              },
-              fields: Object.values(CollectionField),
-            })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.collectionId)) },
+            },
+            fields: Object.values(CollectionField),
+          })
           : []
 
       return {
@@ -339,11 +339,11 @@ export class CollectionService extends LoggerBase {
     const collections =
       connections.length > 0
         ? await queryCollections(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.collectionId)) },
-            },
-            fields: Object.values(CollectionField),
-          })
+          filter: {
+            id: { in: uniq(connections.map((c) => c.collectionId)) },
+          },
+          fields: Object.values(CollectionField),
+        })
         : []
 
     const total = await countInsightsProjects(qx, filter)
@@ -389,11 +389,11 @@ export class CollectionService extends LoggerBase {
 
       const repositories = CollectionService.normalizeRepositories(project.repositories)
 
-      await upsertSegmentRepositories(qx, {
-        insightsProjectId,
-        repositories,
-        segmentId,
-      })
+      // await insertSegmentRepositories(qx, {
+      //   insightsProjectId,
+      //   repositories,
+      //   segmentId,
+      // })
 
       await deleteMissingSegmentRepositories(qx, {
         repositories,
@@ -548,13 +548,13 @@ export class CollectionService extends LoggerBase {
 
       const details = CollectionService.isSingleRepoOrg(settings.orgs)
         ? await GithubIntegrationService.findRepoDetails(
-            mainOrg.name,
-            settings.orgs[0].repos[0].name,
-          )
+          mainOrg.name,
+          settings.orgs[0].repos[0].name,
+        )
         : {
-            ...(await GithubIntegrationService.findOrgDetails(mainOrg.name)),
-            topics: mainOrg.topics,
-          }
+          ...(await GithubIntegrationService.findOrgDetails(mainOrg.name)),
+          topics: mainOrg.topics,
+        }
 
       if (!details) {
         return null

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -427,15 +427,20 @@ export class CollectionService extends LoggerBase {
 
       // Add mapped repositories to GitHub platform
       const segmentRepository = new SegmentRepository(this.options)
-      const mappedRepos = await segmentRepository.getMappedRepos(segmentId)
+      const githubMappedRepos = await segmentRepository.getGithubMappedRepos(segmentId)
+      const gitlabMappedRepos = await segmentRepository.getGitlabMappedRepos(segmentId)
 
-      for (const repo of mappedRepos) {
+      for (const repo of [...githubMappedRepos, ...gitlabMappedRepos]) {
         const url = repo.url
         try {
           const parsedUrl = new URL(url)
           if (parsedUrl.hostname === 'github.com') {
             const label = parsedUrl.pathname.slice(1) // removes leading '/'
             addToResult(PlatformType.GITHUB, url, label)
+          }
+          if (parsedUrl.hostname === 'gitlab.com') {
+            const label = parsedUrl.pathname.slice(1) // removes leading '/'
+            addToResult(PlatformType.GITLAB, url, label)
           }
         } catch (err) {
           // Do nothing

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -395,10 +395,10 @@ export class CollectionService extends LoggerBase {
       //   segmentId,
       // })
 
-      await deleteMissingSegmentRepositories(qx, {
-        repositories,
-        insightsProjectId,
-      })
+      // await deleteMissingSegmentRepositories(qx, {
+      //   repositories,
+      //   insightsProjectId,
+      // })
 
       if (project.collections) {
         await disconnectProjectsAndCollections(qx, { insightsProjectId })

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -14,7 +14,6 @@ import {
   createInsightsProject,
   deleteCollection,
   deleteInsightsProject,
-  deleteMissingSegmentRepositories,
   disconnectProjectsAndCollections,
   findCollectionProjectConnections,
   queryCollectionById,
@@ -23,7 +22,6 @@ import {
   queryInsightsProjects,
   updateCollection,
   updateInsightsProject,
-  insertSegmentRepositories,
 } from '@crowd/data-access-layer/src/collections'
 import { fetchIntegrationsForSegment } from '@crowd/data-access-layer/src/integrations'
 import { OrganizationField, findOrgById, queryOrgs } from '@crowd/data-access-layer/src/orgs'
@@ -113,13 +111,13 @@ export class CollectionService extends LoggerBase {
       })
       const projects = connections.length
         ? await queryInsightsProjects(qx, {
-          filter: {
-            id: {
-              in: connections.map((c) => c.insightsProjectId),
+            filter: {
+              id: {
+                in: connections.map((c) => c.insightsProjectId),
+              },
             },
-          },
-          fields: Object.values(InsightsProjectField),
-        })
+            fields: Object.values(InsightsProjectField),
+          })
         : []
 
       return {
@@ -178,11 +176,11 @@ export class CollectionService extends LoggerBase {
     const projects =
       connections.length > 0
         ? await queryInsightsProjects(qx, {
-          filter: {
-            id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
-          },
-          fields: Object.values(InsightsProjectField),
-        })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.insightsProjectId)) },
+            },
+            fields: Object.values(InsightsProjectField),
+          })
         : []
 
     const total = await countCollections(qx, filter)
@@ -264,20 +262,20 @@ export class CollectionService extends LoggerBase {
       const segment = project.segmentId ? await findSegmentById(qx, project.segmentId) : null
       const organization = project.organizationId
         ? await findOrgById(qx, project.organizationId, [
-          OrganizationField.ID,
-          OrganizationField.DISPLAY_NAME,
-          OrganizationField.LOGO,
-        ])
+            OrganizationField.ID,
+            OrganizationField.DISPLAY_NAME,
+            OrganizationField.LOGO,
+          ])
         : null
 
       const collections =
         connections.length > 0
           ? await queryCollections(qx, {
-            filter: {
-              id: { in: uniq(connections.map((c) => c.collectionId)) },
-            },
-            fields: Object.values(CollectionField),
-          })
+              filter: {
+                id: { in: uniq(connections.map((c) => c.collectionId)) },
+              },
+              fields: Object.values(CollectionField),
+            })
           : []
 
       return {
@@ -339,11 +337,11 @@ export class CollectionService extends LoggerBase {
     const collections =
       connections.length > 0
         ? await queryCollections(qx, {
-          filter: {
-            id: { in: uniq(connections.map((c) => c.collectionId)) },
-          },
-          fields: Object.values(CollectionField),
-        })
+            filter: {
+              id: { in: uniq(connections.map((c) => c.collectionId)) },
+            },
+            fields: Object.values(CollectionField),
+          })
         : []
 
     const total = await countInsightsProjects(qx, filter)
@@ -548,13 +546,13 @@ export class CollectionService extends LoggerBase {
 
       const details = CollectionService.isSingleRepoOrg(settings.orgs)
         ? await GithubIntegrationService.findRepoDetails(
-          mainOrg.name,
-          settings.orgs[0].repos[0].name,
-        )
+            mainOrg.name,
+            settings.orgs[0].repos[0].name,
+          )
         : {
-          ...(await GithubIntegrationService.findOrgDetails(mainOrg.name)),
-          topics: mainOrg.topics,
-        }
+            ...(await GithubIntegrationService.findOrgDetails(mainOrg.name)),
+            topics: mainOrg.topics,
+          }
 
       if (!details) {
         return null

--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -383,20 +383,7 @@ export class CollectionService extends LoggerBase {
         project.isLF = segment?.isLF ?? false
       }
 
-      const { segmentId } = await updateInsightsProject(qx, insightsProjectId, project)
-
-      const repositories = CollectionService.normalizeRepositories(project.repositories)
-
-      // await insertSegmentRepositories(qx, {
-      //   insightsProjectId,
-      //   repositories,
-      //   segmentId,
-      // })
-
-      // await deleteMissingSegmentRepositories(qx, {
-      //   repositories,
-      //   insightsProjectId,
-      // })
+      await updateInsightsProject(qx, insightsProjectId, project)
 
       if (project.collections) {
         await disconnectProjectsAndCollections(qx, { insightsProjectId })

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -165,6 +165,11 @@ export default class IntegrationService {
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
       )
+
+      if (!insightsProject) {
+        return record
+      }
+
       const qx = SequelizeRepository.getQueryExecutor({
         ...(options || this.options),
         transaction,
@@ -177,24 +182,22 @@ export default class IntegrationService {
             ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
           ]),
         ]
-      }
 
-      if (insightsProject) {
         // TODO: remove the insightsProjectId check when this is not mandatory anymore
         await insertSegmentRepositories(qx, {
           insightsProjectId: insightsProject.id,
           repositories: CollectionService.normalizeRepositories(data.repositories),
           segmentId: record.segmentId,
         })
-
-        await this.updateInsightsProject({
-          insightsProjectId: insightsProject.id,
-          isFirstUpdate: true,
-          platform: data.platform,
-          segmentId: record.segmentId,
-          transaction,
-        })
       }
+
+      await this.updateInsightsProject({
+        insightsProjectId: insightsProject.id,
+        isFirstUpdate: true,
+        platform: data.platform,
+        segmentId: record.segmentId,
+        transaction,
+      })
 
       return record
     } catch (error) {

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -160,26 +160,25 @@ export default class IntegrationService {
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
       )
-      // const qx = SequelizeRepository.getQueryExecutor({
-      //   ...this.options,
-      //   transaction,
-      // })
+      const qx = SequelizeRepository.getQueryExecutor({
+        ...this.options,
+        transaction,
+      })
 
 
-      // if (IntegrationService.isCodePlatform(data.platform)) {
-      //   const repositories = await collectionService.findRepositoriesForSegment(record.segmentId)
-      //   data.repositories = [
-      //     ...new Set([
-      //       ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
-      //     ]),
-      //   ]
+      if (IntegrationService.isCodePlatform(data.platform)) {
+        const repositories = await collectionService.findRepositoriesForSegment(record.segmentId)
+        data.repositories = [
+          ...new Set([
+            ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
+          ]),
+        ]
 
-      //   await insertSegmentRepositories(qx, {
-      //     insightsProjectId: insightsProject.id,
-      //     repositories: CollectionService.normalizeRepositories(data.repositories),
-      //     segmentId: record.segmentId,
-      //   })
-      // }
+        await insertSegmentRepositories(qx, {
+          repositories: CollectionService.normalizeRepositories(data.repositories),
+          segmentId: record.segmentId,
+        })
+      }
 
       // await deleteMissingSegmentRepositories(qx, {
       //   repositories,
@@ -846,10 +845,8 @@ export default class IntegrationService {
     try {
       await GithubReposRepository.updateMapping(integrationId, mapping, txOptions)
 
-
       for (const [url, segmentId] of Object.entries(mapping)) {
-        console.log('updateSegmentRepositories', segmentId, url)
-        // await updateSegmentRepositories(qx, { segmentId: segmentId as string, repository: url as string })
+        await updateSegmentRepositories(qx, { segmentId: segmentId as string, repository: url as string })
       }
 
       // add the repos to the git integration

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -160,13 +160,13 @@ export default class IntegrationService {
         transaction,
       })
 
-      const collectionService = new CollectionService({ ...this.options, transaction })
+      const collectionService = new CollectionService({ ...(options || this.options), transaction })
 
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
       )
       const qx = SequelizeRepository.getQueryExecutor({
-        ...this.options,
+        ...(options || this.options),
         transaction,
       })
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -7,7 +7,7 @@ import moment from 'moment'
 import { Transaction } from 'sequelize'
 
 import { EDITION, Error400, Error404, Error542 } from '@crowd/common'
-import { ICreateInsightsProject } from '@crowd/data-access-layer/src/collections'
+import { deleteMissingSegmentRepositories, ICreateInsightsProject, insertSegmentRepositories, updateSegmentRepositories } from '@crowd/data-access-layer/src/collections'
 import {
   NangoIntegration,
   connectNangoIntegration,
@@ -160,6 +160,31 @@ export default class IntegrationService {
       const [insightsProject] = await collectionService.findInsightsProjectsBySegmentId(
         record.segmentId,
       )
+      // const qx = SequelizeRepository.getQueryExecutor({
+      //   ...this.options,
+      //   transaction,
+      // })
+
+
+      // if (IntegrationService.isCodePlatform(data.platform)) {
+      //   const repositories = await collectionService.findRepositoriesForSegment(record.segmentId)
+      //   data.repositories = [
+      //     ...new Set([
+      //       ...Object.values(repositories).flatMap((entries) => entries.map((e) => e.url)),
+      //     ]),
+      //   ]
+
+      //   await insertSegmentRepositories(qx, {
+      //     insightsProjectId: insightsProject.id,
+      //     repositories: CollectionService.normalizeRepositories(data.repositories),
+      //     segmentId: record.segmentId,
+      //   })
+      // }
+
+      // await deleteMissingSegmentRepositories(qx, {
+      //   repositories,
+      //   insightsProjectId: insightsProject.id,
+      // })
 
       if (insightsProject) {
         await this.updateInsightsProject({
@@ -306,7 +331,7 @@ export default class IntegrationService {
             let shouldUpdateGit: boolean
             const mapping =
               integration.platform === PlatformType.GITHUB ||
-              integration.platform === PlatformType.GITHUB_NANGO
+                integration.platform === PlatformType.GITHUB_NANGO
                 ? await this.getGithubRepos(id)
                 : await this.getGitlabRepos(id)
 
@@ -778,8 +803,8 @@ export default class IntegrationService {
               ...settings,
               ...(integration.settings.nangoMapping
                 ? {
-                    nangoMapping: integration.settings.nangoMapping,
-                  }
+                  nangoMapping: integration.settings.nangoMapping,
+                }
                 : {}),
             },
           },
@@ -810,13 +835,22 @@ export default class IntegrationService {
   async mapGithubRepos(integrationId, mapping, fireOnboarding = true) {
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
+    console.log('mapGithubRepos', integrationId, mapping, fireOnboarding)
+
     const txOptions = {
       ...this.options,
       transaction,
     }
+    const qx = SequelizeRepository.getQueryExecutor(txOptions)
 
     try {
       await GithubReposRepository.updateMapping(integrationId, mapping, txOptions)
+
+
+      for (const [url, segmentId] of Object.entries(mapping)) {
+        console.log('updateSegmentRepositories', segmentId, url)
+        // await updateSegmentRepositories(qx, { segmentId: segmentId as string, repository: url as string })
+      }
 
       // add the repos to the git integration
       const repos: Record<string, string[]> = Object.entries(mapping).reduce(
@@ -2199,14 +2233,20 @@ export default class IntegrationService {
     settings.userProjects = [...userProjects]
 
     const transaction = await SequelizeRepository.createTransaction(this.options)
-
     const txOptions = {
       ...this.options,
       transaction,
     }
+    const qx = SequelizeRepository.getQueryExecutor(txOptions)
+
 
     try {
       await GitlabReposRepository.updateMapping(integrationId, mapping, txOptions)
+
+
+      for (const [segmentId, urls] of Object.entries(mapping)) {
+        await updateSegmentRepositories(qx, { segmentId, repository: urls })
+      }
 
       // add the repos to the git integration
       if (EDITION === Edition.LFX) {

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -846,7 +846,6 @@ export default class IntegrationService {
       ...this.options,
       transaction,
     }
-    const qx = SequelizeRepository.getQueryExecutor(txOptions)
 
     try {
       await GithubReposRepository.updateMapping(integrationId, mapping, txOptions)
@@ -863,6 +862,7 @@ export default class IntegrationService {
         {},
       )
 
+      const qx = SequelizeRepository.getQueryExecutor(txOptions)
       for (const [segmentId, repositories] of Object.entries(repos)) {
         await updateExistingSegmentRepositories(qx, { segmentId, repositories })
         await deleteMissingSegmentRepositories(qx, {
@@ -2244,7 +2244,6 @@ export default class IntegrationService {
       ...this.options,
       transaction,
     }
-    const qx = SequelizeRepository.getQueryExecutor(txOptions)
 
     try {
       await GitlabReposRepository.updateMapping(integrationId, mapping, txOptions)
@@ -2262,6 +2261,7 @@ export default class IntegrationService {
           {},
         )
 
+        const qx = SequelizeRepository.getQueryExecutor(txOptions)
         for (const [segmentId, repositories] of Object.entries(repos)) {
           await updateExistingSegmentRepositories(qx, { segmentId, repositories })
           await deleteMissingSegmentRepositories(qx, {

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -353,6 +353,7 @@ export async function insertSegmentRepositories(
       'segmentRepositories',
       ['insightsProjectId', 'repository', 'segmentId'],
       data,
+      '("repository", "insightsProjectId") DO NOTHING',
     ),
   )
 }

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -51,11 +51,11 @@ export interface IInsightsProject {
   twitter: string
   widgets: string[]
   repositories:
-    | {
-        platform: string
-        url: string
-      }[]
-    | string[]
+  | {
+    platform: string
+    url: string
+  }[]
+  | string[]
 }
 
 export interface ICreateInsightsProject extends IInsightsProject {
@@ -326,7 +326,7 @@ export async function findBySlug(qx: QueryExecutor, slug: string) {
   return collections
 }
 
-export async function upsertSegmentRepositories(
+export async function insertSegmentRepositories(
   qx: QueryExecutor,
   {
     insightsProjectId,
@@ -355,6 +355,27 @@ export async function upsertSegmentRepositories(
       data,
       '("repository", "insightsProjectId") DO NOTHING',
     ),
+  )
+}
+
+export async function updateSegmentRepositories(
+  qx: QueryExecutor,
+  {
+    segmentId,
+    repository
+  }: {
+    segmentId: string,
+    repository: string
+  }
+) {
+
+  return qx.result(
+    `
+      UPDATE "segmentRepositories"
+      SET "segmentId" = $(segmentId)
+      WHERE "repository" = $(repository)
+    `,
+    { segmentId, repository },
   )
 }
 

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -329,11 +329,9 @@ export async function findBySlug(qx: QueryExecutor, slug: string) {
 export async function insertSegmentRepositories(
   qx: QueryExecutor,
   {
-    insightsProjectId,
     repositories,
     segmentId,
   }: {
-    insightsProjectId: string
     repositories: string[]
     segmentId?: string
   },
@@ -343,7 +341,6 @@ export async function insertSegmentRepositories(
   }
 
   const data = repositories.map((repo) => ({
-    insightsProjectId,
     repository: repo,
     segmentId,
   }))
@@ -351,9 +348,9 @@ export async function insertSegmentRepositories(
   return qx.result(
     prepareBulkInsert(
       'segmentRepositories',
-      ['insightsProjectId', 'repository', 'segmentId'],
+      ['repository', 'segmentId'],
       data,
-      '("repository", "insightsProjectId") DO NOTHING',
+      '("repository") DO NOTHING',
     ),
   )
 }

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -353,7 +353,6 @@ export async function insertSegmentRepositories(
       'segmentRepositories',
       ['insightsProjectId', 'repository', 'segmentId'],
       data,
-      '("repository") DO NOTHING',
     ),
   )
 }

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -361,22 +361,25 @@ export async function insertSegmentRepositories(
 export async function updateExistingSegmentRepositories(
   qx: QueryExecutor,
   {
-    segmentId,
+    insightsProjectId,
     repositories,
+    segmentId,
   }: {
-    segmentId: string
+    insightsProjectId: string
     repositories: string[]
+    segmentId: string
   },
 ) {
   return qx.result(
     `
     UPDATE "segmentRepositories"
-    SET "segmentId" = $(segmentId)
+    SET "segmentId" = $(segmentId), "insightsProjectId" = $(insightsProjectId)
     WHERE "repository" IN ($(repositories:csv));
     `,
     {
-      segmentId,
+      insightsProjectId,
       repositories,
+      segmentId,
     },
   )
 }


### PR DESCRIPTION
# Changes proposed ✍️

### What
we want to update the `segmentRepositories` table everytime a mapping repos happen, not just when we update an insights Project
​
### Why
This leads to unconsistent data between insightsProjects and segmentRepositories table.

### How
1. removed `segmentRepositories` update from the `insightsProjects` update
2. The insert in the `segmentRepositories` table is now made only in the integrations create, not on the update
3. once `mapGithubRepos` or `mapGitlabRepos` is triggered we update also the `segmentRepositories` table

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
