### PR TITLE
fix: unmerge operation type error

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -964,7 +964,7 @@ export default class MemberService extends LoggerBase {
                 }
               } else if (key === 'contributions') {
                 // check secondary member has any contributions to extract from current member
-                if (member.contributions) {
+                if (member.contributions && Array.isArray(member.contributions)) {
                   member.contributions = member.contributions.filter(
                     (c) => !(secondaryBackup.contributions || []).some((s) => s.id === c.id),
                   )


### PR DESCRIPTION
# Changes proposed ✍️

### What
- Fix type error being thrown on unmerge operations when profile does not have contributions
- https://app.datadoghq.com/monitors/159644608?from_ts=1756219168000&to_ts=1756220368000&event_id=8253673765962675891&link_source=monitor_notif

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
