### PR TITLE
fix: mapped repos validation endpoint

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -874,6 +874,7 @@ class SegmentRepository extends RepositoryBase<
           LEFT JOIN "integrations" i ON r."integrationId" = i.id
           WHERE r."segmentId" = :segmentId
           AND r."tenantId" = :tenantId
+          AND r."deletedAt" IS NULL
           AND (i.id IS NULL OR i."segmentId" != :segmentId)
           LIMIT 1
         ) as has_repos


### PR DESCRIPTION
# Changes proposed ✍️

### What
- There was a bug in the /mapped-repos endpoint where we make the validation of wether or not that segment/integration has mapped repos from another project. It was missing to also validate if the row in "githubRepos" had been soft deleted before.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
