### PR TITLE
fix: security worker go version and types

### DIFF
--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -8,7 +8,7 @@ ARG PLATFORM=Linux_x86_64
 RUN wget https://github.com/privateerproj/privateer/releases/download/v${VERSION}/privateer_${PLATFORM}.tar.gz
 RUN tar -xzf privateer_${PLATFORM}.tar.gz
 
-FROM golang:1.23.4-alpine3.21 AS plugin
+FROM golang:1.24.4-alpine3.21 AS plugin
 RUN apk add --no-cache make git
 WORKDIR /plugin
 RUN git clone https://github.com/revanite-io/pvtr-github-repo.git

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -115,14 +115,14 @@ export async function saveOSPSBaselineInsightsToDB(
 
   for (const evaluation of evaluationSuite.control_evaluations) {
     await addSuiteControlEvaluation(qx, {
-      controlId: evaluation.control_id,
+      controlId: evaluation['control-id'],
       name: evaluation.name,
-      corruptedState: evaluation.corrupted_state,
+      corruptedState: evaluation['corrupted-state'],
       message: evaluation.message,
       repo: repo.repoUrl,
       insightsProjectId: repo.insightsProjectId,
       insightsProjectSlug: repo.insightsProjectSlug,
-      remediationGuide: evaluation.remediation_guide,
+      remediationGuide: evaluation['remediation-guide'] || '',
       result: evaluation.result,
       securityInsightsEvaluationSuiteId: suite.id,
     })
@@ -130,7 +130,7 @@ export async function saveOSPSBaselineInsightsToDB(
     const controlEvaluation = await findSuiteControlEvaluation(
       qx,
       repo.repoUrl,
-      evaluation.control_id,
+      evaluation['control-id'],
     )
     for (const assessment of evaluation.assessments) {
       await addControlEvaluationAssessment(qx, {
@@ -140,11 +140,11 @@ export async function saveOSPSBaselineInsightsToDB(
         repo: repo.repoUrl,
         insightsProjectId: repo.insightsProjectId,
         insightsProjectSlug: repo.insightsProjectSlug,
-        requirementId: assessment.requirement_id,
+        requirementId: assessment['requirement-id'],
         result: assessment.result,
-        runDuration: assessment.run_duration,
+        runDuration: assessment['run-duration'] || '',
         steps: assessment.steps,
-        stepsExecuted: assessment.steps_executed,
+        stepsExecuted: assessment['steps-executed'] || 0,
         securityInsightsEvaluationId: controlEvaluation.id,
       })
     }

--- a/services/apps/security_best_practices_worker/src/types.ts
+++ b/services/apps/security_best_practices_worker/src/types.ts
@@ -5,6 +5,8 @@ export interface ISecurityInsightsPrivateerResult {
 export interface ISecurityInsightsPrivateerEvaluationSuite {
   name: string
   catalog_id: string
+  start_time: string
+  end_time: string
   result: string
   corrupted_state: boolean
   control_evaluations: ISecurityInsightsPrivateerResultControlEvaluations[]
@@ -12,23 +14,26 @@ export interface ISecurityInsightsPrivateerEvaluationSuite {
 
 export interface ISecurityInsightsPrivateerResultControlEvaluations {
   name: string
-  control_id: string
+  'control-id': string
   result: string
   message: string
-  corrupted_state: boolean
-  remediation_guide: string
+  'corrupted-state': boolean
   assessments: ISecurityInsightsPrivateerResultAssessment[]
 }
 
 export interface ISecurityInsightsPrivateerResultAssessment {
-  requirement_id: string
+  'requirement-id': string
   applicability: string[]
   description: string
   result: string
   message: string
   steps: string[]
-  steps_executed: number
-  run_duration: string
+  'steps-executed': number
+  start?: string
+  end?: string
+  value?: unknown
+  changes?: unknown[]
+  recommendation?: string
 }
 
 export interface IUpsertOSPSBaselineSecurityInsightsParams {


### PR DESCRIPTION
# Changes proposed ✍️

### Issue with Go version
Error when building security-best-practices-worker:
```
go: go.mod requires go >= 1.24.4 (running go 1.23.4; GOTOOLCHAIN=local)
make: *** [Makefile:46: tidy] Error 1
```
The pvtr-github-repo project’s go.mod file specifies:
go >= 1.24.4
https://github.com/revanite-io/pvtr-github-repo/blob/b964c55451f517d9210e6d513227254f3607b708/go.mod#L3

The build environment inside Docker container is using:
go 1.23.4

Since the version is too old, go mod tidy fails, and make binary stops.

### Issue with wrong schema
- It appears that some of the typings have changed, introducing breaking changes https://github.com/ossf/gemara/blob/main/schemas/layer-4.cue
- This would prevent us storing new results as control-id was being wrongly typed.

This PR fixes the types we are currently using. In the future, we will need to incorporate the new fields and sync with the baseline team to warn us about these breaking changes.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
