### PR TITLE
feat: remove excluded repositories from security_deduplicated_merged_copy_pipe [IN-575]

### DIFF
--- a/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
@@ -90,7 +90,8 @@ SQL >
         eval.result <> 'Not Run'
         and assessment.result <> 'Not Run'
         and eval.insightsProjectId in (
-            select insightsProjectId from segmentRepositories sr final
+            select insightsProjectId
+            from segmentRepositories sr final
             where sr.excluded IS NULL OR sr.excluded = false
         )
     group by


### PR DESCRIPTION
This changes the security_deduplicated_merged_copy_pipe pipe to not use excluded repos.

It was supposed to be part of #3359 but when I changed the approach taken on that one, I forgot this pipe.

[Ticket in Jira](https://linuxfoundation.atlassian.net/browse/IN-575)