### PR TITLE
fix: fix missing sequin user in PostgreSQL init SQL script

### DIFF
--- a/scripts/scaffold/sequin/postgres-docker-entrypoint-initdb.d/create-sequin-database.sql
+++ b/scripts/scaffold/sequin/postgres-docker-entrypoint-initdb.d/create-sequin-database.sql
@@ -1,1 +1,22 @@
 CREATE DATABASE sequin;
+
+CREATE ROLE sequin WITH LOGIN PASSWORD 'JustForLocalUse!' REPLICATION;
+
+-- Let the user connect to the DB and create schemas in it
+GRANT CONNECT, CREATE ON DATABASE sequin TO sequin;
+
+-- Switch to that DB (psql meta-command; your migration runner must support it)
+\c sequin
+
+-- Allow creating tables in the public schema
+GRANT USAGE, CREATE ON SCHEMA public TO sequin;
+
+-- Existing objects permissions
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO sequin;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO sequin;
+
+-- Default privileges: apply them to objects CREATED BY sequin
+ALTER DEFAULT PRIVILEGES FOR ROLE sequin IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO sequin;
+ALTER DEFAULT PRIVILEGES FOR ROLE sequin IN SCHEMA public
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO sequin;


### PR DESCRIPTION
When running migrations locally, we were getting an error about a missing "sequin" user. We could just create the user manually and re-run the migration, but that's not ideal.

This is happening because a migration was recently added, which expects this user to exist. The user should exist, as it should have been added when we started using Sequin months ago, but apparently we never "codified" it in the PostgreSQL initialisation script.

This PR adds the user creation to the Sequin SQL initialization script, grants it the necessary permissions, and should allow the migrations to run without errors.