### PR TITLE
fix: handle undefined/null attributes for bot members

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -112,7 +112,7 @@ export default class MemberService extends LoggerBase {
           if (botDetection === MemberBotDetection.CONFIRMED_BOT) {
             this.log.debug({ memberIdentities: data.identities }, 'Member confirmed as bot.')
 
-            const existingIsBot = attributes.isBot as Record<string, boolean>
+            const existingIsBot = (attributes.isBot as Record<string, boolean>) || {}
 
             // add default and system flags only if no active flag exists
             if (!Object.values(existingIsBot).some(Boolean)) {


### PR DESCRIPTION
This pull request includes a minor update to the `MemberService` class to improve type safety and prevent potential runtime errors when handling the `isBot` attribute.

* Reliability improvement:
  * [`services/apps/data_sink_worker/src/service/member.service.ts`](diffhunk://#diff-5f14538d3ea8794763b6d28c635d36183c53d08342166feea7ca2bfd5a906d87L115-R115): Ensured that `existingIsBot` is always an object by providing a default empty object if `attributes.isBot` is undefined or null.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
