### PR TITLE
chore: update platforms widgets mapping for Gerrit and Gitlab

### DIFF
--- a/services/libs/types/src/enums/widgets.ts
+++ b/services/libs/types/src/enums/widgets.ts
@@ -73,11 +73,11 @@ export const DEFAULT_WIDGET_VALUES: Record<
   // Popularity
   [Widgets.STARS]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO, PlatformType.GITLAB],
   },
   [Widgets.FORKS]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO, PlatformType.GITLAB],
   },
   // [Widgets.SOCIAL_MENTIONS]: {
   //   enabled: false,
@@ -128,7 +128,12 @@ export const DEFAULT_WIDGET_VALUES: Record<
   },
   [Widgets.PULL_REQUESTS]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
   [Widgets.ACTIVE_DAYS]: {
     enabled: true,
@@ -140,22 +145,47 @@ export const DEFAULT_WIDGET_VALUES: Record<
   },
   [Widgets.MERGE_LEAD_TIME]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
   [Widgets.REVIEW_TIME_BY_PULL_REQUEST_SIZE]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
   [Widgets.AVERAGE_TIME_TO_MERGE]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
   [Widgets.WAIT_TIME_FOR_1ST_REVIEW]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
   [Widgets.CODE_REVIEW_ENGAGEMENT]: {
     enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITLAB, PlatformType.GITHUB_NANGO],
+    platform: [
+      PlatformType.GITHUB,
+      PlatformType.GITLAB,
+      PlatformType.GITHUB_NANGO,
+      PlatformType.GERRIT,
+    ],
   },
 }


### PR DESCRIPTION
# Changes proposed ✍️

### Issue
Last week on Insights, we noticed that some of the widgets were not including all activity types that they needed. This was specific to GitLab and Gerrit which allows us to get some metrics on Popularity and Development.

### What
* Add GitLab platform to Stars and Forks widgets
* Add Gerrit to code review related metrics

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
