### PR TITLE
chore: disable git v1 for newly updated repos

### DIFF
--- a/backend/src/api/integration/helpers/gitGetRemotes.ts
+++ b/backend/src/api/integration/helpers/gitGetRemotes.ts
@@ -1,9 +1,32 @@
+import { PlatformType } from '@crowd/types'
+
+import IntegrationRepository from '../../../database/repositories/integrationRepository'
 import Permissions from '../../../security/permissions'
 import IntegrationService from '../../../services/integrationService'
 import PermissionChecker from '../../../services/user/permissionChecker'
 
 export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.tenantEdit)
-  const payload = await new IntegrationService(req).gitGetRemotes()
+
+  // Git Integration V2 Release Date - integrations updated after this date should be excluded from old git integration
+  const gitIntegrationV2ReleaseDate = new Date('2025-09-09T00:00:00.000Z')
+
+  const integrations = await IntegrationRepository.findAllByPlatform(PlatformType.GIT, req)
+  // Filter out integrations updated after V2 release date
+  const legacyIntegrations = integrations.filter((integration) => {
+    const updatedAt = new Date(integration.updatedAt)
+    return updatedAt < gitIntegrationV2ReleaseDate
+  })
+
+  const payload = legacyIntegrations.reduce((acc, integration) => {
+    const {
+      id,
+      segmentId,
+      settings: { remotes },
+    } = integration
+    acc[segmentId] = { remotes, integrationId: id }
+    return acc
+  }, {})
+
   await req.responseHandler.success(req, res, payload)
 }

--- a/backend/src/api/integration/helpers/gitGetRemotes.ts
+++ b/backend/src/api/integration/helpers/gitGetRemotes.ts
@@ -2,7 +2,6 @@ import { PlatformType } from '@crowd/types'
 
 import IntegrationRepository from '../../../database/repositories/integrationRepository'
 import Permissions from '../../../security/permissions'
-import IntegrationService from '../../../services/integrationService'
 import PermissionChecker from '../../../services/user/permissionChecker'
 
 export default async (req, res) => {


### PR DESCRIPTION
# Changes proposed ✍️
This pull request updates the logic for fetching Git remotes in the `gitGetRemotes` helper to support the transition to Git Integration V2. The main change is that only legacy (pre-V2) Git integrations are now included in the response, filtering out any integrations updated after the V2 release date.

**Git Integration V2 support:**

* Added logic to fetch all Git integrations and filter out those updated after the V2 release date (`2025-09-09`), ensuring only legacy integrations are returned.
* Updated the payload construction to return remotes and integration IDs for each legacy integration, keyed by their `segmentId`.

These changes help ensure that the old Git integration logic only applies to integrations created or updated before the V2 release.

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
