### PR TITLE
fix: kafka connection config in git integration v2

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/queue/queue_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/queue/queue_service.py
@@ -22,7 +22,6 @@ class QueueService(BaseService):
         self._connected = False
 
     def _build_kafka_config(self):
-        """Build Kafka configuration with SSL support (same as test script)"""
         config = {
             "bootstrap_servers": CROWD_KAFKA_BROKERS,
             "client_id": self._CLIENT_ID,

--- a/services/apps/git_integration/src/crowdgit/services/queue/queue_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/queue/queue_service.py
@@ -1,12 +1,13 @@
 from crowdgit.services.base.base_service import BaseService
 from aiokafka import AIOKafkaProducer
 import asyncio
+import json
+import ssl
 from typing import List, Dict
 from crowdgit.settings import (
     CROWD_KAFKA_TOPIC,
     CROWD_KAFKA_BROKERS,
-    CROWD_KAFKA_PASSWORD,
-    CROWD_KAFKA_USER,
+    CROWD_KAFKA_EXTRA,
 )
 from crowdgit.errors import QueueConnectionError, QueueMessageProduceError
 
@@ -17,16 +18,33 @@ class QueueService(BaseService):
     def __init__(self):
         super().__init__()
         self.kafka_topic = CROWD_KAFKA_TOPIC
+        self.kafka_producer = AIOKafkaProducer(**self._build_kafka_config())
+        self._connected = False
+
+    def _build_kafka_config(self):
+        """Build Kafka configuration with SSL support (same as test script)"""
         config = {
             "bootstrap_servers": CROWD_KAFKA_BROKERS,
             "client_id": self._CLIENT_ID,
-            "sasl_mechanism": "PLAIN",
-            "sasl_plain_username": CROWD_KAFKA_USER,
-            "sasl_plain_password": CROWD_KAFKA_PASSWORD,
             "acks": "all",
         }
-        self.kafka_producer = AIOKafkaProducer(**config)
-        self._connected = False
+
+        # Parse extra configuration from kafkajs config
+        extra_config = json.loads(CROWD_KAFKA_EXTRA)
+
+        if extra_config.get("ssl"):
+            config["security_protocol"] = "SASL_SSL"
+            ssl_context = ssl.create_default_context()
+            config["ssl_context"] = ssl_context
+        else:
+            config["security_protocol"] = "SASL_PLAINTEXT"
+
+        sasl_config = extra_config["sasl"]
+        config["sasl_mechanism"] = sasl_config["mechanism"].upper()
+        config["sasl_plain_username"] = sasl_config["username"]
+        config["sasl_plain_password"] = sasl_config["password"]
+
+        return config
 
     async def ensure_connected(self):
         """Ensure connection is established and healthy"""


### PR DESCRIPTION
This pull request refactors the Kafka producer configuration in the `QueueService` to make it more flexible and secure. The main improvement is that Kafka connection parameters (including SSL and SASL settings) are now dynamically loaded from the `CROWD_KAFKA_EXTRA` environment variable, allowing easier configuration changes without code updates.

Kafka configuration improvements:

* Refactored the initialization of the Kafka producer in `QueueService` to use a new `_build_kafka_config` method, which dynamically constructs the configuration based on the JSON in `CROWD_KAFKA_EXTRA` instead of hardcoding SASL/SSL parameters.
* Added support for SSL connections by conditionally setting `security_protocol` and `ssl_context` based on the configuration, increasing security and flexibility.
* Removed direct imports and usage of `CROWD_KAFKA_USER` and `CROWD_KAFKA_PASSWORD` in favor of extracting SASL credentials from the extra configuration, centralizing sensitive configuration management. [[1]](diffhunk://#diff-8b8e4695b63ee5c2437dab425f0c5c581acdc72d31e82f9825759a47a20d9dc7R4-R10) [[2]](diffhunk://#diff-8b8e4695b63ee5c2437dab425f0c5c581acdc72d31e82f9825759a47a20d9dc7R21-R46)

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
