### PR TITLE
fix: affiliation overrides in `moveRolesBetweenEntities`

### DIFF
--- a/backend/src/database/repositories/member/memberOrganizationAffiliationOverridesRepository.ts
+++ b/backend/src/database/repositories/member/memberOrganizationAffiliationOverridesRepository.ts
@@ -1,6 +1,6 @@
 import {
   changeOverride as changeMemberOrganizationAffiliationOverride,
-  findOverrides as findMemberOrganizationAffiliationOverrides,
+  findMemberAffiliationOverrides,
   findPrimaryWorkExperiencesOfMember,
 } from '@crowd/data-access-layer/src/member_organization_affiliation_overrides'
 import {
@@ -16,7 +16,7 @@ class MemberOrganizationAffiliationOverridesRepository {
     const qx = SequelizeRepository.getQueryExecutor(options)
 
     await changeMemberOrganizationAffiliationOverride(qx, data)
-    const overrides = await findMemberOrganizationAffiliationOverrides(qx, data.memberId, [
+    const overrides = await findMemberAffiliationOverrides(qx, data.memberId, [
       data.memberOrganizationId,
     ])
     return overrides[0]

--- a/backend/src/services/member/memberOrganizationsService.ts
+++ b/backend/src/services/member/memberOrganizationsService.ts
@@ -13,7 +13,7 @@ import {
   queryOrgs,
   updateMemberOrganization,
 } from '@crowd/data-access-layer'
-import { findOverrides as findMemberOrganizationAffiliationOverrides } from '@crowd/data-access-layer/src/member_organization_affiliation_overrides'
+import { findMemberAffiliationOverrides } from '@crowd/data-access-layer/src/member_organization_affiliation_overrides'
 import { LoggerBase } from '@crowd/logging'
 import { IMemberOrganization, IOrganization, IRenderFriendlyMemberOrganization } from '@crowd/types'
 
@@ -69,7 +69,7 @@ export default class MemberOrganizationsService extends LoggerBase {
     }
 
     // Fetch affiliation overrides
-    const affiliationOverrides = await findMemberOrganizationAffiliationOverrides(
+    const affiliationOverrides = await findMemberAffiliationOverrides(
       qx,
       memberId,
       memberOrganizations.map((mo) => mo.id),

--- a/services/libs/data-access-layer/src/member_organization_affiliation_overrides/index.ts
+++ b/services/libs/data-access-layer/src/member_organization_affiliation_overrides/index.ts
@@ -65,7 +65,7 @@ export async function changeOverride(
   )
 }
 
-export async function findOverrides(
+export async function findMemberAffiliationOverrides(
   qx: QueryExecutor,
   memberId: string,
   memberOrganizationIds?: string[],
@@ -113,6 +113,29 @@ export async function findOverrides(
   })
 
   return results
+}
+
+export async function findOrganizationAffiliationOverrides(
+  qx: QueryExecutor,
+  organizationId: string,
+): Promise<IMemberOrganizationAffiliationOverride[]> {
+  return qx.select(
+    `
+      SELECT
+        moa.id,
+        moa."memberId",
+        moa."memberOrganizationId",
+        coalesce(moa."allowAffiliation", true) as "allowAffiliation",
+        coalesce(moa."isPrimaryWorkExperience", false) as "isPrimaryWorkExperience"
+      FROM "memberOrganizationAffiliationOverrides" moa
+      JOIN "memberOrganizations" mo ON moa."memberOrganizationId" = mo.id
+      WHERE mo."organizationId" = $(organizationId)
+      AND mo."deletedAt" IS NULL
+    `,
+    {
+      organizationId,
+    },
+  )
 }
 
 export async function findPrimaryWorkExperiencesOfMember(

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -24,7 +24,7 @@ import {
 import { getLastActivitiesForMembers } from '../activities'
 import { findManyLfxMemberships } from '../lfx_memberships'
 import { findMaintainerRoles } from '../maintainers'
-import { findOverrides as findMemberOrganizationAffiliationOverrides } from '../member_organization_affiliation_overrides'
+import { findMemberAffiliationOverrides } from '../member_organization_affiliation_overrides'
 import {
   IDbMemberCreateData,
   IDbMemberUpdateData,
@@ -377,7 +377,7 @@ export async function queryMembersAdvanced(
         memberOrganizations.find((o) => o.memberId === member.id)?.organizations || []
 
       const affiliationOverrides = memberOrgs.length
-        ? await findMemberOrganizationAffiliationOverrides(
+        ? await findMemberAffiliationOverrides(
             qx,
             member.id,
             memberOrgs.map((o) => o.id),

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -489,10 +489,14 @@ async function moveRolesBetweenEntities(
   const primaryAffiliationOverrides = await findAffiliationOverrides(qx, primaryId)
   const secondaryAffiliationOverrides = await findAffiliationOverrides(qx, secondaryId)
 
-  await mergeRoles(qx, primaryRoles, secondaryRoles, mergeStrat, {
-    primary: primaryAffiliationOverrides,
-    secondary: secondaryAffiliationOverrides,
-  })
+  await mergeRoles(
+    qx,
+    primaryRoles,
+    secondaryRoles,
+    primaryAffiliationOverrides,
+    secondaryAffiliationOverrides,
+    mergeStrat,
+  )
 
   // update rest of the o2 members
   const remainingRoles = await findNonIntersectingRoles(
@@ -583,11 +587,9 @@ export async function mergeRoles(
   qx: QueryExecutor,
   primaryRoles: IMemberOrganization[],
   secondaryRoles: IMemberOrganization[],
+  primaryAffiliationOverrides: IMemberOrganizationAffiliationOverride[],
+  secondaryAffiliationOverrides: IMemberOrganizationAffiliationOverride[],
   mergeStrat: IMergeStrat,
-  affiliationOverrides: {
-    primary: IMemberOrganizationAffiliationOverride[]
-    secondary: IMemberOrganizationAffiliationOverride[]
-  },
 ) {
   let removeRoles: IMemberOrganization[] = []
   let addRoles: IMemberOrganization[] = []
@@ -685,7 +687,7 @@ export async function mergeRoles(
       }
     }
 
-    const existingOverrides = [...affiliationOverrides.primary, ...affiliationOverrides.secondary]
+    const existingOverrides = [...primaryAffiliationOverrides, ...secondaryAffiliationOverrides]
 
     for (const removeRole of removeRoles) {
       // delete affiliation overrides before removing roles to avoid foreign key conflicts


### PR DESCRIPTION
## Changes Proposed ✍️

`moveRolesBetweenEntities` previously assumed it only handled members and always used `findOverrides` (now renamed to `findMemberAffiliationOverrides`). When called during organization merges, it passed organization IDs into the member-specific function, resulting in empty affiliation overrides and broken merge logic.

This update introduces `findOrganizationAffiliationOverrides` for organization lookups and updates `moveRolesBetweenEntities` to pick the correct finder based on `entityType`. Callers were also updated to pass the proper entity type, ensuring both member and organization merges now resolve affiliation overrides correctly.