### PR TITLE
fix: persist primary organization even if role changes in affiliations

### DIFF
--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -42,14 +42,12 @@ async function prepareMemberOrganizationAffiliationTimeline(
   }
 
   const selectPrimaryWorkExperience = (orgs: AffiliationItem[]): AffiliationItem => {
-    logger.info(`selectPrimaryWorkExperience | ${JSON.stringify(orgs)}`)
     if (orgs.length === 1) {
       return orgs[0]
     }
 
     // manual affiliations (identified by segmentId) always take highest precedence
     const manualAffiliations = orgs.filter((row) => 'segmentId' in row && !!row.segmentId)
-    logger.info(`manualAffiliations: ${JSON.stringify(manualAffiliations)}`)
     if (manualAffiliations.length > 0) {
       if (manualAffiliations.length === 1) return manualAffiliations[0]
       // if multiple manual affiliations, pick the one with the longest date range
@@ -61,7 +59,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
     if (primaryOrgs.length > 0) {
       // favor the one with dates if there are multiple primary work experiences
       const withDates = primaryOrgs.filter((row) => !!row.dateStart)
-      logger.info(`primaryrgs withDates: ${JSON.stringify(withDates)}`)
       if (withDates.length > 0) {
         // there can be one primary work experiences with intersecting date ranges so just return the first one found
         return withDates[0]
@@ -73,7 +70,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
       // no work experience was marked as primary by the user, use additional metrics to decide the primary
       // 1. favor the one with dates if there's only one
       const withDates = orgs.filter((row) => !!row.dateStart)
-      logger.info(`withDates: ${JSON.stringify(withDates)}`)
       if (withDates.length === 1) {
         // there can be one primary work exp with intersecting date ranges
         return withDates[0]
@@ -84,7 +80,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
       const memberOrgsOnly = orgs.filter(
         (row: AffiliationItem) => 'segmentId' in row && !!row.segmentId,
       ) as MemberOrganizationWithOverrides[]
-      logger.info(`memberOrgsOnly: ${JSON.stringify(memberOrgsOnly)}`)
       if (memberOrgsOnly.length >= 2) {
         const sortedByMembers = memberOrgsOnly.sort((a, b) => b.memberCount - a.memberCount)
         if (sortedByMembers[0].memberCount > sortedByMembers[1].memberCount) {
@@ -165,6 +160,9 @@ async function prepareMemberOrganizationAffiliationTimeline(
             gapStartDate = null
           }
 
+          logger.info(
+            `date: ${date.toISOString()},selectPrimaryWorkExperience input: ${JSON.stringify(orgs)}`,
+          )
           const primaryOrg = selectPrimaryWorkExperience(orgs)
           logger.info(`primaryOrg selected: ${JSON.stringify(primaryOrg)}`)
 
@@ -182,6 +180,10 @@ async function prepareMemberOrganizationAffiliationTimeline(
             })
             currentPrimaryOrg = primaryOrg
             currentStartDate = new Date(date)
+          } else if (currentPrimaryOrg.id !== primaryOrg.id) {
+            // same org but different record, we need to keep
+            // currentPrimaryOrg = primaryOrg
+            logger.info(`here we should assign ${currentPrimaryOrg} = ${primaryOrg}`)
           }
         }
 

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -326,6 +326,8 @@ async function processAffiliationActivities(
 
   const whereClause = conditions.join(' and ')
 
+  logger.info(`whereClause: ${whereClause}`)
+
   do {
     const rowCount = await qx.result(
       `
@@ -361,7 +363,7 @@ export async function refreshMemberOrganizationAffiliations(qx: QueryExecutor, m
     affiliations.map((affiliation) => processAffiliationActivities(qx, memberId, affiliation)),
   )
 
-  logger.info(`results: ${JSON.stringify(results)}`)
+  logger.info(`results count: ${JSON.stringify(results.length)}`)
 
   const duration = performance.now() - start
   const processed = results.reduce((acc, processed) => acc + processed, 0)

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -42,12 +42,14 @@ async function prepareMemberOrganizationAffiliationTimeline(
   }
 
   const selectPrimaryWorkExperience = (orgs: AffiliationItem[]): AffiliationItem => {
+    logger.info(`selectPrimaryWorkExperience | ${JSON.stringify(orgs)}`)
     if (orgs.length === 1) {
       return orgs[0]
     }
 
     // manual affiliations (identified by segmentId) always take highest precedence
     const manualAffiliations = orgs.filter((row) => 'segmentId' in row && !!row.segmentId)
+    logger.info(`manualAffiliations: ${JSON.stringify(manualAffiliations)}`)
     if (manualAffiliations.length > 0) {
       if (manualAffiliations.length === 1) return manualAffiliations[0]
       // if multiple manual affiliations, pick the one with the longest date range
@@ -59,6 +61,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
     if (primaryOrgs.length > 0) {
       // favor the one with dates if there are multiple primary work experiences
       const withDates = primaryOrgs.filter((row) => !!row.dateStart)
+      logger.info(`primaryrgs withDates: ${JSON.stringify(withDates)}`)
       if (withDates.length > 0) {
         // there can be one primary work experiences with intersecting date ranges so just return the first one found
         return withDates[0]
@@ -70,6 +73,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
       // no work experience was marked as primary by the user, use additional metrics to decide the primary
       // 1. favor the one with dates if there's only one
       const withDates = orgs.filter((row) => !!row.dateStart)
+      logger.info(`withDates: ${JSON.stringify(withDates)}`)
       if (withDates.length === 1) {
         // there can be one primary work exp with intersecting date ranges
         return withDates[0]
@@ -80,6 +84,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
       const memberOrgsOnly = orgs.filter(
         (row: AffiliationItem) => 'segmentId' in row && !!row.segmentId,
       ) as MemberOrganizationWithOverrides[]
+      logger.info(`memberOrgsOnly: ${JSON.stringify(memberOrgsOnly)}`)
       if (memberOrgsOnly.length >= 2) {
         const sortedByMembers = memberOrgsOnly.sort((a, b) => b.memberCount - a.memberCount)
         if (sortedByMembers[0].memberCount > sortedByMembers[1].memberCount) {
@@ -161,6 +166,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
           }
 
           const primaryOrg = selectPrimaryWorkExperience(orgs)
+          logger.info(`primaryOrg selected: ${JSON.stringify(primaryOrg)}`)
 
           if (currentPrimaryOrg == null) {
             // means there's a new range starting

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -98,6 +98,10 @@ async function prepareMemberOrganizationAffiliationTimeline(
     manualAffiliations: IManualAffiliationData[],
     fallbackOrganizationId: string | null,
   ): TimelineItem[] => {
+    logger.info(
+      `buildTimeline | ${JSON.stringify(memberOrganizations)} ${JSON.stringify(manualAffiliations)}`,
+    )
+
     const allAffiliationsWithDates = [...memberOrganizations, ...manualAffiliations].filter(
       (row) => !!row.dateStart,
     )
@@ -108,6 +112,8 @@ async function prepareMemberOrganizationAffiliationTimeline(
             Math.min(...allAffiliationsWithDates.map((row) => new Date(row.dateStart).getTime())),
           )
         : null
+
+    logger.info(`erliestStartDate: ${earliestStartDate}`)
 
     const timeline: TimelineItem[] = []
     const now = new Date()
@@ -201,6 +207,11 @@ async function prepareMemberOrganizationAffiliationTimeline(
 
     // prepend range to cover all activities before the earliest affiliation date
     // also handles edge case where fallback org is null and the timeline is empty.
+
+    logger.info(
+      `timeline: ${timeline.length}, organizationId: ${fallbackOrganizationId}, dateStart: ${fallbackStart.toISOString()}, dateEnd: ${fallbackEnd.toISOString()}`,
+    )
+
     timeline.unshift({
       organizationId: fallbackOrganizationId,
       dateStart: fallbackStart.toISOString(),

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -178,10 +178,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
             currentStartDate = new Date(date)
           } else if (currentPrimaryOrg.id !== primaryOrg.id) {
             // same org but different record, we need to keep
-            // currentPrimaryOrg = primaryOrg
-            logger.info(
-              `here we should assign ${JSON.stringify(currentPrimaryOrg)} = ${JSON.stringify(primaryOrg)}`,
-            )
+            currentPrimaryOrg = primaryOrg
           }
         }
 

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -354,10 +354,14 @@ export async function refreshMemberOrganizationAffiliations(qx: QueryExecutor, m
 
   const affiliations = await prepareMemberOrganizationAffiliationTimeline(qx, memberId)
 
+  logger.info(`affiliations: ${JSON.stringify(affiliations)}`)
+
   // process timeline in parallel
   const results = await Promise.all(
     affiliations.map((affiliation) => processAffiliationActivities(qx, memberId, affiliation)),
   )
+
+  logger.info(`results: ${JSON.stringify(results)}`)
 
   const duration = performance.now() - start
   const processed = results.reduce((acc, processed) => acc + processed, 0)

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -209,7 +209,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
     // also handles edge case where fallback org is null and the timeline is empty.
 
     logger.info(
-      `timeline: ${timeline.length}, organizationId: ${fallbackOrganizationId}, dateStart: ${fallbackStart.toISOString()}, dateEnd: ${fallbackEnd.toISOString()}`,
+      `timeline: ${JSON.stringify(timeline)}, organizationId: ${fallbackOrganizationId}, dateStart: ${fallbackStart.toISOString()}, dateEnd: ${fallbackEnd.toISOString()}`,
     )
 
     timeline.unshift({

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -98,10 +98,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
     manualAffiliations: IManualAffiliationData[],
     fallbackOrganizationId: string | null,
   ): TimelineItem[] => {
-    logger.info(
-      `buildTimeline | ${JSON.stringify(memberOrganizations)} ${JSON.stringify(manualAffiliations)}`,
-    )
-
     const allAffiliationsWithDates = [...memberOrganizations, ...manualAffiliations].filter(
       (row) => !!row.dateStart,
     )
@@ -112,8 +108,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
             Math.min(...allAffiliationsWithDates.map((row) => new Date(row.dateStart).getTime())),
           )
         : null
-
-    logger.info(`erliestStartDate: ${earliestStartDate}`)
 
     const timeline: TimelineItem[] = []
     const now = new Date()
@@ -210,11 +204,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
 
     // prepend range to cover all activities before the earliest affiliation date
     // also handles edge case where fallback org is null and the timeline is empty.
-
-    logger.info(
-      `timeline: ${JSON.stringify(timeline)}, organizationId: ${fallbackOrganizationId}, dateStart: ${fallbackStart.toISOString()}, dateEnd: ${fallbackEnd.toISOString()}`,
-    )
-
     timeline.unshift({
       organizationId: fallbackOrganizationId,
       dateStart: fallbackStart.toISOString(),
@@ -284,10 +273,6 @@ async function prepareMemberOrganizationAffiliationTimeline(
 
   let fallbackOrganizationId = primaryUnknownDatedWorkExperience?.organizationId
 
-  logger.info(
-    `fallbackOrganizationId from primary unknown dated work experience: ${fallbackOrganizationId}`,
-  )
-
   if (!fallbackOrganizationId) {
     fallbackOrganizationId =
       _.chain(memberOrganizations)
@@ -344,8 +329,6 @@ async function processAffiliationActivities(
 
   const whereClause = conditions.join(' and ')
 
-  logger.info(`whereClause: ${whereClause}`)
-
   do {
     const rowCount = await qx.result(
       `
@@ -374,14 +357,10 @@ export async function refreshMemberOrganizationAffiliations(qx: QueryExecutor, m
 
   const affiliations = await prepareMemberOrganizationAffiliationTimeline(qx, memberId)
 
-  logger.info(`affiliations: ${JSON.stringify(affiliations)}`)
-
   // process timeline in parallel
   const results = await Promise.all(
     affiliations.map((affiliation) => processAffiliationActivities(qx, memberId, affiliation)),
   )
-
-  logger.info(`results count: ${JSON.stringify(results.length)}`)
 
   const duration = performance.now() - start
   const processed = results.reduce((acc, processed) => acc + processed, 0)

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -160,11 +160,7 @@ async function prepareMemberOrganizationAffiliationTimeline(
             gapStartDate = null
           }
 
-          logger.info(
-            `date: ${date.toISOString()},selectPrimaryWorkExperience input: ${JSON.stringify(orgs)}`,
-          )
           const primaryOrg = selectPrimaryWorkExperience(orgs)
-          logger.info(`primaryOrg selected: ${JSON.stringify(primaryOrg)}`)
 
           if (currentPrimaryOrg == null) {
             // means there's a new range starting
@@ -183,7 +179,9 @@ async function prepareMemberOrganizationAffiliationTimeline(
           } else if (currentPrimaryOrg.id !== primaryOrg.id) {
             // same org but different record, we need to keep
             // currentPrimaryOrg = primaryOrg
-            logger.info(`here we should assign ${currentPrimaryOrg} = ${primaryOrg}`)
+            logger.info(
+              `here we should assign ${JSON.stringify(currentPrimaryOrg)} = ${JSON.stringify(primaryOrg)}`,
+            )
           }
         }
 

--- a/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
+++ b/services/libs/data-access-layer/src/member-organization-affiliation/index.ts
@@ -284,6 +284,10 @@ async function prepareMemberOrganizationAffiliationTimeline(
 
   let fallbackOrganizationId = primaryUnknownDatedWorkExperience?.organizationId
 
+  logger.info(
+    `fallbackOrganizationId from primary unknown dated work experience: ${fallbackOrganizationId}`,
+  )
+
   if (!fallbackOrganizationId) {
     fallbackOrganizationId =
       _.chain(memberOrganizations)


### PR DESCRIPTION
# Changes proposed ✍️

### What
When we have multiple affiliations for the same org, we want to persist the record of the `PrimaryOrg`.

## Checklist ✅
- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.
