### PR TITLE
chore: add LLM usage toggle based on env variable

### DIFF
--- a/services/apps/merge_suggestions_worker/src/activities/common.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/common.ts
@@ -3,6 +3,7 @@ import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedroc
 import axios from 'axios'
 import { performance } from 'perf_hooks'
 
+import { IS_LLM_ENABLED } from '@crowd/common'
 import { ITenant } from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker//types'
 import LLMSuggestionVerdictsRepository from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker/llmSuggestionVerdicts.repo'
 import TenantRepository from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker/tenant.repo'
@@ -37,10 +38,16 @@ export async function getLLMResult(
   region: string,
   modelSpecificArgs: any,
 ): Promise<ILLMResult> {
+  if (!IS_LLM_ENABLED) {
+    svc.log.error('LLM usage is disabled. Check CROWD_LLM_ENABLED env variable!')
+    return
+  }
+
   if (suggestion.length !== 2) {
     console.log(suggestion)
     throw new Error('Exactly 2 entities are required for LLM comparison')
   }
+
   const client = new BedrockRuntimeClient({
     credentials: {
       accessKeyId: process.env['CROWD_AWS_BEDROCK_ACCESS_KEY_ID'],

--- a/services/libs/common/src/env.ts
+++ b/services/libs/common/src/env.ts
@@ -15,6 +15,8 @@ export const LOG_LEVEL: string = process.env.LOG_LEVEL || 'info'
 
 export const IS_CLOUD_ENV: boolean = IS_PROD_ENV || IS_STAGING_ENV
 
+export const IS_LLM_ENABLED: boolean = process.env.CROWD_LLM_ENABLED === 'true' || false
+
 export const SERVICE = process.env.SERVICE || 'unknown-service'
 
 export const EDITION: Edition = process.env.CROWD_EDITION as Edition

--- a/services/libs/common_services/src/services/llm.service.ts
+++ b/services/libs/common_services/src/services/llm.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@aws-sdk/client-bedrock-runtime'
 import { performance } from 'perf_hooks'
 
+import { IS_LLM_ENABLED } from '@crowd/common'
 import { insertPromptHistoryEntry } from '@crowd/data-access-layer'
 import { QueryExecutor } from '@crowd/data-access-layer'
 import { Logger, LoggerBase } from '@crowd/logging'
@@ -66,6 +67,11 @@ export class LlmService extends LoggerBase {
     metadata?: Record<string, unknown>,
     saveHistory = true,
   ): Promise<ILlmResponse> {
+    if (!IS_LLM_ENABLED) {
+      this.log.error('LLM usage is disabled. Check CROWD_LLM_ENABLED env variable!')
+      return
+    }
+
     const settings = LLM_SETTINGS[type]
     if (!settings) {
       throw new Error(`No settings found for LLM query type: ${type}`)


### PR DESCRIPTION
# Changes proposed ✍️

Prevents LLM usage in non-production envs to avoid unnecessary resource consumption. LLM calls now check the `IS_LLM_ENABLED` flag and return early when disabled.

- Add `IS_LLM_ENABLED` env variable (defaults to `false` unless explicitly set to `'true'`).
- Update `LlmService.queryLlm()` to check the flag and return early when LLM usage is disabled.
- Update `merge_suggestions_worker` to respect the `IS_LLM_ENABLED` flag.
