### PR TITLE
fix: fix the activityRelations_deduplicated_cleaned_copy_pipe pipe

### DIFF
--- a/services/libs/tinybird/pipes/activityRelations_deduplicated_cleaned_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_deduplicated_cleaned_copy_pipe.pipe
@@ -37,6 +37,11 @@ SQL >
                 platform IN ('git', 'gerrit', 'github', 'gitlab')
                 AND channel
                 IN (SELECT arrayJoin(i.repositories) FROM insightsProjects i where isNull (i.deletedAt))
+                AND activityRelations.segmentId IN (
+                    SELECT segmentId
+                    FROM segmentRepositories sr FINAL
+                    WHERE (sr.excluded IS NULL OR sr.excluded = false)
+                )
             )
             OR platform NOT IN ('git', 'gerrit', 'github', 'gitlab')
         )


### PR DESCRIPTION
We noticed the activityRelations_deduplicated_cleaned_copy_pipe pipe has been in an error state for a few days.

For some reason, the JOIN that had been added to get the excluded repositories from the segmentRepositories pipe, was adding more columns to the result of the query, even though no more columns were added to the SELECT section of the query. Since these additional fields didn't match the data source definition the copy pipe dumps data into, it was crashing with the error
> The pipe has columns ['activityRelations.createdAt', 'activityRelations.segmentId', 'activityRelations.type', 'activityRelations.updatedAt'] not found in the destination Data Source.

We opted for using a sub-query, which has the added advantage of being slightly faster than the JOIN.

We should keep an eye on this, though, because when I first implemented it, I think there was an issue that led me to use the JOIN instead of the sub-query, but unfortunately, I don't remember what it was. Hopefull it was just a mistake on my part and this will work without any problems.
