### PR TITLE
fix: add missing datasource definition for country_mapping_ds

### DIFF
--- a/services/libs/tinybird/datasources/datasources/country_mapping_ds.datasource
+++ b/services/libs/tinybird/datasources/datasources/country_mapping_ds.datasource
@@ -1,0 +1,8 @@
+SCHEMA >
+    `country` String,
+    `flag` String,
+    `country_code` String,
+    `timezone_offset` Int16
+
+ENGINE MergeTree
+ENGINE_SORTING_KEY flag, country_code, timezone_offset


### PR DESCRIPTION
The data source definition file for `country_mapping_ds` was missing. I pulled it from Tinybird and added it here.