### PR TITLE
Feat/perform full clone for new repos

### DIFF
--- a/services/apps/git_integration/src/crowdgit/models/__init__.py
+++ b/services/apps/git_integration/src/crowdgit/models/__init__.py
@@ -2,5 +2,12 @@
 
 from .repository import Repository, RepositoryCreate, RepositoryResponse
 from .clone_batch import CloneBatchInfo
+from .service_execution import ServiceExecution
 
-__all__ = ["Repository", "RepositoryCreate", "RepositoryResponse", "CloneBatchInfo"]
+__all__ = [
+    "Repository",
+    "RepositoryCreate",
+    "RepositoryResponse",
+    "CloneBatchInfo",
+    "ServiceExecution",
+]

--- a/services/apps/git_integration/src/crowdgit/models/clone_batch.py
+++ b/services/apps/git_integration/src/crowdgit/models/clone_batch.py
@@ -12,10 +12,6 @@ class CloneBatchInfo(BaseModel):
     latest_commit_in_repo: Optional[str] = Field(
         None, description="Hash of the latest commit in repo"
     )
-    commits_count: int = Field(default=0, description="Number of cloned commits for current batch")
-    total_commits_count: int = Field(
-        default=0, description="Total number of commits cloned so far"
-    )
     edge_commit: Optional[str] = Field(
         default=None,
         description="The oldest commit in the current batch, used to track progress during incremental processing.",

--- a/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
@@ -328,7 +328,6 @@ class CommitService(BaseService):
         processed_member = {}
 
         # Handle username and displayName with fallbacks
-        username = member.get("username") or primary_email
         display_name = member.get("displayName") or primary_email.split("@")[0]
 
         # Clean up names once
@@ -742,7 +741,6 @@ class CommitService(BaseService):
         parent_hashes = commit_metadata_lines[7].split()
 
         # Handle optional fields safely
-        ref_names = commit_metadata_lines[8].strip() if len(commit_metadata_lines) > 8 else ""
         commit_message = commit_metadata_lines[9:] if len(commit_metadata_lines) > 9 else []
 
         # Validate and adjust commit datetime if it's in the future

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -143,37 +143,20 @@ class RepositoryWorker:
             self._bind_repository_context(repository, repo_name)
             # 1. Clone the repository incrementally (check possibility to find commit before starting commits)
             logger.info("Starting repository cloning...")
-            async for batch in self.clone_service.clone_batches_generator(
-                repo_id=repository.id,
-                remote=repository.url,
-                target_commit_hash=repository.last_processed_commit,
+            async for batch_info in self.clone_service.clone_batches_generator(
+                repository,
                 working_dir_cleanup=True,
             ):
-                logger.info(f"Clone batch info: {batch}")
-                if batch.is_first_batch:
-                    await self.software_value_service.run(repository.id, batch.repo_path)
-                    await self.maintainer_service.process_maintainers(
-                        repo_id=repository.id,
-                        repo_url=batch.remote,
-                        repo_path=batch.repo_path,
-                        maintainer_file=repository.maintainer_file,
-                        last_maintainer_run_at=repository.last_maintainer_run_at,
-                    )
+                logger.info(f"Clone batch info: {batch_info}")
+                if batch_info.is_first_batch:
+                    await self.software_value_service.run(repository.id, batch_info.repo_path)
+                    await self.maintainer_service.process_maintainers(repository, batch_info)
                 else:
-                    await self.commit_service.process_single_batch_commits(
-                        repo_id=repository.id,
-                        repo_path=batch.repo_path,
-                        edge_commit=batch.edge_commit,
-                        prev_batch_edge_commit=batch.prev_batch_edge_commit,
-                        remote=batch.remote,
-                        segment_id=repository.segment_id,
-                        integration_id=repository.integration_id,
-                        is_final_batch=batch.is_final_batch,
-                    )
+                    await self.commit_service.process_single_batch_commits(repository, batch_info)
 
-                if batch.is_final_batch:
+                if batch_info.is_final_batch:
                     await update_last_processed_commit(
-                        repo_id=repository.id, commit_hash=batch.latest_commit_in_repo
+                        repo_id=repository.id, commit_hash=batch_info.latest_commit_in_repo
                     )
 
             logger.info("Incremental processing completed successfully")

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -134,13 +134,14 @@ class RepositoryWorker:
             service.reset_logger_context()
 
     async def _process_single_repository(self, repository: Repository):
-        """Process a single repository through services with incremental processing"""
+        """Process a single repository through services with full clone for new repos, incremental for existing"""
         logger.info("Processing repository: {}", repository.url)
         processing_state = RepositoryState.PENDING
 
         try:
             repo_name = get_repo_name(repository.url)
             self._bind_repository_context(repository, repo_name)
+            # Use full clone for new repositories (no last_processed_commit), batched clone for existing ones
             clone_with_batches = True if repository.last_processed_commit else False
             logger.info(
                 f"Starting repository cloning for {repo_name} with batching={clone_with_batches}"


### PR DESCRIPTION
# Changes proposed ✍️
This pull request refactors the repository cloning and processing logic to improve clarity, efficiency, and maintainability. The main changes include switching from passing individual parameters to using `Repository` and `CloneBatchInfo` model objects across service layers, streamlining batch cloning logic, and removing redundant commit counting fields. These updates also enhance the handling of full versus incremental batch clones and unify metrics and logging.

**Refactoring and API Improvements:**

* Updated service methods (`clone_service.py`, `commit_service.py`, `maintainer_service.py`) to accept `Repository` and `CloneBatchInfo` objects instead of multiple individual parameters, improving code readability and extensibility. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dR272-R322) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R29) [[3]](diffhunk://#diff-0366278cb614d0495d2031b478a0688a0ad38f78f5bd419d1a4a2fc4e6f38da5L331-R333)

**Cloning Logic Enhancements:**

* Improved batch cloning logic: full clones for new repositories now bypass inefficient batching, while incremental clones use batched processing for already-processed repositories. This is reflected in the new `_clone_repo` method and changes to `clone_batches_generator`. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dR272-R322) [[2]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL130-L206)
* Refactored `_update_batch_info` to simplify batch status updates and remove unnecessary commit counting fields. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL130-L206) [[2]](diffhunk://#diff-c0db27c51235bb952d05d30f2292d73221844c144661dae678fe3af07164c859L15-L18)

**Commit Processing Adjustments:**

* Commit processing now uses the new model-based API, and batch/final batch logic is unified. The git log execution now properly distinguishes between full and batched clones. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L106-R107) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L141-R164) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R223) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L229-R248)

**Metrics and Logging Consistency:**

* Metrics and logging now consistently use repository and batch info objects, improving traceability and error handling across all service layers. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL385-R361) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L141-R164) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L190-R194) [[4]](diffhunk://#diff-0366278cb614d0495d2031b478a0688a0ad38f78f5bd419d1a4a2fc4e6f38da5L344-R353)

**Model and Import Cleanup:**

* Removed unused fields from `CloneBatchInfo` and updated imports to consolidate model references. [[1]](diffhunk://#diff-c0db27c51235bb952d05d30f2292d73221844c144661dae678fe3af07164c859L15-L18) [[2]](diffhunk://#diff-4eaefb7bda8b9b49494b7fbccb76e9f568bcfca0125f3eb8ff5a123b84d5bebcR5-R13) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L8-L9) [[4]](diffhunk://#diff-0366278cb614d0495d2031b478a0688a0ad38f78f5bd419d1a4a2fc4e6f38da5R35)

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
