### PR TITLE
chore: update security schemas

### DIFF
--- a/backend/src/database/migrations/U1757500000__addRecommendationToSecurityInsightsAssessments.sql
+++ b/backend/src/database/migrations/U1757500000__addRecommendationToSecurityInsightsAssessments.sql
@@ -1,0 +1,7 @@
+-- Rollback: Remove additional columns from securityInsightsEvaluationAssessments table
+ALTER TABLE public."securityInsightsEvaluationAssessments" 
+DROP COLUMN "recommendation",
+DROP COLUMN "start",
+DROP COLUMN "end",
+DROP COLUMN "value",
+DROP COLUMN "changes";

--- a/backend/src/database/migrations/V1757500000__addRecommendationToSecurityInsightsAssessments.sql
+++ b/backend/src/database/migrations/V1757500000__addRecommendationToSecurityInsightsAssessments.sql
@@ -1,0 +1,7 @@
+-- Add additional columns to securityInsightsEvaluationAssessments table
+ALTER TABLE public."securityInsightsEvaluationAssessments" 
+ADD COLUMN "recommendation" text,
+ADD COLUMN "start" text,
+ADD COLUMN "end" text,
+ADD COLUMN "value" jsonb,
+ADD COLUMN "changes" jsonb;

--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -11,7 +11,10 @@ RUN tar -xzf privateer_${PLATFORM}.tar.gz
 FROM golang:1.24.4-alpine3.21 AS plugin
 RUN apk add --no-cache make git
 WORKDIR /plugin
-RUN git clone https://github.com/revanite-io/pvtr-github-repo.git
+ARG PVTR_COMMIT=88d79df63e6140c593cf15366ed63992e1fbed63
+# To run the latest version of the plugin, we need to use the latest commit of the pvtr-github-repo repository.
+# Currently using the version https://github.com/revanite-io/pvtr-github-repo/commit/88d79df63e6140c593cf15366ed63992e1fbed63
+RUN git clone https://github.com/revanite-io/pvtr-github-repo.git && cd pvtr-github-repo && git checkout ${PVTR_COMMIT}
 RUN cd pvtr-github-repo && make binary && cp github-repo ../github-repo
 
 FROM node:20-alpine as builder

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -146,6 +146,11 @@ export async function saveOSPSBaselineInsightsToDB(
         steps: assessment.steps,
         stepsExecuted: assessment['steps-executed'] || 0,
         securityInsightsEvaluationId: controlEvaluation.id,
+        recommendation: assessment.recommendation,
+        start: assessment.start,
+        end: assessment.end,
+        value: assessment.value,
+        changes: assessment.changes,
       })
     }
   }

--- a/services/apps/security_best_practices_worker/src/types.ts
+++ b/services/apps/security_best_practices_worker/src/types.ts
@@ -29,7 +29,7 @@ export interface ISecurityInsightsPrivateerResultAssessment {
   message: string
   steps: string[]
   'steps-executed': number
-  start?: string
+  start: string
   end?: string
   value?: unknown
   changes?: Record<string, unknown>

--- a/services/apps/security_best_practices_worker/src/types.ts
+++ b/services/apps/security_best_practices_worker/src/types.ts
@@ -32,7 +32,7 @@ export interface ISecurityInsightsPrivateerResultAssessment {
   start?: string
   end?: string
   value?: unknown
-  changes?: unknown[]
+  changes?: Record<string, unknown>
   recommendation?: string
 }
 

--- a/services/libs/data-access-layer/src/security_insights/index.ts
+++ b/services/libs/data-access-layer/src/security_insights/index.ts
@@ -204,6 +204,11 @@ export async function addControlEvaluationAssessment(
                 "steps", 
                 "stepsExecuted",
                 "runDuration", 
+                "recommendation",
+                "start",
+                "end",
+                "value",
+                "changes",
                 "createdAt", 
                 "updatedAt"
             )
@@ -222,6 +227,11 @@ export async function addControlEvaluationAssessment(
                 $(steps),
                 $(stepsExecuted),
                 $(runDuration),
+                $(recommendation),
+                $(start),
+                $(end),
+                $(value),
+                $(changes),
                 now(), 
                 now()
             )
@@ -234,7 +244,12 @@ export async function addControlEvaluationAssessment(
                 "message"        = EXCLUDED."message",
                 "steps"          = EXCLUDED."steps",
                 "stepsExecuted"  = EXCLUDED."stepsExecuted",
-                "runDuration"    = EXCLUDED."runDuration"
+                "runDuration"    = EXCLUDED."runDuration",
+                "recommendation" = EXCLUDED."recommendation",
+                "start"          = EXCLUDED."start",
+                "end"            = EXCLUDED."end",
+                "value"          = EXCLUDED."value",
+                "changes"        = EXCLUDED."changes"
                 
     `,
     {
@@ -251,6 +266,11 @@ export async function addControlEvaluationAssessment(
       steps: assessment.steps,
       stepsExecuted: assessment.stepsExecuted,
       runDuration: assessment.runDuration,
+      recommendation: assessment.recommendation,
+      start: assessment.start,
+      end: assessment.end,
+      value: assessment.value ? JSON.stringify(assessment.value) : null,
+      changes: assessment.changes ? JSON.stringify(assessment.changes) : null,
     },
   )
 }

--- a/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
+++ b/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
@@ -36,7 +36,7 @@ SCHEMA >
     `message` String `json:$.record.message` DEFAULT '',
     `stepsExecuted` UInt8 `json:$.record.stepsExecuted` DEFAULT 0,
     `runDuration` String `json:$.record.runDuration` DEFAULT '',
-    `recommendation` String `json:$.record.recommendation` DEFAULT '',
+    `recommendation` Nullable(String) `json:$.record.recommendation`,
     `start` String `json:$.record.start` DEFAULT '',
     `end` Nullable(String) `json:$.record.end`,
     `value` Nullable(String) `json:$.record.value`,

--- a/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
+++ b/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
@@ -38,9 +38,9 @@ SCHEMA >
     `runDuration` String `json:$.record.runDuration` DEFAULT '',
     `recommendation` String `json:$.record.recommendation` DEFAULT '',
     `start` String `json:$.record.start` DEFAULT '',
-    `end` String `json:$.record.end` DEFAULT '',
-    `value` String `json:$.record.value` DEFAULT '',
-    `changes` String `json:$.record.changes` DEFAULT '',
+    `end` Nullable(String) `json:$.record.end`,
+    `value` Nullable(String) `json:$.record.value`,
+    `changes` Nullable(String) `json:$.record.changes`,
     `createdAt` DateTime64(3) `json:$.record.createdAt`,
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 

--- a/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
+++ b/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
@@ -14,6 +14,11 @@ DESCRIPTION >
     - `message` provides details about the assessment result (empty string if no message).
     - `stepsExecuted` indicates the number of assessment steps that were executed (UInt8, 0 default).
     - `runDuration` contains the time taken to complete the assessment (empty string if not measured).
+    - `recommendation` contains the recommended action or guidance for addressing the assessment result (empty string if not provided).
+    - `start` contains the start timestamp for the assessment (required string).
+    - `end` contains the end timestamp for the assessment (optional string, empty if not provided).
+    - `value` contains any additional value data from the assessment (empty string if not provided).
+    - `changes` contains any changes data from the assessment (empty string if not provided).
     - `createdAt` and `updatedAt` are standard timestamp fields for record lifecycle tracking.
 
 TAGS "Security insights widget"
@@ -31,6 +36,11 @@ SCHEMA >
     `message` String `json:$.record.message` DEFAULT '',
     `stepsExecuted` UInt8 `json:$.record.stepsExecuted` DEFAULT 0,
     `runDuration` String `json:$.record.runDuration` DEFAULT '',
+    `recommendation` String `json:$.record.recommendation` DEFAULT '',
+    `start` String `json:$.record.start` DEFAULT '',
+    `end` String `json:$.record.end` DEFAULT '',
+    `value` String `json:$.record.value` DEFAULT '',
+    `changes` String `json:$.record.changes` DEFAULT '',
     `createdAt` DateTime64(3) `json:$.record.createdAt`,
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 

--- a/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
@@ -78,7 +78,9 @@ SQL >
                 'description',
                 assessment.description,
                 'result',
-                assessment.result
+                assessment.result,
+                'recommendation',
+                assessment.recommendation
             )
         ) AS assessments
     FROM securityInsightsEvaluations eval final

--- a/services/libs/types/src/securityInsights.ts
+++ b/services/libs/types/src/securityInsights.ts
@@ -37,8 +37,8 @@ export interface ISecurityInsightsEvaluationAssessment {
   steps: string[]
   stepsExecuted: number
   runDuration: string
-  recommendation?: string
   start: string
+  recommendation?: string
   end?: string
   value?: unknown
   changes?: Record<string, unknown>

--- a/services/libs/types/src/securityInsights.ts
+++ b/services/libs/types/src/securityInsights.ts
@@ -37,6 +37,11 @@ export interface ISecurityInsightsEvaluationAssessment {
   steps: string[]
   stepsExecuted: number
   runDuration: string
+  recommendation?: string
+  start: string
+  end?: string
+  value?: unknown
+  changes?: Record<string, unknown>
 }
 
 export interface ISecurityInsightsObsoleteRepo {


### PR DESCRIPTION
# Changes proposed ✍️

### What
- Update security schemas to accomodate new recommendation column and the new schema from the pvtr plugin according to layer 4 of gemara
- Fix privateer plugin to specific commit so that we can run or re-deploy the security-best-practices-worker always with the same version unless we want to update it.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
