### PR TITLE
fix: security datasource and pipe

### DIFF
--- a/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
+++ b/services/libs/tinybird/datasources/securityInsightsEvaluationAssessments.datasource
@@ -45,5 +45,6 @@ SCHEMA >
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 
 ENGINE ReplacingMergeTree
+ENGINE_PARTITION_KEY toYear(createdAt)
 ENGINE_SORTING_KEY insightsProjectSlug, repo, requirementId
 ENGINE_VER updatedAt

--- a/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
@@ -80,7 +80,7 @@ SQL >
                 'result',
                 assessment.result,
                 'recommendation',
-                assessment.recommendation
+                ifNull(assessment.recommendation, '')
             )
         ) AS assessments
     FROM securityInsightsEvaluations eval final


### PR DESCRIPTION
# Changes proposed ✍️

### What
- Datasource and pipe are already updated in production following the changes on this PR https://github.com/CrowdDotDev/crowd.dev/pull/3404. When updating production I noticed 2 issues:
  - The `securityInsightsEvaluationAssessments.datasource` was missing `ENGINE_PARTITION_KEY toYear(createdAt)` which existed already in production. I'm adding this to the code datasource to match what we have in production.
  - Since `assessment.recommendation` might be null and the pipe was expecting `Array(Map(String, String))` as the output, tb through an error. So added an `ifNull(assessment.recommendation, '')` to have `recommendation` as an empty string in case it was null.

Both of these fixes are already in production.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
