### PR TITLE
fix: fix a typo on the activityTypes DB migration

### DIFF
--- a/backend/src/database/migrations/V1757490935__create_activityTypes_table.sql
+++ b/backend/src/database/migrations/V1757490935__create_activityTypes_table.sql
@@ -72,7 +72,7 @@ INSERT INTO "activityTypes" ("activityType", platform, "isCodeContribution", "is
 INSERT INTO "activityTypes" ("activityType", platform, "isCodeContribution", "isCollaboration") VALUES
 ('issues-opened', 'gitlab', false, true),
 ('issues-closed', 'gitlab', false, true),
-('issue-comment', 'gitlab', false, true),
+('issue-comment', 'gitlab', false, true);
 
 -- Confluence platform (Collaboration)
 INSERT INTO "activityTypes" ("activityType", platform, "isCodeContribution", "isCollaboration") VALUES


### PR DESCRIPTION
There was a typo from removing a line in an insert statement in #3386.