### PR TITLE
chore: add no maintainer found error

### DIFF
--- a/services/apps/git_integration/src/crowdgit/enums.py
+++ b/services/apps/git_integration/src/crowdgit/enums.py
@@ -15,6 +15,7 @@ class ErrorCode(str, Enum):
     QUEUE_CONNECTION_ERROR = "queue-connection-error"
     VALIDATION = "validation"
     NO_MAINTAINER_FILE = "no-maintainer-file"
+    NO_MAINTAINER_FOUND = "no-maintainer-found"
     MAINTAINER_ANALYSIS_FAILED = "maintainer-analysis-failed"
     MAINTAINER_INTERVAL_NOT_ELAPSED = "maintainer-interval-not-elapsed"
     CLEANUP_FAILED = "cleanup-failed"

--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -240,7 +240,9 @@ class MaintainerService(BaseService):
                 cost=maintainer_info.cost,
             )
         elif maintainer_info.output.error == "not_found":
-            raise MaintanerAnalysisError(ai_cost=maintainer_info.cost)
+            raise MaintanerAnalysisError(
+                error_code=ErrorCode.NO_MAINTAINER_FOUND, ai_cost=maintainer_info.cost
+            )
         else:
             self.logger.error(
                 f"Expected a list of maintainer info or an error message, got: {str(maintainer_info)}"


### PR DESCRIPTION
# Changes proposed ✍️
This pull request introduces a new error code for cases when no maintainer is found during analysis and updates the logic to use this error code when appropriate. The main changes are focused on improving error handling in the maintainer analysis workflow.

**Error handling improvements:**

* Added a new error code `NO_MAINTAINER_FOUND` to the `ErrorCode` enum in `crowdgit/enums.py` to represent situations where no maintainer is identified.
* Updated the `analyze_file_content` method in `maintainer_service.py` to raise a `MaintanerAnalysisError` with the new `NO_MAINTAINER_FOUND` error code when the maintainer analysis output indicates "not_found".

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
