### PR TITLE
fix: fix the activityTypes data source definition for Tinybird

### DIFF
--- a/services/libs/tinybird/datasources/activityTypes.datasource
+++ b/services/libs/tinybird/datasources/activityTypes.datasource
@@ -10,13 +10,13 @@ DESCRIPTION >
 TAGS "Activity preprocessing pipeline"
 
 SCHEMA >
-    `id` UUID `json:$.id`,
-    `activityType` LowCardinality(String) `json:$.activityType`,
-    `platform` LowCardinality(String) `json:$.platform`,
-    `isCodeContribution` Bool `json:$.isCodeContribution`,
-    `isCollaboration` Bool `json:$.isCollaboration`,
-    `createdAt` DateTime64(3) `json:$.createdAt`,
-    `updatedAt` DateTime64(3) `json:$.updatedAt`
+    `id` UUID `json:$.record.id`,
+    `activityType` LowCardinality(String) `json:$.record.activityType`,
+    `platform` LowCardinality(String) `json:$.record.platform`,
+    `isCodeContribution` Bool `json:$.record.isCodeContribution`,
+    `isCollaboration` Bool `json:$.record.isCollaboration`,
+    `createdAt` DateTime64(3) `json:$.record.createdAt`,
+    `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 
 ENGINE ReplacingMergeTree
 ENGINE_SORTING_KEY (isCodeContribution, isCollaboration, platform)


### PR DESCRIPTION
The datasource definition for the Tinybird activityTypes data source was missing a detail.

Instead of defining the fields as 
```
`id` UUID `json:$.record.id`
```

They were defined as
```
`id` UUID `json:$.id`
```

They were missing the `.record`,  so when parsing the payload, Tinybird was looking for non-existing keys in the JSON object, and thus resulting in null values for all fields in all rows.