### PR TITLE
fix: invalid attribute  in maintainers logs

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -349,7 +349,7 @@ class MaintainerService(BaseService):
             processing should occur, and remaining_hours shows time left until next processing
         """
         if not repository.last_maintainer_run_at:
-            self.logger.info(f"First time processing maintainers for repo {repository.remote}...")
+            self.logger.info(f"First time processing maintainers for repo {repository.url}...")
             return True, 0.0
 
         time_since_last_run = datetime.now(timezone.utc) - repository.last_maintainer_run_at


### PR DESCRIPTION
# Changes proposed ✍️
This pull request makes a minor update to a log message in the maintainer interval checking logic. The change improves the clarity of the log output by using the repository's `url` instead of its `remote` property.

* Logging improvement: Updated the log message in `check_if_interval_elapsed` to display `repository.url` instead of `repository.remote` for better clarity in identifying repositories. (`services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py`)

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
