### PR TITLE
chore: add message to security assessment in TB

### DIFF
--- a/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/security_deduplicated_merged_copy_pipe.pipe
@@ -80,7 +80,9 @@ SQL >
                 'result',
                 assessment.result,
                 'recommendation',
-                ifNull(assessment.recommendation, '')
+                ifNull(assessment.recommendation, ''),
+                'message',
+                assessment.message
             )
         ) AS assessments
     FROM securityInsightsEvaluations eval final


### PR DESCRIPTION
# Changes proposed ✍️

### What
- We were missing the `message` in the copy pipe as well. All the data was already in Postgres and Tinybird, but we were not exporting message to the final security datasource.

This change is already in production.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
