### PR TITLE
fix: add support for gitlabRepos in git v2 migration

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -2480,7 +2480,7 @@ export default class IntegrationService {
         for (const [segmentId, urls] of Object.entries(repos)) {
           let isGitintegrationConfigured
           const segmentOptions: IRepositoryOptions = {
-            ...this.options,
+            ...txOptions,
             currentSegments: [
               {
                 ...this.options.currentSegments[0],
@@ -2503,14 +2503,14 @@ export default class IntegrationService {
               {
                 remotes: Array.from(new Set([...gitRemotes, ...urls])),
               },
-              segmentOptions,
+              { ...segmentOptions, transaction },
             )
           } else {
             await this.gitConnectOrUpdate(
               {
                 remotes: urls,
               },
-              segmentOptions,
+              { ...segmentOptions, transaction },
             )
           }
         }


### PR DESCRIPTION
# Changes proposed ✍️
This pull request updates the repository migration logic in the `IntegrationService` to support both GitHub and GitLab repositories, improving compatibility and future-proofing the migration process. The main changes focus on renaming parameters for clarity and expanding the migration to include `gitlabRepos` in addition to `githubRepos`.

**Migration logic improvements:**

* Renamed the `inheritFromGithubRepos` parameter and related comments to `inheritFromExistingRepos` throughout `integrationService.ts` to clarify that both GitHub and GitLab repositories are considered during migration. [[1]](diffhunk://#diff-80e1c7e63674653fe2cf5bcbe4a2212499d72014f328ad2e6b617146f0a256fdL1291-R1291) [[2]](diffhunk://#diff-80e1c7e63674653fe2cf5bcbe4a2212499d72014f328ad2e6b617146f0a256fdL1309-R1321)
* Updated the repository query logic in `syncRepositoriesToGitV2` to fetch existing repositories from both `githubRepos` and `gitlabRepos` tables using a SQL query that checks for both sources and avoids duplicates.
* Changed the mapping and warning logic to use the combined result set (`existingRepos`) and updated log messages to reflect that both tables are checked.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
