### PR TITLE
feat: allow filtering contributions and collaborations [IN-707]

### DIFF
--- a/services/libs/tinybird/pipes/activities_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_filtered.pipe
@@ -40,9 +40,7 @@ SQL >
             AND a.platform
             = {{ String(platform, description="Filter activity platform", required=False) }}
         {% end %}
-        {% if defined(includeCodeContributions) or defined(includeCollaborations) %}
-            AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
-        {% end %}
+        AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(activity_type) %}
             AND a.type = {{ String(activity_type, description="Filter activity type", required=False) }}
         {% end %}

--- a/services/libs/tinybird/pipes/activities_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_filtered.pipe
@@ -2,18 +2,17 @@ DESCRIPTION >
     - `activities_filtered.pipe` is the core filtering infrastructure pipe for activity data across the entire analytics platform.
     - This pipe serves as the foundation for most activity-related widgets, by providing a consistent, filtered view of contribution activities.
     - It filters activities from `activityRelations_deduplicated_cleaned_ds` datasource based on project segment, time ranges, repositories, platforms, and activity types.
-    - By default, this pipe returns only contribution activities (`isContribution = 1`) unless explicitly overridden with `onlyContributions = 0`.
     - The pipe automatically scopes data to the current project using `segments_filtered` pipe for security and data isolation.
     - Parameters:
     - `project`: Inherited from `segments_filtered`, project slug (e.g., 'k8s', 'tensorflow')
-    - `repos`: Inherited from `segments_filtered`, array of repository URLs for filtering
+    - `repos`: Optional array of repository URLs for filtering (e.g., ['https://github.com/kubernetes/kubernetes']). Inherited from `segments_filtered`.
     - `startDate`: Optional DateTime filter for activities after timestamp (e.g., '2024-01-01 00:00:00')
     - `endDate`: Optional DateTime filter for activities before timestamp (e.g., '2024-12-31 23:59:59')
-    - `repos`: Optional array of repository URLs (e.g., ['https://github.com/kubernetes/kubernetes'])
     - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack')
     - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit')
     - `activity_types`: Optional array of activity types (e.g., ['authored-commit', 'co-authored-commit'])
-    - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities
+    - `includeCodeContributions`: Optional boolean to include code contribution activities. Defaults to 1. Set to 0 to exclude. Inherited from activityTypes_filtered.
+    - `includeCollaborations`: Optional boolean to include or exclude collaboration activities. Inherited from activityTypes_filtered.
     - Response: `id` (activityId), `timestamp`, `type`, `platform`, `memberId`, `organizationId`, `segmentId`.
     - This pipe is consumed by many of downstream pipes and widgets across the platform for consistent activity filtering.
     - Performance is optimized through proper sorting keys on `segmentId`, `timestamp`, `type`, `platform`, and `memberId` in the source datasource.
@@ -41,10 +40,9 @@ SQL >
             AND a.platform
             = {{ String(platform, description="Filter activity platform", required=False) }}
         {% end %}
-        {% if (
-            not defined(onlyContributions)
-            or (defined(onlyContributions) and onlyContributions == 1)
-        ) %} AND a.isContribution {% end %}
+        {% if defined(includeCodeContributions) or defined(includeCollaborations) %}
+            AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
+        {% end %}
         {% if defined(activity_type) %}
             AND a.type = {{ String(activity_type, description="Filter activity type", required=False) }}
         {% end %}

--- a/services/libs/tinybird/pipes/activities_filtered_historical_cutoff.pipe
+++ b/services/libs/tinybird/pipes/activities_filtered_historical_cutoff.pipe
@@ -14,7 +14,8 @@ DESCRIPTION >
     - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack')
     - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit')
     - `activity_types`: Optional array of activity types (e.g., ['authored-commit', 'co-authored-commit'])
-    - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities
+    - `includeCodeContributions`: Optional boolean to include code contribution activities. Defaults to 1. Set to 0 to exclude. Inherited from activityTypes_filtered.
+    - `includeCollaborations`: Optional boolean to include or exclude collaboration activities. Inherited from activityTypes_filtered.
     - Response: `id` (activityId), `timestamp`, `type`, `platform`, `memberId`, `organizationId`, `segmentId`.
 
 NODE activities_filtered_by_timestamp_and_channel
@@ -41,9 +42,7 @@ SQL >
             AND a.platform
             = {{ String(platform, description="Filter activity platform", required=False) }}
         {% end %}
-        {% if not defined(onlyContributions) or (
-            defined(onlyContributions) and onlyContributions == 1
-        ) %} AND a.isContribution {% end %}
+       AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(activity_type) %}
             AND a.type = {{ String(activity_type, description="Filter activity type", required=False) }}
         {% end %}

--- a/services/libs/tinybird/pipes/activities_filtered_historical_cutoff.pipe
+++ b/services/libs/tinybird/pipes/activities_filtered_historical_cutoff.pipe
@@ -42,7 +42,7 @@ SQL >
             AND a.platform
             = {{ String(platform, description="Filter activity platform", required=False) }}
         {% end %}
-       AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
+        AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(activity_type) %}
             AND a.type = {{ String(activity_type, description="Filter activity type", required=False) }}
         {% end %}

--- a/services/libs/tinybird/pipes/activities_filtered_retention.pipe
+++ b/services/libs/tinybird/pipes/activities_filtered_retention.pipe
@@ -13,7 +13,8 @@ DESCRIPTION >
     - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack')
     - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit')
     - `activity_types`: Optional array of activity types (e.g., ['authored-commit', 'co-authored-commit'])
-    - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities
+    - `includeCodeContributions`: Optional boolean to include code contribution activities. Defaults to 1. Set to 0 to exclude. Inherited from activityTypes_filtered.
+    - `includeCollaborations`: Optional boolean to include or exclude collaboration activities. Inherited from activityTypes_filtered.
     - `granularity`: Required string for time aggregation and period extension ('daily', 'weekly', 'monthly', 'quarterly', 'yearly')
     - Response: `id` (activityId), `timestamp`, `type`, `platform`, `memberId`, `organizationId`, `segmentId`.
 
@@ -57,9 +58,7 @@ SQL >
             AND a.platform
             = {{ String(platform, description="Filter activity platform", required=False) }}
         {% end %}
-        {% if not defined(onlyContributions) or (
-            defined(onlyContributions) and onlyContributions == 1
-        ) %} AND a.isContribution {% end %}
+        AND (a.type, a.platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(activity_type) %}
             AND a.type = {{ String(activity_type, description="Filter activity type", required=False) }}
         {% end %}

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -1,0 +1,35 @@
+DESCRIPTION >
+    - `activityTypes_filtered.pipe` allows filtering activityTypes from the respective data source.
+    - By default, this only returns code contribution activities (`includeCodeContributions = 1`).
+    - Parameters:
+    - `includeCodeContributions`: Optional boolean to include code contribution activities. Defaults to 1. Set to 0 to exclude.
+    - `includeCollaborations`: Optional boolean to include or exclude collaboration activities.
+    - Response: `activityType`, `platform`.
+    - This pipe is used by other downstream pipes as an auxiliary method of filtering data by activity types.
+
+NODE activityTypes_selected
+SQL >
+    %
+    SELECT activityType, platform
+    FROM activityTypes
+    WHERE (
+        -- If neither parameter is defined, default to including code contributions.
+        {% if not defined(includeCodeContributions) and not defined(includeCollaborations) %}
+            isCodeContribution = 1
+        {% else %}
+
+            -- Start with a false literal to safely prepend OR clauses in the next statements,
+            -- even if the previous guard didn't output anything.
+            0
+
+            {% if defined(includeCodeContributions) %}
+                OR ({{ UInt8(includeCodeContributions, description="Include code contribution activities", required=False) }} = 1
+                AND isCodeContribution = 1)
+            {% endif %}
+
+            {% if defined(includeCollaborations) %}
+                OR ({{ UInt8(includeCollaborations, description="Include non-code collaboration activities", required=False) }} = 1
+                AND isCollaboration = 1)
+            {% endif %}
+        {% endif %}
+    )

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -17,8 +17,9 @@ SQL >
     WHERE
         (
             -- If no parameters are defined, default to including code contributions.
-            {% if not defined(includeCodeContributions) and not defined(includeCollaborations) and not defined(includeOtherContributions) %}
-                isCodeContribution = 1
+            {% if not defined(includeCodeContributions) and not defined(
+                includeCollaborations
+            ) and not defined(includeOtherContributions) %}isCodeContribution = 1
             {% else %}
                 -- Start with a false literal to safely prepend OR clauses in the next statements,
                 -- even if the previous guard didn't output anything.

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -25,11 +25,11 @@ SQL >
             {% if defined(includeCodeContributions) %}
                 OR ({{ UInt8(includeCodeContributions, description="Include code contribution activities", required=False) }} = 1
                 AND isCodeContribution = 1)
-            {% endif %}
+            {% end %}
 
             {% if defined(includeCollaborations) %}
                 OR ({{ UInt8(includeCollaborations, description="Include non-code collaboration activities", required=False) }} = 1
                 AND isCollaboration = 1)
-            {% endif %}
-        {% endif %}
+            {% end %}
+        {% end %}
     )

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -12,24 +12,36 @@ SQL >
     %
     SELECT activityType, platform
     FROM activityTypes
-    WHERE (
-        -- If neither parameter is defined, default to including code contributions.
-        {% if not defined(includeCodeContributions) and not defined(includeCollaborations) %}
-            isCodeContribution = 1
-        {% else %}
-
-            -- Start with a false literal to safely prepend OR clauses in the next statements,
-            -- even if the previous guard didn't output anything.
-            0
-
-            {% if defined(includeCodeContributions) %}
-                OR ({{ UInt8(includeCodeContributions, description="Include code contribution activities", required=False) }} = 1
-                AND isCodeContribution = 1)
+    WHERE
+        (
+            -- If neither parameter is defined, default to including code contributions.
+            {% if not defined(includeCodeContributions) and not defined(includeCollaborations) %}
+                isCodeContribution = 1
+            {% else %}
+                -- Start with a false literal to safely prepend OR clauses in the next statements,
+                -- even if the previous guard didn't output anything.
+                0
+                {% if defined(includeCodeContributions) %}
+                    OR (
+                        {{
+                            UInt8(
+                                includeCodeContributions,
+                                description="Include code contribution activities",
+                                required=False,
+                            )
+                        }} = 1 AND isCodeContribution = 1
+                    )
+                {% end %}
+                {% if defined(includeCollaborations) %}
+                    OR (
+                        {{
+                            UInt8(
+                                includeCollaborations,
+                                description="Include non-code collaboration activities",
+                                required=False,
+                            )
+                        }} = 1 AND isCollaboration = 1
+                    )
+                {% end %}
             {% end %}
-
-            {% if defined(includeCollaborations) %}
-                OR ({{ UInt8(includeCollaborations, description="Include non-code collaboration activities", required=False) }} = 1
-                AND isCollaboration = 1)
-            {% end %}
-        {% end %}
-    )
+        )

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -11,15 +11,14 @@ DESCRIPTION >
 
 NODE activityTypes_selected
 SQL >
-
     %
     WITH
-      {{ UInt8(includeCodeContributions, default=1) }} AS icc,
-      {{ UInt8(includeCollaborations, default=0) }} AS icol,
-      {{ UInt8(includeOtherContributions, default=0) }} AS ioc
+        {{ UInt8(includeCodeContributions, default=1) }} AS icc,
+        {{ UInt8(includeCollaborations, default=0) }} AS icol,
+        {{ UInt8(includeOtherContributions, default=0) }} AS ioc
     SELECT activityType, platform
     FROM activityTypes
     WHERE
-          (icc = 1  AND isCodeContribution = 1)
-       OR (icol = 1 AND isCollaboration   = 1)
-       OR (ioc = 1  AND isCodeContribution = 0 AND isCollaboration = 0)
+        (icc = 1 AND isCodeContribution = 1)
+        OR (icol = 1 AND isCollaboration = 1)
+        OR (ioc = 1 AND isCodeContribution = 0 AND isCollaboration = 0)

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -1,9 +1,11 @@
 DESCRIPTION >
     - `activityTypes_filtered.pipe` allows filtering activityTypes from the respective data source.
     - By default, this only returns code contribution activities (`includeCodeContributions = 1`).
+    - To return all activities, set `includeCodeContributions = 1`, `includeCollaborations = 1`, and `includeOtherContributions = 1`.
     - Parameters:
     - `includeCodeContributions`: Optional boolean to include code contribution activities. Defaults to 1. Set to 0 to exclude.
     - `includeCollaborations`: Optional boolean to include or exclude collaboration activities.
+    - `includeOtherContributions`: Optional boolean to include other contribution activities (activities that are neither code contributions nor collaborations).
     - Response: `activityType`, `platform`.
     - This pipe is used by other downstream pipes as an auxiliary method of filtering data by activity types.
 
@@ -14,8 +16,8 @@ SQL >
     FROM activityTypes
     WHERE
         (
-            -- If neither parameter is defined, default to including code contributions.
-            {% if not defined(includeCodeContributions) and not defined(includeCollaborations) %}
+            -- If no parameters are defined, default to including code contributions.
+            {% if not defined(includeCodeContributions) and not defined(includeCollaborations) and not defined(includeOtherContributions) %}
                 isCodeContribution = 1
             {% else %}
                 -- Start with a false literal to safely prepend OR clauses in the next statements,
@@ -41,6 +43,17 @@ SQL >
                                 required=False,
                             )
                         }} = 1 AND isCollaboration = 1
+                    )
+                {% end %}
+                {% if defined(includeOtherContributions) %}
+                    OR (
+                        {{
+                            UInt8(
+                                includeOtherContributions,
+                                description="Include other contribution activities",
+                                required=False,
+                            )
+                        }} = 1 AND isCodeContribution = 0 AND isCollaboration = 0
                     )
                 {% end %}
             {% end %}

--- a/services/libs/tinybird/pipes/activityTypes_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityTypes_filtered.pipe
@@ -11,51 +11,15 @@ DESCRIPTION >
 
 NODE activityTypes_selected
 SQL >
+
     %
+    WITH
+      {{ UInt8(includeCodeContributions, default=1) }} AS icc,
+      {{ UInt8(includeCollaborations, default=0) }} AS icol,
+      {{ UInt8(includeOtherContributions, default=0) }} AS ioc
     SELECT activityType, platform
     FROM activityTypes
     WHERE
-        (
-            -- If no parameters are defined, default to including code contributions.
-            {% if not defined(includeCodeContributions) and not defined(
-                includeCollaborations
-            ) and not defined(includeOtherContributions) %}isCodeContribution = 1
-            {% else %}
-                -- Start with a false literal to safely prepend OR clauses in the next statements,
-                -- even if the previous guard didn't output anything.
-                0
-                {% if defined(includeCodeContributions) %}
-                    OR (
-                        {{
-                            UInt8(
-                                includeCodeContributions,
-                                description="Include code contribution activities",
-                                required=False,
-                            )
-                        }} = 1 AND isCodeContribution = 1
-                    )
-                {% end %}
-                {% if defined(includeCollaborations) %}
-                    OR (
-                        {{
-                            UInt8(
-                                includeCollaborations,
-                                description="Include non-code collaboration activities",
-                                required=False,
-                            )
-                        }} = 1 AND isCollaboration = 1
-                    )
-                {% end %}
-                {% if defined(includeOtherContributions) %}
-                    OR (
-                        {{
-                            UInt8(
-                                includeOtherContributions,
-                                description="Include other contribution activities",
-                                required=False,
-                            )
-                        }} = 1 AND isCodeContribution = 0 AND isCollaboration = 0
-                    )
-                {% end %}
-            {% end %}
-        )
+          (icc = 1  AND isCodeContribution = 1)
+       OR (icol = 1 AND isCollaboration   = 1)
+       OR (ioc = 1  AND isCodeContribution = 0 AND isCollaboration = 0)

--- a/services/libs/tinybird/pipes/health_score_active_contributors.pipe
+++ b/services/libs/tinybird/pipes/health_score_active_contributors.pipe
@@ -7,7 +7,8 @@ SQL >
     SELECT segmentId, COALESCE(uniq(memberId), 0) AS activeContributors
     FROM activityRelations_deduplicated_cleaned_ds
     WHERE
-        memberId != '' AND isContribution
+        memberId != ''
+        AND (type, platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(project) %}
             AND segmentId = (SELECT segmentId FROM segments_filtered)
             {% if defined(repos) %}

--- a/services/libs/tinybird/pipes/health_score_contributor_dependency.pipe
+++ b/services/libs/tinybird/pipes/health_score_contributor_dependency.pipe
@@ -4,7 +4,8 @@ SQL >
     SELECT segmentId, memberId, count() AS contributionCount, MIN(timestamp), MAX(timestamp)
     FROM activityRelations_deduplicated_cleaned_ds
     WHERE
-        memberId != '' AND isContribution
+        memberId != ''
+        AND (type, platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(project) %}
             AND segmentId = (SELECT segmentId FROM segments_filtered)
             {% if defined(repos) %}

--- a/services/libs/tinybird/pipes/health_score_organization_dependency.pipe
+++ b/services/libs/tinybird/pipes/health_score_organization_dependency.pipe
@@ -4,7 +4,8 @@ SQL >
     SELECT segmentId, organizationId, count() AS contributionCount
     FROM activityRelations_deduplicated_cleaned_ds
     WHERE
-        organizationId != '' AND isContribution
+        organizationId != ''
+        AND (type, platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
         {% if defined(project) %}
             AND segmentId = (SELECT segmentId FROM segments_filtered)
             {% if defined(repos) %}

--- a/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
+++ b/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
@@ -8,5 +8,5 @@ SQL >
         countDistinctState(memberId) AS contributorCount,
         countDistinctState(organizationId) AS organizationCount
     FROM activityRelations_deduplicated_cleaned_ds
-    WHERE isContribution = true
+    WHERE (type, platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
     GROUP BY segmentId

--- a/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
+++ b/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
@@ -8,5 +8,10 @@ SQL >
         countDistinctState(memberId) AS contributorCount,
         countDistinctState(organizationId) AS organizationCount
     FROM activityRelations_deduplicated_cleaned_ds
-    WHERE (type, platform) IN (SELECT activityType, platform FROM activityTypes_filtered)
+    WHERE
+        (type, platform) IN (
+            SELECT activityType, platform
+            FROM activityTypes
+            WHERE isCodeContribution = 1 OR isCollaboration = 1
+        )
     GROUP BY segmentId

--- a/services/libs/tinybird/pipes/top_member_org_copy.pipe
+++ b/services/libs/tinybird/pipes/top_member_org_copy.pipe
@@ -17,7 +17,14 @@ NODE top_member_org_copy_member_activity_count
 SQL >
     SELECT memberId, count(*) AS activityCount
     FROM activityRelations_deduplicated_cleaned_ds
-    WHERE (timestamp >= (now() - toIntervalYear(10))) AND (timestamp < now())
+    WHERE
+        (timestamp >= (now() - toIntervalYear(10)))
+        AND (timestamp < now())
+        AND (type, platform) IN (
+            SELECT activityType, platform
+            FROM activityTypes_filtered at
+            WHERE at.isCodeContribution = true OR at.isCollaboration = true
+        )
     GROUP BY memberId
     ORDER BY activityCount DESC
     LIMIT 100
@@ -41,7 +48,15 @@ NODE top_member_org_copy_organization_activity_count
 SQL >
     SELECT organizationId, count(*) AS activityCount
     FROM activityRelations_deduplicated_cleaned_ds
-    WHERE (timestamp >= (now() - toIntervalYear(10))) AND (timestamp < now()) AND organizationId != ''
+    WHERE
+        (timestamp >= (now() - toIntervalYear(10)))
+        AND (timestamp < now())
+        AND organizationId != ''
+        AND (type, platform) IN (
+            SELECT activityType, platform
+            FROM activityTypes_filtered at
+            WHERE at.isCodeContribution = true OR at.isCollaboration = true
+        )
     GROUP BY organizationId
     ORDER BY activityCount DESC
     LIMIT 100

--- a/services/libs/tinybird/pipes/top_member_org_copy.pipe
+++ b/services/libs/tinybird/pipes/top_member_org_copy.pipe
@@ -22,8 +22,8 @@ SQL >
         AND (timestamp < now())
         AND (type, platform) IN (
             SELECT activityType, platform
-            FROM activityTypes_filtered at
-            WHERE at.isCodeContribution = true OR at.isCollaboration = true
+            FROM activityTypes
+            WHERE isCodeContribution = 1 OR isCollaboration = 1
         )
     GROUP BY memberId
     ORDER BY activityCount DESC
@@ -54,8 +54,8 @@ SQL >
         AND organizationId != ''
         AND (type, platform) IN (
             SELECT activityType, platform
-            FROM activityTypes_filtered at
-            WHERE at.isCodeContribution = true OR at.isCollaboration = true
+            FROM activityTypes
+            WHERE isCodeContribution = 1 OR isCollaboration = 1
         )
     GROUP BY organizationId
     ORDER BY activityCount DESC


### PR DESCRIPTION
This replaces the `isContribution` filter in the pipes that use activities, and adds the ability to filter by activity type "category", by including a new `includeCodeContributions` and `includeCollaborations` parameters.

By default, if neither parameter is passed to the pipe, it considers `includeCodeContributions = 1`.

The changes in `services/libs/tinybird/pipes/top_member_org_copy.pipe` were done so that the "Top contributors" and "Top organizations" widgets in the app front page use filtered data.

I'm not sure what to do for the "Top LF projects" widget, though. It uses the `projects_list` pipe from Tinybird, but that one does not touch activities, so we can't filter its data by activity type directly. The pipe gets its data from the `insightsProjects_filtered` pipe, which in turn gets its data from `insights_projects_populated_ds` data source, and that one is populated by a copy pipe, which does get activities data - but if we filter the data before it is copied, we affect every other pipe downstream from that one, which is no good.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces isContribution filters with activity type-based filtering via new activityTypes_filtered pipe and updates related pipes/widgets to support includeCodeContributions/includeCollaborations.
> 
> - **Pipes: activity filtering overhaul**
>   - Replace `isContribution` checks with `AND (type, platform) IN (SELECT activityType, platform FROM `activityTypes_filtered`)` in:
>     - `activities_filtered.pipe`, `activities_filtered_historical_cutoff.pipe`, `activities_filtered_retention.pipe`
>     - `health_score_active_contributors.pipe`, `health_score_contributor_dependency.pipe`, `health_score_organization_dependency.pipe`
>     - `segmentId_aggregates_mv.pipe`
>   - Add params inherited from `activityTypes_filtered`: `includeCodeContributions`, `includeCollaborations` (and docs tweaks to `repos`).
> - **New pipe**
>   - `activityTypes_filtered.pipe`: parameterized filter over `activityTypes` with `includeCodeContributions` (default 1), `includeCollaborations`, `includeOtherContributions`; outputs `(activityType, platform)`.
> - **Widgets data sources**
>   - `top_member_org_copy.pipe`: constrain member/org activity counts to code contributions or collaborations using `activityTypes` (exclude other activity types).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b769fa088a286bbe859a82fe916565a25cd8403. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->