### PR TITLE
feat: remove default filters

### DIFF
--- a/frontend/src/modules/activity/store/constants.js
+++ b/frontend/src/modules/activity/store/constants.js
@@ -1,10 +1,2 @@
 export const DEFAULT_ACTIVITY_FILTERS = {
-  member: {
-    isTeamMember: {
-      not: true,
-    },
-    isBot: {
-      not: true,
-    },
-  },
 };


### PR DESCRIPTION
# Changes proposed ✍️

### What
We want to remove the basic filters when queryActivity is called. At the moment, we don’t need to filter by isBot or isTeamMember.
However, we’ve kept the default filter skeleton `DEFAULT_ACTIVITY_FILTERS` in place for potential future use.

## Checklist ✅
- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.

