### PR TITLE
fix: BrokenProcessPool in commits processing 

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -256,16 +256,16 @@ class CloneService(BaseService):
         total_branches_tags = len(total_branches_tags.splitlines())
         if total_branches_tags <= 200:
             # Small repo, get a decent amount of history
-            calculated_depth = 500
+            calculated_depth = 200
         elif total_branches_tags <= 1000:
             # Medium repo, get a moderate amount of history
-            calculated_depth = 300
+            calculated_depth = 100
         elif total_branches_tags <= 5000:
             # Large repo, get less history
-            calculated_depth = 20
+            calculated_depth = 10
         else:
             # Very large repo, get a minimal history
-            calculated_depth = 10
+            calculated_depth = 5
         self.logger.info(
             f"total_branches_tags={total_branches_tags}, calculated_depth={calculated_depth}"
         )

--- a/services/apps/git_integration/src/crowdgit/settings.py
+++ b/services/apps/git_integration/src/crowdgit/settings.py
@@ -18,7 +18,7 @@ WORKER_ERROR_BACKOFF_SEC = int(load_env_var("WORKER_ERROR_BACKOFF_SEC", default=
 REPOSITORY_UPDATE_INTERVAL_HOURS = int(
     load_env_var("REPOSITORY_UPDATE_INTERVAL_HOURS", default=24)
 )
-MAX_WORKER_PROCESSES = int(load_env_var("MAX_WORKER_PROCESSES", default=min(4, os.cpu_count())))
+MAX_WORKER_PROCESSES = int(load_env_var("MAX_WORKER_PROCESSES", default=min(3, os.cpu_count())))
 DEFAULT_TENANT_ID = load_env_var(
     "CROWD_SSO_LF_TENANT_ID", default="875c38bd-2b1b-4e91-ad07-0cfbabb4c49f"
 )


### PR DESCRIPTION
# Changes proposed ✍️
This pull request introduces several improvements to resource management and error handling in the commit processing workflow, along with adjustments to default configuration values for cloning and worker processes. The main focus is on making the commit processing more robust against process pool failures, improving logging for better observability, and tuning default parameters for performance and resource usage.

**Commit Processing Robustness and Logging:**

- Improved error handling in `commit_service.py` to catch and handle `BrokenProcessPool` exceptions both during task submission and result processing, ensuring the process pool is cleaned up and logging warnings when issues occur. Additional logging was added to track task submission and chunk completion progress. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R663) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R677-R700)
- Added an informational log message when cleaning up the process pool to aid in debugging resource management issues.

**Configuration and Defaults Adjustments:**

- Reduced the default value for `MAX_WORKER_PROCESSES` from 4 to 3 in `settings.py`, likely to lower resource usage and prevent over-provisioning on smaller machines.
- Adjusted the logic in `_calculate_batch_depth` in `clone_service.py` to use smaller history depths for cloning repositories, which can help speed up cloning and reduce resource usage for large repositories.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
