### PR TITLE
feat: add platforms_by_segment.pipe

### DIFF
--- a/services/libs/tinybird/pipes/platforms_by_segments.pipe
+++ b/services/libs/tinybird/pipes/platforms_by_segments.pipe
@@ -1,0 +1,25 @@
+DESCRIPTION >
+  - Returns a single array of distinct platforms.
+  - Source: activityRelations_deduplicated_ds.
+  - Filters by segmentId (required at runtime) and optional time range (after/before).
+  - Notes:
+    - CamelCase identifiers are quoted.
+    - The query compiles without params. If SEGMENTS is missing, it returns empty results.
+
+NODE platforms_array
+SQL >
+  %
+  /* Distinct platforms as one array (no sort for max perf) */
+  SELECT
+      groupUniqArray("platform") AS platforms
+  FROM activityRelations_deduplicated_ds
+  WHERE
+      "segmentId" IN {{ Array(segments, 'String', required=True, description="Segment IDs") }}
+      {% if defined(after) and after %}
+        AND "timestamp" > parseDateTimeBestEffort({{ String(after) }})
+      {% end %}
+      {% if defined(before) and before %}
+        AND "timestamp" < parseDateTimeBestEffort({{ String(before) }})
+      {% end %}
+      AND "platform" IS NOT NULL
+      AND "platform" != ''


### PR DESCRIPTION
# Changes proposed ✍️

### What
For QuestDB deprecation, we need a query that returns the distinct platforms used by a set of segments, based on their activities.

### How
A new pipe is added: `pipes/platforms_by_segmtne.pipe`

## Checklist ✅

- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.
