### PR TITLE
fix: memberTags usage in leftover operations

### DIFF
--- a/services/libs/data-access-layer/src/old/apps/automations_worker/data.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/automations_worker/data.repo.ts
@@ -240,20 +240,6 @@ export class DataRepository extends RepositoryBase<DataRepository> {
         )
       }
 
-      // load tags
-      promises.push(
-        this.getMemberTags(memberIds).then((tags) => {
-          for (const member of results) {
-            member.tags = tags
-              .filter((t) => t.memberId === member.id)
-              .map((t) => {
-                delete t.memberId
-                return t
-              })
-          }
-        }),
-      )
-
       // load no merge
       promises.push(
         this.getMemberNoMerge(memberIds).then((noMerges) => {
@@ -379,23 +365,6 @@ export class DataRepository extends RepositoryBase<DataRepository> {
       select "memberId", "noMergeId"
       from "memberNoMerge"
       where "memberId" in ($(memberIds:csv));
-      `,
-      {
-        memberIds,
-      },
-    )
-
-    return results
-  }
-
-  async getMemberTags(memberIds: string[]): Promise<any[]> {
-    const results = await this.db().any(
-      `
-      select mt."memberId", t.*
-      from "memberTags" mt
-              inner join tags t on t.id = mt."tagId"
-      where mt."memberId" in ($(memberIds:csv))
-        and t."deletedAt" is null;
       `,
       {
         memberIds,

--- a/services/libs/data-access-layer/src/old/apps/script_executor_worker/member.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/script_executor_worker/member.repo.ts
@@ -208,7 +208,6 @@ class MemberRepository {
       { name: 'memberSegmentAffiliations', conditions: ['memberId'] },
       { name: 'memberSegmentsAgg', conditions: ['memberId'] },
       { name: 'memberSegments', conditions: ['memberId'] },
-      { name: 'memberTags', conditions: ['memberId'] },
       { name: 'memberToMerge', conditions: ['memberId', 'toMergeId'] },
       { name: 'memberToMergeRaw', conditions: ['memberId', 'toMergeId'] },
       { name: 'members', conditions: ['id'] },

--- a/services/libs/opensearch/src/repo/member.repo.ts
+++ b/services/libs/opensearch/src/repo/member.repo.ts
@@ -105,20 +105,6 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
         where mnm."memberId" = $(memberId)
         and m2."deletedAt" is null
         group by mnm."memberId"),
-  member_tags as (
-        select mt."memberId",
-        json_agg(
-              json_build_object(
-                      'id', t.id,
-                      'name', t.name
-                  )
-        )           as all_tags,
-      jsonb_agg(t.id) as all_ids
-      from "memberTags" mt
-        inner join tags t on mt."tagId" = t.id
-      where mt."memberId" = $(memberId)
-      and t."deletedAt" is null
-      group by mt."memberId"),
   member_organizations as (
       select mo."memberId",
       json_agg(
@@ -192,7 +178,6 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
 
     coalesce(i.identities, '[]'::json)            as "identities",
     coalesce(mo.all_organizations, json_build_array()) as organizations,
-    coalesce(mt.all_tags, json_build_array())          as tags,
     coalesce(ma.all_affiliations, json_build_array())  as affiliations,
     coalesce(tmd.to_merge_ids, array []::text[])       as "toMergeIds",
     coalesce(nmd.no_merge_ids, array []::text[])       as "noMergeIds"
@@ -200,7 +185,6 @@ export class MemberRepository extends RepositoryBase<MemberRepository> {
     inner join identities i on m.id = i."memberId"
     left join to_merge_data tmd on m.id = tmd."memberId"
     left join no_merge_data nmd on m.id = nmd."memberId"
-    left join member_tags mt on m.id = mt."memberId"
     left join member_affiliations ma on m.id = ma."memberId"
     left join member_organizations mo on m.id = mo."memberId"
   where m.id = $(memberId)


### PR DESCRIPTION
# Changes proposed ✍️

### What
- "memberTags" table no longer exists. However, there were still some queries trying to get data from memberTags. Namely the temporal workflow that cleans up members.
- This PR removes all queries to memberTags.
