### PR TITLE
chore: activity types table description

### DIFF
--- a/backend/src/database/migrations/U1759325136__add_description_to_activity_types.sql
+++ b/backend/src/database/migrations/U1759325136__add_description_to_activity_types.sql
@@ -1,0 +1,4 @@
+-- Revert: Drop description column from activityTypes table
+-- This reverts migration V1759325136__add_description_to_activity_types.sql
+
+ALTER TABLE "activityTypes" DROP COLUMN description;

--- a/backend/src/database/migrations/V1759325136__add_description_to_activity_types.sql
+++ b/backend/src/database/migrations/V1759325136__add_description_to_activity_types.sql
@@ -4,125 +4,125 @@ ALTER TABLE "activityTypes" ADD COLUMN description TEXT;
 -- Update descriptions for existing activity types
 
 -- Confluence platform
-UPDATE "activityTypes" SET description = 'Added file attachment to Confluence page or blog' WHERE "activityType" = 'attachment' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Created file attachment in Confluence' WHERE "activityType" = 'attachment-created' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Created blog post in Confluence' WHERE "activityType" = 'blogpost-created' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Updated blog post in Confluence' WHERE "activityType" = 'blogpost-updated' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Added comment in Confluence' WHERE "activityType" = 'comment' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Created comment in Confluence' WHERE "activityType" = 'comment-created' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Created page in Confluence' WHERE "activityType" = 'page-created' AND platform = 'confluence';
-UPDATE "activityTypes" SET description = 'Updated page in Confluence' WHERE "activityType" = 'page-updated' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Added file attachment to a Confluence page or blog post' WHERE "activityType" = 'attachment' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created file attachment in a Confluence page or blog post' WHERE "activityType" = 'attachment-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Published a new Confluence blog post' WHERE "activityType" = 'blogpost-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Updated an existing Confluence blog post' WHERE "activityType" = 'blogpost-updated' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Posted a comment on a Confluence page or blog post' WHERE "activityType" = 'comment' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created comment in a Confluence page or blog post' WHERE "activityType" = 'comment-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created a new Confluence page' WHERE "activityType" = 'page-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Edited or updated a Confluence page' WHERE "activityType" = 'page-updated' AND platform = 'confluence';
 
 -- Dev.to platform
-UPDATE "activityTypes" SET description = 'Commented on Dev.to article' WHERE "activityType" = 'comment' AND platform = 'devto';
+UPDATE "activityTypes" SET description = 'Commented on a Dev.to article' WHERE "activityType" = 'comment' AND platform = 'devto';
 
 -- Discord platform
 UPDATE "activityTypes" SET description = 'Joined Discord server/guild' WHERE "activityType" = 'joined_guild' AND platform = 'discord';
-UPDATE "activityTypes" SET description = 'Sent message in Discord channel' WHERE "activityType" = 'message' AND platform = 'discord';
-UPDATE "activityTypes" SET description = 'Sent message in Discord thread' WHERE "activityType" = 'thread_message' AND platform = 'discord';
-UPDATE "activityTypes" SET description = 'Started thread in Discord channel' WHERE "activityType" = 'thread_started' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Sent a message in a Discord channel' WHERE "activityType" = 'message' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Sent a message in a Discord thread' WHERE "activityType" = 'thread_message' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Started thread in a Discord channel' WHERE "activityType" = 'thread_started' AND platform = 'discord';
 
 -- Discourse platform
-UPDATE "activityTypes" SET description = 'Liked post in Discourse forum' WHERE "activityType" = 'like' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Liked post in a Discourse forum' WHERE "activityType" = 'like' AND platform = 'discourse';
 UPDATE "activityTypes" SET description = 'Joined Discourse forum' WHERE "activityType" = 'join' AND platform = 'discourse';
-UPDATE "activityTypes" SET description = 'Created topic in Discourse forum' WHERE "activityType" = 'create_topic' AND platform = 'discourse';
-UPDATE "activityTypes" SET description = 'Replied to topic in Discourse forum' WHERE "activityType" = 'message_in_topic' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Created topic in a Discourse forum' WHERE "activityType" = 'create_topic' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Replied to topic in a Discourse forum' WHERE "activityType" = 'message_in_topic' AND platform = 'discourse';
 
 -- Gerrit platform
-UPDATE "activityTypes" SET description = 'Abandoned code changeset in Gerrit' WHERE "activityType" = 'changeset-abandoned' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Closed code changeset in Gerrit' WHERE "activityType" = 'changeset-closed' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Created code changeset in Gerrit' WHERE "activityType" = 'changeset-created' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Merged code changeset in Gerrit' WHERE "activityType" = 'changeset-merged' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Submitted new code changeset in Gerrit' WHERE "activityType" = 'changeset-new' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Commented on code changeset in Gerrit' WHERE "activityType" = 'changeset_comment-created' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Created code patchset in Gerrit' WHERE "activityType" = 'patchset-created' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Approved code patchset in Gerrit' WHERE "activityType" = 'patchset_approval-created' AND platform = 'gerrit';
-UPDATE "activityTypes" SET description = 'Commented on code patchset in Gerrit' WHERE "activityType" = 'patchset_comment-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Abandoned a code change in Gerrit' WHERE "activityType" = 'changeset-abandoned' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Closed a code review in Gerrit' WHERE "activityType" = 'changeset-closed' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Submitted a new changeset in Gerrit' WHERE "activityType" = 'changeset-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Merged a code change into the main branch in Gerrit' WHERE "activityType" = 'changeset-merged' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Started a new code review change' WHERE "activityType" = 'changeset-new' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Commented on a code changeset in Gerrit' WHERE "activityType" = 'changeset_comment-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Uploaded a new patchset for review in Gerrit' WHERE "activityType" = 'patchset-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Approved a code patchset for review in Gerrit' WHERE "activityType" = 'patchset_approval-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Commented on a code patchset in Gerrit' WHERE "activityType" = 'patchset_comment-created' AND platform = 'gerrit';
 
 -- Git platform
-UPDATE "activityTypes" SET description = 'Approved git commit in default branch' WHERE "activityType" = 'approved-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Authored git commit in default branch' WHERE "activityType" = 'authored-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Co-authored git commit in default branch' WHERE "activityType" = 'co-authored-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Committed git changes in default branch' WHERE "activityType" = 'committed-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Influenced git commit in default branch' WHERE "activityType" = 'influenced-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Informed about git commit in default branch' WHERE "activityType" = 'informed-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Reported git commit in default branch' WHERE "activityType" = 'reported-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Resolved git commit in default branch' WHERE "activityType" = 'resolved-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Reviewed git commit in default branch' WHERE "activityType" = 'reviewed-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Signed off git commit in default branch' WHERE "activityType" = 'signed-off-commit' AND platform = 'git';
-UPDATE "activityTypes" SET description = 'Tested git commit in default branch' WHERE "activityType" = 'tested-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Approved a Git commit during code review in the default branch' WHERE "activityType" = 'approved-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Authored a Git commit in the default branch' WHERE "activityType" = 'authored-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Co-authored a Git commit with another user in the default branch' WHERE "activityType" = 'co-authored-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Committed changes to a repository in the default branch' WHERE "activityType" = 'committed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Indirectly influenced a Git commit's creation in the default branch' WHERE "activityType" = 'influenced-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Contributed ideas or guidance that led to a Git commit in the default branch' WHERE "activityType" = 'informed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Reported an issue fixed by a Git commit in the default branch' WHERE "activityType" = 'reported-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Resolved an issue with a Git commit in the default branch' WHERE "activityType" = 'resolved-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Reviewed a Git commit in the default branch' WHERE "activityType" = 'reviewed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Signed off on a Git commit for compliance/review in the default branch' WHERE "activityType" = 'signed-off-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Tested changes and marked them accordingly in the default branch' WHERE "activityType" = 'tested-commit' AND platform = 'git';
 
 -- GitHub platform
-UPDATE "activityTypes" SET description = 'Authored and pushed a commit in a pull requeston GitHub' WHERE "activityType" = 'authored-commit' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Commented on GitHub discussion' WHERE "activityType" = 'discussion-comment' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Started GitHub discussion' WHERE "activityType" = 'discussion-started' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Forked GitHub repository' WHERE "activityType" = 'fork' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Commented on GitHub issue' WHERE "activityType" = 'issue-comment' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Closed GitHub issue' WHERE "activityType" = 'issues-closed' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Opened GitHub issue' WHERE "activityType" = 'issues-opened' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Assigned to GitHub pull request' WHERE "activityType" = 'pull_request-assigned' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Closed GitHub pull request' WHERE "activityType" = 'pull_request-closed' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Commented on GitHub pull request' WHERE "activityType" = 'pull_request-comment' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Merged GitHub pull request' WHERE "activityType" = 'pull_request-merged' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Opened GitHub pull request' WHERE "activityType" = 'pull_request-opened' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Requested review on GitHub pull request' WHERE "activityType" = 'pull_request-review-requested' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Reviewed GitHub pull request' WHERE "activityType" = 'pull_request-reviewed' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Starred GitHub repository' WHERE "activityType" = 'star' AND platform = 'github';
-UPDATE "activityTypes" SET description = 'Unstarred GitHub repository' WHERE "activityType" = 'unstar' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Authored and pushed a commit in a pull request on GitHub' WHERE "activityType" = 'authored-commit' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on a GitHub discussion' WHERE "activityType" = 'discussion-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Started a GitHub discussion' WHERE "activityType" = 'discussion-started' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Forked a GitHub repository' WHERE "activityType" = 'fork' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on a GitHub issue' WHERE "activityType" = 'issue-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Closed a GitHub issue' WHERE "activityType" = 'issues-closed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Opened a GitHub issue' WHERE "activityType" = 'issues-opened' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Assigned to a GitHub pull request' WHERE "activityType" = 'pull_request-assigned' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Closed a GitHub pull request' WHERE "activityType" = 'pull_request-closed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on a GitHub pull request' WHERE "activityType" = 'pull_request-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Merged a GitHub pull request' WHERE "activityType" = 'pull_request-merged' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Opened a GitHub pull request' WHERE "activityType" = 'pull_request-opened' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Requested a review on a GitHub pull request' WHERE "activityType" = 'pull_request-review-requested' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Reviewed a GitHub pull request' WHERE "activityType" = 'pull_request-reviewed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Starred a GitHub repository' WHERE "activityType" = 'star' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Unstarred a GitHub repository' WHERE "activityType" = 'unstar' AND platform = 'github';
 
 -- GitLab platform
 UPDATE "activityTypes" SET description = 'Authored and pushed a commit in a merge request on GitLab' WHERE "activityType" = 'authored-commit' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Forked GitLab repository' WHERE "activityType" = 'fork' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Commented on GitLab issue' WHERE "activityType" = 'issue-comment' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Closed GitLab issue' WHERE "activityType" = 'issues-closed' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Opened GitLab issue' WHERE "activityType" = 'issues-opened' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Assigned to GitLab merge request' WHERE "activityType" = 'merge_request-assigned' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Closed GitLab merge request' WHERE "activityType" = 'merge_request-closed' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Commented on GitLab merge request' WHERE "activityType" = 'merge_request-comment' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Merged GitLab merge request' WHERE "activityType" = 'merge_request-merged' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Opened GitLab merge request' WHERE "activityType" = 'merge_request-opened' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Approved GitLab merge request review' WHERE "activityType" = 'merge_request-review-approved' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Requested changes on GitLab merge request' WHERE "activityType" = 'merge_request-review-changes-requested' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Requested review on GitLab merge request' WHERE "activityType" = 'merge_request-review-requested' AND platform = 'gitlab';
-UPDATE "activityTypes" SET description = 'Starred GitLab repository' WHERE "activityType" = 'star' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Forked a GitLab repository' WHERE "activityType" = 'fork' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Commented on a GitLab issue' WHERE "activityType" = 'issue-comment' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Closed a GitLab issue' WHERE "activityType" = 'issues-closed' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Opened a GitLab issue' WHERE "activityType" = 'issues-opened' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Assigned to a GitLab merge request' WHERE "activityType" = 'merge_request-assigned' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Closed a GitLab merge request' WHERE "activityType" = 'merge_request-closed' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Commented on a GitLab merge request' WHERE "activityType" = 'merge_request-comment' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Merged a GitLab merge request' WHERE "activityType" = 'merge_request-merged' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Opened a GitLab merge request' WHERE "activityType" = 'merge_request-opened' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Approved a GitLab merge request review' WHERE "activityType" = 'merge_request-review-approved' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Requested changes on a GitLab merge request' WHERE "activityType" = 'merge_request-review-changes-requested' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Requested review on a GitLab merge request' WHERE "activityType" = 'merge_request-review-requested' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Starred a GitLab repository' WHERE "activityType" = 'star' AND platform = 'gitlab';
 
 -- Groups.io platform
-UPDATE "activityTypes" SET description = 'Sent message in Groups.io mailing list' WHERE "activityType" = 'message' AND platform = 'groupsio';
+UPDATE "activityTypes" SET description = 'Sent message in a Groups.io mailing list' WHERE "activityType" = 'message' AND platform = 'groupsio';
 UPDATE "activityTypes" SET description = 'Joined Groups.io mailing list' WHERE "activityType" = 'member_join' AND platform = 'groupsio';
 UPDATE "activityTypes" SET description = 'Left Groups.io mailing list' WHERE "activityType" = 'member_leave' AND platform = 'groupsio';
 
 -- Hackernews platform
-UPDATE "activityTypes" SET description = 'Commented on Hacker News story' WHERE "activityType" = 'comment' AND platform = 'hackernews';
-UPDATE "activityTypes" SET description = 'Posted story on Hacker News' WHERE "activityType" = 'post' AND platform = 'hackernews';
+UPDATE "activityTypes" SET description = 'Commented on a Hacker News story' WHERE "activityType" = 'comment' AND platform = 'hackernews';
+UPDATE "activityTypes" SET description = 'Posted a story on Hacker News' WHERE "activityType" = 'post' AND platform = 'hackernews';
 
 -- Jira platform
-UPDATE "activityTypes" SET description = 'Added an assignee to Jira issue' WHERE "activityType" = 'issue-assigned' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Added attachment to Jira issue' WHERE "activityType" = 'issue-attachment-added' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Closed Jira issue' WHERE "activityType" = 'issue-closed' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Created comment on Jira issue' WHERE "activityType" = 'issue-comment-created' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Updated comment on Jira issue' WHERE "activityType" = 'issue-comment-updated' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Created Jira issue' WHERE "activityType" = 'issue-created' AND platform = 'jira';
-UPDATE "activityTypes" SET description = 'Updated Jira issue' WHERE "activityType" = 'issue-updated' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Added an assignee to a Jira issue' WHERE "activityType" = 'issue-assigned' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Added attachment to a Jira issue' WHERE "activityType" = 'issue-attachment-added' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Closed a Jira issue' WHERE "activityType" = 'issue-closed' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Created comment on a Jira issue' WHERE "activityType" = 'issue-comment-created' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Updated comment on a Jira issue' WHERE "activityType" = 'issue-comment-updated' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Created a Jira issue' WHERE "activityType" = 'issue-created' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Updated a Jira issue' WHERE "activityType" = 'issue-updated' AND platform = 'jira';
 
 -- LinkedIn platform
-UPDATE "activityTypes" SET description = 'Commented on LinkedIn post' WHERE "activityType" = 'comment' AND platform = 'linkedin';
-UPDATE "activityTypes" SET description = 'Reacted to LinkedIn post' WHERE "activityType" = 'reaction' AND platform = 'linkedin';
+UPDATE "activityTypes" SET description = 'Commented on a LinkedIn post' WHERE "activityType" = 'comment' AND platform = 'linkedin';
+UPDATE "activityTypes" SET description = 'Reacted to a LinkedIn post' WHERE "activityType" = 'reaction' AND platform = 'linkedin';
 
 -- Reddit platform
-UPDATE "activityTypes" SET description = 'Commented on Reddit post' WHERE "activityType" = 'comment' AND platform = 'reddit';
+UPDATE "activityTypes" SET description = 'Commented on a Reddit post' WHERE "activityType" = 'comment' AND platform = 'reddit';
 UPDATE "activityTypes" SET description = 'Posted on Reddit' WHERE "activityType" = 'post' AND platform = 'reddit';
 
 -- Slack platform
-UPDATE "activityTypes" SET description = 'Joined Slack channel' WHERE "activityType" = 'channel_joined' AND platform = 'slack';
-UPDATE "activityTypes" SET description = 'Sent message in Slack channel' WHERE "activityType" = 'message' AND platform = 'slack';
+UPDATE "activityTypes" SET description = 'Joined a Slack channel' WHERE "activityType" = 'channel_joined' AND platform = 'slack';
+UPDATE "activityTypes" SET description = 'Sent a message in a Slack channel' WHERE "activityType" = 'message' AND platform = 'slack';
 
 -- Stack Overflow platform
-UPDATE "activityTypes" SET description = 'Answered question on Stack Overflow' WHERE "activityType" = 'answer' AND platform = 'stackoverflow';
-UPDATE "activityTypes" SET description = 'Asked question on Stack Overflow' WHERE "activityType" = 'question' AND platform = 'stackoverflow';
+UPDATE "activityTypes" SET description = 'Answered a question on Stack Overflow' WHERE "activityType" = 'answer' AND platform = 'stackoverflow';
+UPDATE "activityTypes" SET description = 'Asked a question on Stack Overflow' WHERE "activityType" = 'question' AND platform = 'stackoverflow';
 
 -- Twitter platform
-UPDATE "activityTypes" SET description = 'Used hashtag in Twitter post' WHERE "activityType" = 'hashtag' AND platform = 'twitter';
-UPDATE "activityTypes" SET description = 'Mentioned user in Twitter post' WHERE "activityType" = 'mention' AND platform = 'twitter';
+UPDATE "activityTypes" SET description = 'Used hashtag in a Twitter post' WHERE "activityType" = 'hashtag' AND platform = 'twitter';
+UPDATE "activityTypes" SET description = 'Mentioned user in a Twitter post' WHERE "activityType" = 'mention' AND platform = 'twitter';
 UPDATE "activityTypes" SET description = 'Followed user on Twitter' WHERE "activityType" = 'follow' AND platform = 'twitter';
 
 -- Add NOT NULL constraint to description column

--- a/backend/src/database/migrations/V1759325136__add_description_to_activity_types.sql
+++ b/backend/src/database/migrations/V1759325136__add_description_to_activity_types.sql
@@ -1,0 +1,129 @@
+-- Add description column to activityTypes table
+ALTER TABLE "activityTypes" ADD COLUMN description TEXT;
+
+-- Update descriptions for existing activity types
+
+-- Confluence platform
+UPDATE "activityTypes" SET description = 'Added file attachment to Confluence page or blog' WHERE "activityType" = 'attachment' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created file attachment in Confluence' WHERE "activityType" = 'attachment-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created blog post in Confluence' WHERE "activityType" = 'blogpost-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Updated blog post in Confluence' WHERE "activityType" = 'blogpost-updated' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Added comment in Confluence' WHERE "activityType" = 'comment' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created comment in Confluence' WHERE "activityType" = 'comment-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Created page in Confluence' WHERE "activityType" = 'page-created' AND platform = 'confluence';
+UPDATE "activityTypes" SET description = 'Updated page in Confluence' WHERE "activityType" = 'page-updated' AND platform = 'confluence';
+
+-- Dev.to platform
+UPDATE "activityTypes" SET description = 'Commented on Dev.to article' WHERE "activityType" = 'comment' AND platform = 'devto';
+
+-- Discord platform
+UPDATE "activityTypes" SET description = 'Joined Discord server/guild' WHERE "activityType" = 'joined_guild' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Sent message in Discord channel' WHERE "activityType" = 'message' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Sent message in Discord thread' WHERE "activityType" = 'thread_message' AND platform = 'discord';
+UPDATE "activityTypes" SET description = 'Started thread in Discord channel' WHERE "activityType" = 'thread_started' AND platform = 'discord';
+
+-- Discourse platform
+UPDATE "activityTypes" SET description = 'Liked post in Discourse forum' WHERE "activityType" = 'like' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Joined Discourse forum' WHERE "activityType" = 'join' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Created topic in Discourse forum' WHERE "activityType" = 'create_topic' AND platform = 'discourse';
+UPDATE "activityTypes" SET description = 'Replied to topic in Discourse forum' WHERE "activityType" = 'message_in_topic' AND platform = 'discourse';
+
+-- Gerrit platform
+UPDATE "activityTypes" SET description = 'Abandoned code changeset in Gerrit' WHERE "activityType" = 'changeset-abandoned' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Closed code changeset in Gerrit' WHERE "activityType" = 'changeset-closed' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Created code changeset in Gerrit' WHERE "activityType" = 'changeset-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Merged code changeset in Gerrit' WHERE "activityType" = 'changeset-merged' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Submitted new code changeset in Gerrit' WHERE "activityType" = 'changeset-new' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Commented on code changeset in Gerrit' WHERE "activityType" = 'changeset_comment-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Created code patchset in Gerrit' WHERE "activityType" = 'patchset-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Approved code patchset in Gerrit' WHERE "activityType" = 'patchset_approval-created' AND platform = 'gerrit';
+UPDATE "activityTypes" SET description = 'Commented on code patchset in Gerrit' WHERE "activityType" = 'patchset_comment-created' AND platform = 'gerrit';
+
+-- Git platform
+UPDATE "activityTypes" SET description = 'Approved git commit in default branch' WHERE "activityType" = 'approved-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Authored git commit in default branch' WHERE "activityType" = 'authored-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Co-authored git commit in default branch' WHERE "activityType" = 'co-authored-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Committed git changes in default branch' WHERE "activityType" = 'committed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Influenced git commit in default branch' WHERE "activityType" = 'influenced-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Informed about git commit in default branch' WHERE "activityType" = 'informed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Reported git commit in default branch' WHERE "activityType" = 'reported-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Resolved git commit in default branch' WHERE "activityType" = 'resolved-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Reviewed git commit in default branch' WHERE "activityType" = 'reviewed-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Signed off git commit in default branch' WHERE "activityType" = 'signed-off-commit' AND platform = 'git';
+UPDATE "activityTypes" SET description = 'Tested git commit in default branch' WHERE "activityType" = 'tested-commit' AND platform = 'git';
+
+-- GitHub platform
+UPDATE "activityTypes" SET description = 'Authored and pushed a commit in a pull requeston GitHub' WHERE "activityType" = 'authored-commit' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on GitHub discussion' WHERE "activityType" = 'discussion-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Started GitHub discussion' WHERE "activityType" = 'discussion-started' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Forked GitHub repository' WHERE "activityType" = 'fork' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on GitHub issue' WHERE "activityType" = 'issue-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Closed GitHub issue' WHERE "activityType" = 'issues-closed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Opened GitHub issue' WHERE "activityType" = 'issues-opened' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Assigned to GitHub pull request' WHERE "activityType" = 'pull_request-assigned' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Closed GitHub pull request' WHERE "activityType" = 'pull_request-closed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Commented on GitHub pull request' WHERE "activityType" = 'pull_request-comment' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Merged GitHub pull request' WHERE "activityType" = 'pull_request-merged' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Opened GitHub pull request' WHERE "activityType" = 'pull_request-opened' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Requested review on GitHub pull request' WHERE "activityType" = 'pull_request-review-requested' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Reviewed GitHub pull request' WHERE "activityType" = 'pull_request-reviewed' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Starred GitHub repository' WHERE "activityType" = 'star' AND platform = 'github';
+UPDATE "activityTypes" SET description = 'Unstarred GitHub repository' WHERE "activityType" = 'unstar' AND platform = 'github';
+
+-- GitLab platform
+UPDATE "activityTypes" SET description = 'Authored and pushed a commit in a merge request on GitLab' WHERE "activityType" = 'authored-commit' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Forked GitLab repository' WHERE "activityType" = 'fork' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Commented on GitLab issue' WHERE "activityType" = 'issue-comment' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Closed GitLab issue' WHERE "activityType" = 'issues-closed' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Opened GitLab issue' WHERE "activityType" = 'issues-opened' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Assigned to GitLab merge request' WHERE "activityType" = 'merge_request-assigned' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Closed GitLab merge request' WHERE "activityType" = 'merge_request-closed' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Commented on GitLab merge request' WHERE "activityType" = 'merge_request-comment' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Merged GitLab merge request' WHERE "activityType" = 'merge_request-merged' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Opened GitLab merge request' WHERE "activityType" = 'merge_request-opened' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Approved GitLab merge request review' WHERE "activityType" = 'merge_request-review-approved' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Requested changes on GitLab merge request' WHERE "activityType" = 'merge_request-review-changes-requested' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Requested review on GitLab merge request' WHERE "activityType" = 'merge_request-review-requested' AND platform = 'gitlab';
+UPDATE "activityTypes" SET description = 'Starred GitLab repository' WHERE "activityType" = 'star' AND platform = 'gitlab';
+
+-- Groups.io platform
+UPDATE "activityTypes" SET description = 'Sent message in Groups.io mailing list' WHERE "activityType" = 'message' AND platform = 'groupsio';
+UPDATE "activityTypes" SET description = 'Joined Groups.io mailing list' WHERE "activityType" = 'member_join' AND platform = 'groupsio';
+UPDATE "activityTypes" SET description = 'Left Groups.io mailing list' WHERE "activityType" = 'member_leave' AND platform = 'groupsio';
+
+-- Hackernews platform
+UPDATE "activityTypes" SET description = 'Commented on Hacker News story' WHERE "activityType" = 'comment' AND platform = 'hackernews';
+UPDATE "activityTypes" SET description = 'Posted story on Hacker News' WHERE "activityType" = 'post' AND platform = 'hackernews';
+
+-- Jira platform
+UPDATE "activityTypes" SET description = 'Added an assignee to Jira issue' WHERE "activityType" = 'issue-assigned' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Added attachment to Jira issue' WHERE "activityType" = 'issue-attachment-added' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Closed Jira issue' WHERE "activityType" = 'issue-closed' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Created comment on Jira issue' WHERE "activityType" = 'issue-comment-created' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Updated comment on Jira issue' WHERE "activityType" = 'issue-comment-updated' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Created Jira issue' WHERE "activityType" = 'issue-created' AND platform = 'jira';
+UPDATE "activityTypes" SET description = 'Updated Jira issue' WHERE "activityType" = 'issue-updated' AND platform = 'jira';
+
+-- LinkedIn platform
+UPDATE "activityTypes" SET description = 'Commented on LinkedIn post' WHERE "activityType" = 'comment' AND platform = 'linkedin';
+UPDATE "activityTypes" SET description = 'Reacted to LinkedIn post' WHERE "activityType" = 'reaction' AND platform = 'linkedin';
+
+-- Reddit platform
+UPDATE "activityTypes" SET description = 'Commented on Reddit post' WHERE "activityType" = 'comment' AND platform = 'reddit';
+UPDATE "activityTypes" SET description = 'Posted on Reddit' WHERE "activityType" = 'post' AND platform = 'reddit';
+
+-- Slack platform
+UPDATE "activityTypes" SET description = 'Joined Slack channel' WHERE "activityType" = 'channel_joined' AND platform = 'slack';
+UPDATE "activityTypes" SET description = 'Sent message in Slack channel' WHERE "activityType" = 'message' AND platform = 'slack';
+
+-- Stack Overflow platform
+UPDATE "activityTypes" SET description = 'Answered question on Stack Overflow' WHERE "activityType" = 'answer' AND platform = 'stackoverflow';
+UPDATE "activityTypes" SET description = 'Asked question on Stack Overflow' WHERE "activityType" = 'question' AND platform = 'stackoverflow';
+
+-- Twitter platform
+UPDATE "activityTypes" SET description = 'Used hashtag in Twitter post' WHERE "activityType" = 'hashtag' AND platform = 'twitter';
+UPDATE "activityTypes" SET description = 'Mentioned user in Twitter post' WHERE "activityType" = 'mention' AND platform = 'twitter';
+UPDATE "activityTypes" SET description = 'Followed user on Twitter' WHERE "activityType" = 'follow' AND platform = 'twitter';
+
+-- Add NOT NULL constraint to description column
+ALTER TABLE "activityTypes" ALTER COLUMN description SET NOT NULL;

--- a/services/libs/tinybird/datasources/activityTypes.datasource
+++ b/services/libs/tinybird/datasources/activityTypes.datasource
@@ -3,6 +3,7 @@ DESCRIPTION >
     - `id` is the unique identifier for the activity type record.
     - `activityType` specifies the activity type (issues-opened, pull-request-opened, etc.). Using LowCardinality.
     - `platform` is the platform the activity type applies to (github, gitlab, gerrit, etc.). Using LowCardinality.
+    - `description` provides a human-readable description of what the activity type and platform represents.
     - `isCodeContribution` indicates whether this activity counts as a code contribution.
     - `isCollaboration` indicates whether this activity counts as a collaboration.
     - `createdAt` and `updatedAt` are standard timestamp fields for record lifecycle tracking.
@@ -13,6 +14,7 @@ SCHEMA >
     `id` UUID `json:$.record.id`,
     `activityType` LowCardinality(String) `json:$.record.activityType`,
     `platform` LowCardinality(String) `json:$.record.platform`,
+    `description` String `json:$.record.description`,
     `isCodeContribution` Bool `json:$.record.isCodeContribution`,
     `isCollaboration` Bool `json:$.record.isCollaboration`,
     `createdAt` DateTime64(3) `json:$.record.createdAt`,


### PR DESCRIPTION
## Changes
### Add `description` column to `activityTypes` table

This PR adds a description column to the activityTypes table to provide human-readable descriptions for each activity type and platform combination.

Changes:
- Database Migration: Added migration V1759325136__add_description_to_activity_types.sql that:
    - Adds a new description TEXT column to the activityTypes table
    - Populates descriptions for all existing activity types across 15+ platforms (GitHub, GitLab, Discord,
  Confluence, Jira, etc.)
    - Sets the column as NOT NULL after population
 - Revert Migration: Added corresponding revert migration U1759325136__add_description_to_activity_types.sql for
  rollback capability
 - Tinybird Schema Update: Updated the activityTypes.datasource to include the new description field in the schema
  and documentation

 Examples of descriptions added:

 - "Opened a GitHub pull request" for pull_request-opened on github platform
 - "Sent a message in a Discord channel" for message on discord platform
 - "Created a Jira issue" for issue-created on jira platform

**This enhancement will be used by Insights Copilot to be able decide a lot better on which activity type to use when querying data.**