### PR TITLE
feat: migrate github stats

### DIFF
--- a/backend/src/database/repositories/integrationProgressRepository.ts
+++ b/backend/src/database/repositories/integrationProgressRepository.ts
@@ -5,6 +5,7 @@ import { GitHubStats } from '@/serverless/integrations/usecases/github/rest/getR
 
 import { IRepositoryOptions } from './IRepositoryOptions'
 import SequelizeRepository from './sequelizeRepository'
+import { TinybirdClient } from '@crowd/data-access-layer/src/database'
 
 class IntegrationProgressRepository {
   static async getPendingStreamsCount(integrationId: string, options: IRepositoryOptions) {
@@ -66,12 +67,52 @@ class IntegrationProgressRepository {
     return (result[0] as any).id as string
   }
 
-  static async getDbStatsForGithub(
-    repos: Repos,
+  static async getDbStatsForGithub({
+    options,
+    repos,
+    segmentIds,
+  }:{
     options: IRepositoryOptions,
+    repos: Repos,
+    segmentIds: string[],
+  }
   ): Promise<GitHubStats> {
     // TODO questdb to tinybird remove - it's here for linter to be happy
-    options.log.info('getDbStatsForGithub', { repos })
+    options.log.info('Repos to query', { repos })
+    options.log.info('Segment IDs to query', { segmentIds })
+    const tb = new TinybirdClient()
+    
+    segmentIds = ["5c43e166-28c1-4408-b830-e220876e0d4e"]
+    repos = ["https://github.com/apache/dubbo","https://github.com/apache/spark"]
+
+    const repos2: Repos = [
+      {
+        url: 'https://github.com/apache/dubbo',
+        name: 'dubbo',
+        owner: 'apache',
+        private: false,
+      },{
+        url: 'https://github.com/apache/spark',
+        name: 'spark',
+        owner: 'apache',
+        private: false,
+      }
+    ]
+
+    const params = {
+      G1_platform: 'github',
+      G1_channel: repos2.map((r) => r.url).join(','),
+      countOnly: 1,
+      segments: segmentIds.join(','),
+    }
+
+    // const starsQueryParams = {
+    //   G1_activityType: 'star',
+    //   G1_platform: 'github',
+    //   G1_channel: repos2.map((r) => r.url).join(','),
+    //   segments: segmentIds.join(','),
+    //   countOnly: 1,
+    // }
     // TODO questdb to tinybird
     // const starsQuery = `
     //   SELECT COUNT_DISTINCT("sourceId") AS count
@@ -121,25 +162,34 @@ class IntegrationProgressRepository {
 
     // const remotes = repos.map((r) => r.url)
 
-    // const promises: Promise<any[]>[] = [
-    //   options.qdb.query(starsQuery, {
-    //     remotes,
-    //   }),
-    //   options.qdb.query(unstarsQuery, {
-    //     remotes,
-    //   }),
-    //   options.qdb.query(forksQuery, {
-    //     remotes,
-    //   }),
-    //   options.qdb.query(issuesOpenedQuery, {
-    //     remotes,
-    //   }),
-    //   options.qdb.query(prOpenedQuery, {
-    //     remotes,
-    //   }),
-    // ]
+    console.log(`Querying with params:`, params)
 
-    // const results = await Promise.all(promises)
+    const promises: Promise<any[]>[] = [
+      tb.pipe('activities_relations_filtered', {
+        ...params,
+        G1_activityType: 'star',
+      }),
+      tb.pipe('activities_relations_filtered', {
+        ...params,
+        G1_activityType: 'unstar',
+      }),
+      tb.pipe('activities_relations_filtered', {
+        ...params,
+        indirectFork: 1,
+      }),
+      tb.pipe('activities_relations_filtered', {
+        ...params,
+        G1_activityType: 'issues-opened',
+      }),
+      tb.pipe('activities_relations_filtered', {
+        ...params,
+        G1_activityType: 'pull_request-opened',
+      }),
+    ]
+
+    const results = await Promise.all(promises)
+    console.log('DB stats results:', JSON.stringify(results))
+
     return {
       // stars: parseInt(results[0][0].count, 10) - parseInt(results[1][0].count, 10),
       // forks: parseInt(results[2][0].count, 10),

--- a/backend/src/database/repositories/integrationProgressRepository.ts
+++ b/backend/src/database/repositories/integrationProgressRepository.ts
@@ -1,13 +1,32 @@
 import { QueryTypes } from 'sequelize'
 
+import { queryActivitiesCounter } from '@crowd/data-access-layer'
+import { Counter, TinybirdClient } from '@crowd/data-access-layer/src/database'
+
 import { Repos } from '@/serverless/integrations/types/regularTypes'
 import { GitHubStats } from '@/serverless/integrations/usecases/github/rest/getRemoteStats'
 
 import { IRepositoryOptions } from './IRepositoryOptions'
 import SequelizeRepository from './sequelizeRepository'
-import { TinybirdClient } from '@crowd/data-access-layer/src/database'
 
 class IntegrationProgressRepository {
+  static createPayloadWithActivityType(
+    activityTypes: string[],
+    repos: Repos,
+    segments: string[] = [],
+  ) {
+    return {
+      filter: {
+        and: [
+          { platform: { in: ['github'] } },
+          { or: repos.map((repo) => ({ channel: { eq: repo.url } })) },
+          { type: { in: activityTypes } },
+        ],
+      },
+      segmentIds: segments,
+    }
+  }
+
   static async getPendingStreamsCount(integrationId: string, options: IRepositoryOptions) {
     const transaction = options.transaction
     const seq = SequelizeRepository.getSequelize(options)
@@ -68,137 +87,55 @@ class IntegrationProgressRepository {
   }
 
   static async getDbStatsForGithub({
-    options,
     repos,
-    segmentIds,
-  }:{
-    options: IRepositoryOptions,
-    repos: Repos,
-    segmentIds: string[],
-  }
-  ): Promise<GitHubStats> {
-    // TODO questdb to tinybird remove - it's here for linter to be happy
-    options.log.info('Repos to query', { repos })
-    options.log.info('Segment IDs to query', { segmentIds })
+    segments,
+  }: {
+    repos: Repos
+    segments: string[]
+  }): Promise<GitHubStats> {
     const tb = new TinybirdClient()
-    
-    segmentIds = ["5c43e166-28c1-4408-b830-e220876e0d4e"]
-    repos = ["https://github.com/apache/dubbo","https://github.com/apache/spark"]
 
-    const repos2: Repos = [
-      {
-        url: 'https://github.com/apache/dubbo',
-        name: 'dubbo',
-        owner: 'apache',
-        private: false,
-      },{
-        url: 'https://github.com/apache/spark',
-        name: 'spark',
-        owner: 'apache',
-        private: false,
-      }
+    const promises: Promise<{ data: Counter }>[] = [
+      queryActivitiesCounter(
+        IntegrationProgressRepository.createPayloadWithActivityType(['star'], repos, segments),
+        tb,
+      ),
+      queryActivitiesCounter(
+        IntegrationProgressRepository.createPayloadWithActivityType(['unstar'], repos, segments),
+        tb,
+      ),
+      queryActivitiesCounter(
+        {
+          ...IntegrationProgressRepository.createPayloadWithActivityType(['fork'], repos, segments),
+          indirectFork: 1,
+        },
+        tb,
+      ),
+      queryActivitiesCounter(
+        IntegrationProgressRepository.createPayloadWithActivityType(
+          ['issues-opened'],
+          repos,
+          segments,
+        ),
+        tb,
+      ),
+      queryActivitiesCounter(
+        IntegrationProgressRepository.createPayloadWithActivityType(
+          ['pull_request-opened'],
+          repos,
+          segments,
+        ),
+        tb,
+      ),
     ]
 
-    const params = {
-      G1_platform: 'github',
-      G1_channel: repos2.map((r) => r.url).join(','),
-      countOnly: 1,
-      segments: segmentIds.join(','),
-    }
-
-    // const starsQueryParams = {
-    //   G1_activityType: 'star',
-    //   G1_platform: 'github',
-    //   G1_channel: repos2.map((r) => r.url).join(','),
-    //   segments: segmentIds.join(','),
-    //   countOnly: 1,
-    // }
-    // TODO questdb to tinybird
-    // const starsQuery = `
-    //   SELECT COUNT_DISTINCT("sourceId") AS count
-    //   FROM activities
-    //   WHERE platform = 'github'
-    //   AND type = 'star'
-    //   AND "deletedAt" IS NULL
-    //   AND channel IN ($(remotes:csv))
-    // `
-
-    // const unstarsQuery = `
-    //   SELECT COUNT_DISTINCT("sourceId") AS count
-    //   FROM activities
-    //   WHERE platform = 'github'
-    //   AND type = 'unstar'
-    //   AND "deletedAt" IS NULL
-    //   AND channel IN ($(remotes:csv))
-    // `
-
-    // const forksQuery = `
-    //   SELECT COUNT_DISTINCT("sourceId") AS count
-    //   FROM activities
-    //   WHERE platform = 'github'
-    //   AND type = 'fork'
-    //   AND "deletedAt" IS NULL
-    //   AND "gitIsIndirectFork" != TRUE
-    //   AND channel IN ($(remotes:csv))
-    // `
-
-    // const issuesOpenedQuery = `
-    //   SELECT COUNT_DISTINCT("sourceId") AS count
-    //   FROM activities
-    //   WHERE platform = 'github'
-    //   AND type = 'issues-opened'
-    //   AND "deletedAt" IS NULL
-    //   AND channel IN ($(remotes:csv))
-    // `
-
-    // const prOpenedQuery = `
-    //   SELECT COUNT_DISTINCT("sourceId") AS count
-    //   FROM activities
-    //   WHERE platform = 'github'
-    //   AND type = 'pull_request-opened'
-    //   AND "deletedAt" IS NULL
-    //   AND channel IN ($(remotes:csv))
-    // `
-
-    // const remotes = repos.map((r) => r.url)
-
-    console.log(`Querying with params:`, params)
-
-    const promises: Promise<any[]>[] = [
-      tb.pipe('activities_relations_filtered', {
-        ...params,
-        G1_activityType: 'star',
-      }),
-      tb.pipe('activities_relations_filtered', {
-        ...params,
-        G1_activityType: 'unstar',
-      }),
-      tb.pipe('activities_relations_filtered', {
-        ...params,
-        indirectFork: 1,
-      }),
-      tb.pipe('activities_relations_filtered', {
-        ...params,
-        G1_activityType: 'issues-opened',
-      }),
-      tb.pipe('activities_relations_filtered', {
-        ...params,
-        G1_activityType: 'pull_request-opened',
-      }),
-    ]
-
-    const results = await Promise.all(promises)
-    console.log('DB stats results:', JSON.stringify(results))
+    const result = await Promise.all(promises)
 
     return {
-      // stars: parseInt(results[0][0].count, 10) - parseInt(results[1][0].count, 10),
-      // forks: parseInt(results[2][0].count, 10),
-      // totalIssues: parseInt(results[3][0].count, 10),
-      // totalPRs: parseInt(results[4][0].count, 10),
-      stars: 0,
-      forks: 0,
-      totalIssues: 0,
-      totalPRs: 0,
+      stars: (result[0]?.data?.[0]?.count ?? 0) - (result[1]?.data?.[0]?.count ?? 0),
+      forks: result[2]?.data?.[0]?.count ?? 0,
+      totalIssues: result[3]?.data?.[0]?.count ?? 0,
+      totalPRs: result[4]?.data?.[0]?.count ?? 0,
     }
   }
 

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -2114,7 +2114,6 @@ export default class IntegrationService {
       const githubRepos = await this.getGithubRepos(integrationId)
       const mappedSegments = githubRepos.map((repo) => repo.segment.id)
 
-      // TODO get giihubRepos segments + integration.segmentId (attenzione al deletedAt)
       const cacheRemote = new RedisCache(
         'github-progress-remote',
         this.options.redis,

--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -346,8 +346,10 @@ export async function queryActivities(
   }
 }
 
-export async function queryActivitiesCounter(arg: IQueryActivitiesParameters & { indirectFork?: number }, tbClient: TinybirdClient): Promise<{data: Counter}> {
-  
+export async function queryActivitiesCounter(
+  arg: IQueryActivitiesParameters & { indirectFork?: number },
+  tbClient: TinybirdClient,
+): Promise<{ data: Counter }> {
   const payload = {
     ...buildActivitiesParams(arg),
     ...(arg.indirectFork && { indirectFork: arg.indirectFork }),

--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -6,6 +6,7 @@ import moment from 'moment'
 import {
   ActivityRelations,
   ActivityTimeseriesDatapoint,
+  Counter,
   DbConnOrTx,
   TinybirdClient,
 } from '@crowd/database'
@@ -343,6 +344,17 @@ export async function queryActivities(
     limit: arg.limit,
     offset: arg.offset,
   }
+}
+
+export async function queryActivitiesCounter(arg: IQueryActivitiesParameters & { indirectFork?: number }, tbClient: TinybirdClient): Promise<{data: Counter}> {
+  
+  const payload = {
+    ...buildActivitiesParams(arg),
+    ...(arg.indirectFork && { indirectFork: arg.indirectFork }),
+    countOnly: 1,
+  }
+
+  return tbClient.pipe('activities_relations_filtered', payload)
 }
 
 export function mapActivityRowToResult(a: any, columns: string[]): any {

--- a/services/libs/database/src/tinybirdClient.ts
+++ b/services/libs/database/src/tinybirdClient.ts
@@ -30,6 +30,10 @@ export type ActivityTimeseriesDatapoint = {
   count: number
 }
 
+export type Counter = {
+  count: number
+}
+
 export class TinybirdClient {
   private host: string
   private token: string

--- a/services/libs/tinybird/pipes/activities_relations_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_relations_filtered.pipe
@@ -439,9 +439,7 @@ SQL >
 NODE activities_enriched_v1
 SQL >
     %
-    {% if defined(countOnly) and (countOnly == '1' or countOnly == 1) %}
-        -- NOTE: filtered_relations suppresses pagination in count mode
-        -- If id is unique in activityRelations_deduplicated_ds you may switch to count(*)
+    {% if defined(countOnly) and countOnly == '1' %}
         SELECT countDistinct(fr.id) AS count FROM filtered_relations fr
     {% else %}
         SELECT

--- a/services/libs/tinybird/pipes/activities_relations_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_relations_filtered.pipe
@@ -5,25 +5,31 @@ DESCRIPTION >
     - By default, this pipe returns only contribution activities (`isContribution = 1`) unless explicitly overridden with `onlyContributions = 0`.
     - Security / scoping: if you use a `segments_filtered` pipe in your environment, replace the `segmentId` filter to read from it (see comment in Node 1).
     - Parameters:
-    - `segments`: Optional array of segment IDs (e.g., ['7c3f6874-b10e-499b-a672-00281ab6c510']). If you use `segments_filtered`, remove this and rely on that pipe.
-    - `startDate`: Optional DateTime to filter activities after (e.g., '2024-01-01 00:00:00').
-    - `endDate`: Optional DateTime to filter activities before (e.g., '2024-12-31 23:59:59').
-    - `repos`: Optional array of repository URLs (e.g., ['https://github.com/apache/dubbo']).
-    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack').
-    - `activity_type`: Optional string filter for a single activity type (e.g., 'star', 'authored-commit').
-    - `activity_types`: Optional array of activity types.
-    - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities.
-    - `page`: Optional integer page index for pagination (OFFSET-based), defaults to 0.
-    - `pageSize`: Optional integer page size, defaults to 10.
-    - Response (final node): all relation fields from Node 1 plus `url`, `body`, `title` from activities.
+      - `segments`: Optional array of segment IDs (e.g., ['7c3f6874-b10e-499b-a672-00281ab6c510']). If you use `segments_filtered`, remove this and rely on that pipe.
+      - `startDate`: Optional DateTime to filter activities after (e.g., '2024-01-01 00:00:00').
+      - `endDate`: Optional DateTime to filter activities before (e.g., '2024-12-31 23:59:59').
+      - `repos`: Optional array of repository URLs (e.g., ['https://github.com/apache/dubbo']).
+      - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack').
+      - `activity_type`: Optional string filter for a single activity type (e.g., 'star', 'authored-commit').
+      - `activity_types`: Optional array of activity types.
+      - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities.
+      - `page`: Optional integer page index for pagination (OFFSET-based), defaults to 0.
+      - `pageSize`: Optional integer page size, defaults to 10.
+      - `orderBy`: Optional enum ['timestamp_ASC','createdAt_ASC','createdAt_DESC'] else defaults to timestamp DESC.
+      - `searchTerm`: Optional case-insensitive search in channel/type/title/body.
+      - Dynamic OR blocks via `G1..G5_*` as in query below (include/exclude groups).
+    - Response (final node): all relation fields from Node 1 plus `url`, `body`, `title`, `attributes` from activities.
     - Performance:
-    - The enrichment only scans the subset of `activities_deduplicated_ds` whose `id` is found in the filtered page from Node 1, minimizing I/O.
-    - Keep page sizes reasonable (50–200) for consistent latency.
-    - Ensure `activityId` and `id` types are aligned (both UUID or both String). If they differ, this pipe casts to String at join time.
+      - The enrichment only scans the subset of `activities_deduplicated_ds` whose `id` is found in the filtered (and paginated) set from Node 1, minimizing I/O.
+      - Keep page sizes reasonable (50–200) for consistent latency.
+      - Ensure `activityId` and `id` types are aligned (both UUID or both String). If they differ, this pipe casts to String at join time.
 
 NODE filtered_relations
 SQL >
     %
+    -- Toggle to detect count mode (no pagination/order)
+    {% set is_count = defined(countOnly) and (countOnly == '1' or countOnly == 1) %}
+
     SELECT
         ar.activityId AS id,
         ar.channel,
@@ -38,13 +44,46 @@ SQL >
         ar.type
     FROM activityRelations_deduplicated_ds AS ar
     WHERE
+        -- NOTE: if you use a segments_filtered pipe, replace this with:
+        -- ar.segmentId IN (SELECT segmentId FROM segments_filtered)
         ar.segmentId IN {{ Array(segments, 'String', required=True, description="Segment IDs") }}
+
+        -- Default: only contributions unless onlyContributions=0
+        {% if not defined(onlyContributions) or Int8(onlyContributions, 1) == 1 %}
+            AND ar.isContribution = 1
+        {% end %}
+
         {% if defined(startDate) %}
             AND ar.timestamp > parseDateTimeBestEffort({{ String(startDate) }})
         {% end %}
         {% if defined(endDate) %}
             AND ar.timestamp < parseDateTimeBestEffort({{ String(endDate) }})
         {% end %}
+
+        -- Top-level platform and activity type filters (shortcuts)
+        {% if defined(platform) %}
+            AND ar.platform = {{ String(platform) }}
+        {% end %}
+        {% if defined(activity_type) %}
+            AND ar.type = {{ String(activity_type) }}
+        {% end %}
+        {% if defined(activity_types) %}
+            AND ar.type IN {{ Array(activity_types, 'String') }}
+        {% end %}
+
+        -- repos filter: semi-join to activities on URL contains any repo string
+        {% if defined(repos) %}
+            AND CAST(ar.activityId AS String) IN (
+                SELECT CAST(id AS String)
+                FROM activities_deduplicated_ds
+                WHERE
+                    {% for r in repos %}
+                        {% if not loop.first %} OR {% endif %}
+                        positionCaseInsensitive(url, {{ String(r) }}) > 0
+                    {% endfor %}
+            )
+        {% end %}
+
         -- Dynamic OR block with include/exclude (up to 5 groups)
         {% set opened = 0 %} {% set need_or = 0 %}
         {% if defined(G1_memberIds) or defined(G1_memberIds_exclude) or defined(
@@ -370,39 +409,51 @@ SQL >
                                 )
                         {% end %}
                         {% if opened == 1 %}) {% end %}
-                        -- Search term (AND with the rest if present)
-                        {% if defined(searchTerm) and searchTerm %}
-                            AND (
-                                positionCaseInsensitive(ar.channel, {{ String(searchTerm) }}) > 0
-                                OR positionCaseInsensitive(ar.type, {{ String(searchTerm) }}) > 0
-                                OR CAST(ar.activityId AS String) IN (
-                                    SELECT CAST(id AS String)
-                                    FROM activities_deduplicated_ds
-                                    WHERE
-                                        positionCaseInsensitive(title, {{ String(searchTerm) }}) > 0
-                                        OR positionCaseInsensitive(body, {{ String(searchTerm) }}) > 0
-                                )
-                            )
-                        {% end %}
-                        {% if defined(orderBy) %}
-                            {% if orderBy == 'timestamp_ASC' %}
-                                ORDER BY ar.timestamp ASC, ar.activityId ASC
-                            {% elif orderBy == 'createdAt_ASC' %}
-                                ORDER BY ar.timestamp ASC, ar.activityId ASC
-                            {% elif orderBy == 'createdAt_DESC' %}
-                                ORDER BY ar.timestamp DESC, ar.activityId DESC
-                            {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
-                            {% end %}
-                        {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
-                        {% end %}
-                        LIMIT {{ Int32(pageSize, 10) }}
-                        OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
+
+        -- Search term (AND with the rest if present)
+        {% if defined(searchTerm) and searchTerm %}
+            AND (
+                positionCaseInsensitive(ar.channel, {{ String(searchTerm) }}) > 0
+                OR positionCaseInsensitive(ar.type, {{ String(searchTerm) }}) > 0
+                OR CAST(ar.activityId AS String) IN (
+                    SELECT CAST(id AS String)
+                    FROM activities_deduplicated_ds
+                    WHERE
+                        positionCaseInsensitive(title, {{ String(searchTerm) }}) > 0
+                        OR positionCaseInsensitive(body, {{ String(searchTerm) }}) > 0
+                )
+            )
+        {% end %}
+
+        -- Order only when not counting
+        {% if not is_count %}
+            {% if defined(orderBy) %}
+                {% if orderBy == 'timestamp_ASC' %}
+                    ORDER BY ar.timestamp ASC, ar.activityId ASC
+                {% elif orderBy == 'createdAt_ASC' %}
+                    ORDER BY ar.timestamp ASC, ar.activityId ASC
+                {% elif orderBy == 'createdAt_DESC' %}
+                    ORDER BY ar.timestamp DESC, ar.activityId DESC
+                {% else %}
+                    ORDER BY ar.timestamp DESC, ar.activityId DESC
+                {% end %}
+            {% else %}
+                ORDER BY ar.timestamp DESC, ar.activityId DESC
+            {% end %}
+
+            -- Pagination only when not counting
+            LIMIT {{ Int32(pageSize, 10) }}
+            OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
+        {% end %}
 
 NODE activities_enriched_v1
 SQL >
     %
-    {% if defined(countOnly) and countOnly == '1' %}
-        SELECT countDistinct(fr.id) AS count FROM filtered_relations fr
+    {% if defined(countOnly) and (countOnly == '1' or countOnly == 1) %}
+        -- NOTE: filtered_relations suppresses pagination in count mode
+        -- If id is unique in activityRelations_deduplicated_ds you may switch to count(*)
+        SELECT countDistinct(fr.id) AS count
+        FROM filtered_relations fr
     {% else %}
         SELECT
             fr.id,

--- a/services/libs/tinybird/pipes/activities_relations_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_relations_filtered.pipe
@@ -5,36 +5,32 @@ DESCRIPTION >
     - By default, this pipe returns only contribution activities (`isContribution = 1`) unless explicitly overridden with `onlyContributions = 0`.
     - Security / scoping: if you use a `segments_filtered` pipe in your environment, replace the `segmentId` filter to read from it (see comment in Node 1).
     - Parameters:
-      - `segments`: Optional array of segment IDs (e.g., ['7c3f6874-b10e-499b-a672-00281ab6c510']). If you use `segments_filtered`, remove this and rely on that pipe.
-      - `startDate`: Optional DateTime to filter activities after (e.g., '2024-01-01 00:00:00').
-      - `endDate`: Optional DateTime to filter activities before (e.g., '2024-12-31 23:59:59').
-      - `repos`: Optional array of repository URLs (e.g., ['https://github.com/apache/dubbo']).
-      - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack').
-      - `activity_type`: Optional string filter for a single activity type (e.g., 'star', 'authored-commit').
-      - `activity_types`: Optional array of activity types.
-      - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities.
-      - `page`: Optional integer page index for pagination (OFFSET-based), defaults to 0.
-      - `pageSize`: Optional integer page size, defaults to 10.
-      - `orderBy`: Optional enum ['timestamp_ASC','createdAt_ASC','createdAt_DESC'] else defaults to timestamp DESC.
-      - `searchTerm`: Optional case-insensitive search in channel/type/title/body.
-      - Dynamic OR blocks via `G1..G5_*` as in query below (include/exclude groups).
+    - `segments`: Optional array of segment IDs (e.g., ['7c3f6874-b10e-499b-a672-00281ab6c510']). If you use `segments_filtered`, remove this and rely on that pipe.
+    - `startDate`: Optional DateTime to filter activities after (e.g., '2024-01-01 00:00:00').
+    - `endDate`: Optional DateTime to filter activities before (e.g., '2024-12-31 23:59:59').
+    - `repos`: Optional array of repository URLs (e.g., ['https://github.com/apache/dubbo']).
+    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack').
+    - `activity_type`: Optional string filter for a single activity type (e.g., 'star', 'authored-commit').
+    - `activity_types`: Optional array of activity types.
+    - `onlyContributions`: Optional boolean, defaults to 1 (contributions only), set to 0 for all activities.
+    - `page`: Optional integer page index for pagination (OFFSET-based), defaults to 0.
+    - `pageSize`: Optional integer page size, defaults to 10.
+    - `orderBy`: Optional enum ['timestamp_ASC','createdAt_ASC','createdAt_DESC'] else defaults to timestamp DESC.
+    - `searchTerm`: Optional case-insensitive search in channel/type/title/body.
+    - Dynamic OR blocks via `G1..G5_*` as in query below (include/exclude groups).
     - Response (final node): all relation fields from Node 1 plus `url`, `body`, `title`, `attributes` from activities.
     - Performance:
-      - The enrichment only scans the subset of `activities_deduplicated_ds` whose `id` is found in the filtered (and paginated) set from Node 1, minimizing I/O.
-      - Keep page sizes reasonable (50–200) for consistent latency.
-      - Ensure `activityId` and `id` types are aligned (both UUID or both String). If they differ, this pipe casts to String at join time.
+    - The enrichment only scans the subset of `activities_deduplicated_ds` whose `id` is found in the filtered (and paginated) set from Node 1, minimizing I/O.
+    - Keep page sizes reasonable (50–200) for consistent latency.
+    - Ensure `activityId` and `id` types are aligned (both UUID or both String). If they differ, this pipe casts to String at join time.
 
 NODE filtered_relations
 SQL >
     %
-   
-  {% set is_count = 0 %}
+    {% set is_count = 0 %}
     {% if defined(countOnly) %}
-        {% if String(countOnly) == '1' or Int8(countOnly, 0) == 1 %}
-            {% set is_count = 1 %}
-        {% end %}
+        {% if String(countOnly) == '1' or Int8(countOnly, 0) == 1 %} {% set is_count = 1 %} {% end %}
     {% end %}
-
     SELECT
         ar.activityId AS id,
         ar.channel,
@@ -49,7 +45,6 @@ SQL >
         ar.type
     FROM activityRelations_deduplicated_ds AS ar
     WHERE
-       
         ar.segmentId IN {{ Array(segments, 'String', required=True, description="Segment IDs") }}
         {% if defined(startDate) %}
             AND ar.timestamp > parseDateTimeBestEffort({{ String(startDate) }})
@@ -57,17 +52,9 @@ SQL >
         {% if defined(endDate) %}
             AND ar.timestamp < parseDateTimeBestEffort({{ String(endDate) }})
         {% end %}
-        
-         {% if defined(platform) %}
-            AND ar.platform = {{ String(platform) }}
-        {% end %}
-        {% if defined(activity_type) %}
-            AND ar.type = {{ String(activity_type) }}
-        {% end %}
-        {% if defined(activity_types) %}
-            AND ar.type IN {{ Array(activity_types, 'String') }}
-        {% end %}
-
+        {% if defined(platform) %} AND ar.platform = {{ String(platform) }} {% end %}
+        {% if defined(activity_type) %} AND ar.type = {{ String(activity_type) }} {% end %}
+        {% if defined(activity_types) %} AND ar.type IN {{ Array(activity_types, 'String') }} {% end %}
         -- repos filter: semi-join to activities on URL contains any repo string
         {% if defined(repos) %}
             AND CAST(ar.activityId AS String) IN (
@@ -80,8 +67,7 @@ SQL >
                     {% end %}
             )
         {% end %}
-        
-         -- indirectFork filter: semi-join on activities.attributes->isIndirectFork
+        -- indirectFork filter: semi-join on activities.attributes->isIndirectFork
         {% if defined(indirectFork) %}
             AND CAST(ar.activityId AS String) IN (
                 SELECT CAST(id AS String)
@@ -95,7 +81,6 @@ SQL >
                     {% end %}
             )
         {% end %}
-        
         -- Dynamic OR block with include/exclude (up to 5 groups)
         {% set opened = 0 %} {% set need_or = 0 %}
         {% if defined(G1_memberIds) or defined(G1_memberIds_exclude) or defined(
@@ -435,22 +420,21 @@ SQL >
                                 )
                             )
                         {% end %}
-                      {% if not is_count %}
-
-                        {% if defined(orderBy) %}
-                            {% if orderBy == 'timestamp_ASC' %}
-                                ORDER BY ar.timestamp ASC, ar.activityId ASC
-                            {% elif orderBy == 'createdAt_ASC' %}
-                                ORDER BY ar.timestamp ASC, ar.activityId ASC
-                            {% elif orderBy == 'createdAt_DESC' %}
-                                ORDER BY ar.timestamp DESC, ar.activityId DESC
+                        {% if not is_count %}
+                            {% if defined(orderBy) %}
+                                {% if orderBy == 'timestamp_ASC' %}
+                                    ORDER BY ar.timestamp ASC, ar.activityId ASC
+                                {% elif orderBy == 'createdAt_ASC' %}
+                                    ORDER BY ar.timestamp ASC, ar.activityId ASC
+                                {% elif orderBy == 'createdAt_DESC' %}
+                                    ORDER BY ar.timestamp DESC, ar.activityId DESC
+                                {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
+                                {% end %}
                             {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
                             {% end %}
-                        {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
+                            LIMIT {{ Int32(pageSize, 10) }}
+                            OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
                         {% end %}
-                        LIMIT {{ Int32(pageSize, 10) }}
-                        OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
-                       {% end %}
 
 NODE activities_enriched_v1
 SQL >
@@ -458,8 +442,7 @@ SQL >
     {% if defined(countOnly) and (countOnly == '1' or countOnly == 1) %}
         -- NOTE: filtered_relations suppresses pagination in count mode
         -- If id is unique in activityRelations_deduplicated_ds you may switch to count(*)
-        SELECT countDistinct(fr.id) AS count
-        FROM filtered_relations fr
+        SELECT countDistinct(fr.id) AS count FROM filtered_relations fr
     {% else %}
         SELECT
             fr.id,

--- a/services/libs/tinybird/pipes/activities_relations_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_relations_filtered.pipe
@@ -27,8 +27,13 @@ DESCRIPTION >
 NODE filtered_relations
 SQL >
     %
-    -- Toggle to detect count mode (no pagination/order)
-    {% set is_count = defined(countOnly) and (countOnly == '1' or countOnly == 1) %}
+   
+  {% set is_count = 0 %}
+    {% if defined(countOnly) %}
+        {% if String(countOnly) == '1' or Int8(countOnly, 0) == 1 %}
+            {% set is_count = 1 %}
+        {% end %}
+    {% end %}
 
     SELECT
         ar.activityId AS id,
@@ -44,24 +49,16 @@ SQL >
         ar.type
     FROM activityRelations_deduplicated_ds AS ar
     WHERE
-        -- NOTE: if you use a segments_filtered pipe, replace this with:
-        -- ar.segmentId IN (SELECT segmentId FROM segments_filtered)
+       
         ar.segmentId IN {{ Array(segments, 'String', required=True, description="Segment IDs") }}
-
-        -- Default: only contributions unless onlyContributions=0
-        {% if not defined(onlyContributions) or Int8(onlyContributions, 1) == 1 %}
-            AND ar.isContribution = 1
-        {% end %}
-
         {% if defined(startDate) %}
             AND ar.timestamp > parseDateTimeBestEffort({{ String(startDate) }})
         {% end %}
         {% if defined(endDate) %}
             AND ar.timestamp < parseDateTimeBestEffort({{ String(endDate) }})
         {% end %}
-
-        -- Top-level platform and activity type filters (shortcuts)
-        {% if defined(platform) %}
+        
+         {% if defined(platform) %}
             AND ar.platform = {{ String(platform) }}
         {% end %}
         {% if defined(activity_type) %}
@@ -78,12 +75,27 @@ SQL >
                 FROM activities_deduplicated_ds
                 WHERE
                     {% for r in repos %}
-                        {% if not loop.first %} OR {% endif %}
+                        {% if not loop.first %} OR {% end %}
                         positionCaseInsensitive(url, {{ String(r) }}) > 0
-                    {% endfor %}
+                    {% end %}
             )
         {% end %}
-
+        
+         -- indirectFork filter: semi-join on activities.attributes->isIndirectFork
+        {% if defined(indirectFork) %}
+            AND CAST(ar.activityId AS String) IN (
+                SELECT CAST(id AS String)
+                FROM activities_deduplicated_ds
+                WHERE
+                    {% if Int8(indirectFork) == 1 %}
+                        (
+                            JSONExtractBool(attributes, 'isIndirectFork') = 1
+                            OR lower(JSONExtractString(attributes, 'isIndirectFork')) = 'true'
+                        )
+                    {% end %}
+            )
+        {% end %}
+        
         -- Dynamic OR block with include/exclude (up to 5 groups)
         {% set opened = 0 %} {% set need_or = 0 %}
         {% if defined(G1_memberIds) or defined(G1_memberIds_exclude) or defined(
@@ -409,42 +421,36 @@ SQL >
                                 )
                         {% end %}
                         {% if opened == 1 %}) {% end %}
+                        -- Search term (AND with the rest if present)
+                        {% if defined(searchTerm) and searchTerm %}
+                            AND (
+                                positionCaseInsensitive(ar.channel, {{ String(searchTerm) }}) > 0
+                                OR positionCaseInsensitive(ar.type, {{ String(searchTerm) }}) > 0
+                                OR CAST(ar.activityId AS String) IN (
+                                    SELECT CAST(id AS String)
+                                    FROM activities_deduplicated_ds
+                                    WHERE
+                                        positionCaseInsensitive(title, {{ String(searchTerm) }}) > 0
+                                        OR positionCaseInsensitive(body, {{ String(searchTerm) }}) > 0
+                                )
+                            )
+                        {% end %}
+                      {% if not is_count %}
 
-        -- Search term (AND with the rest if present)
-        {% if defined(searchTerm) and searchTerm %}
-            AND (
-                positionCaseInsensitive(ar.channel, {{ String(searchTerm) }}) > 0
-                OR positionCaseInsensitive(ar.type, {{ String(searchTerm) }}) > 0
-                OR CAST(ar.activityId AS String) IN (
-                    SELECT CAST(id AS String)
-                    FROM activities_deduplicated_ds
-                    WHERE
-                        positionCaseInsensitive(title, {{ String(searchTerm) }}) > 0
-                        OR positionCaseInsensitive(body, {{ String(searchTerm) }}) > 0
-                )
-            )
-        {% end %}
-
-        -- Order only when not counting
-        {% if not is_count %}
-            {% if defined(orderBy) %}
-                {% if orderBy == 'timestamp_ASC' %}
-                    ORDER BY ar.timestamp ASC, ar.activityId ASC
-                {% elif orderBy == 'createdAt_ASC' %}
-                    ORDER BY ar.timestamp ASC, ar.activityId ASC
-                {% elif orderBy == 'createdAt_DESC' %}
-                    ORDER BY ar.timestamp DESC, ar.activityId DESC
-                {% else %}
-                    ORDER BY ar.timestamp DESC, ar.activityId DESC
-                {% end %}
-            {% else %}
-                ORDER BY ar.timestamp DESC, ar.activityId DESC
-            {% end %}
-
-            -- Pagination only when not counting
-            LIMIT {{ Int32(pageSize, 10) }}
-            OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
-        {% end %}
+                        {% if defined(orderBy) %}
+                            {% if orderBy == 'timestamp_ASC' %}
+                                ORDER BY ar.timestamp ASC, ar.activityId ASC
+                            {% elif orderBy == 'createdAt_ASC' %}
+                                ORDER BY ar.timestamp ASC, ar.activityId ASC
+                            {% elif orderBy == 'createdAt_DESC' %}
+                                ORDER BY ar.timestamp DESC, ar.activityId DESC
+                            {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
+                            {% end %}
+                        {% else %} ORDER BY ar.timestamp DESC, ar.activityId DESC
+                        {% end %}
+                        LIMIT {{ Int32(pageSize, 10) }}
+                        OFFSET {{ Int32(page, 0) * Int32(pageSize, 10) }}
+                       {% end %}
 
 NODE activities_enriched_v1
 SQL >


### PR DESCRIPTION
# Changes proposed ✍️

### What
We want to migrate the `getDbStatsForGithub` from using Tinybird instead of quest db. The idea is to reuse the `queryActivities` function already implemented. 

### How
1. fix the queryActivities pipe: the countOnly was working on paginated query, so it was not returning the correct number
2. created a new `queryActivitiesCounter` functino which foce the countOnly equal to 1, applies the filters and count the activities.
3. To speed up the performance of the db we use the `segmentsId` associated to the repo we want to read the stats. For doing so we also fetch from `githubRepos` table in case we have mapped repositories

### Note:
Added few logs for testing this in staging, we should remove few of those before deploying production

## Checklist ✅
- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.
