### PR TITLE
fix: function arguments

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -285,7 +285,7 @@ class MaintainerService(BaseService):
                 ai_cost=maintainer_info.cost,
             )
 
-    def get_maintainer_file_prompt(example_files: list[str], file_names: list[str]) -> str:
+    def get_maintainer_file_prompt(self, example_files: list[str], file_names: list[str]) -> str:
         """
         Generates the prompt for the LLM to identify a maintainer file from a list.
         """


### PR DESCRIPTION
# Changes proposed ✍️
This pull request makes a minor fix to the `get_maintainer_file_prompt` function in `maintainer_service.py`. The function is now defined as an instance method by adding `self` as its first parameter, which aligns it with object-oriented best practices and allows it to access instance variables if needed.

- Refactored `get_maintainer_file_prompt` to be an instance method by adding `self` as the first parameter (`maintainer_service.py`).

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
