### PR TITLE
feat: `activityRelations_data_copilot` pipe

### DIFF
--- a/services/libs/tinybird/pipes/activityRelations_data_copilot.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_data_copilot.pipe
@@ -1,0 +1,59 @@
+DESCRIPTION >
+    - `activityRelations_data_copilot` contains deduplicated and cleaned raw activity relation data.
+    - It also has denormalized non-relationship data so for almost all reporting use cases this datasource should be used.
+    - Activity types that contain commit information are as follows: `approved-commit`, `influenced-commit`, `resolved-commit`, `informed-commit`, `tested-commit`, `reviewed-commit`, `reported-commit`, `pull_request-comment`, `signed-off-commit`, `co-authored-commit`, `pull_request-assigned`, `pull_request-review-requested`, `pull_request-opened`, `pull_request-review-thread-comment`, `pull_request-merged`, `pull_request-reviewed`, `committed-commit`, `authored-commit`, `pull_request-closed`
+    - `activityId` column uuid primary key of the activity.
+    - `createdAt column is the system timestamp when the record was created.
+    - `updatedAt` column is the system timestamp when the record was last updated.
+    - `memberId` column is the ID of the member who performed the activity. Joins to `members_sorted.datasource`'s `id` field.
+    - `objectMemberId` column is the ID of the member who is the target of the activity (e.g. review assigned to, pr assigned to). Joins to `members_sorted.datasource`'s `id` field.
+    - `organizationId` column is the ID of the organization the activity is affiliated with.
+    - `platform` column indicates the platform where the activity took place (e.g. github, discord).
+    - `segmentId` column indicates the subproject id the activity belongs to.
+    - `sourceId` column is the original ID from the source platform identifying the activity.
+    - `type` column defines the kind of activity (e.g. authored_commit, message, pull_request-reviewed).
+    - `timestamp` column is the original timestamp of the activity from the source.
+    - `sourceParentId` column is the ID of the parent object in the source system (e.g. PR number, comment thread).
+    - `channel` column is the name of the channel where the activity occurred. For code-related activities, this contains the full repository URL; for other types such as messages, it contains the name of the message channel (e.g. Slack or Discord channel name).
+    - `sentimentScore` column is a numeric score between 0 and 100 representing message sentiment.
+    - `gitInsertions` column shows how many lines of code were added (only for commit activities, is empty for rest).
+    - `gitDeletions` column shows how many lines of code were deleted. (only for commit activities, is empty for rest)
+    - `isContribution` column is a boolean (0/1) indicating if the activity is considered a contribution.
+    - `pullRequestReviewState` column shows the state of a PR review. Only related to type = `pull_request-reviewed` activities. Possible values: `COMMENTED`, `APPROVED`, `CHANGES_REQUESTED`, `DISMISSED`.
+    - `gitChangedLines` column is the total number of inserted + deleted lines of code.
+    - `gitChangedLinesBucket` column groups gitChangedLines into predefined buckets for aggregation.
+    - `organizationCountryCode` column is the denormalized ISO country code of the organization the activity is affiliated with
+    - `organizationName` column is the denormalized display name of the organization the activity is affiliated with
+
+NODE activityRelations_data_copilot_0
+SQL >
+
+    SELECT
+        activityId,
+        conversationId,
+        createdAt,
+        updatedAt,
+        memberId,
+        objectMemberId,
+        organizationId,
+        parentId,
+        platform,
+        segmentId,
+        sourceId,
+        type,
+        timestamp,
+        sourceParentId,
+        channel,
+        sentimentScore,
+        gitInsertions,
+        gitDeletions,
+        score,
+        isContribution,
+        pullRequestReviewState,
+        gitChangedLines,
+        gitChangedLinesBucket,
+        organizationCountryCode,
+        organizationName
+    FROM activityRelations_deduplicated_cleaned_ds
+
+


### PR DESCRIPTION
# Changes proposed ✍️
Adds a new `activityRelations_data_copilot` for data copilot. It gets its data from `activityRelations_deduplicated_cleaned_ds` only difference is that fields that contain PII (`username` and `objectMemberUsername`) are omitted from the result set. Agents will use this pipe instead of the raw data source when they need raw data.

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screenshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
