### PR TITLE
fix: return null when llm return null

### DIFF
--- a/services/libs/common_services/src/services/llm.service.ts
+++ b/services/libs/common_services/src/services/llm.service.ts
@@ -158,6 +158,12 @@ export class LlmService extends LoggerBase {
   ): Promise<ILlmResult<LlmMemberEnrichmentResult>> {
     const response = await this.queryLlm(LlmQueryType.MEMBER_ENRICHMENT, prompt, memberId)
 
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<LlmMemberEnrichmentResult>
+    }
+
     const result = JSON.parse(response.answer)
 
     return {
@@ -174,6 +180,12 @@ export class LlmService extends LoggerBase {
       prompt,
       memberId,
     )
+
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<{ profileIndex: number }>
+    }
 
     const result = JSON.parse(response.answer)
 
@@ -193,6 +205,12 @@ export class LlmService extends LoggerBase {
       memberId,
     )
 
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<T>
+    }
+
     const result = JSON.parse(response.answer)
 
     return {
@@ -210,6 +228,12 @@ export class LlmService extends LoggerBase {
       prompt,
       memberId,
     )
+
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<T>
+    }
 
     const result = JSON.parse(response.answer)
 

--- a/services/libs/common_services/src/services/llm.service.ts
+++ b/services/libs/common_services/src/services/llm.service.ts
@@ -225,6 +225,12 @@ export class LlmService extends LoggerBase {
       prompt,
     )
 
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<T>
+    }
+
     const result = JSON.parse(response.answer)
 
     return {
@@ -236,6 +242,12 @@ export class LlmService extends LoggerBase {
   public async findRepoCategories<T>(prompt: string): Promise<ILlmResult<T>> {
     const response = await this.queryLlm(LlmQueryType.REPO_CATEGORIES, prompt)
 
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<T>
+    }
+
     const result = JSON.parse(response.answer)
 
     return {
@@ -246,6 +258,12 @@ export class LlmService extends LoggerBase {
 
   public async findRepoCollections<T>(prompt: string): Promise<ILlmResult<T>> {
     const response = await this.queryLlm(LlmQueryType.REPO_COLLECTIONS, prompt)
+
+    if (!response) {
+      return {
+        result: null,
+      } as ILlmResult<T>
+    }
 
     const result = JSON.parse(response.answer)
 

--- a/services/libs/common_services/src/services/llm.service.ts
+++ b/services/libs/common_services/src/services/llm.service.ts
@@ -36,6 +36,10 @@ export class LlmService extends LoggerBase {
   ) {
     super(parentLog)
 
+    if (!bedrockCredentials.accessKeyId || !bedrockCredentials.secretAccessKey) {
+      this.log.warn('LLM usage is not configured properly. Missing Bedrock credentials!')
+    }
+
     this.qx = qx
     this.clientRegionMap = new Map()
   }
@@ -67,7 +71,11 @@ export class LlmService extends LoggerBase {
     metadata?: Record<string, unknown>,
     saveHistory = true,
   ): Promise<ILlmResponse> {
-    if (!IS_LLM_ENABLED) {
+    if (
+      !IS_LLM_ENABLED ||
+      !this.bedrockCredentials.accessKeyId ||
+      !this.bedrockCredentials.secretAccessKey
+    ) {
       this.log.error('LLM usage is disabled. Check CROWD_LLM_ENABLED env variable!')
       return
     }

--- a/services/libs/common_services/src/services/llm.service.ts
+++ b/services/libs/common_services/src/services/llm.service.ts
@@ -47,6 +47,11 @@ export class LlmService extends LoggerBase {
   private client(settings: ILlmSettings): BedrockRuntimeClient {
     const region = LLM_MODEL_REGION_MAP[settings.modelId]
 
+    if (!this.bedrockCredentials.accessKeyId || !this.bedrockCredentials.secretAccessKey) {
+      this.log.warn('LLM usage is not configured properly. Missing Bedrock credentials!')
+      return null
+    }
+
     let client: BedrockRuntimeClient
     if (this.clientRegionMap.has(region)) {
       client = this.clientRegionMap.get(region)


### PR DESCRIPTION
# Changes proposed ✍️

### What
add check on all the functions which use the `queryLlm` function. If the result is null we avoid to parse the json. 
So we avoid to throw error when the IS_LLM_ENABLED is false


## Checklist ✅
- [X] Label appropriately with `Feature`, `Improvement`, or `Bug`.
