### PR TITLE
fix(git-integration): target commit from an outdated branch (CM-717)

### DIFF
--- a/backend/src/database/migrations/U1759851185__addBranchColumnToRepositories.sql
+++ b/backend/src/database/migrations/U1759851185__addBranchColumnToRepositories.sql
@@ -1,0 +1,3 @@
+-- Remove branch column from git.repositories table
+ALTER TABLE git.repositories 
+DROP COLUMN IF EXISTS "branch";

--- a/backend/src/database/migrations/V1759851185__addBranchColumnToRepositories.sql
+++ b/backend/src/database/migrations/V1759851185__addBranchColumnToRepositories.sql
@@ -1,0 +1,5 @@
+ALTER TABLE git.repositories 
+ADD COLUMN "branch" VARCHAR(255) DEFAULT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN git.repositories."branch" IS 'The default branch being tracked for this repository (e.g., main, master, develop).';

--- a/services/apps/git_integration/src/crowdgit/models/clone_batch.py
+++ b/services/apps/git_integration/src/crowdgit/models/clone_batch.py
@@ -19,6 +19,9 @@ class CloneBatchInfo(BaseModel):
         default=None,
         description="The edge commit from the previous batch, used to track progress during incremental processing.",
     )
+    clone_with_batches: bool = Field(
+        default=True, description="Whether repo is cloned with batches"
+    )
 
     class Config:
         """Pydantic configuration"""

--- a/services/apps/git_integration/src/crowdgit/models/repository.py
+++ b/services/apps/git_integration/src/crowdgit/models/repository.py
@@ -28,6 +28,10 @@ class Repository(BaseModel):
         None,
         description="Timestamp of when the repository maintainer processing was last executed",
     )
+    branch: str | None = Field(
+        None,
+        description="The default branch being tracked for this repository (e.g., main, master, develop)",
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 

--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -13,7 +13,12 @@ from crowdgit.enums import ErrorCode, ExecutionStatus, OperationType
 from crowdgit.errors import CommandExecutionError, CrowdGitError
 from crowdgit.models import CloneBatchInfo, Repository, ServiceExecution
 from crowdgit.services.base.base_service import BaseService
-from crowdgit.services.utils import get_default_branch, get_repo_name, run_shell_command
+from crowdgit.services.utils import (
+    get_default_branch,
+    get_remote_default_branch,
+    get_repo_name,
+    run_shell_command,
+)
 
 DEFAULT_CLONE_BATCH_DEPTH = 10
 DEFAULT_STORAGE_OPTIMIZATION_THRESHOLD_MB = 2000
@@ -47,9 +52,9 @@ class CloneService(BaseService):
         except CommandExecutionError:
             return False
 
-    async def _init_minimal_clone(self, path: str, remote: str) -> None:
+    async def _perform_minimal_clone(self, path: str, remote: str) -> None:
         """
-        Inits minimal clone of depth=1
+        Perform minimal clone of depth=1
         """
         # increasing post buffer to avoid RPC failed error
         await run_shell_command(
@@ -140,6 +145,7 @@ class CloneService(BaseService):
         For batched clones (clone_with_batches=True): Checks if target commit reached or full history fetched.
         """
         batch_info.repo_path = repo_path
+        batch_info.clone_with_batches = clone_with_batches
 
         if batch_info.is_first_batch:
             # Set latest commit only from first batch
@@ -271,16 +277,86 @@ class CloneService(BaseService):
         )
         return calculated_depth
 
-    async def _clone_repo(self, repo_path: str, remote: str):
-        """Perform full repository clone for new repositories that haven't been processed before"""
+    async def _perform_full_clone(self, repo_path: str, remote: str):
+        """Perform full repository clone"""
+        self.logger.info(f"Performing full clone for repo {remote}...")
         await run_shell_command(["git", "clone", remote, repo_path], cwd=repo_path)
         self.logger.info(f"Successfully completed full clone of repository: {remote}")
+
+    async def has_default_branch_changed(self, remote: str, saved_branch: str | None) -> bool:
+        """Check if the default branch has changed compared to the saved branch
+        Args:
+            remote: The remote repository URL
+            saved_branch: The branch currently saved in the database (can be None)
+        Returns:
+            True if default branch has changed and requires re-cloning, False otherwise
+        """
+        try:
+            remote_default_branch = await get_remote_default_branch(remote)
+
+            if remote_default_branch is None:
+                self.logger.warning(f"Could not determine default branch for {remote}")
+                return False
+
+            if saved_branch is None:
+                self.logger.info(f"No saved branch for {remote} assuming it's not changed")
+                return False
+
+            if saved_branch != remote_default_branch:
+                self.logger.info(
+                    f"Branch changed for {remote}: saved='{saved_branch}' vs remote='{remote_default_branch}'"
+                )
+                return True
+
+            self.logger.debug(f"Branch unchanged for {remote}: {saved_branch}")
+            return False
+
+        except Exception as e:
+            self.logger.error(f"Error validating branch for {remote}: {e}")
+            # On error, assume no change to avoid unnecessary re-cloning
+            return False
+
+    async def determine_clone_strategy(
+        self, repo_path: str, remote: str, branch: str | None, last_processed_commit: str | None
+    ) -> bool:
+        """Determine whether to use full clone or minimal clone strategy based on repository state.
+
+        Args:
+            repo_path: Local path where repository will be cloned
+            remote: Remote repository URL (e.g., 'https://github.com/user/repo')
+            branch: Current saved branch name or None for new repositories
+            last_processed_commit: Last processed commit hash or None for new repositories
+
+        Returns: (clone_with_batches)
+            bool: False for full clone (clone_with_batches=False), True for minimal clone (clone_with_batches=True)
+
+        Strategy:
+            - Full clone: New repositories (last_processed_commit=None) or branch changed
+            - Minimal clone: Existing repositories with unchanged branch for incremental processing
+        """
+
+        self.logger.info(
+            f"Starting clone decision for {remote} (branch: {branch}, last_commit: {last_processed_commit})"
+        )
+
+        default_branch_changed = await self.has_default_branch_changed(remote, branch)
+
+        if not last_processed_commit or default_branch_changed:
+            reason = "new repository" if not last_processed_commit else "branch changed"
+            self.logger.info(f"Performing full clone for {remote} - reason: {reason}")
+            await self._perform_full_clone(repo_path, remote)
+            return False
+
+        self.logger.info(
+            f"Performing minimal clone for {remote} - existing repository with unchanged branch"
+        )
+        await self._perform_minimal_clone(repo_path, remote)
+        return True
 
     async def clone_batches_generator(
         self,
         repository: Repository,
         working_dir_cleanup: bool | None = False,
-        clone_with_batches: bool | None = True,
     ) -> AsyncIterator[CloneBatchInfo]:
         """
         Async generator that yields CloneBatchInfo for repository cloning.
@@ -302,22 +378,15 @@ class CloneService(BaseService):
             remote=remote,
             is_final_batch=False,
             is_first_batch=True,
-            total_commits_count=0,
         )
         try:
             temp_repo_path = tempfile.mkdtemp(prefix=f"{get_repo_name(remote)}_")
-            batch_info.repo_path = temp_repo_path
             batch_start_time = time.time()
 
-            if not clone_with_batches:
-                self.logger.info(f"Performing full clone for repo: {remote}")
-                await self._clone_repo(temp_repo_path, remote)
-            else:
-                # Incremental processing: start with minimal clone and fetch in batches
-                self.logger.info(
-                    f"Performing incremental batched clone for existing repository: {remote}"
-                )
-                await self._init_minimal_clone(temp_repo_path, remote)
+            clone_with_batches = await self.determine_clone_strategy(
+                temp_repo_path, remote, repository.branch, repository.last_processed_commit
+            )
+            if clone_with_batches:
                 batch_depth = await self._calculate_batch_depth(temp_repo_path, remote)
             await self._update_batch_info(
                 batch_info, temp_repo_path, repository.last_processed_commit, clone_with_batches

--- a/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
@@ -115,7 +115,6 @@ class CommitService(BaseService):
         self,
         repository: Repository,
         batch_info: CloneBatchInfo,
-        clone_with_batches: bool,
     ) -> None:
         """
         Process commits from a cloned batch.
@@ -147,7 +146,7 @@ class CommitService(BaseService):
             )
             raw_commits = await self._execute_git_log(
                 batch_info.repo_path,
-                clone_with_batches,
+                batch_info.clone_with_batches,
                 batch_info.prev_batch_edge_commit,
                 batch_info.edge_commit,
             )


### PR DESCRIPTION
# Changes proposed ✍️
This pull request introduces significant improvements to the repository cloning and processing workflow, primarily by tracking and responding to changes in the default branch of git repositories. The changes add a `branch` column to the database, update the models and migration scripts, and enhance the cloning logic to detect and handle default branch changes, ensuring accurate and efficient processing.

**Database schema and model updates:**

* Added a new `branch` column to the `git.repositories` table to track the default branch for each repository, with corresponding migration scripts to add and remove the column. [[1]](diffhunk://#diff-5465d95497448c8aec33f486f5493397f665e4473a464fd3f63a284489304958R1-R5) [[2]](diffhunk://#diff-88d2d7028d7d90b2975389b1f4d69a7f3ee5a4329b2b9f44befacfb94f11c410R1-R3)
* Updated the `Repository` model to include the new `branch` field, and updated relevant SQL queries and return values to handle the branch information. [[1]](diffhunk://#diff-0e235e7087557a52a84e3b0e8c71e23a0f4266aeb4b4962b895a7b5031149d25R31-R34) [[2]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L55-R55) [[3]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L104-R104) [[4]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L137-R148)

**Cloning logic improvements:**

* Implemented logic to detect if the default branch has changed on the remote repository (`has_default_branch_changed`) and to determine the appropriate cloning strategy (`determine_clone_strategy`). Full clones are now triggered when the branch changes or for new repositories, while incremental (batched) clones are used otherwise. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL274-L283) [[2]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL305-R389)
* Added a utility function `get_remote_default_branch` to determine the default branch of a remote repository without cloning it.

**Clone and commit processing updates:**

* Refactored the clone service to use the new strategy logic, including renaming internal methods for clarity and propagating the `clone_with_batches` flag through the batch info and commit processing logic. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL50-R57) [[2]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dR148) [[3]](diffhunk://#diff-c0db27c51235bb952d05d30f2292d73221844c144661dae678fe3af07164c859R22-R24) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L118) [[5]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L150-R149)
* Updated the repository worker to save the current default branch to the database after processing, ensuring branch tracking remains accurate.

These changes together make the system more robust against changes in repository configuration and improve the efficiency of repository processing.
## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
