### PR TITLE
fix: pr-title-jira-key workflow example

### DIFF
--- a/.github/workflows/pr-title-jira-key-lint.yml
+++ b/.github/workflows/pr-title-jira-key-lint.yml
@@ -28,10 +28,14 @@ jobs:
               
               Your PR title doesn't contain a Jira issue key. Consider adding it for better traceability.
               
-              **Examples:**
+              **Example:**
               - \`feat: add user authentication (CDP-123)\`
-              - \`fix(CDP-123): resolve login issue\`
-              
+              - \`feat: add user authentication (IN-123)\`
+
+              **Projects:**
+              - CDP: Community Data Platform
+              - IN: Insights
+
               Please add a Jira issue key to your PR title.`;
               
               github.rest.issues.createComment({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) e
 
 **PR Title Requirements:**
 - Must follow conventional commit format: `type(scope): description`
-- Should include JIRA ticket key in title: `feat(CDP-123): add new feature`
+- Should include JIRA ticket key in title: `feat: add new feature (CDP-123)`
 
 **PR Process:**
 1. Ensure your commits follow the conventional commit format


### PR DESCRIPTION
- Remove issue key from commit subject as it's not allowed.