### PR TITLE
feat(git-integration_: optimize full clones by getting a single branch and skipping tags

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -62,7 +62,7 @@ class CloneService(BaseService):
         )
         self.logger.info("Initializing minimal clone")
         await run_shell_command(
-            ["git", "clone", "--depth=1", "--no-tags", "--single-branch", remote, path], cwd=path
+            ["git", "clone", "--depth=1", "--no-tags", "--single-branch", remote, "."], cwd=path
         )
         self.logger.info("Minimal clone initialized successfully")
 
@@ -280,7 +280,7 @@ class CloneService(BaseService):
     async def _perform_full_clone(self, repo_path: str, remote: str):
         """Perform full repository clone"""
         self.logger.info(f"Performing full clone for repo {remote}...")
-        await run_shell_command(["git", "clone", remote, repo_path], cwd=repo_path)
+        await run_shell_command(["git", "clone", "--no-tags", "--single-branch", remote, "."], cwd=repo_path)
         self.logger.info(f"Successfully completed full clone of repository: {remote}")
 
     async def has_default_branch_changed(self, remote: str, saved_branch: str | None) -> bool:


### PR DESCRIPTION
This pull request updates the way Git repositories are cloned in the `clone_service.py` module to ensure consistency and improve reliability. The changes primarily affect both minimal and full clone operations by standardizing the use of certain Git flags and target directories.

**Improvements to Git clone operations:**

* Both minimal and full clone commands now use `"."` as the target directory instead of the full path, aligning with best practices for running commands inside the destination directory. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL65-R65) [[2]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL283-R283)
* The full clone operation now explicitly uses the `--no-tags` and `--single-branch` flags to match the minimal clone behavior, which can help reduce unnecessary data transfer and speed up cloning.