### PR TITLE
fix(git-integration): insertions/deletions slowing processing [CM-724]

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
@@ -758,8 +758,10 @@ class CommitService(BaseService):
                 completed_chunks += 1
                 self.logger.info(f"Chunk {completed_chunks}/{len(futures)} completed")
                 if chunk_activities_db and chunk_activities_queue:
-                    await batch_insert_activities(chunk_activities_db)
-                    await self.queue_service.send_batch_activities(chunk_activities_queue)
+                    await asyncio.gather(
+                        batch_insert_activities(chunk_activities_db),
+                        self.queue_service.send_batch_activities(chunk_activities_queue),
+                    )
             except Exception as e:
                 if isinstance(e, BrokenProcessPool):
                     self.logger.warning(


### PR DESCRIPTION
This pull request refactors how commit insertions and deletions ("numstats") are collected and processed in the `CommitService`. The main improvement is to gather all commit metadata and numstats in a single batch upfront, rather than running a separate git command for each commit. This change significantly improves performance and efficiency, especially for repositories with many commits. The code is also simplified by removing subprocess usage and streamlining commit dictionary construction.

The most important changes are:

**Performance and Efficiency Improvements:**

* Added batch retrieval of commit numstats: Now, both commit metadata and numstats are fetched in a single batch using `git log`, and numstats are parsed once and mapped to commit hashes for efficient lookup. This eliminates the need to run a separate git command for each commit. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R225-R290) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L236-R345) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L647-R719) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L813-R810)

* Updated the commit processing pipeline: The main processing functions (`process_single_batch_commits`, `_process_activities_from_commits`, `process_commits_chunk`, and `_construct_commit_dict`) have been updated to pass and use the pre-parsed numstats map, rather than querying for insertions/deletions per commit. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L147-R146) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R155) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R626) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R642) [[5]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L611-R670) [[6]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L637-R697) [[7]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R737) [[8]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L813-R810)

**Code Simplification and Cleanup:**

* Removed subprocess usage: The old logic that used `subprocess.run` to fetch insertions/deletions per commit (and the associated retry logic) has been deleted, as it's no longer needed.

* Improved concurrency: Batch database and queue operations are now run concurrently using `asyncio.gather` for better throughput.

* Refactored utility methods: Commit validation, email validation, and related static methods were reorganized for clarity, but their logic remains unchanged.

These changes make the commit processing much faster and the codebase easier to maintain.