### PR TITLE
fix: show activity type committed-commit [CM-739]

### DIFF
--- a/frontend/src/modules/activity/config/display/git/git-activity-content.vue
+++ b/frontend/src/modules/activity/config/display/git/git-activity-content.vue
@@ -72,7 +72,7 @@ const sourceId = computed(() => {
 });
 
 const showActivityContent = computed(() => {
-  if (props.activity.type === 'authored-commit') {
+  if (props.activity.type === 'authored-commit' || props.activity.type === 'committed-commit') {
     return !!props.activity.title || !!props.activity.body;
   }
 


### PR DESCRIPTION
## What:

Even if data is coming from the api, the portal is not showing the body of the activity: 

<img width="1102" height="191" alt="image" src="https://github.com/user-attachments/assets/06d39eaa-fa83-4476-9674-2ac5ff3894d3" />
