### PR TITLE
fix: fix activityTypes Tinybird data source sorting key

### DIFF
--- a/services/libs/tinybird/datasources/activityTypes.datasource
+++ b/services/libs/tinybird/datasources/activityTypes.datasource
@@ -23,5 +23,5 @@ SCHEMA >
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 
 ENGINE ReplacingMergeTree
-ENGINE_SORTING_KEY (isCodeContribution, isCollaboration, platform)
+ENGINE_SORTING_KEY (platform, activityType)
 ENGINE_VER updatedAt

--- a/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
+++ b/services/libs/tinybird/pipes/segmentId_aggregates_mv.pipe
@@ -15,3 +15,6 @@ SQL >
             WHERE isCodeContribution = 1 OR isCollaboration = 1
         )
     GROUP BY segmentId
+
+TYPE MATERIALIZED
+DATASOURCE segmentsAggregatedMV


### PR DESCRIPTION
In the activityTypes Tinybird data source, we were missing the `activityType` field in the `ENGINE_SORTING_KEY`, which caused problems with deduplication.

This fixes it, and also removes isCodeContribution and isCollaboration from the sorting key to also prevent issues with duplicates, in case we change a setting in one of the activity types.

Note: there's no Jira ticket for this one, as this was an emergency fix yesterday.