### PR TITLE
fix: querying created project on onboarding projects script [CM-732]

### DIFF
--- a/services/apps/script_executor_worker/src/bin/onboard-projects.ts
+++ b/services/apps/script_executor_worker/src/bin/onboard-projects.ts
@@ -219,7 +219,6 @@ async function createProject(project: ProjectRow, bearerToken: string): Promise<
         Authorization: `Bearer ${bearerToken}`,
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
       },
       timeout: 30000,
     })
@@ -278,7 +277,6 @@ async function queryProjectByName(
           Authorization: `Bearer ${bearerToken}`,
           'Content-Type': 'application/json',
           Accept: 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
         },
         timeout: 30000,
       },
@@ -383,7 +381,6 @@ async function createGithubIntegration(
         Authorization: `Bearer ${bearerToken}`,
         'Content-Type': 'application/json',
         Accept: 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
       },
       timeout: 30000,
     })


### PR DESCRIPTION
The POST `segment/project` doesn't return a response payload consistently. This was resulting in the script not being able to process projects as it couldn't get the subproject id from the response. To overcome this, after the project is successfully created, we query the newly created project with the POST `/segment/project/query` to get the sub-project segmentId.