### PR TITLE
fix: truncate with dots body too long [CM-725]

### DIFF
--- a/services/libs/data-access-layer/src/activities/insert.ts
+++ b/services/libs/data-access-layer/src/activities/insert.ts
@@ -54,7 +54,9 @@ function truncateWithDots(s: string, max: number): string {
   let out = s.slice(0, max)
 
   // If the last code unit is a HIGH surrogate (D800–DBFF), drop it to avoid a dangling pair
-  if (/[\uD800-\uDBFF]$/.test(out)) out = out.slice(0, -1)
+  if (/[\uD800-\uDBFF]$/.test(out)) {
+    out = out.slice(0, -1)
+  }
 
   // Remove any trailing combining marks (prevents leaving accents/modifiers without a base)
   out = out.replace(/\p{M}+$/u, '')


### PR DESCRIPTION
### changes proposed:

## What:

When the body is longer than 2000 chars it gets truncated in a weird way, so tinybird cannot parse the object and they go in quarantine.

example of some rows in quarantine:

```
... fix: Bug Fixes \ud83d",
... retry checkbox.\n\n\ud83d",
... Built successfully\") | [✅ \ud83d
```

## How: 
added a `truncateWithDots` which beofre sending the body remove the ending chars and add `...`