### PR TITLE
chore: disable package downloads and dependency

### DIFF
--- a/frontend/src/modules/admin/modules/insights-projects/widgets.ts
+++ b/frontend/src/modules/admin/modules/insights-projects/widgets.ts
@@ -13,8 +13,8 @@ export enum Widgets {
   // GITHUB_MENTIONS = 'githubMentions',
   // PRESS_MENTIONS = 'pressMentions',
   SEARCH_QUERIES = 'searchQueries',
-  PACKAGE_DOWNLOADS = 'packageDownloads',
-  PACKAGE_DEPENDENCY = 'packageDependency',
+  // PACKAGE_DOWNLOADS = 'packageDownloads',
+  // PACKAGE_DEPENDENCY = 'packageDependency',
   MAILING_LIST_MESSAGES = 'mailingListMessages',
   ISSUES_RESOLUTION = 'issuesResolution',
   COMMIT_ACTIVITIES = 'commitActivities',
@@ -77,6 +77,7 @@ export const WIDGETS_GROUPS = [
         name: 'Forks',
         key: Widgets.FORKS,
       },
+      // NOTE: Not implemented yet
       // {
       //   name: 'Social mentions',
       //   key: Widgets.SOCIAL_MENTIONS,
@@ -93,14 +94,15 @@ export const WIDGETS_GROUPS = [
         name: 'Search queries',
         key: Widgets.SEARCH_QUERIES,
       },
-      {
-        name: 'Package downloads',
-        key: Widgets.PACKAGE_DOWNLOADS,
-      },
-      {
-        name: 'Package dependency',
-        key: Widgets.PACKAGE_DEPENDENCY,
-      },
+      // NOTE: Temporary disabled due to legal issues
+      // {
+      //   name: 'Package downloads',
+      //   key: Widgets.PACKAGE_DOWNLOADS,
+      // },
+      // {
+      //   name: 'Package dependency',
+      //   key: Widgets.PACKAGE_DEPENDENCY,
+      // },
       {
         name: 'Mailing lists messages',
         key: Widgets.MAILING_LIST_MESSAGES,

--- a/services/libs/types/src/enums/widgets.ts
+++ b/services/libs/types/src/enums/widgets.ts
@@ -15,8 +15,8 @@ export enum Widgets {
   // GITHUB_MENTIONS = 'githubMentions',
   // PRESS_MENTIONS = 'pressMentions',
   SEARCH_QUERIES = 'searchQueries',
-  PACKAGE_DOWNLOADS = 'packageDownloads',
-  PACKAGE_DEPENDENCY = 'packageDependency',
+  // PACKAGE_DOWNLOADS = 'packageDownloads',
+  // PACKAGE_DEPENDENCY = 'packageDependency',
   MAILING_LIST_MESSAGES = 'mailingListMessages',
   ISSUES_RESOLUTION = 'issuesResolution',
   COMMIT_ACTIVITIES = 'commitActivities',
@@ -79,6 +79,7 @@ export const DEFAULT_WIDGET_VALUES: Record<
     enabled: true,
     platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO, PlatformType.GITLAB],
   },
+  // NOTE: Not implemented yet
   // [Widgets.SOCIAL_MENTIONS]: {
   //   enabled: false,
   //   platform: [ALL_PLATFORM_TYPES],
@@ -95,14 +96,15 @@ export const DEFAULT_WIDGET_VALUES: Record<
     enabled: true,
     platform: ALL_PLATFORM_TYPES,
   },
-  [Widgets.PACKAGE_DOWNLOADS]: {
-    enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
-  },
-  [Widgets.PACKAGE_DEPENDENCY]: {
-    enabled: true,
-    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
-  },
+  // NOTE: Temporary disabled due to legal issues
+  // [Widgets.PACKAGE_DOWNLOADS]: {
+  //   enabled: true,
+  //   platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+  // },
+  // [Widgets.PACKAGE_DEPENDENCY]: {
+  //   enabled: true,
+  //   platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+  // },
   [Widgets.MAILING_LIST_MESSAGES]: {
     enabled: true,
     platform: [PlatformType.GROUPSIO],


### PR DESCRIPTION
- Disable Package Downloads and Package Dependencies widgets for new projects and from the UI

Note: We will still keep the collection of the data running in the background for now as we might want to use the data, we simply won’t show it in the UI anymore.