### PR TITLE
fix(git-integration): optimize commit range to exclude previously processed commits [CM-724]

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
@@ -253,8 +253,8 @@ class CommitService(BaseService):
     async def _get_optimized_commit_range(
         self,
         repo_path: str,
-        edge_commit: str | None,
-        prev_batch_edge_commit: str | None,
+        edge_commit: str,
+        prev_batch_edge_commit: str,
         last_processed_commit: str | None,
     ) -> str:
         """
@@ -278,7 +278,7 @@ class CommitService(BaseService):
 
         if last_processed_commit and last_processed_commit != edge_commit:
             try:
-                self.logger.info("Checking last processed commit existance in current batch")
+                self.logger.info("Checking last processed commit existence in current batch")
                 await run_shell_command(
                     ["git", "cat-file", "-e", last_processed_commit], cwd=repo_path
                 )


### PR DESCRIPTION
This pull request enhances the commit processing logic by optimizing how commit ranges are determined when processing batches. The main improvement is the introduction of a mechanism to skip already-processed commits by leveraging the last successfully processed commit, which helps avoid redundant work and improves efficiency.

Key improvements to commit range calculation:

* Added a new method `_get_optimized_commit_range` to dynamically determine the commit range, using `last_processed_commit` to skip previously processed commits when possible.
* Modified `_execute_git_log` to use the optimized commit range by calling `_get_optimized_commit_range`, and updated its signature to accept `last_processed_commit` as an argument. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6R302) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L284-R326)
* Updated `process_single_batch_commits` to pass `repository.last_processed_commit` to the relevant methods, enabling the optimization.