### PR TITLE
chore(git-integration): change depth & storage threshold values

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -267,9 +267,6 @@ class CloneService(BaseService):
             calculated_depth = 50
         elif total_branches_tags <= 5000:
             # Large repo, get less history
-            calculated_depth = 20
-        else:
-            # Very large repo, get a minimal history
             calculated_depth = 5
         self.logger.info(
             f"total_branches_tags={total_branches_tags}, calculated_depth={calculated_depth}"


### PR DESCRIPTION
This pull request updates the clone depth calculation logic in the `CloneService` to better optimize cloning performance, especially for larger repositories. The main changes involve adjusting the storage optimization threshold and reducing the amount of history fetched for small and medium-sized repositories.

Clone depth and storage optimization adjustments:

* Increased the `DEFAULT_STORAGE_OPTIMIZATION_THRESHOLD_MB` from 2000 to 10000 in `clone_service.py` to allow for more storage before triggering optimization.
* Reduced the calculated clone depth for small repositories from 200 to 100 and for medium repositories from 100 to 50, making clone operations more efficient for these sizes.