### PR TITLE
fix(git-integration): depth calculation

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -265,7 +265,7 @@ class CloneService(BaseService):
         elif total_branches_tags <= 1000:
             # Medium repo, get a moderate amount of history
             calculated_depth = 50
-        elif total_branches_tags <= 5000:
+        else:
             # Large repo, get less history
             calculated_depth = 5
         self.logger.info(


### PR DESCRIPTION
This pull request makes a small change to the logic for calculating batch depth in the `clone_service.py`. The condition for handling large repositories has been simplified, making the code easier to maintain. 

- Simplified the conditional logic in `_calculate_batch_depth` by removing the explicit check for repositories with up to 5000 branches/tags and instead using an `else` clause for large repositories, which sets `calculated_depth` to 5.