### PR TITLE
chore(revert): bring back package downloads and dependency

### DIFF
--- a/frontend/src/modules/admin/modules/insights-projects/widgets.ts
+++ b/frontend/src/modules/admin/modules/insights-projects/widgets.ts
@@ -13,8 +13,8 @@ export enum Widgets {
   // GITHUB_MENTIONS = 'githubMentions',
   // PRESS_MENTIONS = 'pressMentions',
   SEARCH_QUERIES = 'searchQueries',
-  // PACKAGE_DOWNLOADS = 'packageDownloads',
-  // PACKAGE_DEPENDENCY = 'packageDependency',
+  PACKAGE_DOWNLOADS = 'packageDownloads',
+  PACKAGE_DEPENDENCY = 'packageDependency',
   MAILING_LIST_MESSAGES = 'mailingListMessages',
   ISSUES_RESOLUTION = 'issuesResolution',
   COMMIT_ACTIVITIES = 'commitActivities',
@@ -94,15 +94,14 @@ export const WIDGETS_GROUPS = [
         name: 'Search queries',
         key: Widgets.SEARCH_QUERIES,
       },
-      // NOTE: Temporary disabled due to legal issues
-      // {
-      //   name: 'Package downloads',
-      //   key: Widgets.PACKAGE_DOWNLOADS,
-      // },
-      // {
-      //   name: 'Package dependency',
-      //   key: Widgets.PACKAGE_DEPENDENCY,
-      // },
+      {
+        name: 'Package downloads',
+        key: Widgets.PACKAGE_DOWNLOADS,
+      },
+      {
+        name: 'Package dependency',
+        key: Widgets.PACKAGE_DEPENDENCY,
+      },
       {
         name: 'Mailing lists messages',
         key: Widgets.MAILING_LIST_MESSAGES,

--- a/services/libs/types/src/enums/widgets.ts
+++ b/services/libs/types/src/enums/widgets.ts
@@ -15,8 +15,8 @@ export enum Widgets {
   // GITHUB_MENTIONS = 'githubMentions',
   // PRESS_MENTIONS = 'pressMentions',
   SEARCH_QUERIES = 'searchQueries',
-  // PACKAGE_DOWNLOADS = 'packageDownloads',
-  // PACKAGE_DEPENDENCY = 'packageDependency',
+  PACKAGE_DOWNLOADS = 'packageDownloads',
+  PACKAGE_DEPENDENCY = 'packageDependency',
   MAILING_LIST_MESSAGES = 'mailingListMessages',
   ISSUES_RESOLUTION = 'issuesResolution',
   COMMIT_ACTIVITIES = 'commitActivities',
@@ -96,15 +96,14 @@ export const DEFAULT_WIDGET_VALUES: Record<
     enabled: true,
     platform: ALL_PLATFORM_TYPES,
   },
-  // NOTE: Temporary disabled due to legal issues
-  // [Widgets.PACKAGE_DOWNLOADS]: {
-  //   enabled: true,
-  //   platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
-  // },
-  // [Widgets.PACKAGE_DEPENDENCY]: {
-  //   enabled: true,
-  //   platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
-  // },
+  [Widgets.PACKAGE_DOWNLOADS]: {
+    enabled: true,
+    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+  },
+  [Widgets.PACKAGE_DEPENDENCY]: {
+    enabled: true,
+    platform: [PlatformType.GITHUB, PlatformType.GITHUB_NANGO],
+  },
   [Widgets.MAILING_LIST_MESSAGES]: {
     enabled: true,
     platform: [PlatformType.GROUPSIO],


### PR DESCRIPTION
- We are no longer obligated to hide the package downloads/dependency widgets. Bringing them back.