### PR TITLE
fix: prevent emptying `insightsProjects.repositories` on connecting no code integration

### DIFF
--- a/scripts/scaffold.yaml
+++ b/scripts/scaffold.yaml
@@ -123,7 +123,7 @@ services:
       - crowd-bridge
 
   kafka:
-    image: bitnami/kafka:3.8.1
+    image: bitnamilegacy/kafka:3.8.1
     restart: unless-stopped
     environment:
       - KAFKA_CFG_NODE_ID=0


### PR DESCRIPTION
Fixes a bug where `insightsProjects.repositories` got empitied out when we connect a no-code integration