### PR TITLE
fix: type error on the count query

### DIFF
--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -11,7 +11,6 @@ import {
   TinybirdClient,
 } from '@crowd/database'
 import { ActivityDisplayService } from '@crowd/integrations'
-import { getServiceLogger } from '@crowd/logging'
 import {
   ActivityTypeSettings,
   IActivityBySentimentMoodResult,
@@ -36,8 +35,6 @@ import {
   IQueryActivityResult,
   IQueryGroupedActivitiesParameters,
 } from './types'
-
-const log = getServiceLogger()
 
 export async function getActivitiesById(
   conn: DbConnOrTx,
@@ -333,7 +330,6 @@ export async function queryActivities(
   })
 
   let countTb = 0
-  log.info(`No count flag is set to: ${arg.noCount}`)
   if (!arg.noCount) {
     const countResp = await tb.pipe<{ data: { count: number }[] }>(
       'activities_relations_filtered',
@@ -342,7 +338,6 @@ export async function queryActivities(
         countOnly: 1,
       },
     )
-    log.info(`counter response: ${JSON.stringify(countResp)}`)
     countTb = Number(countResp?.data?.[0]?.count ?? 0)
   }
 

--- a/services/libs/database/src/tinybirdClient.ts
+++ b/services/libs/database/src/tinybirdClient.ts
@@ -1,10 +1,6 @@
 import axios from 'axios'
 import https from 'https'
 
-import { getServiceLogger } from '@crowd/logging'
-
-const log = getServiceLogger()
-
 export type QueryParams = Record<
   string,
   string | number | boolean | Date | (string | number | boolean)[] | undefined | null
@@ -69,13 +65,9 @@ export class TinybirdClient {
       }
     }
 
-    log.info(`Tinybird pipe call: ${pipeName} with params: ${searchParams.toString()}`)
-
     const url = `${this.host}/v0/pipes/${encodeURIComponent(pipeName)}.json${
       searchParams.toString() ? `?${searchParams}` : ''
     }`
-
-    log.info(`Tinybird request URL: ${url}`)
 
     const result = await axios.get<T>(url, {
       headers: {


### PR DESCRIPTION
## Fix: Correct count access in queryActivities function

### Problem
The `queryActivities` function was not correctly accessing the count value from Tinybird's response when `noCount` parameter was not set, resulting in always returning `count: 0` in the response.
