### PR TITLE
fix: connect git integration payload (CM-756)

### DIFF
--- a/backend/src/api/integration/helpers/gitAuthenticate.ts
+++ b/backend/src/api/integration/helpers/gitAuthenticate.ts
@@ -6,10 +6,7 @@ export default async (req, res) => {
   new PermissionChecker(req).validateHas(Permissions.values.tenantEdit)
   const integrationData = {
     ...req.body,
-    remotes:
-      req.body.remotes?.map((remote) => {
-        return { url: remote, forkedFrom: null }
-      }) || [],
+    remotes: req.body.remotes?.map((remote) => ({ url: remote, forkedFrom: null })) || [],
   }
 
   const payload = await new IntegrationService(req).gitConnectOrUpdate(integrationData)


### PR DESCRIPTION
This pull request updates the way remote repository data is handled during Git integration authentication. The main change is to ensure that the `remotes` field in the integration payload is always an array of objects with a `url` and a `forkedFrom` property, rather than just an array of URLs.

**Integration payload improvements:**

* In `gitAuthenticate.ts`, the `remotes` field in the payload sent to `IntegrationService.gitConnectOrUpdate` is now transformed into an array of objects with `url` and `forkedFrom: null` properties, ensuring consistent structure for downstream processing.