### PR TITLE
feat: add sql endpoint for tinybird queryActvitites, for preventing 414

### DIFF
--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -11,7 +11,6 @@ import {
   TinybirdClient,
 } from '@crowd/database'
 import { ActivityDisplayService } from '@crowd/integrations'
-import { getServiceLogger } from '@crowd/logging'
 import {
   ActivityTypeSettings,
   IActivityBySentimentMoodResult,
@@ -36,8 +35,6 @@ import {
   IQueryActivityResult,
   IQueryGroupedActivitiesParameters,
 } from './types'
-
-const logger = getServiceLogger()
 
 export async function getActivitiesById(
   conn: DbConnOrTx,
@@ -262,14 +259,10 @@ export async function queryActivities(
 
   const tbParams = buildActivitiesParams(arg)
 
-  logger.info(`Querying activities from Tinybird with params: ${JSON.stringify(tbParams)}`)
-
   const tbActivities = await tb.pipeSql<{ data: ActivityRelations[] }>(
     'activities_relations_filtered',
     tbParams,
   )
-
-  await tb.pipe<{ data: ActivityRelations[] }>('activities_relations_filtered', tbParams)
 
   const { orgIds, memberIds } = extractUniqueIds(tbActivities.data)
 

--- a/services/libs/data-access-layer/src/activities/tinybirdAdapter.ts
+++ b/services/libs/data-access-layer/src/activities/tinybirdAdapter.ts
@@ -1,4 +1,3 @@
-// tinybirdAdapter.ts
 import { IQueryActivitiesParameters } from './types'
 
 /* =========================
@@ -253,7 +252,7 @@ const leafToDelta = (field: LeafField, pred: unknown, neg: boolean, inOr: boolea
     return asMeta(meta)
   }
 
-  // textContains → treated as global searchTerm (negated ignored)
+  // textContains → global searchTerm (AND with everything); negated is ignored
   if (
     typeof pred === 'object' &&
     pred !== null &&
@@ -418,7 +417,7 @@ function parseLogicalFilter(filter: unknown): Parsed {
 }
 
 /* =========================
- * Emit Tinybird params (arrays)
+ * Emit Tinybird params
  * ========================= */
 
 const emitGroup = (params: TBParams, n: number, g: GroupFilter): void => {
@@ -480,24 +479,24 @@ export function buildActivitiesParams(arg: ExtendedArgs): TBParams {
     params.indirectFork = arg.indirectFork ? 1 : 0
   }
 
-  // Pagination
+  // pagination
   const pageSize = arg.noLimit === true ? 0 : (arg.limit ?? DEFAULT_PAGE_SIZE)
   const offset = arg.offset ?? 0
   params.pageSize = pageSize
   params.page = pageSize > 0 ? Math.floor(offset / Math.max(1, pageSize)) : 0
 
-  // Order & count
+  // order & count
   params.orderBy = pickOrder(arg.orderBy)
   if (arg.countOnly) params.countOnly = 1
 
-  // Parse logical filter (preferred)
+  // parse logical filter (preferred)
   const parsed = parseLogicalFilter(arg.filter)
 
-  // Search term (explicit override wins)
+  // search term (explicit override wins)
   const st = isNonEmptyString(arg.searchTerm) ? arg.searchTerm.trim() : parsed.searchTerm
   if (st) params.searchTerm = st
 
-  // Base time window (AND) — normalize/clean just before emitting
+  // base time window (AND) — normalize/clean just before emitting
   const normalizedStart = normalizeDate(parsed.startDate)
   const normalizedEnd = normalizeDate(parsed.endDate)
   if (normalizedStart) params.startDate = normalizedStart
@@ -514,7 +513,7 @@ export function buildActivitiesParams(arg: ExtendedArgs): TBParams {
     params.endDate = tmp
   }
 
-  // Groups (max 5)
+  // groups (max 5)
   const MAX = 5
   if (parsed.groups.length > MAX) {
     console.warn(

--- a/services/libs/database/src/tinybirdClient.ts
+++ b/services/libs/database/src/tinybirdClient.ts
@@ -1,8 +1,6 @@
 import axios from 'axios'
 import https from 'https'
 
-import { getServiceLogger } from '@crowd/logging'
-
 export type QueryParams = Record<
   string,
   string | number | boolean | Date | (string | number | boolean)[] | undefined | null
@@ -35,8 +33,6 @@ export type ActivityTimeseriesDatapoint = {
 export type Counter = {
   count: number
 }
-
-const logger = getServiceLogger()
 
 export class TinybirdClient {
   private host: string
@@ -80,18 +76,12 @@ export class TinybirdClient {
       httpsAgent: TinybirdClient.httpsAgent,
     })
 
-    logger.info(`Tinybird pipe "${pipeName}" response: ${JSON.stringify(result.data)}`)
-
     // TODO: check the response type
     return result.data
   }
 
   /**
    * POST to /v0/sql to avoid URL length limits and send typed parameters.
-   * - Uses Tinybird templating with `q: "% SELECT * FROM _"` and `pipeline` = pipe name.
-   * - Sends arrays as native JSON arrays (e.g., ["a","b"]), matching {{ Array(..., 'String') }}.
-   * - Sends ISO strings for dates if you already normalized them at the adapter layer.
-   * - Leaves numbers/booleans/strings untouched.
    */
   async pipeSql<T = unknown>(pipeName: PipeNames, params: QueryParams = {}): Promise<T> {
     // Guard against reserved keys
@@ -125,8 +115,6 @@ export class TinybirdClient {
       }
     }
 
-    logger.info(`Querying Tinybird SQL pipe "${pipeName}" with body: ${body}`)
-
     const result = await axios.post<T>(url, body, {
       headers: {
         Authorization: `Bearer ${this.token}`,
@@ -136,8 +124,6 @@ export class TinybirdClient {
       responseType: 'json',
       httpsAgent: TinybirdClient.httpsAgent,
     })
-
-    logger.info(`Tinybird SQL pipe "${pipeName}" response: ${result}`)
 
     return result.data
   }


### PR DESCRIPTION
## What

Use the **SQL API** on Tinybird as described in the [official documentation](https://www.tinybird.co/docs/api-reference/query-api#post--v0-sql).  
This allows us to send queries via **POST** with a JSON body instead of long GET requests.

## Why

When using the standard `/v0/pipes/<pipe>.json` GET approach, Tinybird can return a **414 (URI Too Long)** error if the request contains too many query parameters — for example, when passing large arrays.

## How

1. Added a new `pipeSql` method to the `tinybirdClient`, using `POST /v0/sql`.
2. Updated the parameter builder to correctly handle arrays and preserve their types in the JSON body.
3. (Optional) Normalized the Tinybird response to match the existing `pipe` method shape for consistency.
