### PR TITLE
fix: use git url instead of GitHub for kernel repo

### DIFF
--- a/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
+++ b/backend/src/serverless/integrations/usecases/github/rest/getInstalledRepositories.ts
@@ -16,7 +16,7 @@ const normalizeForkedFrom = (forkedFrom: string | null): string | null => {
 
   // Special case: Linux kernel on GitHub should map to the official kernel.org git repository
   // because that's the one onboarded in our system, not the GitHub mirror.
-  if (forkedFrom === 'https://github.com/torvalds/linux') {
+  if (forkedFrom.endsWith('github.com/torvalds/linux')) {
     return 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux'
   }
 

--- a/backend/src/services/githubIntegrationService.ts
+++ b/backend/src/services/githubIntegrationService.ts
@@ -26,7 +26,7 @@ export default class GithubIntegrationService {
 
     // Special case: Linux kernel on GitHub should map to the official kernel.org git repository
     // because that's the one onboarded in our system, not the GitHub mirror.
-    if (forkedFrom === 'https://github.com/torvalds/linux') {
+    if (forkedFrom.endsWith('github.com/torvalds/linux')) {
       return 'https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux'
     }
 


### PR DESCRIPTION
This pull request introduces a normalization function to ensure that the `forkedFrom` URL for forked repositories is correctly mapped in special cases, specifically for the Linux kernel repository. The normalization logic is added in both the GitHub REST integration use case and the `GithubIntegrationService` class. This change prevents the system from referencing the GitHub mirror of the Linux kernel and instead maps it to the official kernel.org repository URL.

**Normalization of forked repository URLs**

* Added a `normalizeForkedFrom` function in `getInstalledRepositories.ts` to handle special cases, mapping the Linux kernel GitHub mirror to the official kernel.org URL.
* Updated the `parseRepos` function in `getInstalledRepositories.ts` to use the new normalization function when setting the `forkedFrom` property.

**GithubIntegrationService enhancements**

* Implemented a static `normalizeForkedFrom` method in `GithubIntegrationService.ts` to centralize normalization logic for forked repository URLs.
* Updated repository parent URL handling in `GithubIntegrationService.ts` to use the normalization method when fetching parent repository information and when constructing repository data. [[1]](diffhunk://#diff-1bc7048a7aa92501cf11f670082a96e2084a827190a09ffacefe4b4fd871b09eL35-R52) [[2]](diffhunk://#diff-1bc7048a7aa92501cf11f670082a96e2084a827190a09ffacefe4b4fd871b09eL224-R241)