### PR TITLE
chore: add known bots to the list

### DIFF
--- a/services/libs/common/src/constants.ts
+++ b/services/libs/common/src/constants.ts
@@ -168,6 +168,9 @@ export const knownBots = new Set([
   'web-flow',
   'weblate',
   'zuul',
+  'dependabot[bot]',
+  'github-actions[bot]',
+  'renovate[bot]',
 
   // Service automation bots
   'codecov',


### PR DESCRIPTION
- Adding very well known bots that are being missed to the list of known bots.