### PR TITLE
fix: remove is contribution from queryActivities pipe

### DIFF
--- a/services/libs/tinybird/pipes/activities_relations_filtered.pipe
+++ b/services/libs/tinybird/pipes/activities_relations_filtered.pipe
@@ -35,6 +35,7 @@ SQL >
             SELECT
                 ar.activityId AS id,
                 ar.channel,
+                ar.memberId,
                 ar.organizationId,
                 ar.platform,
                 ar.segmentId,


### PR DESCRIPTION
## what:
Removing the `isContribution` default filter since this filter was removed from `activityRelations`