### PR TITLE
fix: insights projects repositories on integrations update

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -233,7 +233,7 @@ export default class IntegrationService {
               segmentId,
               txOptions,
             })
-          : []
+          : insightsProject.repositories || []
 
         await this.updateInsightsProject({
           insightsProjectId,


### PR DESCRIPTION
This PR is an extension of this previous PR https://github.com/CrowdDotDev/crowd.dev/pull/3537 which fixed a bug where insightsProjects.repositories got emptied out when we connect a no-code integration. However, this was only fixed for when we create an integration and not for when we update an integration. This PR also fixes the update scenario.