### PR TITLE
fix: handle non-array contributions in unmerge preview

### DIFF
--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -958,8 +958,11 @@ export default class MemberService extends LoggerBase {
               } else if (key === 'contributions') {
                 // check secondary member has any contributions to extract from current member
                 if (member.contributions && Array.isArray(member.contributions)) {
+                  const secondaryContributions = Array.isArray(secondaryBackup.contributions)
+                    ? secondaryBackup.contributions
+                    : []
                   member.contributions = member.contributions.filter(
-                    (c) => !(secondaryBackup.contributions || []).some((s) => s.id === c.id),
+                    (c) => !secondaryContributions.some((s) => s.id === c.id),
                   )
                 }
               } else if (


### PR DESCRIPTION
## Changes

Add `Array.isArray` check on `secondaryBackup.contributions` to avoid TypeError if it’s not an array.