### PR TITLE
fix: watch changing groups and reload page (CM-768)

### DIFF
--- a/frontend/src/modules/member/pages/member-list-page.vue
+++ b/frontend/src/modules/member/pages/member-list-page.vue
@@ -88,6 +88,7 @@ import { useMemberStore } from '@/modules/member/store/pinia';
 import { storeToRefs } from 'pinia';
 import {
   ref, onMounted, computed,
+  watch,
 } from 'vue';
 import { MemberService } from '@/modules/member/member-service';
 import { mapGetters } from '@/shared/vuex/vuex.helpers';
@@ -194,6 +195,34 @@ const onPaginationChange = ({
     tableLoading.value = false;
   });
 };
+
+watch(
+  selectedProjectGroup,
+  (newProjectGroup, oldProjectGroup) => {
+    if (newProjectGroup?.id !== oldProjectGroup?.id) {
+      pagination.value.page = 1;
+      loading.value = true;
+      tableLoading.value = true;
+
+      fetchMembers({
+        reload: true,
+        body: {
+          offset: 0,
+          limit: pagination.value.perPage,
+        },
+      }).then((result) => {
+        if (result && result.count !== undefined) {
+          membersCount.value = result.count;
+        }
+      }).finally(() => {
+        tableLoading.value = false;
+        loading.value = false;
+      });
+
+      fetchMembersToMergeCount();
+    }
+  },
+);
 
 onMounted(() => {
   fetchMembersToMergeCount();


### PR DESCRIPTION
# Fix: Auto-refresh member list when project group changes

## Problem
When users select a different project group from the menu, the member list page doesn't automatically refresh to show members from the new project group. 

## Solution
Added a `watch` for `selectedProjectGroup` in the member list page that reloads the member list when the project is selected. 