### PR TITLE
chore: remove sync disclaimer (CM-514)

### DIFF
--- a/frontend/src/config/integrations/github-nango/components/settings/github-settings-org-item.vue
+++ b/frontend/src/config/integrations/github-nango/components/settings/github-settings-org-item.vue
@@ -75,15 +75,6 @@
           </lf-dropdown>
         </div>
       </div>
-
-      <div v-if="isSynced" class="flex w-full justify-end mt-2 mb-1">
-        <div class="flex items-center text-right gap-1">
-          <lf-icon name="circle-info" type="regular" :size="14" />
-          <p class="text-2xs text-gray-500">
-            Sync of future organization repositories comming soon.
-          </p>
-        </div>
-      </div>
     </div>
     <slot />
   </div>


### PR DESCRIPTION
- Functionality to sync to the future repos of an organization if organization is marked as full sync is now live.
- This PR removed the o ld disclaimer mentioning that this feature would be coming soon.