### PR TITLE
fix: handle fkey constraint violations in organization merge with llm

### DIFF
--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -509,14 +509,11 @@ export async function addOrganizationSuggestionToNoMerge(suggestion: string[]): 
   } catch (error: unknown) {
     // Handle foreign key constraint violation gracefully
     if (error instanceof Error && 'code' in error && error.code === '23503') {
-      svc.log.info({ suggestion }, 'Organization no longer exists, skipping no merge!')
+      svc.log.info({ suggestion }, 'Foreign key constraint violation, skipping no merge!')
       return
     }
 
-    svc.log.error(
-      { error, suggestion },
-      'Error adding organization suggestion to no merge! Ignoring error...',
-    )
+    svc.log.error({ error, suggestion }, 'Error adding organization suggestion to no merge!')
     throw error
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds try/catch to skip on foreign key constraint violations when inserting organization no-merge suggestions, with improved logging.
> 
> - **Merge Suggestions Worker** (`services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts`):
>   - Handle foreign key constraint (`23503`) when calling `addOrgNoMerge` by logging and skipping instead of failing.
>   - Improve debug message to specify the suggestions array must contain exactly two IDs.
>   - Add error logging and rethrow for non-FK errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 513ed15c1d2ad9df4b9c004aec1295973f0b784f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->