### PR TITLE
fix(jobs): internal platform to nango-integration mapping

### DIFF
--- a/services/apps/cron_service/src/jobs/nangoMonitoring.job.ts
+++ b/services/apps/cron_service/src/jobs/nangoMonitoring.job.ts
@@ -115,7 +115,7 @@ const job: IJobDefinition = {
           ctx.log.warn(`${int.platform} integration with id "${int.id}" is not connected to Nango!`)
         } else {
           const results = await getNangoConnectionStatus(
-            platformToNangoIntegration(int.platform, int.settings),
+            platformToNangoIntegration(int.platform as PlatformType, int.settings),
             nangoConnection.connection_id,
           )
           if (!results)


### PR DESCRIPTION
This pull request updates the logic for determining the Nango integration name when checking the connection status in the `nangoMonitoring.job.ts` cron job. Instead of using a conditional inline check, it now delegates this responsibility to the `platformToNangoIntegration` helper function, which takes both `int.platform` and `int.settings` as arguments. This change should improve code readability and maintainability.

- Refactored the Nango integration name selection logic to use the `platformToNangoIntegration` helper function in `nangoMonitoring.job.ts`, replacing the previous inline conditional.