### PR TITLE
feat: limit members and org leaderboards to 100 results (IN-862)

### DIFF
--- a/services/libs/tinybird/pipes/leaderboards_copy.pipe
+++ b/services/libs/tinybird/pipes/leaderboards_copy.pipe
@@ -35,7 +35,7 @@ SQL >
     SELECT *, 0.0 as previousPeriodValue, 'resolution-rate' as leaderboardType
     FROM leaderboards_resolution_rate
     UNION ALL
-    SELECT *, 'members' as leaderboardType
+    SELECT *, 'contributors' as leaderboardType
     FROM leaderboards_members
     UNION ALL
     SELECT *, 'organizations' as leaderboardType

--- a/services/libs/tinybird/pipes/leaderboards_members.pipe
+++ b/services/libs/tinybird/pipes/leaderboards_members.pipe
@@ -63,3 +63,4 @@ SQL >
     LEFT JOIN leaderboards_members_previous_period pp ON p.id = pp.memberId
     WHERE c.memberActivityCount > 0
     ORDER BY value DESC
+    LIMIT 100

--- a/services/libs/tinybird/pipes/leaderboards_organizations.pipe
+++ b/services/libs/tinybird/pipes/leaderboards_organizations.pipe
@@ -67,3 +67,4 @@ SQL >
     LEFT JOIN leaderboards_organizations_previous_period pp ON p.id = pp.organizationId
     WHERE c.organizationActivityCount > 0
     ORDER BY value DESC
+    LIMIT 100


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Limits member and organization leaderboards to top 100 and renames the `leaderboards_members` type in the unified copy to `contributors`.
> 
> - **Tinybird pipes**
>   - **Leaderboards**:
>     - Enforce `LIMIT 100` in `leaderboards_members_results` and `leaderboards_organizations_results`.
>   - **Copy union**:
>     - Rename `leaderboardType` for `leaderboards_members` from `members` to `contributors` in `leaderboards_copy_union`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eb1ecc10ea8f99076f0fb37c0be807ce2b42395. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->