### PR TITLE
fix: re-create integration when changing credentials

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -1509,6 +1509,17 @@ export default class IntegrationService {
           IntegrationService.constructNangoConnectionPayload(integrationData)
 
         connectionId = await connectNangoIntegration(confluenceIntegrationType, nangoPayload)
+
+        // Delete old integration record since we have a new connectionId
+        // (integration.id must match Nango connectionId for nango integrations other than GitHub)
+        this.options.log.info(
+          `Deleting old integration ${existingIntegration.id} and creating new one with ${connectionId}`,
+        )
+        await IntegrationRepository.destroy(existingIntegration.id, {
+          ...this.options,
+          transaction,
+        })
+        await deleteNangoConnection(confluenceIntegrationType, existingIntegration.id)
       }
 
       await setNangoMetadata(NangoIntegration.CONFLUENCE_BASIC, connectionId, {
@@ -2206,6 +2217,17 @@ export default class IntegrationService {
           `jira integration type determined: ${jiraIntegrationType}, starting nango connection...`,
         )
         connectionId = await connectNangoIntegration(jiraIntegrationType, nangoPayload)
+
+        // Delete old integration record since we have a new connectionId
+        // (integration.id must match Nango connectionId for nango integrations other than GitHub)
+        this.options.log.info(
+          `Deleting old integration ${existingIntegration.id} and creating new one with ${connectionId}`,
+        )
+        await IntegrationRepository.destroy(existingIntegration.id, {
+          ...this.options,
+          transaction,
+        })
+        await deleteNangoConnection(jiraIntegrationType, existingIntegration.id)
       }
 
       await setNangoMetadata(jiraIntegrationType, connectionId, {


### PR DESCRIPTION
This pull request updates the integration handling logic to ensure that, when creating a new Nango connection for Confluence or Jira integrations, any existing integration record and its associated Nango connection are properly deleted. This helps maintain consistency between our integration records and Nango connections.

Integration cleanup improvements:

* When a new Nango connection is created for a Confluence integration, the old integration record is deleted and its corresponding Nango connection is also removed to ensure that integration IDs remain in sync with Nango connection IDs.
* The same cleanup logic is applied for Jira integrations: the old integration record and its Nango connection are deleted when a new connection is established.