### PR TITLE
feat: add jitter for github nango onboarding

### DIFF
--- a/services/apps/nango_worker/src/workflows/syncGithubIntegration.ts
+++ b/services/apps/nango_worker/src/workflows/syncGithubIntegration.ts
@@ -1,10 +1,10 @@
-import { proxyActivities } from '@temporalio/workflow'
+import { proxyActivities, sleep } from '@temporalio/workflow'
 
 import * as activities from '../activities/nangoActivities'
 import { ISyncGithubIntegrationArguments } from '../types'
 
 const activity = proxyActivities<typeof activities>({
-  startToCloseTimeout: '10 minutes',
+  startToCloseTimeout: '1 hour',
 })
 
 export async function syncGithubIntegration(args: ISyncGithubIntegrationArguments): Promise<void> {
@@ -59,6 +59,12 @@ export async function syncGithubIntegration(args: ISyncGithubIntegrationArgument
       await activity.startNangoSync(result.providerConfigKey, connectionId)
 
       created++
+
+      if (created < limit) {
+        // random delay between 1-5 minutes to not overload nango server
+        const jitterMs = 60000 + Math.random() * 240000
+        await sleep(jitterMs)
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request makes improvements to the `syncGithubIntegration` workflow to better handle activity timeouts and reduce server load by introducing randomized delays between sync operations.

Workflow reliability and load management:

* Increased the `startToCloseTimeout` for proxied activities from 10 minutes to 1 hour in `syncGithubIntegration.ts` to accommodate longer-running operations.
* Added a randomized delay (jitter) of 1-5 minutes between sync operations using `sleep`, helping to prevent overloading the Nango server.