### PR TITLE
fix: merge members llm prompt

### DIFF
--- a/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
@@ -52,6 +52,11 @@ export async function mergeMembersWithLLM(
                   - If the values are DIFFERENT, immediately return 'false' - these are definitely different people
                   - This rule applies REGARDLESS of how similar other fields appear.
                   This check must be performed FIRST before evaluating any other similarities. Only do such labeling if both members have identities in the same platform. If they don't have identities in the same platform, ignore the rule.
+                  BOT CHECKS - NEVER MERGE IF ONE PROFILE IS A BOT AND THE OTHER IS NOT
+                  - Check the bot status in attributes.isBot.default for each member
+                  - If one member has attributes.isBot.default === true and the other has attributes.isBot.default === false (or undefined), return 'false'
+                  - Bots and humans are never the same entity
+                  - This check must be performed before evaluating any other similarities
                   Print 'true' if they are the same member, 'false' otherwise. No explanation required. Don't print anything else.`
 
   const suggestions = await memberActivitiesProxy.getRawMemberMergeSuggestions(


### PR DESCRIPTION
This PR follows this discussion https://linuxfoundation.slack.com/archives/C06ULRCFJF8/p1763982626411879.
This PR updates the LLM prompt to automatically merge member profiles and to make it a lot more strict when it comes to merging profiles with different identities for the same platform.

Even with the pro tip we saw a lot of merges that had different values for the same platform.

Tests made against two profiles that were previously merged before:
- Bot merged with normal profile: `['b18bb1c0-859c-11f0-83d5-5fc87b30e90a', 'a10f9ad5-e705-4acc-8378-53416788eb80']`
- Two profiles with 2 github verified usernames: `['7fcf7950-b95b-11ee-8ae5-b5749935eef4', 'f249ae23-af7c-4b28-910c-3e736d65c671']`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens the LLM prompt to prevent merging when same-platform identities differ and to never merge bot with human profiles.
> 
> - **LLM Prompt Updates** in `services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts`:
>   - Add critical rule to NEVER merge if both members share the same `identities.platform` but have different `identities.value` (checked first, regardless of other similarities).
>   - Add bot checks to NEVER merge when `attributes.isBot.default` differs (bot vs human), evaluated before other similarities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23d9fd13afe600f729a76b748f701569f517b867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->