### PR TITLE
fix: activityRelations update on merge operations

### DIFF
--- a/services/libs/data-access-layer/src/activityRelations/index.ts
+++ b/services/libs/data-access-layer/src/activityRelations/index.ts
@@ -226,7 +226,9 @@ export async function moveActivityRelationsToAnotherMember(
     const rowCount = await qe.result(
       `
           UPDATE "activityRelations"
-          SET "memberId" = $(toId)
+          SET
+            "memberId" = $(toId),
+            "updatedAt" = now()
           WHERE "activityId" in (
             select "activityId" from "activityRelations"
             where "memberId" = $(fromId)
@@ -259,7 +261,9 @@ export async function moveActivityRelationsWithIdentityToAnotherMember(
     const rowCount = await qe.result(
       `
           UPDATE "activityRelations"
-          SET "memberId" = $(toId)
+          SET
+            "memberId" = $(toId),
+            "updatedAt" = now()
           WHERE "activityId" in (
             select "activityId" from "activityRelations"
             where 
@@ -295,7 +299,9 @@ export async function moveActivityRelationsToAnotherOrganization(
     const rowCount = await qe.result(
       `
           UPDATE "activityRelations"
-          SET "organizationId" = $(toId)
+          SET
+            "organizationId" = $(toId),
+            "updatedAt" = now()
           WHERE "activityId" in (
             select "activityId" from "activityRelations"
             where "organizationId" = $(fromId)


### PR DESCRIPTION
This PR fixes the update on `activityRelations` to make sure that the "updatedAt" is updated as well. We need this for data to be properly propagated to Tinybird.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Also update updatedAt when reassigning activityRelations during member/org merge operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06ea80f3a85df494d5f9ec46f2e281de6997d84b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->