### PR TITLE
fix: add postprocessing for removing useless attributes (CM-799)

### DIFF
--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -307,8 +307,6 @@ export async function executeQuery(
     { pgPromiseFormat: true },
   )
 
-  console.log('FILTER STRING:', filterString)
-
   const countQuery = buildCountQuery({
     withAggregates,
     searchConfig,


### PR DESCRIPTION
# Filter Member Attributes in API Response

## Problem
The members API was returning all attributes stored in the database, including many unused ones like `bio`, `url`, `company`, `location`, etc. This resulted in bloated API responses and unnecessary data transfer.

## Solution
Added attribute filtering to the `executeQuery` function in `base.ts` to only return the essential member attributes:
- `isBot`
- `jobTitle` 
- `avatarUrl`
- `isTeamMember`