### PR TITLE
fix: nango workflows retry policy

### DIFF
--- a/services/apps/nango_worker/src/workflows/processNangoWebhook.ts
+++ b/services/apps/nango_worker/src/workflows/processNangoWebhook.ts
@@ -5,6 +5,7 @@ import { IProcessNangoWebhookArguments } from '../types'
 
 const activity = proxyActivities<typeof activities>({
   startToCloseTimeout: '3 minutes',
+  retry: { maximumAttempts: 20, backoffCoefficient: 2 },
 })
 
 export async function processNangoWebhook(args: IProcessNangoWebhookArguments): Promise<void> {


### PR DESCRIPTION
This pull request makes a small update to the workflow configuration in `processNangoWebhook.ts`. The main change is the addition of a retry policy to the `proxyActivities` call, which improves the workflow's resilience to transient failures.