### PR TITLE
fix: query activities errors

### DIFF
--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -11,7 +11,6 @@ import {
   TinybirdClient,
 } from '@crowd/database'
 import { ActivityDisplayService } from '@crowd/integrations'
-import { getServiceLogger } from '@crowd/logging'
 import {
   ActivityTypeSettings,
   IActivityBySentimentMoodResult,


### PR DESCRIPTION
## Summary

This PR fixes the `activities_enriched_v1` pipe so that:

- **Counting** is delegated to `filtered_relations` when `countOnly = 1`.
- **Enrichment** only happens when `countOnly != 1`, by joining the already filtered/paginated rows from `filtered_relions` with `activities_deduplicated_ds`.
