### PR TITLE
feat: support edge case of forked repo having frequent force pushes (CM-745)

### DIFF
--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -32,7 +32,7 @@ async def insert_repository(url: str, priority: int = 0) -> str:
 async def get_repository_by_url(url: str) -> dict[str, Any] | None:
     """Get repository by URL"""
     sql_query = """
-    SELECT id, url, state, priority, "lastProcessedAt", "lockedAt", "createdAt", "updatedAt", "maintainerFile", "forkedFrom"
+    SELECT id, url, state, priority, "lastProcessedAt", "lockedAt", "createdAt", "updatedAt", "maintainerFile", "forkedFrom", "stuckRequiresReOnboard"
     FROM git.repositories
     WHERE url = $1 AND "deletedAt" IS NULL
     """
@@ -49,7 +49,7 @@ async def get_recently_processed_repository_by_url(url: str) -> Repository | Non
     Used to check if a repository needs reprocessing based on the update interval.
     """
     sql_query = """
-    SELECT id, url, state, priority, "lastProcessedAt", "lockedAt", "createdAt", "updatedAt", "maintainerFile", "forkedFrom", "segmentId"
+    SELECT id, url, state, priority, "lastProcessedAt", "lockedAt", "createdAt", "updatedAt", "maintainerFile", "forkedFrom", "segmentId", "stuckRequiresReOnboard"
     FROM git.repositories
     WHERE url = $1
         AND "deletedAt" IS NULL
@@ -88,7 +88,7 @@ async def acquire_onboarding_repo() -> Repository | None:
         LIMIT 1
         FOR UPDATE SKIP LOCKED
     )
-    RETURNING id, url, state, priority, "lastProcessedAt", "lastProcessedCommit", "lockedAt", "createdAt", "updatedAt", "segmentId", "integrationId", "maintainerFile", "lastMaintainerRunAt", "branch", "forkedFrom"
+    RETURNING id, url, state, priority, "lastProcessedAt", "lastProcessedCommit", "lockedAt", "createdAt", "updatedAt", "segmentId", "integrationId", "maintainerFile", "lastMaintainerRunAt", "branch", "forkedFrom", "stuckRequiresReOnboard"
     """
     return await acquire_repository(
         onboarding_repo_sql_query,
@@ -138,7 +138,7 @@ async def acquire_recurrent_repo() -> Repository | None:
         LIMIT 1
         FOR UPDATE SKIP LOCKED
     )
-    RETURNING id, url, state, priority, "lastProcessedAt", "lastProcessedCommit", "lockedAt", "createdAt", "updatedAt", "segmentId", "integrationId", "maintainerFile", "lastMaintainerRunAt", "branch", "forkedFrom"
+    RETURNING id, url, state, priority, "lastProcessedAt", "lastProcessedCommit", "lockedAt", "createdAt", "updatedAt", "segmentId", "integrationId", "maintainerFile", "lastMaintainerRunAt", "branch", "forkedFrom", "stuckRequiresReOnboard"
     """
     states_to_exclude = (
         RepositoryState.PENDING,

--- a/services/apps/git_integration/src/crowdgit/models/repository.py
+++ b/services/apps/git_integration/src/crowdgit/models/repository.py
@@ -41,6 +41,10 @@ class Repository(BaseModel):
     parent_repo: Repository | None = Field(
         None, description="The parent repository (in case of fork) object from our database"
     )
+    stuck_requires_re_onboard: bool = Field(
+        default=False,
+        description="Indicates if the stuck repository is resolved by a re-onboarding",
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
@@ -67,6 +71,7 @@ class Repository(BaseModel):
             "maintainerFile": "maintainer_file",
             "lastMaintainerRunAt": "last_maintainer_run_at",
             "forkedFrom": "forked_from",
+            "stuckRequiresReOnboard": "stuck_requires_re_onboard",
         }
         for db_field, model_field in field_mapping.items():
             if db_field in repo_data:

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -115,7 +115,7 @@ class RepositoryWorker:
             logger.warning(
                 f"Repo {repository.url} is stuck for {processing_duration_hours} hours!"
             )
-            if repository.forked_from == repository.url:
+            if repository.stuck_requires_re_onboard:
                 logger.warning(
                     f"Repo {repository.url} is stuck due to force-push or dangling commit. Will be re-onboarded"
                 )
@@ -196,10 +196,6 @@ class RepositoryWorker:
         """
         if not repository.forked_from:
             return None
-
-        if repository.forked_from == repository.url:
-            # EDGE CASE: not a fork but repo get reonboarded a lot and we treat it as a "fork" to avoid producing tons of duplicate activities
-            return repository.forked_from
 
         logger.info(
             f"Repository {repository.url} is forked from {repository.forked_from}, validating parent repo..."


### PR DESCRIPTION
This pull request introduces support for handling repositories that require frequent re-onboarding, in addition to improving how activities are filtered to avoid duplication. The changes add a new field to the repository model and database queries, and refactor the commit processing logic to use this new information. The refactor also generalizes activity filtering to work for both forked and frequently re-onboarded repositories, and cleans up related logic.

**Repository model and database updates:**

* Added the `stuckRequiresReOnboard` field to repository-related SQL queries and to the `Repository` model as `stuck_requires_re_onboard`, allowing the system to track repositories that require re-onboarding to resolve stuck states. [[1]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L35-R35) [[2]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L52-R52) [[3]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L91-R91) [[4]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L141-R141) [[5]](diffhunk://#diff-0e235e7087557a52a84e3b0e8c71e23a0f4266aeb4b4962b895a7b5031149d25R44-R47) [[6]](diffhunk://#diff-0e235e7087557a52a84e3b0e8c71e23a0f4266aeb4b4962b895a7b5031149d25R74)

**Commit processing and activity filtering refactor:**

* Refactored commit processing methods (`process_single_batch_commits`, `process_commits_chunk`, and related helpers) to use a `batch_info` object and the updated `Repository` model, improving clarity and maintainability. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L140-R140) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L700-R696) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L719-R707) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L730-R718) [[5]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L769-R766) [[6]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L818-R809)
* Generalized the activity filtering logic: replaced `_filter_parent_repo_activities` with `_filter_existing_activities`, which now filters out activities for both forked repositories and those requiring frequent re-onboarding, reducing duplicate activity creation. [[1]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L619-R618) [[2]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L642-R635) [[3]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L667-R668) [[4]](diffhunk://#diff-5f9a35a522d4ffb19f07c53b26f849377c268ae8229828668772ac79003048a6L740-R747)

**Worker logic improvements:**

* Updated repository worker logic to use the new `stuck_requires_re_onboard` field when determining if a repository is stuck and needs re-onboarding, and removed now-unnecessary edge case handling for forks. [[1]](diffhunk://#diff-99afb87393964ba703782f1ef366b6859c77d742d3544d9359a975bb6157ab80L118-R118) [[2]](diffhunk://#diff-99afb87393964ba703782f1ef366b6859c77d742d3544d9359a975bb6157ab80L200-L203)