### PR TITLE
fix: connected platforms in insights projects copy pipe

### DIFF
--- a/services/libs/tinybird/datasources/integrations.datasource
+++ b/services/libs/tinybird/datasources/integrations.datasource
@@ -20,7 +20,8 @@ SCHEMA >
     `integrationIdentifier` String `json:$.record.integrationIdentifier` DEFAULT '',
     `segmentId` String `json:$.record.segmentId` DEFAULT '',
     `createdAt` DateTime64(3) `json:$.record.createdAt`,
-    `updatedAt` DateTime64(3) `json:$.record.updatedAt`
+    `updatedAt` DateTime64(3) `json:$.record.updatedAt`,
+    `deletedAt` Nullable(DateTime64(3)) `json:$.record.deletedAt`
 
 ENGINE ReplacingMergeTree
 ENGINE_SORTING_KEY segmentId, id

--- a/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
@@ -21,7 +21,7 @@ DESCRIPTION >
     Returns connected platforms by segmentId
 
 SQL >
-    SELECT platform, segmentId FROM integrations FINAL
+    SELECT platform, segmentId FROM integrations FINAL WHERE deletedAt is null
 
 NODE insights_projects_populated_copy_connected_platforms
 DESCRIPTION >


### PR DESCRIPTION
**Issue**
In the connected data sources we are displaying all platforms even if they have been disconnected (soft deletion in integrations table).
https://insights.linuxfoundation.org/project/OpenStack?timeRange=past365days&start=2024-12-03&end=2025-12-03

**Fix**
- Add `deletedAt` to integrations datasource
- In insightsProjects copy pipe only consider integrations that haven't been deleted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude soft-deleted integrations from connected platforms and add `deletedAt` to `integrations` datasource.
> 
> - **Tinybird Datasource**:
>   - Update `services/libs/tinybird/datasources/integrations.datasource` schema to include `deletedAt Nullable(DateTime64(3))`.
> - **Tinybird Pipe**:
>   - In `services/libs/tinybird/pipes/insights_projects_populated_copy.pipe`:
>     - Filter integrations to active ones: `SELECT platform, segmentId FROM integrations FINAL WHERE deletedAt is null` for `insights_projects_populated_copy_integrations_deduplicated`.
>     - Maintain project mapping filter on `insightsProjects` where `deletedAt` is null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49169b2b0a7cee6961a553cce2495f43aa0d86bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->