### PR TITLE
chore: increase DEFAULT_NANGO_FETCH_LIMIT

### DIFF
--- a/services/libs/nango/src/client.ts
+++ b/services/libs/nango/src/client.ts
@@ -36,7 +36,7 @@ export type {
 
 let backendClient: BackendNango | undefined = undefined
 
-const DEFAULT_NANGO_FETCH_LIMIT = 50
+const DEFAULT_NANGO_FETCH_LIMIT = 100
 
 let config: INangoClientConfig | undefined | null = undefined
 export const NANGO_CLOUD_CONFIG = () => {


### PR DESCRIPTION
This pull request makes a small configuration change to the `services/libs/nango/src/client.ts` file. The default fetch limit for Nango API requests has been increased from 50 to 100, which will allow fetching more items per request.