### PR TITLE
fix(git-integration): disable dedup to update cycle attribute (CM-815)

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/commit/commit_service.py
@@ -753,15 +753,6 @@ class CommitService(BaseService):
             ) = await self._filter_existing_activities(
                 activities_db, activities_queue, repository.parent_repo
             )
-        if repository.stuck_requires_re_onboard:
-            self.logger.info(
-                f"Frequent re-onboardings detected! excluding existing activities from repo: {repository.url}"
-            )
-            (
-                activities_db,
-                activities_queue,
-                skipped_activities,
-            ) = await self._filter_existing_activities(activities_db, activities_queue, repository)
 
         self.logger.info(
             f"Processed {processed_commits} commits, skipped {bad_commits} invalid commits, filtered {skipped_activities} activities from parent repo in {batch_info.repo_path}"


### PR DESCRIPTION
This pull request makes a targeted change to the commit processing logic in `commit_service.py`. Specifically, it removes the extra filtering step for existing activities when a repository requires frequent re-onboarding, simplifying the processing flow.

* Commit processing logic simplification:
  * Removed the conditional block that checked `repository.stuck_requires_re_onboard` and performed additional filtering of existing activities from the repository, streamlining the commit activity filtering process. (`services/apps/git_integration/src/crowdgit/services/commit/commit_service.py`)