### PR TITLE
fix: pass userId as argument to notify fe after merge operation

### DIFF
--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -407,7 +407,13 @@ export class CommonMemberService extends LoggerBase {
         retry: {
           maximumAttempts: 10,
         },
-        args: [originalId, toMergeId, original.displayName, toMerge.displayName],
+        args: [
+          originalId,
+          toMergeId,
+          original.displayName,
+          toMerge.displayName,
+          options?.currentUser?.id,
+        ],
         searchAttributes: {
           TenantId: [DEFAULT_TENANT_ID],
         },


### PR DESCRIPTION
This pull request introduces a minor change to the `CommonMemberService` class to enhance workflow argument passing. The update adds support for passing the current user's ID as an argument when merging members.

Enhancement to workflow arguments:

* Updated the `args` array in the workflow trigger to include `options?.currentUser?.id`, allowing the current user's ID to be passed along with member IDs and display names.