### PR TITLE
feat: pr changeset fixes for sourceId

### DIFF
--- a/services/libs/tinybird/pipes/pull_request_analysis_MV_baseline_merge.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_MV_baseline_merge.pipe
@@ -116,22 +116,22 @@ SQL >
         argMin(
             updatedAt,
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
         ) AS reviewedUpdatedAt,
         min(
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
@@ -141,7 +141,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
@@ -150,7 +153,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )

--- a/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
@@ -103,7 +103,9 @@ SQL >
             timestamp,
             type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS openedUpdatedAt,
-        toInt64(countIf(type = 'patchset-created' AND sourceParentId = prSourceId)) AS numberOfPatchsets,
+        toInt64(
+            countIf(type = 'patchset-created' AND sourceParentId = prSourceId)
+        ) AS numberOfPatchsets,
         argMin(
             updatedAt, if(type IN ('pull_request-assigned', 'merge_request-assigned'), timestamp, NULL)
         ) AS assignedUpdatedAt,
@@ -128,22 +130,22 @@ SQL >
         argMin(
             updatedAt,
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
         ) AS reviewedUpdatedAt,
         min(
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
@@ -153,7 +155,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
@@ -162,7 +167,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 timestamp,
                 NULL
             )
@@ -365,8 +373,7 @@ SQL >
         ) AS resolvedInSeconds,
         if(existing.platform != '', existing.platform, new.platform) as platform,
         COALESCE(
-            if(new.numberOfPatchsets > 0, new.numberOfPatchsets, NULL),
-            existing.numberOfPatchsets
+            if(new.numberOfPatchsets > 0, new.numberOfPatchsets, NULL), existing.numberOfPatchsets
         ) as numberOfPatchsets,
         toStartOfInterval(
             greatest(

--- a/services/libs/tinybird/pipes/pull_request_analysis_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_copy_pipe.pipe
@@ -34,7 +34,9 @@ SQL >
 NODE pull_request_first_reviewed
 SQL >
     SELECT
-        if(type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId) AS sourceParentId,
+        if(
+            type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId
+        ) AS sourceParentId,
         MIN(timestamp) AS reviewedAt
     FROM activityRelations_deduplicated_cleaned_ds
     WHERE
@@ -46,7 +48,9 @@ SQL >
 NODE pull_request_first_review_approved
 SQL >
     SELECT
-        if(type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId) AS sourceParentId,
+        if(
+            type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId
+        ) AS sourceParentId,
         MIN(timestamp) AS approvedAt
     FROM activityRelations_deduplicated_cleaned_ds
     WHERE

--- a/services/libs/tinybird/pipes/pull_request_analysis_initial_snapshot.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_initial_snapshot.pipe
@@ -44,7 +44,9 @@ SQL >
 NODE pull_request_first_reviewed
 SQL >
     SELECT
-        if(type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId) AS sourceParentId,
+        if(
+            type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId
+        ) AS sourceParentId,
         argMin(updatedAt, timestamp) AS updatedAt,
         MIN(timestamp) AS reviewedAt
     FROM activityRelations_enriched_deduplicated_ds
@@ -61,7 +63,9 @@ SQL >
 NODE pull_request_first_review_approved
 SQL >
     SELECT
-        if(type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId) AS sourceParentId,
+        if(
+            type = 'patchset_approval-created', splitByChar('-', sourceParentId)[1], sourceParentId
+        ) AS sourceParentId,
         argMin(updatedAt, timestamp) AS updatedAt,
         MIN(timestamp) AS approvedAt
     FROM activityRelations_enriched_deduplicated_ds


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Normalize Gerrit event IDs to PRs, use patchset approvals as review/approval signals (drop comment-based), refine pr/patchset counting, and propagate platform in merge.
> 
> - **Data normalization and event mapping**:
>   - Normalize Gerrit IDs: map `changeset-abandoned|merged` to `sourceId` for closed/merged/resolved; map `patchset_approval-created` to parent PR via `splitByChar('-', sourceParentId)[1]`.
>   - Derive `prSourceId` from `sourceId` for open/create and from parent for other events; include `changeset-abandoned` and `changeset-merged` in derivation.
> - **Review/approval logic**:
>   - Treat `patchset_approval-created` (when parent matches PR) as review/approval signals.
>   - Remove comment-based signals (`changeset_comment-created`, `patchset_comment-created`).
> - **Metrics and fields**:
>   - Count `patchset-created` only when `sourceParentId` matches the PR; update `numberOfPatchsets` by taking the latest value (not additive).
>   - Propagate `platform` via baseline/new merge.
> - **Pipes updated**:
>   - `pull_request_analysis_MV_baseline_merge.pipe`, `pull_request_analysis_baseline_merge_MV.pipe`, `pull_request_analysis_copy_pipe.pipe`, `pull_request_analysis_initial_snapshot.pipe`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ddab1e7ae67662979eb5966831ce4fc0b283140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->