### PR TITLE
fix: filter out bad timestamp issue activities to prevent overflows

### DIFF
--- a/services/libs/tinybird/pipes/issue_analysis_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/issue_analysis_copy_pipe.pipe
@@ -1,6 +1,5 @@
 DESCRIPTION >
-	Compacts activities from same issue into one, keeping necessary information in a single row. Helps to serve issue-wide widgets in the development tab.
-
+    Compacts activities from same issue into one, keeping necessary information in a single row. Helps to serve issue-wide widgets in the development tab.
 
 NODE issues_opened
 SQL >
@@ -16,31 +15,22 @@ SQL >
     FROM activityRelations_deduplicated_cleaned_bucket_union
     WHERE type = 'issues-opened' AND toYear(timestamp) >= 1971
 
-
-
 NODE issues_closed
 SQL >
-
     SELECT sourceParentId, MIN(timestamp) AS closedAt
     FROM activityRelations_deduplicated_cleaned_bucket_union
     WHERE type = 'issues-closed' AND sourceParentId != '' AND toYear(timestamp) >= 1971
     GROUP BY sourceParentId
 
-
-
 NODE issues_comment
 SQL >
-
     SELECT sourceParentId, MIN(timestamp) AS commentedAt
     FROM activityRelations_deduplicated_cleaned_bucket_union
     WHERE type = 'issue-comment' AND sourceParentId != '' AND toYear(timestamp) >= 1971
     GROUP BY sourceParentId
 
-
-
 NODE issue_analysis_results_merged
 SQL >
-
     SELECT
         opened.id,
         opened.sourceId,
@@ -71,5 +61,3 @@ TYPE COPY
 TARGET_DATASOURCE issues_analyzed
 COPY_MODE replace
 COPY_SCHEDULE 20 * * * *
-
-


### PR DESCRIPTION
We have 1970-dated issue activities that cause overflows when calculating  `closedInSeconds` and `respondedInSeconds. We now filter these activities out in the issue analysis copy pipe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk SQL filter change that only excludes invalid/pre-1971 timestamps; main impact is potentially dropping a small set of bad events from issue metrics.
> 
> **Overview**
> Prevents overflow/invalid duration calculations in the issue analysis Tinybird pipe by filtering out issue `opened` and `closed` activities with timestamps before 1971 (`toYear(timestamp) >= 1971`).
> 
> This ensures `closedInSeconds`/`respondedInSeconds` are computed only from sane timestamps, at the cost of excluding affected legacy/badly-ingested events from the `issues_analyzed` copy output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5702de688f335ce427cc9e2e2c64e5aa6e78c674. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->