### PR TITLE
fix: app crashes when connection github on external projects [IN-885]

### DIFF
--- a/frontend/src/config/integrations/github-nango/components/settings/github-settings-drawer.vue
+++ b/frontend/src/config/integrations/github-nango/components/settings/github-settings-drawer.vue
@@ -142,19 +142,13 @@ const fetchSubProjects = () => {
   const EXTERNAL_OSS_SEGMENT_ID = '0fc01c53-8a6a-47db-b0cd-53de0ee65190';
 
   if (props.grandparentId === EXTERNAL_OSS_SEGMENT_ID && props.segmentId) {
-    console.log('[GitHub Integration] OSS segment detected - using current subproject only');
-    console.log('[GitHub Integration] Fetching subproject:', props.segmentId);
     // Only fetch current subproject, avoiding thousands of others
     LfService.findSegment(props.segmentId).then((currentSubproject) => {
-      console.log('[GitHub Integration] Subproject loaded:', currentSubproject.name);
       subprojects.value = [currentSubproject];
     });
   } else {
-    console.log('[GitHub Integration] Fetching all subprojects for segment:', props.grandparentId);
     LfService.findSegment(props.grandparentId).then((segment) => {
-      const allSubprojects = segment.projects.map((p) => p.subprojects).flat().filter((s) => s !== undefined);
-      console.log('[GitHub Integration] All subprojects loaded:', allSubprojects.length);
-      subprojects.value = allSubprojects;
+      subprojects.value = segment.projects.map((p) => p.subprojects).flat().filter((s) => s !== undefined);
     });
   }
 };


### PR DESCRIPTION
This pull request optimizes the loading of subprojects in the GitHub settings drawer to prevent performance issues when dealing with open source (OSS) projects that have a very large number of subprojects. Instead of fetching all subprojects for these OSS projects, the code now only fetches the currently selected subproject.

Performance improvements for OSS projects:

* Updated the `fetchSubProjects` function in `github-settings-drawer.vue` to detect when the parent segment is an external OSS project and, in that case, only fetch the current subproject instead of all subprojects, preventing crashes due to excessive data loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> For external OSS segments, fetch only the current subproject in `github-settings-drawer.vue` to avoid loading thousands of subprojects and crashing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78cd02ab280fb5f619670683183cf3fffec5e302. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->