### PR TITLE
feat: pipes fixes for gerrit pr

### DIFF
--- a/services/libs/tinybird/pipes/median_time_to_close.pipe
+++ b/services/libs/tinybird/pipes/median_time_to_close.pipe
@@ -1,13 +1,13 @@
 DESCRIPTION >
-    - `median_time_to_merge.pipe` serves the "Median time to merge" widget in the Development tab.
-    - Calculates the median time in seconds from PR opening to merge for the selected time period.
+    - `median_time_to_close.pipe` serves the "Median time to close" widget in the Development tab.
+    - Calculates the median time in seconds from PR opening to close/resolution for the selected time period.
     - **When `granularity` is NOT provided, returns a single KPI value** (median) across the entire time range.
-    - **When `granularity` is provided, returns time-series data** showing median time to merge aggregated by different time periods (daily, weekly, monthly, quarterly, yearly).
-    - Uses `generate_timeseries` pipe to create consistent time periods and left joins PR data to handle periods with no merged PRs.
-    - Only includes PRs that have been merged (`isNotNull(pra.mergedAt)`) to ensure accurate merge time calculations.
-    - Replaces the deprecated `averageTimeToMerge` widget with more robust median-based statistics.
+    - **When `granularity` is provided, returns time-series data** showing median time to close aggregated by different time periods (daily, weekly, monthly, quarterly, yearly).
+    - Uses `generate_timeseries` pipe to create consistent time periods and left joins PR data to handle periods with no closed PRs.
+    - Only includes PRs that have been closed (`isNotNull(prf.resolvedAt)`) to ensure accurate close time calculations.
+    - Replaces the deprecated `averageTimeToClose` widget with more robust median-based statistics.
     - Available for projects connected with Gerrit, GitHub, or GitLab platforms.
-    - Primary use case: monitoring code review and merge cycle time, identifying bottlenecks in the merge process.
+    - Primary use case: monitoring PR lifecycle and close cycle time, identifying bottlenecks in the resolution process.
     - Parameters:
     - `project`: Required string for project slug (e.g., 'k8s', 'tensorflow') - inherited from `segments_filtered`
     - `repos`: Optional array of repository URLs for filtering (e.g., ['https://github.com/kubernetes/kubernetes'])
@@ -16,19 +16,19 @@ DESCRIPTION >
     - `platform`: Optional string filter for source platform (e.g., 'gerrit', 'github', 'gitlab')
     - `granularity`: Optional string for time aggregation ('daily', 'weekly', 'monthly', 'quarterly', 'yearly')
     - Response:
-    - Without granularity: `medianTimeToMergeSeconds` (median value in seconds)
-    - With granularity: `startDate`, `endDate`, and `medianTimeToMergeSeconds` for each time period
+    - Without granularity: `medianTimeToCloseSeconds` (median value in seconds)
+    - With granularity: `startDate`, `endDate`, and `medianTimeToCloseSeconds` for each time period
 
-TAGS "Widget", "Pull requests", "Development metrics", "Merge time"
+TAGS "Development metrics", "Widget", "Pull requests", "Close time"
 
-NODE timeseries_generation_for_median_time_to_merge
+NODE timeseries_generation_for_median_time_to_close
 SQL >
     %
     {% if defined(granularity) %}
         SELECT
             ds."startDate",
             ds."endDate",
-            ifNull(round(median(prf.mergedInSeconds)), 0) AS "medianTimeToMergeSeconds"
+            ifNull(round(median(prf.resolvedInSeconds)), 0) AS "medianTimeToCloseSeconds"
         FROM generate_timeseries ds
         LEFT JOIN
             pull_requests_filtered prf
@@ -45,8 +45,9 @@ SQL >
                 THEN toStartOfYear(prf.openedAt)
             END
             = ds."startDate"
-            AND isNotNull(prf.mergedAt)
-            AND isNotNull(prf.mergedInSeconds)
+            AND isNotNull(prf.resolvedAt)
+            AND isNotNull(prf.resolvedInSeconds)
+            AND prf.resolvedInSeconds > 0
             {% if defined(platform) %}
                 AND prf.platform
                 = {{
@@ -82,14 +83,14 @@ SQL >
     {% else %} SELECT 1
     {% end %}
 
-NODE median_time_to_merge_merged
+NODE median_time_to_close_merged
 SQL >
     %
     {% if not defined(granularity) %}
-        SELECT round(median(prf.mergedInSeconds)) AS "medianTimeToMergeSeconds"
+        SELECT round(median(prf.resolvedInSeconds)) AS "medianTimeToCloseSeconds"
         FROM pull_requests_filtered prf
         WHERE
-            isNotNull(prf.mergedAt) AND isNotNull(prf.mergedInSeconds)
+            isNotNull(prf.resolvedAt) AND isNotNull(prf.resolvedInSeconds) AND prf.resolvedInSeconds > 0
             {% if defined(platform) %}
                 AND prf.platform
                 = {{
@@ -120,5 +121,5 @@ SQL >
                     )
                 }}
             {% end %}
-    {% else %} SELECT * FROM timeseries_generation_for_median_time_to_merge
+    {% else %} SELECT * FROM timeseries_generation_for_median_time_to_close
     {% end %}

--- a/services/libs/tinybird/pipes/median_time_to_review.pipe
+++ b/services/libs/tinybird/pipes/median_time_to_review.pipe
@@ -19,7 +19,7 @@ DESCRIPTION >
     - Without granularity: `medianTimeToReviewSeconds` (median value in seconds)
     - With granularity: `startDate`, `endDate`, and `medianTimeToReviewSeconds` for each time period
 
-TAGS "Widget", "Pull requests", "Development metrics", "Review time"
+TAGS "Development metrics", "Widget", "Pull requests", "Review time"
 
 NODE timeseries_generation_for_median_time_to_review
 SQL >
@@ -47,6 +47,7 @@ SQL >
             = ds."startDate"
             AND isNotNull(prf.reviewedAt)
             AND isNotNull(prf.reviewedInSeconds)
+            AND prf.reviewedInSeconds > 0
             {% if defined(platform) %}
                 AND prf.platform
                 = {{
@@ -89,7 +90,7 @@ SQL >
         SELECT round(median(prf.reviewedInSeconds)) AS "medianTimeToReviewSeconds"
         FROM pull_requests_filtered prf
         WHERE
-            isNotNull(prf.reviewedAt) AND isNotNull(prf.reviewedInSeconds)
+            isNotNull(prf.reviewedAt) AND isNotNull(prf.reviewedInSeconds) AND prf.reviewedInSeconds > 0
             {% if defined(platform) %}
                 AND prf.platform
                 = {{

--- a/services/libs/tinybird/pipes/patchsets_per_review.pipe
+++ b/services/libs/tinybird/pipes/patchsets_per_review.pipe
@@ -17,7 +17,7 @@ DESCRIPTION >
     - Without granularity: `patchsetsPerReview` (median or average value)
     - With granularity: `startDate`, `endDate`, and `patchsetsPerReview` for each time period
 
-TAGS "Widget", "Pull requests", "Development metrics", "Code review", "Gerrit"
+TAGS "Development metrics", "Widget", "Pull requests", "Code review", "Gerrit"
 
 NODE timeseries_generation_for_patchsets_per_review
 SQL >
@@ -50,6 +50,7 @@ SQL >
             = ds."startDate"
             AND prf.platform = 'gerrit'
             AND isNotNull(prf.numberOfPatchsets)
+            AND prf.numberOfPatchsets > 0
             {% if defined(startDate) %}
                 AND prf.openedAt
                 >= {{
@@ -88,7 +89,7 @@ SQL >
             {% end %}
         FROM pull_requests_filtered prf
         WHERE
-            prf.platform = 'gerrit' AND isNotNull(prf.numberOfPatchsets)
+            prf.platform = 'gerrit' AND isNotNull(prf.numberOfPatchsets) AND prf.numberOfPatchsets > 0
             {% if defined(startDate) %}
                 AND prf.openedAt
                 >= {{

--- a/services/libs/tinybird/pipes/pull_requests_filtered.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_filtered.pipe
@@ -20,4 +20,6 @@ SQL >
         {% if defined(repos) %}
             AND pra.channel
             IN {{ Array(repos, 'String', description="Filter activity repo list", required=False) }}
+        {% else %}
+            AND pra.channel IN (SELECT repository FROM segmentRepositories where excluded = false)
         {% end %}

--- a/services/libs/tinybird/pipes/review_efficiency.pipe
+++ b/services/libs/tinybird/pipes/review_efficiency.pipe
@@ -17,7 +17,7 @@ DESCRIPTION >
     - Without granularity: `openedCount` and `mergedCount` (single values)
     - With granularity: `startDate`, `endDate`, `openedCount`, and `mergedCount` for each time period
 
-TAGS "Widget", "Pull requests", "Development metrics", "Review efficiency"
+TAGS "Development metrics", "Widget", "Pull requests", "Review efficiency"
 
 NODE review_efficiency_timeseries
 SQL >
@@ -27,7 +27,7 @@ SQL >
             ds."startDate",
             ds."endDate",
             ifNull(countIf(isNotNull(prf.id)), 0) AS "openedCount",
-            ifNull(countIf(isNotNull(prf.id) AND isNotNull(prf.mergedAt)), 0) AS "mergedCount"
+            ifNull(countIf(isNotNull(prf.id) AND isNotNull(prf.resolvedAt)), 0) AS "resolvedCount"
         FROM generate_timeseries ds
         LEFT JOIN
             pull_requests_filtered prf
@@ -83,7 +83,7 @@ NODE review_efficiency_merged
 SQL >
     %
     {% if not defined(granularity) %}
-        SELECT count(prf.id) AS "openedCount", countIf(isNotNull(prf.mergedAt)) AS "mergedCount"
+        SELECT count(prf.id) AS "openedCount", countIf(isNotNull(prf.resolvedAt)) AS "resolvedCount"
         FROM pull_requests_filtered prf
         WHERE
             1 = 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `median_time_to_close` metric, updates review efficiency to use resolved counts, enforces >0-value filters, and defaults repo filtering to non-excluded segment repositories.
> 
> - **Tinybird pipes**:
>   - **New metric**: `median_time_to_close.pipe`
>     - Computes `medianTimeToCloseSeconds` from `resolvedInSeconds` (KPI or time series).
>     - Filters require `resolvedAt` and `resolvedInSeconds > 0`.
>   - **Review efficiency** (`review_efficiency.pipe`):
>     - Replaces merged counts with `resolvedCount` based on `resolvedAt` (both KPI and time series).
>   - **Data quality filters**:
>     - `median_time_to_review.pipe`: require `reviewedInSeconds > 0`.
>     - `patchsets_per_review.pipe`: require `numberOfPatchsets > 0`.
>   - **Core filter** (`pull_requests_filtered.pipe`):
>     - When `repos` not provided, default to `segmentRepositories` where `excluded = false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c73f8484db1d6bcd0eb9275913cabf4ac099a1bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->