### PR TITLE
fix(git-integration): sync gerrit repos to git v2 and fix deletions bugs [CM-859]

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -355,26 +355,51 @@ export default class IntegrationService {
         } catch (err) {
           throw new Error404()
         }
-        // remove github remotes from git integration
+        // remove github/gitlab/gerrit remotes from git integration
         if (
           integration.platform === PlatformType.GITHUB ||
           integration.platform === PlatformType.GITLAB ||
-          integration.platform === PlatformType.GITHUB_NANGO
+          integration.platform === PlatformType.GITHUB_NANGO ||
+          integration.platform === PlatformType.GERRIT
         ) {
           let shouldUpdateGit: boolean
-          const mapping =
-            integration.platform === PlatformType.GITHUB ||
-            integration.platform === PlatformType.GITHUB_NANGO
-              ? await this.getGithubRepos(id)
-              : await this.getGitlabRepos(id)
+          let repos: Record<string, string[]> = {}
 
-          const repos: Record<string, string[]> = mapping.reduce((acc, { url, segment }) => {
-            if (!acc[segment.id]) {
-              acc[segment.id] = []
+          // Get repos based on platform
+          if (integration.platform === PlatformType.GERRIT) {
+            if (
+              integration.settings?.remote?.enableGit &&
+              integration.settings?.remote?.repoNames
+            ) {
+              const stripGit = (url: string) => {
+                if (url.endsWith('.git')) {
+                  return url.slice(0, -4)
+                }
+                return url
+              }
+
+              const gerritUrls = integration.settings.remote.repoNames.map((repoName: string) =>
+                stripGit(`${integration.settings.remote.orgURL}/${repoName}`),
+              )
+
+              repos[integration.segmentId] = gerritUrls
             }
-            acc[segment.id].push(url)
-            return acc
-          }, {})
+          } else {
+            // For GitHub/GitLab, use mapping tables
+            const mapping =
+              integration.platform === PlatformType.GITHUB ||
+              integration.platform === PlatformType.GITHUB_NANGO
+                ? await this.getGithubRepos(id)
+                : await this.getGitlabRepos(id)
+
+            repos = mapping.reduce((acc, { url, segment }) => {
+              if (!acc[segment.id]) {
+                acc[segment.id] = []
+              }
+              acc[segment.id].push(url)
+              return acc
+            }, {})
+          }
 
           for (const [segmentId, urls] of Object.entries(repos)) {
             urls.forEach((url) => toRemoveRepo.add(url))
@@ -474,6 +499,14 @@ export default class IntegrationService {
 
           // soft delete gitlab repos
           await GitlabReposRepository.delete(integration.id, {
+            ...this.options,
+            transaction,
+          })
+        }
+
+        // Soft delete git.repositories for git integration
+        if (integration.platform === PlatformType.GIT) {
+          await GitReposRepository.delete(integration.id, {
             ...this.options,
             transaction,
           })


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the handling of Git repository integrations, especially for soft deletion and upserting repository records. The changes ensure more accurate soft deletion, enhance logging, and improve the upsert logic for repositories. Additionally, the integration service is updated to better handle different platforms, particularly Gerrit and generic Git integrations.

Repository management improvements:

* The soft delete method in `GitReposRepository` now only updates repositories that have not already been deleted and returns the count of affected rows, logging this information for better traceability. [[1]](diffhunk://#diff-48f82c046f100f371ed013d3bc384e4143d0633ae7c2906f3211fe1067cbbc55L16-R21) [[2]](diffhunk://#diff-48f82c046f100f371ed013d3bc384e4143d0633ae7c2906f3211fe1067cbbc55R31-R34)
* The upsert logic for repositories now uses the `url` as the conflict key instead of `id`, and resets several fields (including state, priority, and processing metadata) to defaults on conflict, ensuring consistency and correct reprocessing.

Integration service enhancements:

* The integration removal process now properly handles Gerrit and generic Git integrations, including building repository URLs for Gerrit, and soft deleting repositories for generic Git integrations via the repository method. [[1]](diffhunk://#diff-80e1c7e63674653fe2cf5bcbe4a2212499d72014f328ad2e6b617146f0a256fdL358-R402) [[2]](diffhunk://#diff-80e1c7e63674653fe2cf5bcbe4a2212499d72014f328ad2e6b617146f0a256fdR507-R514)
* When connecting or updating a Git integration, repository URLs are now consistently built from organization URLs and repository names, and the process uses improved segment-aware options for better multi-segment support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Syncs Gerrit repos to git-integration v2 and fixes soft-delete/upsert logic with robust cleanup across GitHub/GitLab/Gerrit and generic Git.
> 
> - **Backend – git repositories (`git.repositories`)**:
>   - **Soft delete**: Update only non-deleted rows; return affected count; add info logging.
>   - **Upsert**: Switch conflict target to `url`; set `id` from `EXCLUDED`; clear `deletedAt`; reset `state`→`pending`, `priority`→`1`, and processing fields to `NULL` to requeue.
> - **Integration Service**:
>   - **Destroy flow**: Handle GitHub/GitLab/Gerrit repo removal; for Gerrit, build URLs from `orgURL` + `repoNames`; update or delete `PlatformType.GIT` integration accordingly; soft-delete related `git.repositories`; also soft-delete provider-specific repos.
>   - **Gerrit connect/update**: When `enableGit`, construct remote URLs and call `gitConnectOrUpdate` with segment-aware options to sync to git v2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 880d62afd3a2ae9cbd806f7ab82581382a482a79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->