### PR TITLE
feat: migration to add contributor widgets to all projects

### DIFF
--- a/backend/src/database/migrations/U1766051317__contributorWidgetEnable.sql
+++ b/backend/src/database/migrations/U1766051317__contributorWidgetEnable.sql
@@ -1,0 +1,37 @@
+-- Rollback migration for contributorWidgetEnable
+-- Removes contributor widgets: activeContributors, activeOrganization, contributorsLeaderboard,
+--                               organizationsLeaderboard, contributorDependency, organizationDependency,
+--                               retention, geographicalDistribution
+
+BEGIN;
+
+-- Remove all contributor widgets from all projects
+UPDATE "insightsProjects" ip
+SET
+    widgets = (
+        SELECT COALESCE(array_agg(w), ARRAY[]::TEXT[])
+        FROM unnest(ip.widgets) AS w
+        WHERE w NOT IN (
+            'activeContributors',
+            'activeOrganization',
+            'contributorsLeaderboard',
+            'organizationsLeaderboard',
+            'contributorDependency',
+            'organizationDependency',
+            'retention',
+            'geographicalDistribution'
+        )
+    ),
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE ip.widgets && ARRAY[
+    'activeContributors',
+    'activeOrganization',
+    'contributorsLeaderboard',
+    'organizationsLeaderboard',
+    'contributorDependency',
+    'organizationDependency',
+    'retention',
+    'geographicalDistribution'
+];
+
+COMMIT;

--- a/backend/src/database/migrations/V1766051317__contributorWidgetEnable.sql
+++ b/backend/src/database/migrations/V1766051317__contributorWidgetEnable.sql
@@ -1,0 +1,38 @@
+-- Migration to enable contributor widgets for all projects
+-- Adds: activeContributors, activeOrganization, contributorsLeaderboard, organizationsLeaderboard,
+--       contributorDependency, organizationDependency, retention, geographicalDistribution
+
+BEGIN;
+
+-- Add all contributor widgets to all projects that don't already have them
+UPDATE "insightsProjects" ip
+SET widgets = (
+    SELECT ARRAY(
+        SELECT DISTINCT unnest(
+            ip.widgets ||
+            ARRAY[
+                'activeContributors',
+                'activeOrganization',
+                'contributorsLeaderboard',
+                'organizationsLeaderboard',
+                'contributorDependency',
+                'organizationDependency',
+                'retention',
+                'geographicalDistribution'
+            ]
+        )
+    )
+),
+"updatedAt" = CURRENT_TIMESTAMP
+WHERE NOT (ip.widgets @> ARRAY[
+    'activeContributors',
+    'activeOrganization',
+    'contributorsLeaderboard',
+    'organizationsLeaderboard',
+    'contributorDependency',
+    'organizationDependency',
+    'retention',
+    'geographicalDistribution'
+]);
+
+COMMIT;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add forward and rollback SQL migrations to bulk add/remove contributor widgets on all projects and update timestamps.
> 
> - **Database Migrations**:
>   - `backend/src/database/migrations/V1766051317__contributorWidgetEnable.sql`:
>     - Updates `insightsProjects.widgets` to include `activeContributors`, `activeOrganization`, `contributorsLeaderboard`, `organizationsLeaderboard`, `contributorDependency`, `organizationDependency`, `retention`, `geographicalDistribution` (deduped), and sets `updatedAt`.
>   - `backend/src/database/migrations/U1766051317__contributorWidgetEnable.sql`:
>     - Removes the above widgets from `insightsProjects.widgets` and sets `updatedAt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d8b4befbeca762cd6987e2c1efb6f7715fff4b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->