### PR TITLE
feat: disable gerrit for some widgets

### DIFF
--- a/services/libs/tinybird/pipes/pull_requests_average_resolve_velocity.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_average_resolve_velocity.pipe
@@ -20,4 +20,4 @@ SQL >
     select round(avg(pra.resolvedInSeconds)) "averagePullRequestResolveVelocitySeconds"
     from activities_filtered af
     left join pull_requests_analyzed pra on af.id = pra.id
-    where isNotNull(pra.resolvedAt)
+    where isNotNull(pra.resolvedAt) AND platform != 'gerrit'

--- a/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe
@@ -26,7 +26,7 @@ SQL >
         round(avg(dateDiff('second', prf.approvedAt, prf.mergedAt))) AS approvedToMergedSeconds
     from pull_requests_filtered prf
     where
-        1 = 1
+        platform != 'gerrit'
         {% if defined(startDate) %}
             AND prf.openedAt
             > {{ DateTime(startDate, description="Filter activity timestamp after", required=False) }}

--- a/services/libs/tinybird/pipes/pull_requests_review_time_by_size.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_review_time_by_size.pipe
@@ -20,7 +20,7 @@ SQL >
         count(pra.sourceId) as pullRequestCount
     from pull_requests_filtered pra
     where
-        not empty(gitChangedLinesBucket)
+        not empty(gitChangedLinesBucket) AND platform != 'gerrit'
         {% if defined(startDate) %}
             AND pra.reviewedAt
             > {{ DateTime(startDate, description="Filter activity timestamp after", required=False) }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Excludes Gerrit-platform PRs from average resolve velocity, merge lead time, and review time by size metrics.
> 
> - **Tinybird pipes: PR metrics filtering**
>   - Add `platform != 'gerrit'` filter to:
>     - `services/libs/tinybird/pipes/pull_requests_average_resolve_velocity.pipe`
>     - `services/libs/tinybird/pipes/pull_requests_merge_lead_time.pipe`
>     - `services/libs/tinybird/pipes/pull_requests_review_time_by_size.pipe`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87ecdcb525517bbd0299fd9353f0e1303510e8a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->