### PR TITLE
fix: fallback to global token when nango auth fails & increase frequency [CM-861]

### DIFF
--- a/services/libs/integrations/src/integrations/stackoverflow/index.ts
+++ b/services/libs/integrations/src/integrations/stackoverflow/index.ts
@@ -10,7 +10,7 @@ import processStream from './processStream'
 const descriptor: IIntegrationDescriptor = {
   type: PlatformType.STACKOVERFLOW,
   memberAttributes: STACKOVERFLOW_MEMBER_ATTRIBUTES,
-  checkEvery: 60,
+  checkEvery: 360, // 6 hours
   generateStreams,
   processStream,
   processData,

--- a/services/libs/integrations/src/integrations/stackoverflow/types.ts
+++ b/services/libs/integrations/src/integrations/stackoverflow/types.ts
@@ -1,4 +1,4 @@
-export const STACKOVERFLOW_MAX_RETROSPECT_IN_HOURS = 5
+export const STACKOVERFLOW_MAX_RETROSPECT_IN_HOURS = 7
 export const STACKOVERFLOW_LAST_MAX_PAGES = 20
 
 export enum StackOverflowActivityType {


### PR DESCRIPTION
This pull request improves the robustness and flexibility of StackOverflow API integrations by handling failed access token retrievals more gracefully and making minor configuration adjustments. The main focus is on ensuring that the integration can fall back to a global API key if a user-specific token cannot be obtained, reducing the risk of failed API calls.

**Improvements to StackOverflow API authentication and error handling:**

* All StackOverflow API calls (`getAnswers.ts`, `getQuestions.ts`, `getQuestionsByKeywords.ts`, `getUser.ts`) now attempt to fetch a user-specific access token, but log a warning and fall back to using a global API key if token retrieval fails. This prevents failures when user tokens are unavailable. [[1]](diffhunk://#diff-67e2b9d4c1e55f3ba3be1c3fe5c65dfa0bc68ba4428069fdd61738df99cf8907L27-R57) [[2]](diffhunk://#diff-bcaa99768a673db31161309d97ffe4ec5b1d0c69366fe3eaa938cede789d0cfbL53-R83) [[3]](diffhunk://#diff-fc4a70ac8186d374861254e5de7e108e5e9835bc241bdbc283dd7d01c6ac681dL50-R83) [[4]](diffhunk://#diff-5bcb2daae10c35fcb4d7454cd177a2a8f8dbc4c7698dadf6efca58c8d88afd06L28-R54)

**Configuration and parameter tweaks:**

* Increased the StackOverflow integration's check interval from every 60 minutes to every 6 hours, reducing the frequency of checks. (`index.ts`)
* Increased the maximum retrospect period for StackOverflow data retrieval from 5 to 7 hours. (`types.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add conditional fallback to global StackOverflow key when Nango token fetch fails across API calls, and update check interval to 6h with a 7h retrospect window.
> 
> - **StackOverflow API auth/error handling**:
>   - All API calls (`getAnswers.ts`, `getQuestions.ts`, `getQuestionsByKeywords.ts`, `getUser.ts`) now try to fetch a Nango `access_token`; on failure, log a warning and proceed using the global `key`.
>   - Refactor request `params` construction to include `access_token` only when available.
> - **Config tweaks**:
>   - Update `checkEvery` to `360` (6 hours) in `index.ts`.
>   - Increase `STACKOVERFLOW_MAX_RETROSPECT_IN_HOURS` from `5` to `7` in `types.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2459d3be8168e173d5265fe96a7d3c545ea46ac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->