### PR TITLE
feat: support collections sorting by contributor count

### DIFF
--- a/services/libs/tinybird/pipes/collections_list.pipe
+++ b/services/libs/tinybird/pipes/collections_list.pipe
@@ -16,17 +16,37 @@ DESCRIPTION >
     - Count mode (`count=true`): `count` (total number of collections)
     - Data mode (default): `id`, `name`, `slug`, `description`, `projectCount`, `starred`, `softwareValue`, `contributorCount`, `featuredProjects` array
 
-NODE collections_paginated
+NODE collections_list_software_value
 SQL >
-    %
+    SELECT
+        collectionId,
+        coalesce(sum(softwareValue), 0) as "softwareValue",
+        coalesce(sum(contributorCount), 0) as "contributorCount"
+    FROM segments_aggregates_with_ids_datasource
+    WHERE collectionId != ''
+    GROUP BY collectionId
+
+NODE collections_enriched
+SQL >
     SELECT
         collections_filtered.id,
         collections_filtered.name,
         collections_filtered.slug,
         collections_filtered.description,
         collections_filtered.projectCount,
-        collections_filtered.starred
+        collections_filtered.starred,
+        coalesce(collections_list_software_value.softwareValue, 0) as softwareValue,
+        coalesce(collections_list_software_value.contributorCount, 0) as contributorCount
     FROM collections_filtered
+    LEFT JOIN
+        collections_list_software_value
+        ON collections_list_software_value.collectionId = collections_filtered.id
+
+NODE collections_paginated
+SQL >
+    %
+    SELECT id, name, slug, description, projectCount, starred, softwareValue, contributorCount
+    FROM collections_enriched
     order by
         {{
             column(
@@ -61,16 +81,6 @@ SQL >
         (collectionsInsightsProjects.collectionId in (select id from collections_paginated))
         and collectionsInsightsProjects.starred
 
-NODE collections_list_software_value
-SQL >
-    SELECT
-        collectionId,
-        coalesce(sum(softwareValue), 0) as "softwareValue",
-        coalesce(sum(contributorCount), 0) as "contributorCount"
-    FROM segments_aggregates_with_ids_datasource
-    WHERE collectionId != ''
-    GROUP BY collectionId
-
 NODE merging_fields_together
 SQL >
     %
@@ -83,8 +93,8 @@ SQL >
             collections_paginated.description as description,
             collections_paginated.projectCount as "projectCount",
             collections_paginated.starred as starred,
-            collections_list_software_value.softwareValue as softwareValue,
-            collections_list_software_value.contributorCount as contributorCount,
+            collections_paginated.softwareValue as softwareValue,
+            collections_paginated.contributorCount as contributorCount,
             arrayFilter(
                 x -> x['name'] != '',
                 groupArray(
@@ -102,18 +112,15 @@ SQL >
         LEFT JOIN
             collections_featured_projects
             ON collections_featured_projects.collectionId = collections_paginated.id
-        LEFT JOIN
-            collections_list_software_value
-            ON collections_list_software_value.collectionId = collections_paginated.id
         GROUP BY
-            collections_paginated.id as id,
-            collections_paginated.name as name,
-            collections_paginated.slug as slug,
-            collections_paginated.description as description,
-            collections_paginated.projectCount as "projectCount",
-            collections_paginated.starred as starred,
-            collections_list_software_value.softwareValue as softwareValue,
-            collections_list_software_value.contributorCount as contributorCount
+            collections_paginated.id,
+            collections_paginated.name,
+            collections_paginated.slug,
+            collections_paginated.description,
+            collections_paginated.projectCount,
+            collections_paginated.starred,
+            collections_paginated.softwareValue,
+            collections_paginated.contributorCount
         order by
             {{
                 column(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces pre-enrichment and sorting enhancements for collections.
> 
> - Adds `collections_enriched` joining `collections_list_software_value` so `softwareValue` and `contributorCount` are available for sorting/pagination
> - Updates `collections_paginated` to select `softwareValue`/`contributorCount` and handle dynamic `orderByField`; keeps secondary sort by `projectCount` (and when sorting by `starred`, adds `projectCount` DESC)
> - Simplifies `merging_fields_together` by removing redundant join to `collections_list_software_value` and grouping only on paginated fields
> - PR ensures response consistently includes `softwareValue` and `contributorCount` for each collection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a03137f6639b64344a1d097636e5d3ae35da9453. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->