### PR TITLE
chore: update health score sink (CM-898)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_sink.pipe
+++ b/services/libs/tinybird/pipes/health_score_sink.pipe
@@ -5,6 +5,10 @@ SQL >
         segmentId,
         slug,
         if(isNaN(overallScore), null, overallScore) as overallScore,
+        if(isNaN(securityPercentage), null, securityPercentage) as securityPercentage,
+        if(isNaN(contributorPercentage), null, contributorPercentage) as contributorPercentage,
+        if(isNaN(popularityPercentage), null, popularityPercentage) as popularityPercentage,
+        if(isNaN(developmentPercentage), null, developmentPercentage) as developmentPercentage,
         toStartOfDay(now()) as date
     FROM health_score_copy_ds
 


### PR DESCRIPTION
Request to add 4 more columns to the health score sink:
- securityPercentage
- contributorPercentage
- popularityPercentage
- developmentPercentage

Changes to this sink pipe https://app.tinybird.co/aws/us-west-2/lfx_insights/pipe/health_score_sink

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the Tinybird `health_score_sink` to include additional percentage metrics and ensures NaNs are exported as nulls.
> 
> - Adds `securityPercentage`, `contributorPercentage`, `popularityPercentage`, and `developmentPercentage` to `SELECT` in `health_score_sink.pipe`
> - Wraps new fields (and `overallScore`) with `if(isNaN(...), null, ...)` to avoid exporting NaNs
> - No changes to sink schedule, destination (`kafka`), format (`csv`), or topic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e512bfd7a42f794f4f834ec03117b5e245b4c02d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->