### PR TITLE
feat: archived repo checker cronjob write to repositories [CM-873]

### DIFF
--- a/services/cronjobs/archived_repositories/src/database.ts
+++ b/services/cronjobs/archived_repositories/src/database.ts
@@ -59,6 +59,7 @@ export async function updateRepositoryStatus(
 
   try {
     await Promise.all([
+      // TODO: stop writing to segmentRepositories post migration
       client.query(
         `UPDATE "segmentRepositories" 
          SET archived = $1, excluded = $2, last_archived_check = NOW(), updated_at = NOW()


### PR DESCRIPTION
This pull request updates the logic for marking repositories as archived or excluded in the database. Now, when the status of a repository is updated, changes are applied to both the `segmentRepositories` and `repositories` tables at the same time to ensure consistency.

**Database consistency improvements:**

* The `updateRepositoryStatus` function now updates both the `segmentRepositories` and `repositories` tables concurrently when changing a repository's archived or excluded status, ensuring both tables remain in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures repository status is written to both storage tables for consistency.
> 
> - Update `updateRepositoryStatus` to run parallel `UPDATE`s on `segmentRepositories` and `repositories`, setting `archived`/`excluded` and refreshing `last_archived_check`/`updated_at` (and `lastArchivedCheckAt`/`updatedAt`) for the matching repository URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5db54fd3efd2847fb259689038835dd625c3bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->