### PR TITLE
fix: optimize PR analysis materialized view (IN-899)

### DIFF
--- a/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
@@ -1,22 +1,16 @@
 DESCRIPTION >
-	Compacts activities from same PR into one, keeping necessary information in a single row.
-Uses existing pull_requests_analyzed data as baseline and merges new events on top.
-
+    Compacts activities from same PR into one, keeping necessary information in a single row.
+    Uses existing pull_requests_analyzed data as baseline and merges new events on top.
 
 NODE snapshot_resolver
 DESCRIPTION >
     Resolve latest snapshot ID once for reuse across all nodes.
 
 SQL >
-
-    SELECT max(snapshotId) as latestSnapshotId
-    FROM activityRelations_enrich_snapshot_MV_ds
-
-
+    SELECT max(snapshotId) as latestSnapshotId FROM activityRelations_enrich_snapshot_MV_ds
 
 NODE new_pull_request_related_activity
 SQL >
-
     SELECT
         activityId as id,
         sourceId,
@@ -56,14 +50,11 @@ SQL >
             'changeset-merged'
         )
 
-
-
 NODE new_events_aggregated
 DESCRIPTION >
     Aggregates new events from the latest snapshot by PR source ID.
 
 SQL >
-
     SELECT
         if(
             type IN (
@@ -77,19 +68,13 @@ SQL >
             sourceParentId
         ) AS prSourceId,
         argMinIf(
-            id,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            id, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS id,
         argMinIf(
-            channel,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            channel, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS channel,
         argMinIf(
-            segmentId,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            segmentId, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS segmentId,
         argMinIf(
             gitChangedLinesBucket,
@@ -97,9 +82,7 @@ SQL >
             type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS gitChangedLinesBucket,
         argMinIf(
-            memberId,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            memberId, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS memberId,
         argMinIf(
             organizationId,
@@ -107,59 +90,47 @@ SQL >
             type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS organizationId,
         argMinIf(
-            platform,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            platform, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS platform,
         minIf(
             ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS openedAt,
         argMinIf(
-            updatedAt,
-            ts,
-            type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
+            updatedAt, ts, type IN ('pull_request-opened', 'merge_request-opened', 'changeset-created')
         ) AS openedUpdatedAt,
-        toInt64(countIf(type = 'patchset-created' AND sourceParentId = prSourceId)) AS numberOfPatchsets,
+        toInt64(
+            countIf(type = 'patchset-created' AND sourceParentId = prSourceId)
+        ) AS numberOfPatchsets,
         argMin(
             updatedAt, if(type IN ('pull_request-assigned', 'merge_request-assigned'), ts, NULL)
         ) AS assignedUpdatedAt,
-        min(
-            if(type IN ('pull_request-assigned', 'merge_request-assigned'), ts, NULL)
-        ) AS assignedAt,
+        min(if(type IN ('pull_request-assigned', 'merge_request-assigned'), ts, NULL)) AS assignedAt,
         argMin(
             updatedAt,
-            if(
-                type IN ('pull_request-review-requested', 'merge_request-review-requested'),
-                ts,
-                NULL
-            )
+            if(type IN ('pull_request-review-requested', 'merge_request-review-requested'), ts, NULL)
         ) AS reviewRequestedUpdatedAt,
         min(
-            if(
-                type IN ('pull_request-review-requested', 'merge_request-review-requested'),
-                ts,
-                NULL
-            )
+            if(type IN ('pull_request-review-requested', 'merge_request-review-requested'), ts, NULL)
         ) AS reviewRequestedAt,
         argMin(
             updatedAt,
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 ts,
                 NULL
             )
         ) AS reviewedUpdatedAt,
         min(
             if(
-                type IN (
-                    'pull_request-reviewed',
-                    'merge_request-review-changes-requested'
-                )
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 ts,
                 NULL
             )
@@ -169,7 +140,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 ts,
                 NULL
             )
@@ -178,7 +152,10 @@ SQL >
             if(
                 (type = 'pull_request-reviewed' AND pullRequestReviewState = 'APPROVED')
                 OR type = 'merge_request-review-approved'
-                OR (type = 'patchset_approval-created' AND splitByChar('-', sourceParentId)[1] = prSourceId),
+                OR (
+                    type = 'patchset_approval-created'
+                    AND splitByChar('-', sourceParentId)[1] = prSourceId
+                ),
                 ts,
                 NULL
             )
@@ -210,18 +187,10 @@ SQL >
         ) AS closedAt,
         argMin(
             updatedAt,
-            if(
-                type IN ('pull_request-merged', 'merge_request-merged', 'changeset-merged'),
-                ts,
-                NULL
-            )
+            if(type IN ('pull_request-merged', 'merge_request-merged', 'changeset-merged'), ts, NULL)
         ) AS mergedUpdatedAt,
         min(
-            if(
-                type IN ('pull_request-merged', 'merge_request-merged', 'changeset-merged'),
-                ts,
-                NULL
-            )
+            if(type IN ('pull_request-merged', 'merge_request-merged', 'changeset-merged'), ts, NULL)
         ) AS mergedAt,
         argMin(
             updatedAt,
@@ -258,28 +227,22 @@ SQL >
     GROUP BY prSourceId
     HAVING prSourceId != ''
 
-
-
 NODE baseline_filtered
 DESCRIPTION >
     Pre-filter baseline using semi-join pattern.
-        This significantly reduces the data scanned in the final JOIN.
+    This significantly reduces the data scanned in the final JOIN.
 
 SQL >
-
     SELECT *
     FROM pull_requests_analyzed
     WHERE sourceId IN (SELECT prSourceId FROM new_events_aggregated)
 
-
-
 NODE pull_request_analysis_results_merged
 DESCRIPTION >
     Merge new events with filtered baseline using ANY LEFT JOIN.
-        New data overwrites existing data where present, preserves existing for unchanged fields.
+    New data overwrites existing data where present, preserves existing for unchanged fields.
 
 SQL >
-
     SELECT
         if(existing.id != '', existing.id, new.id) as id,
         if(existing.sourceId != '', existing.sourceId, new.prSourceId) as sourceId,
@@ -373,8 +336,7 @@ SQL >
         ) AS resolvedInSeconds,
         if(existing.platform != '', existing.platform, new.platform) as platform,
         COALESCE(
-            if(new.numberOfPatchsets > 0, new.numberOfPatchsets, NULL),
-            existing.numberOfPatchsets
+            if(new.numberOfPatchsets > 0, new.numberOfPatchsets, NULL), existing.numberOfPatchsets
         ) as numberOfPatchsets,
         toStartOfInterval(
             greatest(
@@ -390,11 +352,9 @@ SQL >
             INTERVAL 1 hour
         )
         + INTERVAL 1 hour as snapshotId
-    FROM new_events_aggregated new
-    ANY LEFT JOIN baseline_filtered existing ON new.prSourceId = existing.sourceId
+    FROM new_events_aggregated new ANY
+    LEFT JOIN baseline_filtered existing ON new.prSourceId = existing.sourceId
     WHERE if(existing.id != '', existing.id, new.id) != ''
 
-TYPE materialized
+TYPE MATERIALIZED
 DATASOURCE pull_request_analyzed_MV_ds
-
-


### PR DESCRIPTION
Optimizes PR analysis materialized view by prefiltering the baseline PRs table before joining back to the updated rows, resulting in much more lightweight join operation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves performance and clarity of PR analysis materialized view by reducing scanned data and simplifying snapshot selection.
> 
> - Adds `snapshot_resolver` to resolve the latest snapshot ID once and reuse across nodes
> - Refactors `new_pull_request_related_activity` to include `sourceParentId`, `type`, `pullRequestReviewState`, and `ts`, and to reference `snapshot_resolver`
> - Rewrites `new_events_aggregated` to select from `new_pull_request_related_activity`, use `ts` consistently, and compute `prSourceId` for grouping
> - Introduces `baseline_filtered` to prefilter `pull_requests_analyzed` via semi-join on `prSourceId`
> - Updates final merge to `ANY LEFT JOIN` against `baseline_filtered`, keeping existing overwrite/COALESCE semantics and snapshot calculation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd8d2fac7fd051d19b578111093b99243d3dcfcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->