### PR TITLE
feat: git integration migration to new tables [CM-875]

### DIFF
--- a/services/apps/git_integration/src/crowdgit/models/repository.py
+++ b/services/apps/git_integration/src/crowdgit/models/repository.py
@@ -46,11 +46,9 @@ class Repository(BaseModel):
         description="Indicates if the stuck repository is resolved by a re-onboarding",
     )
     re_onboarding_count: int = Field(
-        ...,
+        default=0,
         description="Tracks the number of times this repository has been re-onboarded. Used to identify unreachable commits via activity.attributes.cycle matching pattern onboarding-{reOnboardingCount}",
     )
-    created_at: datetime = Field(..., description="Creation timestamp")
-    updated_at: datetime = Field(..., description="Last update timestamp")
 
     @classmethod
     def from_db(cls, db_data: dict[str, Any]) -> Repository:
@@ -65,8 +63,6 @@ class Repository(BaseModel):
 
         # Map database field names to model field names
         field_mapping = {
-            "createdAt": "created_at",
-            "updatedAt": "updated_at",
             "lastProcessedAt": "last_processed_at",
             "lastProcessedCommit": "last_processed_commit",
             "lockedAt": "locked_at",


### PR DESCRIPTION
This pull request refactors the repository CRUD logic to fully migrate from the legacy `git.repositories` table to the newer `public.repositories` and `git.repositoryProcessing` tables. The changes standardize queries, improve maintainability, and ensure all repository state and processing information is consistently handled in the new schema.

**Repository Data Model Migration:**

* All repository state and processing operations now use `public.repositories` and `git.repositoryProcessing` tables, replacing direct use of the legacy `git.repositories` table in all queries and updates. [[1]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L20-L40) [[2]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L51-R56) [[3]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L66-R94) [[4]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L125-R148)

**Query and Update Refactoring:**

* Common repository column selection is now centralized in the `REPO_SELECT_COLUMNS` constant, ensuring consistent data retrieval across all CRUD operations.
* Repository lock, state, commit, and onboarding count updates now operate on `git.repositoryProcessing` using the `repositoryId` foreign key, not the legacy table's `id`. [[1]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L199-R209) [[2]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L213-R247)
* The maintainer file update logic is simplified to update only `git.repositoryProcessing`, removing the deprecated update to the old `githubRepos` table.

**Model Compatibility:**

* The `Repository` model now expects `gitIntegrationId` (instead of `integrationId`) to match the new schema and maintain compatibility with updated queries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes migration to the new repository schema and streamlines processing logic.
> 
> - Centralizes common columns via `REPO_SELECT_COLUMNS` and refactors queries to join `public.repositories` with `git."repositoryProcessing"` for reads and writes
> - Rewrites `acquire_onboarding_repo` and `acquire_recurrent_repo` using CTEs with `FOR UPDATE OF rp SKIP LOCKED` and updates via `repositoryId`; `get_recently_processed_repository_by_url` now uses the new join
> - Updates state/lock/commit/onboarding count operations (`release_repo`, `update_last_processed_commit`, `increase_re_onboarding_count`, `mark_repo_as_processed`) to target `git."repositoryProcessing"`
> - Simplifies `update_maintainer_run` to update only `git."repositoryProcessing"`; removes legacy `githubRepos` update and unused legacy CRUD
> - Adjusts `Repository` model: expects `gitIntegrationId` (mapped to `integration_id`) and defaults `re_onboarding_count` to 0
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca8c83592be4c757e0bec76e24c39b0e5e9bc943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->