### PR TITLE
fix: add additional bot identifier pattern

### DIFF
--- a/services/libs/common_services/src/services/bot.service.ts
+++ b/services/libs/common_services/src/services/bot.service.ts
@@ -4,7 +4,7 @@ import { IMemberIdentity, MemberBotDetection } from '@crowd/types'
 
 export class BotDetectionService extends LoggerBase {
   // Explicit bot identifiers
-  private static readonly STRONG_PATTERNS = [/\[bot\]/i] as const
+  private static readonly STRONG_PATTERNS = [/\[bot\]/i, /generatedunixname\d+/i] as const
 
   // Basic/common bot identifiers
   private static readonly COMMON_PATTERNS = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances explicit bot detection.
> 
> - Extends `STRONG_PATTERNS` in `services/libs/common_services/src/services/bot.service.ts` with `/generatedunixname\d+/i`, so matching identities are classified as `CONFIRMED_BOT`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02b23fc0bfb8087671eb0ee2a4b862ef58a0ea91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->