### PR TITLE
fix: add `id` to segments SK to avoid loosing parent segment information

### DIFF
--- a/services/libs/tinybird/datasources/segments.datasource
+++ b/services/libs/tinybird/datasources/segments.datasource
@@ -42,5 +42,5 @@ SCHEMA >
 
 ENGINE ReplacingMergeTree
 ENGINE_PARTITION_KEY toYear(createdAt)
-ENGINE_SORTING_KEY slug
+ENGINE_SORTING_KEY slug, id
 ENGINE_VER updatedAt


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the Tinybird/ClickHouse `ReplacingMergeTree` sorting key for `segments`, which can affect deduplication/merge behavior and query performance, and may require backfill/recreation to take effect.
> 
> **Overview**
> Updates the `segments` Tinybird datasource to sort by **both** `slug` and `id` (instead of `slug` only) in the `ReplacingMergeTree` `ENGINE_SORTING_KEY`, preventing records that share a `slug` from overwriting each other and losing parent/child hierarchy details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da53ac178217680878f1408bc628b0881caa6f17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->