### PR TITLE
feat: update insightsProject slug (CM-1043)

### DIFF
--- a/backend/src/services/collectionService.ts
+++ b/backend/src/services/collectionService.ts
@@ -455,7 +455,9 @@ export class CollectionService extends LoggerBase {
         }
       }
 
-      await this.syncRepositoryGroupsWithDb(qx, insightsProjectId, project.repositoryGroups)
+      if (project.repositoryGroups !== undefined) {
+        await this.syncRepositoryGroupsWithDb(qx, insightsProjectId, project.repositoryGroups)
+      }
 
       const txSvc = new CollectionService({
         ...this.options,

--- a/backend/src/services/segmentService.ts
+++ b/backend/src/services/segmentService.ts
@@ -69,6 +69,15 @@ export default class SegmentService extends LoggerBase {
         })
       }
 
+      if (isSegmentSubproject(segment) && data.slug) {
+        const collectionService = new CollectionService({ ...this.options, transaction })
+        const projects = await collectionService.findInsightsProjectsBySegmentId(segment.id)
+        if (projects.length > 0) {
+          const normalizedSlug = data.slug.replace(/^nonlf_/, '')
+          await collectionService.updateInsightsProject(projects[0].id, { slug: normalizedSlug })
+        }
+      }
+
       await SequelizeRepository.commitTransaction(transaction)
 
       return await this.findById(id)

--- a/backend/src/services/segmentService.ts
+++ b/backend/src/services/segmentService.ts
@@ -69,7 +69,7 @@ export default class SegmentService extends LoggerBase {
         })
       }
 
-      if (isSegmentSubproject(segment) && data.slug) {
+      if (isSegmentSubproject(segment) && data.slug && data.slug !== segment.slug) {
         const collectionService = new CollectionService({ ...this.options, transaction })
         const projects = await collectionService.findInsightsProjectsBySegmentId(segment.id)
         if (projects.length > 0) {

--- a/services/libs/data-access-layer/src/collections/index.ts
+++ b/services/libs/data-access-layer/src/collections/index.ts
@@ -332,6 +332,23 @@ export async function updateInsightsProject(
     await syncRepositoriesEnabledStatus(qx, id, enabledUrls)
   }
 
+  // When slug changes, ON UPDATE CASCADE propagates the new slug to securityInsights* tables
+  // but does not touch their updatedAt — update it explicitly so Tinybird picks up the change
+  if (project.slug) {
+    await qx.result(
+      `UPDATE "securityInsightsEvaluationSuites" SET "updatedAt" = NOW() WHERE "insightsProjectSlug" = $(slug)`,
+      { slug: project.slug },
+    )
+    await qx.result(
+      `UPDATE "securityInsightsEvaluations" SET "updatedAt" = NOW() WHERE "insightsProjectSlug" = $(slug)`,
+      { slug: project.slug },
+    )
+    await qx.result(
+      `UPDATE "securityInsightsEvaluationAssessments" SET "updatedAt" = NOW() WHERE "insightsProjectSlug" = $(slug)`,
+      { slug: project.slug },
+    )
+  }
+
   return updated as IInsightsProject
 }
 


### PR DESCRIPTION
 ## Summary

  - When a sub-project (leaf segment) slug is updated in CDP, the corresponding `insightsProjects.slug` is now automatically synced.
  - The three `securityInsights*` tables (`securityInsightsEvaluationAssessments`, `securityInsightsEvaluationSuites`,
  `securityInsightsEvaluations`) get their `insightsProjectSlug` updated automatically via the `ON UPDATE CASCADE` foreign key
  constraint already in place (migration `V1753457861`).

  ## Changes

  **`backend/src/services/segmentService.ts`**
  In the `update()` method, when a leaf segment's slug changes, the linked `insightsProject` is looked up by `segmentId` and its
  slug is updated (stripping the `nonlf_` prefix, consistent with the creation flow).

  **`services/libs/data-access-layer/src/collections/index.ts`**
  Fixed a bug in `createCollection` where optional fields (`logoUrl`, `imageUrl`, `color`) were not defaulted to `null`, causing a
  pg-promise error when callers omitted them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches slug update flows across segments and insights projects and adds direct SQL updates to `securityInsights*` tables; mistakes could cause stale analytics or unintended slug propagation. Scope is limited to update paths and guarded by conditions.
> 
> **Overview**
> Automatically syncs `insightsProjects.slug` when a leaf segment (subproject) slug is updated, normalizing away the `nonlf_` prefix before updating the linked insights project.
> 
> Makes insights project updates safer by only syncing `repositoryGroups` when the field is explicitly provided, and when a project slug changes, explicitly bumps `updatedAt` on `securityInsightsEvaluationSuites`, `securityInsightsEvaluations`, and `securityInsightsEvaluationAssessments` so downstream ingestion (Tinybird) detects the cascaded slug update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dc232a15c130e4351c3d2a594fb86f5e7db1f59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->