### PR TITLE
docs(self-hosting): updated documentation and clean up of the outdated links (CDP-3852)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributions are what make the open-source community such an amazing place to l
 - Help with [open issues](https://github.com/CrowdDotDev/crowd.dev/issues).
 - Add a new integration following our [framework](https://docs.crowd.dev/docs/integration-framework).
 - Help create tutorials and [blog](https://www.crowd.dev/blog) posts.
-- Improve [documentation](https://docs.crowd.dev/docs) by fixing incomplete or missing docs, bad wording, examples, or explanations.
+- Improve [documentation](./docs/self-hosting.md) by fixing incomplete or missing docs, bad wording, examples, or explanations.
 
 Any contributions you make are **greatly appreciated**. ❤️
 
@@ -106,7 +106,7 @@ cd scripts
 
 The app will be available at http://localhost:8081
 
-For more information on development, you can <a href="https://docs.crowd.dev/docs/docker-compose-single-machine-development-with-docker-images">check our docs</a>.
+For more information on development, you can [check our self-hosting guide](./docs/self-hosting.md).
 
 #### Running services individually
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,16 @@ Key features:
 
 
 ## Getting started
-⚠️ This documentation is outdated and needs to be reviewed.
 
-To get started with self-hosting, take a look at our [self-hosting docs](https://docs.crowd.dev/docs/getting-started-with-self-hosting).
+To get started with self-hosting, please refer to our [self-hosting guide](./docs/self-hosting.md).
 
-#### Deployment with Kubernetes
+#### Deployment with Docker
 
-Our services can be deployed using Kubernetes, as well as a lightweight development environment using Docker. You can read more about it in our [self-hosting docs](https://docs.crowd.dev/docs/deployment).
+The project provides a comprehensive CLI tool for managing the platform's infrastructure and services using Docker Compose. You can find more information on how to use it in our [technical documentation](./docs/self-hosting.md).
 
 #### Integrations
 
-We currently support all our integrations for self-hosting. For each one of them, you will need to create your own application. You can see the steps for each integration in our [self-hosting integrations guide](https://docs.crowd.dev/docs/self-hosting).
+We support a wide range of integrations for self-hosting. For each integration, you will need to set up your own application credentials (e.g., via Nango). Details on configuration can be found in the [self-hosting guide](./docs/self-hosting.md).
 
 ### Development environment
 
@@ -65,7 +64,7 @@ WITH_INSIGHTS=1 ./cli scaffold up
 
 This app will be available at http://localhost:8081
 
-For more information on development, you can <a href="https://docs.crowd.dev/docs/docker-compose-single-machine-development-with-docker-images">check our docs</a>.
+For more information on development, you can [check our self-hosting guide](./docs/self-hosting.md).
 
 
 ## Contribution

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,112 @@
+# Self-Hosting LFX Community Data Platform (CDP)
+
+This guide provides technical instructions for self-hosting the Community edition of the LFX Community Data Platform (formerly crowd.dev) using Docker Compose.
+
+## Prerequisites
+
+Before you begin, ensure your system meets the following requirements:
+
+### Hardware Requirements
+- **CPU**: 4+ cores recommended.
+- **RAM**: 16GB+ recommended (the platform runs several services including OpenSearch, Kafka, and Postgres).
+- **Storage**: 50GB+ of free space (depends on the volume of data you plan to ingest).
+
+### Software Requirements
+- **Docker**: Engine 20.10+ and Docker Compose v2.0+.
+- **Node.js**: v16.16.0 (required for some local CLI utilities).
+- **Python**: 3.x (required for Tinybird CLI setup).
+
+## Getting Started
+
+1. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/linuxfoundation/crowd.dev.git
+   cd crowd.dev
+   ```
+
+2. **Install Dependencies**:
+   ```bash
+   pnpm install
+   ```
+
+3. **Configure Environment Variables**:
+   Copy the distribution template to create your local override file:
+   ```bash
+   cp backend/.env.dist.local backend/.env.override.local
+   ```
+   *Note: For a "composed" environment where services run in Docker, you may also want to reference `backend/.env.dist.composed` for the correct hostnames (e.g., `db` instead of `localhost`).*
+
+## Deployment Steps
+
+The platform uses a custom CLI tool located in `scripts/cli` to simplify management.
+
+### 1. Start Infrastructure (Scaffold)
+The "scaffold" includes essential services: PostgreSQL, Redis, OpenSearch, Kafka, and Tinybird.
+
+```bash
+cd scripts
+./cli scaffold up
+```
+
+This command will:
+- Set up the `crowd-bridge` Docker network.
+- Start all infrastructure containers defined in `scripts/scaffold.yaml`.
+- Set up the Tinybird CLI and virtual environment.
+
+### 2. Run Database Migrations
+Once the infrastructure is up, apply the necessary schema migrations for Postgres and Tinybird:
+
+```bash
+./cli migrate-up
+```
+
+### 3. Start Application Services
+You can start all application services (API, Frontend, Workers) at once:
+
+```bash
+./cli service up-all
+```
+
+The application will be available at:
+- **Frontend**: http://localhost:8081
+- **API**: http://localhost:4000/api (default)
+
+## Configuration Details
+
+Key environment variables to review in `backend/.env.override.local`:
+
+- `CROWD_API_URL`: The public-facing URL of your API.
+- `CROWD_API_JWT_SECRET`: A long, random string for securing sessions.
+- `CROWD_DB_*`: Database connection details (defaults work with `scaffold`).
+- `CROWD_REDIS_*`: Redis connection details.
+- `CROWD_TINYBIRD_BASE_URL`: URL for the local Tinybird instance (default: `http://localhost:7181/`).
+
+## Operations & Maintenance
+
+### Checking Logs
+To view logs for a specific service:
+```bash
+./cli service <service-name> logs
+```
+*(Available service names can be found in `scripts/services/`)*
+
+### Backing up the Database
+```bash
+./cli db-backup <backup-name>
+```
+
+### Restoring a Backup
+```bash
+./cli db-restore <backup-name>
+```
+
+## Security & Production Notes
+
+- **Reverse Proxy**: It is highly recommended to use a reverse proxy (like Nginx) to handle SSL/TLS termination. A template is provided in `scripts/scaffold/nginx/`.
+- **Secrets**: Ensure `CROWD_API_JWT_SECRET` and all database passwords are changed from their default values in a production environment.
+- **Persistence**: All data is stored in Docker volumes (e.g., `pgdata-dev`, `opensearch-dev`). Ensure these volumes are backed up regularly.
+
+## Troubleshooting
+
+- **Memory Issues**: If services fail to start, check if Docker has enough memory allocated (especially on macOS/Windows).
+- **Network Conflicts**: Ensure the subnet `10.90.0.0/24` (default) does not conflict with your existing network. You can override this in `scripts/cli` or via environment variables.

--- a/frontend/src/config/integrations/discourse/components/discourse-settings-drawer.vue
+++ b/frontend/src/config/integrations/discourse/components/discourse-settings-drawer.vue
@@ -61,7 +61,7 @@
           <div
             class="text-2xs text-gray-500 leading-normal mb-1"
           >
-            Create a new API key in your Discourse account's settings page. You must be an admin user to connect your acount. <a href="https://docs.crowd.dev/docs/discourse-integration#api-key" target="_blank" rel="noopener noreferrer" class="hover:underline">Read more</a>
+            Create a new API key in your Discourse account's settings page. You must be an admin user to connect your acount.
           </div>
           <el-input
             ref="focus"
@@ -87,7 +87,7 @@
         <div
           class="text-2xs text-gray-500 leading-normal mb-1"
         >
-          Create new webhooks in your Discourse account's settings page with the following credentials. <a href="https://docs.crowd.dev/docs/discourse-integration#webhooks" target="_blank" rel="noopener noreferrer" class="hover:underline">Read more</a>
+          Create new webhooks in your Discourse account's settings page with the following credentials.
         </div>
       </div>
       <el-form

--- a/frontend/src/config/integrations/gitlab/components/gitlab-connect.vue
+++ b/frontend/src/config/integrations/gitlab/components/gitlab-connect.vue
@@ -48,7 +48,7 @@ const connect = async () => {
       title: 'Are you the admin of your GitLab organization?',
       titleClass: 'text-lg pt-2',
       message: `Only GitLab users with admin permissions are able to connect LFX's GitLab integration.
-        If you are an organization member, you will need an approval from the GitLab workspace admin. <a href="https://docs.crowd.dev/docs/github-integration" target="_blank">Read more</a>`,
+        If you are an organization member, you will need an approval from the GitLab workspace admin.`,
       icon: 'fa-circle-info fa-light',
       confirmButtonText: "I'm the GitLab organization admin",
       cancelButtonText: 'Invite organization admin to this workspace',

--- a/frontend/src/config/integrations/hackernews/components/hackernews-settings-drawer.vue
+++ b/frontend/src/config/integrations/hackernews/components/hackernews-settings-drawer.vue
@@ -20,13 +20,8 @@
       <div class="flex flex-col gap-2 items-start mb-2">
         <span class="text-xs font-light mb-2 text-gray-900">
           Monitor mentions of your community/organization on Hacker News.
-          <br />Historical data is available after the 1st of December 2022.
-          <a
-            href="https://docs.crowd.dev/docs/hacker-news-integration"
-            target="__blank"
-          >
-            Read more</a>.
-        </span>
+          Historical data is available after the 1st of December 2022.
+</span>
         <span class="text-sm font-medium">Track posts mentioning your community/organization</span>
         <span class="text-2xs font-light mb-2 text-gray-600">
           Monitor your community/organization being mentioned in the top 500 of


### PR DESCRIPTION
# Changes proposed 

This PR resolves the outdated self-hosting documentation issue (#3852) and cleans up defunct links to `docs.crowd.dev` across the repository.

### What
- **New Technical Guide**: Created [docs/self-hosting.md](cci:7://file:///c:/Users/YATIN%20JAMWAL/OneDrive/Desktop/Linux%20Foundation%20GSoC/crowd.dev/docs/self-hosting.md:0:0-0:0) implementing the current [scripts/cli](cci:7://file:///c:/Users/YATIN%20JAMWAL/OneDrive/Desktop/Linux%20Foundation%20GSoC/crowd.dev/scripts/cli:0:0-0:0) based deployment workflow.
- **README & CONTRIBUTING**: Updated root documentation to point to the new local guide and removed the "outdated documentation" warnings.
- **Frontend Cleanup**: Removed or updated broken documentation links in the GitLab, Discourse, and HackerNews integration components.

### Why
The previous documentation pointed to a defunct external site or encouraged users to contact support instead of providing technical steps. This PR restores a clear, public, and technically accurate self-hosting path for the LFX Community Data Platform.

### How
- Documented the maintained [scripts/cli](cci:7://file:///c:/Users/YATIN%20JAMWAL/OneDrive/Desktop/Linux%20Foundation%20GSoC/crowd.dev/scripts/cli:0:0-0:0) workflow (Docker Compose + Scaffold infrastructure).
- Standardized environment variable guidance based on current [backend/.env.dist.local](cci:7://file:///c:/Users/YATIN%20JAMWAL/OneDrive/Desktop/Linux%20Foundation%20GSoC/crowd.dev/backend/.env.dist.local:0:0-0:0) templates.
- Verified that all documented commands (scaffold up, migrations, service up) are functional in the current repository structure.

## Checklist 
- [x] Label appropriately with `type:documentation `.
- [x] Documentation has been updated.
- [x] All changes are working locally running crowd.dev's Docker environment.
- [x] [Quality standards](https://github.com/linuxfoundation/crowd.dev/blob/main/CONTRIBUTING.md#quality-standards) are met.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/UI copy updates; no functional or runtime behavior changes beyond removing external documentation links from integration prompts.
> 
> **Overview**
> Adds a new local `docs/self-hosting.md` with an up-to-date Docker Compose/`scripts/cli` workflow (scaffold, migrations, service startup), plus basic ops/security/troubleshooting notes.
> 
> Updates `README.md` and `CONTRIBUTING.md` to point self-hosting/development references to the new in-repo guide and removes outdated warnings/links to the defunct `docs.crowd.dev` pages.
> 
> Cleans up frontend integration drawers (Discourse, GitLab, Hacker News) by removing embedded “Read more” links to old documentation URLs from helper text/dialog copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b804c4d1a5b85459f9ddf6885a9511f06143549b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->