### PR TITLE
Fix typos in README, frontend alerts, and backend logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We currently support all our integrations for self-hosting. For each one of them
 
 #### <a name="getting_started">Getting started</a>
 
-1. Get the mono repo from GitHub
+1. Get the monorepo from GitHub
 
 ```shell
 git clone git@github.com:CrowdDotDev/crowd.dev.git

--- a/frontend/src/modules/member/components/list/member-list-toolbar.vue
+++ b/frontend/src/modules/member/components/list/member-list-toolbar.vue
@@ -275,7 +275,7 @@ const handleDoExport = async () => {
 
     if (error !== 'cancel') {
       ToastStore.error(
-        'An error has occured while trying to export the CSV file. Please try again',
+        'An error has occurred while trying to export the CSV file. Please try again',
         {
           title: 'CSV Export failed',
         },

--- a/frontend/src/modules/organization/components/list/organization-list-toolbar.vue
+++ b/frontend/src/modules/organization/components/list/organization-list-toolbar.vue
@@ -201,7 +201,7 @@ const handleDoExport = async () => {
     );
   } catch (error) {
     ToastStore.error(
-      'An error has occured while trying to export the CSV file. Please try again',
+      'An error has occurred while trying to export the CSV file. Please try again',
       {
         title: 'CSV Export failed',
       },

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -259,7 +259,7 @@ class RepositoryWorker:
             processing_state = RepositoryState.COMPLETED
         except StuckRepoError:
             logger.error(
-                f"Repo {repository.url} is stuck for unkown reason, marking it as stuck until manually resolved!"
+                f"Repo {repository.url} is stuck for unknown reason, marking it as stuck until manually resolved!"
             )
             processing_state = RepositoryState.STUCK
         except ReOnboardingRequiredError:

--- a/services/apps/nango_webhook_api/src/main.ts
+++ b/services/apps/nango_webhook_api/src/main.ts
@@ -84,7 +84,7 @@ export const errorMiddleware = (): ErrorRequestHandler => {
       request.log.error(err, { statusCode: err.status }, 'HTTP error occurred!')
       res.status(err.status).json(err.toJSON())
     } else {
-      request.log.error(err, 'Unknown error occured!')
+      request.log.error(err, 'Unknown error occurred!')
       res.status(500).send('Internal Server Error')
     }
   }

--- a/services/apps/search_sync_api/src/middleware/error.ts
+++ b/services/apps/search_sync_api/src/middleware/error.ts
@@ -19,7 +19,7 @@ export const errorMiddleware = (): ErrorRequestHandler => {
       request.log.error(err, { statusCode: err.status }, 'HTTP error occurred!')
       res.status(err.status).json(err.toJSON())
     } else {
-      request.log.error(err, 'Unknown error occured!')
+      request.log.error(err, 'Unknown error occurred!')
       res.status(500).send('Internal Server Error')
     }
   }

--- a/services/apps/webhook_api/src/middleware/error.ts
+++ b/services/apps/webhook_api/src/middleware/error.ts
@@ -19,7 +19,7 @@ export const errorMiddleware = (): ErrorRequestHandler => {
       request.log.error(err, { statusCode: err.status }, 'HTTP error occurred!')
       res.status(err.status).json(err.toJSON())
     } else {
-      request.log.error(err, 'Unknown error occured!')
+      request.log.error(err, 'Unknown error occurred!')
       res.status(500).send('Internal Server Error')
     }
   }


### PR DESCRIPTION
While exploring the project and going through the codebase, I came across a few small spelling mistakes in the README, frontend messages, and backend logs.

I fixed these by correcting the spelling mistakes: "mono repo" to "monorepo" , "occured" to "occurred","unkown" to "unknown".

This was my first contribution to the project, and I enjoyed working on it while getting familiar with the codebase.
I enjoyed making this contribution and look forward to learning more from the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to string spelling fixes in documentation, UI notifications, and log/error messages with no behavioral logic modifications.
> 
> **Overview**
> Fixes minor spelling/wording issues across the repo: updates README wording (`mono repo` → `monorepo`), corrects CSV export toast messages in member/org toolbars (`occured` → `occurred`), and cleans up backend logging/error strings in the git integration worker and multiple API error middlewares (`unkown/occured` → `unknown/occurred`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bade2adb3ef322c2e7b9261a4a3f969e6ad6c4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->