### PR TITLE
feat: standardize frontend segments calls (CM-189)

### DIFF
--- a/backend/src/middlewares/segmentMiddleware.ts
+++ b/backend/src/middlewares/segmentMiddleware.ts
@@ -20,14 +20,16 @@ export async function segmentMiddleware(req, res, next) {
     // read req.params directly and ignore req.currentSegments entirely — so the
     // resolution below is harmless for those endpoints.
     if (req.query.segments) {
-      // GET requests
+      // GET requests — req.query values can be string or string[], normalize to array
+      const segmentIds = ([] as string[]).concat(req.query.segments)
       segments = {
-        rows: await resolveToLeafSegments(segmentRepository, req.query.segments, req),
+        rows: await resolveToLeafSegments(segmentRepository, segmentIds, req),
       }
     } else if (req.body.segments) {
-      // POST/PUT requests
+      // POST/PUT requests — body.segments should always be an array, but normalize defensively
+      const segmentIds = ([] as string[]).concat(req.body.segments)
       segments = {
-        rows: await resolveToLeafSegments(segmentRepository, req.body.segments, req),
+        rows: await resolveToLeafSegments(segmentRepository, segmentIds, req),
       }
     } else {
       segments = await segmentRepository.querySubprojects({ limit: 1, offset: 0 })
@@ -60,8 +62,11 @@ async function resolveToLeafSegments(
 
   const nonLeaf = fetched.filter((s) => !isSegmentSubproject(s))
 
-  const segmentLevel = (s: any) =>
-    s.grandparentSlug ? 'subproject' : s.parentSlug ? 'project' : 'projectGroup'
+  const segmentLevel = (s: any) => {
+    if (s.grandparentSlug) return 'subproject'
+    if (s.parentSlug) return 'project'
+    return 'projectGroup'
+  }
 
   if (nonLeaf.length === 0) {
     // All IDs are already leaf segments — current behavior, no change.

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -380,7 +380,7 @@ const fetchActivities = async ({ reset } = { reset: false }) => {
     offset: offset.value,
     segments: selectedSegment.value
       ? [selectedSegment.value]
-      : segments.value.map((s) => s.id),
+      : [selectedProjectGroup.value.id],
   });
 
   loading.value = false;

--- a/frontend/src/modules/lf/layout/components/lf-banners.vue
+++ b/frontend/src/modules/lf/layout/components/lf-banners.vue
@@ -150,7 +150,6 @@ import {
   watch, ref, computed, onUnmounted,
 } from 'vue';
 import { IntegrationService } from '@/modules/integration/integration-service';
-import { getSegmentsFromProjectGroup } from '@/utils/segments';
 import { isCurrentDateAfterGivenWorkingDays } from '@/utils/date';
 import { useRoute } from 'vue-router';
 import usePermissions from '@/shared/modules/permissions/helpers/usePermissions';
@@ -227,7 +226,7 @@ const showBanner = computed(() => (integrationsWithErrors.value.length
 
 const fetchIntegrations = (projectGroup) => {
   if (projectGroup) {
-    IntegrationService.list(null, null, null, null, getSegmentsFromProjectGroup(projectGroup))
+    IntegrationService.list(null, null, null, null, [projectGroup.id])
       .then((response) => {
         integrations.value = response.rows;
       })

--- a/frontend/src/modules/organization/organization-service.js
+++ b/frontend/src/modules/organization/organization-service.js
@@ -1,7 +1,6 @@
 import authAxios from '@/shared/axios/auth-axios';
 import { AuthService } from '@/modules/auth/services/auth.service'; import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
-import { getSegmentsFromProjectGroup } from '@/utils/segments';
 
 const getSelectedProjectGroup = () => {
   const lsSegmentsStore = useLfSegmentsStore();
@@ -216,10 +215,9 @@ export class OrganizationService {
   }
 
   static async fetchMergeSuggestions(limit, offset, query) {
-    const segments = [
-      ...getSegmentsFromProjectGroup(getSelectedProjectGroup()),
-      getSelectedProjectGroup().id,
-    ];
+    const segments = getSelectedProjectGroup()?.id
+      ? [getSelectedProjectGroup().id]
+      : [];
 
     const data = {
       limit,

--- a/frontend/src/modules/organization/services/organization.api.service.ts
+++ b/frontend/src/modules/organization/services/organization.api.service.ts
@@ -1,6 +1,5 @@
 import authAxios from '@/shared/axios/auth-axios';
 import { Organization } from '@/modules/organization/types/Organization';
-import { getSegmentsFromProjectGroup } from '@/utils/segments';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { storeToRefs } from 'pinia';
 
@@ -30,13 +29,7 @@ export class OrganizationApiService {
   }
 
   static async fetchMergeSuggestions(limit: number = 20, offset: number = 0, query: any = {}) {
-    const lsSegmentsStore = useLfSegmentsStore();
-    const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
-
-    const segments = [
-      ...getSegmentsFromProjectGroup(selectedProjectGroup.value),
-      selectedProjectGroup.value?.id,
-    ];
+    const segments = getSelectedProjectGroupId() ?? [];
 
     const data = {
       limit,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how multiple frontend queries scope by `segments` (now typically sending only the selected project-group id) and relies on backend resolution, which could alter data returned if any endpoints previously depended on explicit sub-project IDs. Backend middleware now normalizes `segments` inputs, affecting request handling across routes that use this middleware.
> 
> **Overview**
> Frontend requests that previously sent *all sub-project segment IDs* now generally send only `[selectedProjectGroup.id]` when no specific sub-project is selected (e.g., activity timeline queries, integration banner fetch, and organization merge suggestions), removing `getSegmentsFromProjectGroup` usage in those paths.
> 
> Backend `segmentMiddleware` now defensively normalizes `req.query.segments`/`req.body.segments` to a string array before resolving leaf segments, avoiding Express query type ambiguity and making segment resolution behavior more consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5dcec98209e0ea126c573bbf248094d0358d9fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->