### PR TITLE
fix: prevent concurrent processing for automotivelinux repos [CM-1103]

### DIFF
--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -125,7 +125,19 @@ async def acquire_repository(query: str, params: tuple = None) -> Repository | N
 async def acquire_recurrent_repo() -> Repository | None:
     """Acquire a regular (non-onboarding) repository, that were not processed in the last x hours (REPOSITORY_UPDATE_INTERVAL_HOURS)"""
     recurrent_repo_sql_query = f"""
-    WITH selected_repo AS (
+    -- Rate-limit guard: Gerrit (automotivelinux) aggressively rate-limits concurrent connections.
+    -- This CTE checks if any automotivelinux repo is already being processed,
+    -- so we skip picking another one from the same host until the current one finishes.
+    WITH automotivelinux_processing AS (
+        SELECT 1
+        FROM git."repositoryProcessing" rp2
+        JOIN public.repositories r2 ON r2.id = rp2."repositoryId"
+        WHERE rp2.state = 'processing'
+            AND rp2."lockedAt" IS NOT NULL
+            AND r2.url LIKE '%gerrit.automotivelinux.org%'
+        LIMIT 1
+    ),
+    selected_repo AS (
         SELECT r.id
         FROM public.repositories r
         JOIN git."repositoryProcessing" rp ON rp."repositoryId" = r.id
@@ -133,6 +145,10 @@ async def acquire_recurrent_repo() -> Repository | None:
             AND rp."lockedAt" IS NULL
             AND r."deletedAt" IS NULL
             AND rp."lastProcessedAt" < NOW() - INTERVAL '1 hour' * $3
+            AND NOT (
+                r.url LIKE '%gerrit.automotivelinux.org%'
+                AND EXISTS (SELECT 1 FROM automotivelinux_processing)
+            )
         ORDER BY rp.priority ASC, rp."lastProcessedAt" ASC
         LIMIT 1
         FOR UPDATE OF rp SKIP LOCKED


### PR DESCRIPTION
This pull request introduces a safeguard to prevent overloading Gerrit (automotivelinux) repositories by ensuring that only one such repository is processed at a time. This is achieved by modifying the SQL query in the `acquire_recurrent_repo` function to check if any automotivelinux repository is already being processed, and if so, skip selecting another from the same host.

Repository processing rate-limiting:

* Updated the SQL query in `acquire_recurrent_repo` (in `crud.py`) to include a Common Table Expression (CTE) that checks if any automotivelinux repository is currently being processed, and prevents acquiring another one from the same host until the current one finishes. This helps avoid triggering Gerrit's aggressive rate-limiting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes repository acquisition SQL/locking behavior, which could affect processing throughput or starvation if the new host-based guard is too strict or misfires. Scope is limited to selection logic for `gerrit.automotivelinux.org` repos.
> 
> **Overview**
> Adds a host-level concurrency guard in `acquire_recurrent_repo` so **only one** `gerrit.automotivelinux.org` (automotivelinux Gerrit) repository can be in `processing` at a time.
> 
> This updates the recurrent-repo selection SQL to first detect any in-flight automotivelinux processing via a CTE, and then skip selecting additional repos from that host until the current one releases its lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88d68a6a0362a2100f96d946d8d32845be13d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->