### PR TITLE
feat: uses left join in query organizations

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1491,14 +1491,8 @@ class OrganizationRepository {
       SELECT
         ${fields}
       FROM organizations o
-      ${
-        withAggregates
-          ? ` INNER JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND ${
-              segmentId ? `osa."segmentId" = $(segmentId)` : `osa."segmentId" IS NULL`
-            }`
-          : ` LEFT JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND ${
-              segmentId ? `osa."segmentId" = $(segmentId)` : `osa."segmentId" IS NULL`
-            }`
+      LEFT JOIN "organizationSegmentsAgg" osa ON osa."organizationId" = o.id AND ${
+        segmentId ? `osa."segmentId" = $(segmentId)` : `osa."segmentId" IS NULL`
       }
       LEFT JOIN "organizationEnrichments" oe ON oe."organizationId" = o.id
       WHERE 1=1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes SQL join semantics for `OrganizationRepository.findAndCountAll`, which can alter which organizations appear (and counts) when aggregates are requested, especially for orgs lacking aggregate rows.
> 
> **Overview**
> Updates the organizations advanced query in `organizationRepository.ts` to **always** `LEFT JOIN` `organizationSegmentsAgg` (previously `INNER JOIN` when `include.aggregates` was enabled).
> 
> This means organization list/count queries with aggregates will now include organizations even when no matching aggregate row exists for the requested segment (leaving aggregate fields `NULL`/`coalesce`d), instead of filtering them out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2199c1899b573c58fcfbcbc2b71b734cf0db697f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->