### PR TITLE
chore: categorize empty repo error [CM-1103]

### DIFF
--- a/services/apps/git_integration/src/crowdgit/enums.py
+++ b/services/apps/git_integration/src/crowdgit/enums.py
@@ -26,6 +26,7 @@ class ErrorCode(str, Enum):
     RATE_LIMITED = "rate-limited"
     ACCESS_FORBIDDEN = "access-forbidden"
     SERVER_ERROR = "server-error-remote"
+    EMPTY_REPO = "empty-repo"
 
 
 class RepositoryState(str, Enum):

--- a/services/apps/git_integration/src/crowdgit/errors.py
+++ b/services/apps/git_integration/src/crowdgit/errors.py
@@ -144,3 +144,9 @@ class ForbiddenError(CrowdGitError):
 class RemoteServerError(CrowdGitError):
     error_message: str = "Remote server returned an internal error"
     error_code: ErrorCode = ErrorCode.SERVER_ERROR
+
+
+@dataclass
+class EmptyRepoError(CrowdGitError):
+    error_message: str = "Repository is empty (no branches or commits)"
+    error_code: ErrorCode = ErrorCode.EMPTY_REPO

--- a/services/apps/git_integration/src/crowdgit/services/utils.py
+++ b/services/apps/git_integration/src/crowdgit/services/utils.py
@@ -6,6 +6,7 @@ from crowdgit.errors import (
     CommandExecutionError,
     CommandTimeoutError,
     DiskSpaceError,
+    EmptyRepoError,
     ForbiddenError,
     NetworkError,
     PermissionError,
@@ -182,6 +183,10 @@ ERROR_CLASSIFICATIONS = [
             "Repository not found",
         },
         RepoAuthRequiredError,
+    ),
+    (
+        {"ambiguous argument 'HEAD': unknown revision or path not in the working tree"},
+        EmptyRepoError,
     ),
 ]
 


### PR DESCRIPTION
This pull request adds support for handling empty repositories in the git integration service. The main changes introduce a new error type for empty repositories, update the error code enumeration, and ensure that ambiguous `HEAD` errors are mapped to this new error. The most important changes are:

**Error handling improvements:**

* Added a new error code `EMPTY_REPO` to the `ErrorCode` enum in `enums.py`, representing the case when a repository is empty (no branches or commits).
* Introduced a new `EmptyRepoError` dataclass in `errors.py` to encapsulate the error message and code for empty repositories.
* Updated the error mapping in `utils.py` so that ambiguous `HEAD` errors (which indicate an empty repository) now raise `EmptyRepoError`.
* Added `EmptyRepoError` to the list of imported errors in `utils.py` to enable its use in error handling logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new error code/exception and maps a specific git stderr pattern to it, only affecting how empty-repo failures are classified and reported.
> 
> **Overview**
> Adds first-class classification for *empty repositories* in the git integration service.
> 
> Introduces `ErrorCode.EMPTY_REPO` and a corresponding `EmptyRepoError`, and updates shell error classification so git failures containing `ambiguous argument 'HEAD'` are surfaced as `EmptyRepoError` instead of a generic command failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f55dcaca5b9af2da4c81808556c64061ca052d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->