### PR TITLE
feat: filter by snapshot id initial snapshot for member/organizations

### DIFF
--- a/services/libs/tinybird/pipes/cdp_member_segment_aggregates_initial_snapshot.pipe
+++ b/services/libs/tinybird/pipes/cdp_member_segment_aggregates_initial_snapshot.pipe
@@ -12,6 +12,7 @@ SQL >
         maxState(act.updatedAt) as lastActivityUpdatedAtState,
         max(act.updatedAt) as updatedAt
     FROM activityRelations_enriched_deduplicated_ds act
+    WHERE snapshotId = (SELECT max(snapshotId) FROM activityRelations_enriched_deduplicated_ds)
     GROUP BY segmentId, memberId
 
 TYPE COPY

--- a/services/libs/tinybird/pipes/cdp_organization_segment_aggregates_initial_snapshot.pipe
+++ b/services/libs/tinybird/pipes/cdp_organization_segment_aggregates_initial_snapshot.pipe
@@ -13,6 +13,7 @@ SQL >
         maxState(act.updatedAt) as lastActivityUpdatedAtState,
         max(act.updatedAt) as updatedAt
     FROM activityRelations_enriched_deduplicated_ds act
+    WHERE snapshotId = (SELECT max(snapshotId) FROM activityRelations_enriched_deduplicated_ds)
     GROUP BY segmentId, organizationId
 
 TYPE COPY


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the source dataset selection for initial aggregate backfills by filtering to the max `snapshotId`, which can materially change computed results if snapshots are incomplete or delayed.
> 
> **Overview**
> Initial backfill pipes for member and organization segment aggregates now **only aggregate rows from the latest snapshot** by adding `WHERE snapshotId = (SELECT max(snapshotId) ...)` to both `cdp_member_segment_aggregates_initial_snapshot.pipe` and `cdp_organization_segment_aggregates_initial_snapshot.pipe`.
> 
> This ensures the on-demand `COPY_MODE replace` outputs are built from a single consistent snapshot rather than mixing historical snapshot data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ef0a6c92acd1cdcfe2032b792236d292849f145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->