### PR TITLE
fix: refresh affiliation on update (CM-1118)

### DIFF
--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -288,7 +288,7 @@ export async function updateMemberUsingSquashedPayload(
   hasContributions: boolean,
   isHighConfidenceSourceSelectedForWorkExperiences: boolean,
 ): Promise<boolean> {
-  const deletedOrgIds: string[] = []
+  const affectedOrgIds: string[] = []
 
   const updated = await svc.postgres.writer.transactionally(async (tx) => {
     let updated = false
@@ -463,7 +463,7 @@ export async function updateMemberUsingSquashedPayload(
       if (results.toDelete.length > 0) {
         for (const org of results.toDelete) {
           updated = true
-          deletedOrgIds.push(org.orgId)
+          affectedOrgIds.push(org.orgId)
           await deleteMemberOrgById(tx.transaction(), org.id)
         }
       }
@@ -474,6 +474,7 @@ export async function updateMemberUsingSquashedPayload(
             throw new Error('Organization ID is missing!')
           }
           updated = true
+          affectedOrgIds.push(org.organizationId)
 
           const newMemberOrgId = await insertWorkExperience(
             tx.transaction(),
@@ -497,6 +498,7 @@ export async function updateMemberUsingSquashedPayload(
       if (results.toUpdate.size > 0) {
         for (const [memberOrg, toUpdate] of results.toUpdate) {
           updated = true
+          affectedOrgIds.push(memberOrg.orgId)
           const updatedMemberOrgId = await updateMemberOrg(
             tx.transaction(),
             memberId,
@@ -543,13 +545,15 @@ export async function updateMemberUsingSquashedPayload(
     return updated
   })
 
-  if (deletedOrgIds.length > 0) {
+  if (affectedOrgIds.length > 0) {
     const commonMemberService = new CommonMemberService(
       pgpQx(svc.postgres.writer.connection()),
       svc.temporal,
       svc.log,
     )
-    await commonMemberService.startAffiliationRecalculation(memberId, deletedOrgIds)
+    await commonMemberService.startAffiliationRecalculation(memberId, [
+      ...new Set(affectedOrgIds),
+    ])
   }
 
   return updated

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -290,15 +290,15 @@ export async function updateMemberUsingSquashedPayload(
 ): Promise<boolean> {
   const affectedOrgIds: string[] = []
 
-  const updated = await svc.postgres.writer.transactionally(async (tx) => {
-    let updated = false
+  const wasUpdated = await svc.postgres.writer.transactionally(async (tx) => {
+    let didUpdate = false
     const qx = dbStoreQx(tx)
 
     // process identities
     if (squashedPayload.identities.length > 0) {
       svc.log.debug({ memberId }, 'Adding to member identities!')
       for (const i of squashedPayload.identities) {
-        updated = true
+        didUpdate = true
         await createMemberIdentity(
           qx,
           {
@@ -330,7 +330,7 @@ export async function updateMemberUsingSquashedPayload(
           const typed = normalized as IMemberEnrichmentDataNormalized
 
           if (typed.contributions) {
-            updated = true
+            didUpdate = true
             await updateMemberContributions(qx, memberId, typed.contributions)
           }
         }
@@ -349,7 +349,7 @@ export async function updateMemberUsingSquashedPayload(
         const priorities = await getPriorityArray()
         attributes = await setAttributesDefaultValues(attributes, priorities)
       }
-      updated = true
+      didUpdate = true
       await updateMemberAttributes(qx, memberId, attributes)
     }
 
@@ -369,7 +369,7 @@ export async function updateMemberUsingSquashedPayload(
           total,
         }
 
-        updated = true
+        didUpdate = true
         await updateMemberReach(qx, memberId, reach)
       }
     }
@@ -462,7 +462,7 @@ export async function updateMemberUsingSquashedPayload(
 
       if (results.toDelete.length > 0) {
         for (const org of results.toDelete) {
-          updated = true
+          didUpdate = true
           affectedOrgIds.push(org.orgId)
           await deleteMemberOrgById(tx.transaction(), org.id)
         }
@@ -473,7 +473,7 @@ export async function updateMemberUsingSquashedPayload(
           if (!org.organizationId) {
             throw new Error('Organization ID is missing!')
           }
-          updated = true
+          didUpdate = true
           affectedOrgIds.push(org.organizationId)
 
           const newMemberOrgId = await insertWorkExperience(
@@ -497,7 +497,7 @@ export async function updateMemberUsingSquashedPayload(
 
       if (results.toUpdate.size > 0) {
         for (const [memberOrg, toUpdate] of results.toUpdate) {
-          updated = true
+          didUpdate = true
           affectedOrgIds.push(memberOrg.orgId)
           const updatedMemberOrgId = await updateMemberOrg(
             tx.transaction(),
@@ -533,7 +533,7 @@ export async function updateMemberUsingSquashedPayload(
       }
     }
 
-    if (updated) {
+    if (didUpdate) {
       await setMemberEnrichmentUpdatedAt(tx.transaction(), memberId)
       await syncMember(memberId)
     } else {
@@ -542,7 +542,7 @@ export async function updateMemberUsingSquashedPayload(
 
     svc.log.debug({ memberId }, 'Member sources processed successfully!')
 
-    return updated
+    return didUpdate
   })
 
   if (affectedOrgIds.length > 0) {
@@ -551,9 +551,7 @@ export async function updateMemberUsingSquashedPayload(
       svc.temporal,
       svc.log,
     )
-    await commonMemberService.startAffiliationRecalculation(memberId, [
-      ...new Set(affectedOrgIds),
-    ])
+    await commonMemberService.startAffiliationRecalculation(memberId, [...new Set(affectedOrgIds)], true)
   }
 
   return updated

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -8,6 +8,7 @@ import {
   replaceDoubleQuotes,
   setAttributesDefaultValues,
 } from '@crowd/common'
+import { CommonMemberService } from '@crowd/common_services'
 import {
   changeMemberOrganizationAffiliationOverrides,
   checkOrganizationAffiliationPolicy,
@@ -287,7 +288,9 @@ export async function updateMemberUsingSquashedPayload(
   hasContributions: boolean,
   isHighConfidenceSourceSelectedForWorkExperiences: boolean,
 ): Promise<boolean> {
-  return await svc.postgres.writer.transactionally(async (tx) => {
+  const deletedOrgIds: string[] = []
+
+  const updated = await svc.postgres.writer.transactionally(async (tx) => {
     let updated = false
     const qx = dbStoreQx(tx)
 
@@ -460,6 +463,7 @@ export async function updateMemberUsingSquashedPayload(
       if (results.toDelete.length > 0) {
         for (const org of results.toDelete) {
           updated = true
+          deletedOrgIds.push(org.orgId)
           await deleteMemberOrgById(tx.transaction(), org.id)
         }
       }
@@ -538,6 +542,17 @@ export async function updateMemberUsingSquashedPayload(
 
     return updated
   })
+
+  if (deletedOrgIds.length > 0) {
+    const commonMemberService = new CommonMemberService(
+      pgpQx(svc.postgres.writer.connection()),
+      svc.temporal,
+      svc.log,
+    )
+    await commonMemberService.startAffiliationRecalculation(memberId, deletedOrgIds)
+  }
+
+  return updated
 }
 
 export function doesIncomingOrgExistInExistingOrgs(

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -551,10 +551,14 @@ export async function updateMemberUsingSquashedPayload(
       svc.temporal,
       svc.log,
     )
-    await commonMemberService.startAffiliationRecalculation(memberId, [...new Set(affectedOrgIds)], true)
+    await commonMemberService.startAffiliationRecalculation(
+      memberId,
+      [...new Set(affectedOrgIds)],
+      true,
+    )
   }
 
-  return updated
+  return wasUpdated
 }
 
 export function doesIncomingOrgExistInExistingOrgs(

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -292,6 +292,7 @@ export async function updateMemberUsingSquashedPayload(
 
   const wasUpdated = await svc.postgres.writer.transactionally(async (tx) => {
     let didUpdate = false
+
     const qx = dbStoreQx(tx)
 
     // process identities


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new post-update Temporal-driven affiliation recalculation step based on changed member organizations; incorrect org ID collection or job triggering could cause missed or excess recalculations and added load.
> 
> **Overview**
> When enrichment updates a member, the worker now **tracks which organization affiliations were affected** by work-experience deletes/creates/updates.
> 
> After the DB transaction completes, it uses `CommonMemberService.startAffiliationRecalculation` to **recompute affiliations** for the member and the deduped set of affected org IDs, while preserving the existing `didUpdate`/`updatedAt` vs `lastTriedAt` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5368a1951b1c71b14209638696a37ecbb9347e73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->