### PR TITLE
fix: handle empty organization data correctly (CM-1113)

### DIFF
--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -450,7 +450,8 @@ export async function findOrCreateOrganization(
   integrationId?: string,
   throttleUpdatedAt = false,
 ): Promise<string | undefined> {
-  let verifiedIdentities = data.identities ? data.identities.filter((i) => i.verified) : []
+  data.identities = data.identities ?? []
+  let verifiedIdentities = data.identities.filter((i) => i.verified)
 
   if (verifiedIdentities.length === 0 && !data.displayName) {
     const message = `Missing organization identity or displayName while creating/updating organization!`

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -450,7 +450,7 @@ export async function findOrCreateOrganization(
   integrationId?: string,
   throttleUpdatedAt = false,
 ): Promise<string | undefined> {
-  const verifiedIdentities = data.identities ? data.identities.filter((i) => i.verified) : []
+  let verifiedIdentities = data.identities ? data.identities.filter((i) => i.verified) : []
 
   if (verifiedIdentities.length === 0 && !data.displayName) {
     const message = `Missing organization identity or displayName while creating/updating organization!`
@@ -470,6 +470,16 @@ export async function findOrCreateOrganization(
     }
 
     data.identities = data.identities.filter((i) => i.value !== undefined)
+
+    // Re-derive after normalization may have set domain identity values to undefined
+    verifiedIdentities = data.identities.filter((i) => i.verified)
+
+    if (verifiedIdentities.length === 0 && !data.displayName) {
+      log.debug(
+        'Organization has no valid verified identities after domain normalization and no displayName, skipping.',
+      )
+      return undefined
+    }
 
     let existing
     // find existing org by sent verified identities


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes organization upsert behavior to return `undefined` (skip) instead of throwing when verified identities are lost during domain normalization, which can affect whether organizations are created/updated in ingestion flows.
> 
> **Overview**
> Improves `findOrCreateOrganization` to better handle *empty/invalid identity data* by defaulting `data.identities` to an empty array and re-computing `verifiedIdentities` after domain normalization/filtering.
> 
> If normalization removes all verified identities and there is no `displayName`, the function now logs and returns `undefined` (skips processing) instead of erroring, preventing failures on malformed organization inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae719a86fc9c6203a6c789130f0bb33aa30fcfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->