### PR TITLE
fix: ignore results that have no activity data (CM-1112)

### DIFF
--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -435,7 +435,12 @@ export default class ActivityService extends LoggerBase {
     let relevantPayloads = payloads.filter((p) => {
       if (!p.activity) {
         this.log.warn(
-          { platform: p.platform },
+          {
+            resultId: p.resultId,
+            integrationId: p.integrationId,
+            segmentId: p.segmentId,
+            platform: p.platform,
+          },
           'Activity data is missing, skipping and marking as processed.',
         )
         resultMap.set(p.resultId, { success: true })

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -432,7 +432,14 @@ export default class ActivityService extends LoggerBase {
   ): Promise<Map<string, IProcessActivityResult>> {
     const resultMap = new Map<string, IProcessActivityResult>()
 
-    let relevantPayloads = payloads
+    let relevantPayloads = payloads.filter((p) => {
+      if (!p.activity) {
+        this.log.warn({ platform: p.platform }, 'Activity data is missing, skipping and marking as processed.')
+        resultMap.set(p.resultId, { success: true })
+        return false
+      }
+      return true
+    })
     this.log.trace(`[ACTIVITY] Processing ${relevantPayloads.length} activities!`)
 
     const prepareMemberResults = this.prepareMemberData(relevantPayloads)

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -271,11 +271,8 @@ export default class ActivityService extends LoggerBase {
       // propagates out of prepareMemberData and crashes the entire batch, marking all other
       // results in the batch with the same error even though they are valid.
       if (!activity) {
-        this.log.error({ platform }, 'Activity data is missing.')
-        results.set(resultId, {
-          success: false,
-          err: new UnrepeatableError('Activity data is missing.'),
-        })
+        this.log.warn({ platform }, 'Activity data is missing, skipping and marking as processed.')
+        results.set(resultId, { success: true })
         continue
       }
 

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -434,7 +434,10 @@ export default class ActivityService extends LoggerBase {
 
     let relevantPayloads = payloads.filter((p) => {
       if (!p.activity) {
-        this.log.warn({ platform: p.platform }, 'Activity data is missing, skipping and marking as processed.')
+        this.log.warn(
+          { platform: p.platform },
+          'Activity data is missing, skipping and marking as processed.',
+        )
         resultMap.set(p.resultId, { success: true })
         return false
       }

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -432,22 +432,23 @@ export default class ActivityService extends LoggerBase {
   ): Promise<Map<string, IProcessActivityResult>> {
     const resultMap = new Map<string, IProcessActivityResult>()
 
-    let relevantPayloads = payloads.filter((p) => {
-      if (!p.activity) {
+    let relevantPayloads: IActivityProcessData[] = []
+    for (const payload of payloads) {
+      if (!payload.activity) {
         this.log.warn(
           {
-            resultId: p.resultId,
-            integrationId: p.integrationId,
-            segmentId: p.segmentId,
-            platform: p.platform,
+            resultId: payload.resultId,
+            integrationId: payload.integrationId,
+            segmentId: payload.segmentId,
+            platform: payload.platform,
           },
           'Activity data is missing, skipping and marking as processed.',
         )
-        resultMap.set(p.resultId, { success: true })
-        return false
+        resultMap.set(payload.resultId, { success: true })
+        continue
       }
-      return true
-    })
+      relevantPayloads.push(payload)
+    }
     this.log.trace(`[ACTIVITY] Processing ${relevantPayloads.length} activities!`)
 
     const prepareMemberResults = this.prepareMemberData(relevantPayloads)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes error-handling semantics by treating missing activity data as success, which could mask upstream data issues or alter retry behavior, but the logic is small and localized to batch processing.
> 
> **Overview**
> Prevents batches in `ActivityService` from failing when a result/payload is missing `activity` data by **skipping those entries** and marking them as successfully processed.
> 
> Missing-activity cases now emit `warn` logs (instead of `error` + `UnrepeatableError`) and are filtered out early in `processActivities` and guarded in `prepareMemberData`, so valid activities in the same batch continue processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 581b25976691835039b9447d964738381fd201fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->