### PR TITLE
feat: deprecate stuck statue and auto re-onboard stuck repos [CM-1098]

### DIFF
--- a/backend/src/database/migrations/V1776428661__dropStuckFlagFromRepositoryProcessing.sql
+++ b/backend/src/database/migrations/V1776428661__dropStuckFlagFromRepositoryProcessing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE git."repositoryProcessing" DROP COLUMN IF EXISTS "stuckRequiresReOnboard";

--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -31,7 +31,6 @@ REPO_SELECT_COLUMNS = """
     rp.branch,
     rp."maintainerFile",
     rp."lastMaintainerRunAt",
-    rp."stuckRequiresReOnboard",
     rp."reOnboardingCount"
 """
 
@@ -166,7 +165,6 @@ async def acquire_recurrent_repo() -> Repository | None:
     states_to_exclude = (
         RepositoryState.PENDING,
         RepositoryState.PROCESSING,
-        RepositoryState.STUCK,
         RepositoryState.PENDING_REONBOARD,
         RepositoryState.AUTH_REQUIRED,
     )

--- a/services/apps/git_integration/src/crowdgit/enums.py
+++ b/services/apps/git_integration/src/crowdgit/enums.py
@@ -21,7 +21,6 @@ class ErrorCode(str, Enum):
     CLEANUP_FAILED = "cleanup-failed"
     PARENT_REPO_INVALID = "parent-repo-invalid"
     REONBOARDING_REQUIRED = "reonboarding-required"
-    STUCK_REPO = "stuck-repo"
     REPO_AUTH_REQUIRED = "repo-auth-required"
     RATE_LIMITED = "rate-limited"
     ACCESS_FORBIDDEN = "access-forbidden"
@@ -37,7 +36,6 @@ class RepositoryState(str, Enum):
     COMPLETED = "completed"
     FAILED = "failed"
     REQUIRES_PARENT = "requires_parent"  # fork repo without valid parent repo in out system
-    STUCK = "stuck"  # requires manual resolution
     PENDING_REONBOARD = "pending_reonboard"  # re-onboarding deferred until weekend
     AUTH_REQUIRED = "auth_required"  # private repo or repo requiring authentication
 

--- a/services/apps/git_integration/src/crowdgit/errors.py
+++ b/services/apps/git_integration/src/crowdgit/errors.py
@@ -117,12 +117,6 @@ class ReOnboardingRequiredError(CrowdGitError):
 
 
 @dataclass
-class StuckRepoError(CrowdGitError):
-    error_message = "Repos stuck in processing state for a long time"
-    error_code: ErrorCode = ErrorCode.STUCK_REPO
-
-
-@dataclass
 class RepoAuthRequiredError(CrowdGitError):
     error_message: str = "Repository requires authentication (likely private or deleted)"
     error_code: ErrorCode = ErrorCode.REPO_AUTH_REQUIRED

--- a/services/apps/git_integration/src/crowdgit/models/repository.py
+++ b/services/apps/git_integration/src/crowdgit/models/repository.py
@@ -41,10 +41,6 @@ class Repository(BaseModel):
     parent_repo: Repository | None = Field(
         None, description="The parent repository (in case of fork) object from our database"
     )
-    stuck_requires_re_onboard: bool = Field(
-        default=False,
-        description="Indicates if the stuck repository is resolved by a re-onboarding",
-    )
     re_onboarding_count: int = Field(
         default=0,
         description="Tracks the number of times this repository has been re-onboarded. Used to identify unreachable commits via activity.attributes.cycle matching pattern onboarding-{reOnboardingCount}",
@@ -71,7 +67,6 @@ class Repository(BaseModel):
             "maintainerFile": "maintainer_file",
             "lastMaintainerRunAt": "last_maintainer_run_at",
             "forkedFrom": "forked_from",
-            "stuckRequiresReOnboard": "stuck_requires_re_onboard",
             "reOnboardingCount": "re_onboarding_count",
         }
         for db_field, model_field in field_mapping.items():

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -14,7 +14,6 @@ from crowdgit.errors import (
     ParentRepoInvalidError,
     ReOnboardingRequiredError,
     RepoAuthRequiredError,
-    StuckRepoError,
 )
 
 # Import configured loguru logger from crowdgit.logger
@@ -117,14 +116,9 @@ class RepositoryWorker:
         # handling
         if repo_stuck:
             logger.warning(
-                f"Repo {repository.url} is stuck for {processing_duration_hours} hours!"
+                f"Repo {repository.url} is stuck for {processing_duration_hours} hours — queuing for re-onboarding"
             )
-            if repository.stuck_requires_re_onboard:
-                logger.warning(
-                    f"Repo {repository.url} is stuck due to force-push or dangling commit. Will be re-onboarded"
-                )
-                raise ReOnboardingRequiredError()
-            raise StuckRepoError()
+            raise ReOnboardingRequiredError()
 
     async def _process_repositories(self):
         """
@@ -258,11 +252,6 @@ class RepositoryWorker:
 
             logger.info("Incremental processing completed successfully")
             processing_state = RepositoryState.COMPLETED
-        except StuckRepoError:
-            logger.error(
-                f"Repo {repository.url} is stuck for unkown reason, marking it as stuck until manually resolved!"
-            )
-            processing_state = RepositoryState.STUCK
         except ReOnboardingRequiredError:
             logger.info(f"Repo {repository.url} needs re-onboarding, deferring until weekend")
             processing_state = RepositoryState.PENDING_REONBOARD


### PR DESCRIPTION
This pull request removes the concept of "stuck" repositories and related code from the git integration service. Instead of marking repositories as "stuck" and requiring manual intervention, repositories that are stuck in processing are now automatically queued for re-onboarding. This simplifies error handling and reduces the need for manual resolution.

**Database and Model Cleanup:**
* Dropped the `stuckRequiresReOnboard` column from the `repositoryProcessing` table and removed all references to this field from the codebase, including the `Repository` model and database CRUD logic. [[1]](diffhunk://#diff-ca4c8d7c7f7c8293f6b878b7d105d9ab5361831bf29a1bb0dbff58afc3bdab1aR1) [[2]](diffhunk://#diff-0e235e7087557a52a84e3b0e8c71e23a0f4266aeb4b4962b895a7b5031149d25L44-L47) [[3]](diffhunk://#diff-0e235e7087557a52a84e3b0e8c71e23a0f4266aeb4b4962b895a7b5031149d25L74) [[4]](diffhunk://#diff-8fb533e3e9ed143e53529b30470ca03cfb6077619e13d430877dd6f3bacf0508L34)

**Repository State and Error Handling:**
* Removed the `STUCK` state from `RepositoryState` and the `STUCK_REPO` error code from `ErrorCode`, as well as the `StuckRepoError` exception class. [[1]](diffhunk://#diff-3549d7f615050c73e13531692a9fb691ef63edd66f32e26b3ec9642fff47d16cL24) [[2]](diffhunk://#diff-3549d7f615050c73e13531692a9fb691ef63edd66f32e26b3ec9642fff47d16cL40) [[3]](diffhunk://#diff-f6e294bed29a0ee15f28813541bcea440f25e0c039a8b2744bdfca6118c7df64L119-L124) [[4]](diffhunk://#diff-99afb87393964ba703782f1ef366b6859c77d742d3544d9359a975bb6157ab80L17)
* Updated repository stuck handling logic in `repository_worker.py` to always raise `ReOnboardingRequiredError` and queue the repository for re-onboarding, instead of marking it as stuck.
* Removed logic that set repository state to `STUCK` in the worker, since this state no longer exists.
* Updated the logic for acquiring repositories to process, so that repositories in the removed `STUCK` state are no longer excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes repository processing state machine and DB schema, which can affect how repos are selected/handled and may alter operational behavior for long-running jobs. Risk is moderate due to migration and state transitions, but scope is contained to git-integration processing logic.
> 
> **Overview**
> Deprecates the **`STUCK` repository concept** by removing the `RepositoryState.STUCK`, the `STUCK_REPO` error code, and the `StuckRepoError` path.
> 
> Stuck-processing detection in `repository_worker.py` now always triggers `ReOnboardingRequiredError`, moving affected repos into `PENDING_REONBOARD` instead of leaving them in a manual-resolution state.
> 
> Cleans up persistence and models by dropping `git.repositoryProcessing.stuckRequiresReOnboard` (migration) and removing the field from repo SELECTs and the `Repository` model DB mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6459b74f1ec59104e26c7aeee0b241e5eb4cab47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->