### PR TITLE
chore: added missing builder file for pcc sync worker

### DIFF
--- a/scripts/builders/pcc-sync-worker.env
+++ b/scripts/builders/pcc-sync-worker.env
@@ -1,0 +1,4 @@
+DOCKERFILE="./services/docker/Dockerfile.pcc_sync_worker"
+CONTEXT="../"
+REPO="sjc.ocir.io/axbydjxa5zuh/pcc-sync-worker"
+SERVICES="pcc-sync-worker"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `scripts/builders` env file used for image build/publish configuration, with no runtime code changes.
> 
> **Overview**
> Adds a missing `scripts/builders/pcc-sync-worker.env` file so the `pcc-sync-worker` can be built and pushed using the standard builder configuration (Dockerfile path, build context, target repo, and service name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4532b343d82d1ff5fe6f00a0a68b1d6e1a699bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->