### PR TITLE
feat: add recalculate all affiliation (IN-1083)

### DIFF
--- a/services/apps/script_executor_worker/package.json
+++ b/services/apps/script_executor_worker/package.json
@@ -10,6 +10,7 @@
     "cleanup-fork-activities": "npx tsx src/bin/cleanup-fork-activities-and-maintainers.ts",
     "cleanup-member-aggregates": "npx tsx src/bin/cleanup-member-aggregates.ts",
     "recalculate-enrichment-affiliations": "npx tsx src/bin/recalculate-enrichment-affiliations.ts",
+    "recalculate-all-affiliations": "npx tsx src/bin/recalculate-all-affiliations.ts",
     "add-lf-projects-to-collection": "npx tsx src/bin/add-lf-projects-to-collection.ts",
     "lint": "npx eslint --ext .ts src --max-warnings=0",
     "format": "npx prettier --write \"src/**/*.ts\"",

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -26,6 +26,7 @@
  *   --start-after <id>    Resume from a specific memberId (exclusive, for restarts)
  *   --dry-run             Log what would be processed without starting workflows
  *   --limit <n>           Stop after triggering at most N workflows (for testing)
+ *   --max-pages <n>       Stop after processing at most N pages (useful for dry-run testing)
  *   --workflow-delay <ms> Milliseconds to wait after each workflow start (default: 0)
  *
  * Environment Variables Required:
@@ -61,6 +62,7 @@ interface ScriptOptions {
   startAfter: string | null
   dryRun: boolean
   limit: number | null
+  maxPages: number | null
 }
 
 function parseArgs(): ScriptOptions {
@@ -80,6 +82,8 @@ function parseArgs(): ScriptOptions {
   const dryRun = args.includes('--dry-run')
   const limitRaw = getArg('--limit')
   const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : null
+  const maxPagesRaw = getArg('--max-pages')
+  const maxPages = maxPagesRaw !== undefined ? parseInt(maxPagesRaw, 10) : null
 
   if (isNaN(pageSize) || pageSize <= 0) {
     log.error('--page-size must be a positive integer')
@@ -101,8 +105,12 @@ function parseArgs(): ScriptOptions {
     log.error('--limit must be a positive integer')
     process.exit(1)
   }
+  if (maxPages !== null && (isNaN(maxPages) || maxPages <= 0)) {
+    log.error('--max-pages must be a positive integer')
+    process.exit(1)
+  }
 
-  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit }
+  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit, maxPages }
 }
 
 // Returns a page of distinct memberIds from memberOrganizations, cursor-based.
@@ -230,6 +238,7 @@ async function main() {
   log.info(`Start after:     ${opts.startAfter ?? '(beginning)'}`)
   log.info(`Mode:            ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
   log.info(`Limit:           ${opts.limit ?? '(none)'}`)
+  log.info(`Max pages:       ${opts.maxPages ?? '(none)'}`)
   log.info('='.repeat(80))
 
   const dbConnection = await getDbConnection(WRITE_DB_CONFIG())
@@ -333,6 +342,11 @@ async function main() {
     cursor = lastMemberId
 
     if (memberIds.length < opts.pageSize) {
+      hasMore = false
+    }
+
+    if (opts.maxPages !== null && pageNum >= opts.maxPages) {
+      log.info(`Max pages of ${opts.maxPages} reached.`)
       hasMore = false
     }
 

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -120,7 +120,17 @@ function parseArgs(): ScriptOptions {
     process.exit(1)
   }
 
-  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit, maxPages, emptyPageDelayMs }
+  return {
+    pageSize,
+    concurrency,
+    pageDelayMs,
+    workflowDelayMs,
+    startAfter,
+    dryRun,
+    limit,
+    maxPages,
+    emptyPageDelayMs,
+  }
 }
 
 // Returns a page of distinct memberIds from memberOrganizations, cursor-based.
@@ -257,7 +267,9 @@ async function main() {
   log.info(`Mode:            ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
   log.info(`Limit:           ${opts.limit ?? '(none)'}`)
   log.info(`Max pages:       ${opts.maxPages ?? '(none)'}`)
-  log.info(`Empty page delay: ${opts.emptyPageDelayMs !== null ? `${opts.emptyPageDelayMs}ms` : `same as page-delay (${opts.pageDelayMs}ms)`}`)
+  log.info(
+    `Empty page delay: ${opts.emptyPageDelayMs !== null ? `${opts.emptyPageDelayMs}ms` : `same as page-delay (${opts.pageDelayMs}ms)`}`,
+  )
   log.info('='.repeat(80))
 
   const dbConnection = await getDbConnection(WRITE_DB_CONFIG())
@@ -324,8 +336,8 @@ async function main() {
           opts.concurrency,
           async ({ memberId, activeOrgIds, staleOrgIds }) => {
             log.info(
-            `Triggering memberUpdate for broken member: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
-          )
+              `Triggering memberUpdate for broken member: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
+            )
             await temporal.workflow.start('memberUpdate', {
               taskQueue: 'profiles',
               workflowId: `member-update/${DEFAULT_TENANT_ID}/${memberId}`,
@@ -371,9 +383,10 @@ async function main() {
       hasMore = false
     }
 
-    const delayMs = brokenMembers.length === 0 && opts.emptyPageDelayMs !== null
-      ? opts.emptyPageDelayMs
-      : opts.pageDelayMs
+    const delayMs =
+      brokenMembers.length === 0 && opts.emptyPageDelayMs !== null
+        ? opts.emptyPageDelayMs
+        : opts.pageDelayMs
     if (delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, delayMs))
     }

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -143,7 +143,7 @@ async function findBrokenMembers(
     WITH pairs AS (
       SELECT DISTINCT "memberId", "organizationId"
       FROM "activityRelations"
-      WHERE "memberId" = ANY($(memberIds))
+      WHERE "memberId" = ANY($(memberIds)::uuid[])
         AND "organizationId" IS NOT NULL
     )
     SELECT DISTINCT p."memberId"
@@ -169,7 +169,7 @@ async function findBrokenMembers(
     `
     SELECT "memberId", array_agg(DISTINCT "organizationId") AS "activeOrgIds"
     FROM "memberOrganizations"
-    WHERE "memberId" = ANY($(brokenMemberIds))
+    WHERE "memberId" = ANY($(brokenMemberIds)::uuid[])
       AND "deletedAt" IS NULL
     GROUP BY "memberId"
     `,

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -50,9 +50,10 @@ import { TEMPORAL_CONFIG, getTemporalClient } from '@crowd/temporal'
 
 const log = getServiceChildLogger('recalculate-all-affiliations')
 
-interface MemberWithActiveOrgs {
+interface BrokenMember {
   memberId: string
   activeOrgIds: string[]
+  staleOrgIds: string[]
 }
 
 interface ScriptOptions {
@@ -151,11 +152,11 @@ async function fetchMemberIdPage(
 async function findBrokenMembers(
   qx: ReturnType<typeof pgpQx>,
   memberIds: string[],
-): Promise<MemberWithActiveOrgs[]> {
+): Promise<BrokenMember[]> {
   // First reduce to distinct (memberId, organizationId) pairs — a member may have
   // thousands of activities but only a handful of distinct org attributions.
   // The NOT EXISTS then runs on the small deduplicated set, not on every activity row.
-  const brokenRows = await qx.select(
+  const staleRows = await qx.select(
     `
     WITH pairs AS (
       SELECT DISTINCT "memberId", "organizationId"
@@ -163,7 +164,7 @@ async function findBrokenMembers(
       WHERE "memberId" = ANY($(memberIds)::uuid[])
         AND "organizationId" IS NOT NULL
     )
-    SELECT DISTINCT p."memberId"
+    SELECT p."memberId", p."organizationId" AS "staleOrgId"
     FROM pairs p
     WHERE NOT EXISTS (
       SELECT 1 FROM "memberOrganizations" mo
@@ -175,11 +176,18 @@ async function findBrokenMembers(
     { memberIds },
   )
 
-  if (brokenRows.length === 0) {
+  if (staleRows.length === 0) {
     return []
   }
 
-  const brokenMemberIds = brokenRows.map((r: Record<string, unknown>) => r.memberId as string)
+  const staleMap = new Map<string, string[]>()
+  for (const r of staleRows as Record<string, string>[]) {
+    const existing = staleMap.get(r.memberId) ?? []
+    existing.push(r.staleOrgId)
+    staleMap.set(r.memberId, existing)
+  }
+
+  const brokenMemberIds = [...staleMap.keys()]
 
   // Fetch currently active org IDs to pass to memberUpdate
   const orgRows = await qx.select(
@@ -193,7 +201,7 @@ async function findBrokenMembers(
     { brokenMemberIds },
   )
 
-  const orgMap = new Map<string, string[]>(
+  const activeOrgMap = new Map<string, string[]>(
     orgRows.map((r: Record<string, unknown>) => [
       r.memberId as string,
       (r.activeOrgIds as string[] | null) ?? [],
@@ -202,7 +210,8 @@ async function findBrokenMembers(
 
   return brokenMemberIds.map((memberId: string) => ({
     memberId,
-    activeOrgIds: orgMap.get(memberId) ?? [],
+    activeOrgIds: activeOrgMap.get(memberId) ?? [],
+    staleOrgIds: staleMap.get(memberId) ?? [],
   }))
 }
 
@@ -289,9 +298,9 @@ async function main() {
         const loggedSoFar = totalBroken - brokenMembers.length
         const remaining = opts.limit !== null ? opts.limit - loggedSoFar : brokenMembers.length
         const toLog = brokenMembers.slice(0, remaining)
-        for (const { memberId, activeOrgIds } of toLog) {
+        for (const { memberId, activeOrgIds, staleOrgIds } of toLog) {
           log.info(
-            `[DRY RUN] memberUpdate | memberId: ${memberId} | activeOrgs: ${activeOrgIds.length}`,
+            `[DRY RUN] broken member: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
           )
         }
         if (opts.limit !== null && loggedSoFar + toLog.length >= opts.limit) {
@@ -313,8 +322,10 @@ async function main() {
         const { succeeded, failed } = await runWithConcurrency(
           toProcess,
           opts.concurrency,
-          async ({ memberId, activeOrgIds }) => {
-            log.info({ memberId, activeOrgs: activeOrgIds.length }, 'Triggering memberUpdate workflow')
+          async ({ memberId, activeOrgIds, staleOrgIds }) => {
+            log.info(
+            `Triggering memberUpdate for broken member: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
+          )
             await temporal.workflow.start('memberUpdate', {
               taskQueue: 'profiles',
               workflowId: `member-update/${DEFAULT_TENANT_ID}/${memberId}`,

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -267,10 +267,19 @@ async function main() {
 
     if (brokenMembers.length > 0) {
       if (opts.dryRun) {
-        for (const { memberId, activeOrgIds } of brokenMembers) {
+        const loggedSoFar = totalBroken - brokenMembers.length
+        const remaining = opts.limit !== null ? opts.limit - loggedSoFar : brokenMembers.length
+        const toLog = brokenMembers.slice(0, remaining)
+        for (const { memberId, activeOrgIds } of toLog) {
           log.info(
             `[DRY RUN] memberUpdate | memberId: ${memberId} | activeOrgs: ${activeOrgIds.length}`,
           )
+        }
+        if (opts.limit !== null && loggedSoFar + toLog.length >= opts.limit) {
+          log.info(`Limit of ${opts.limit} members reached.`)
+          hasMore = false
+          cursor = lastMemberId
+          continue
         }
       } else {
         const triggeredSoFar = totalSucceeded + totalFailed

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -22,11 +22,12 @@
  *                         Kept small intentionally: each page triggers an
  *                         activityRelations lookup per member via memberId index.
  *   --concurrency <n>     Max concurrent Temporal workflow starts per page (default: 20)
- *   --page-delay <ms>     Milliseconds to wait between pages (default: 5000)
+ *   --page-delay <ms>     Milliseconds to wait between pages (default: 2000)
  *   --start-after <id>    Resume from a specific memberId (exclusive, for restarts)
  *   --dry-run             Log what would be processed without starting workflows
  *   --limit <n>           Stop after triggering at most N workflows (for testing)
  *   --max-pages <n>       Stop after processing at most N pages (useful for dry-run testing)
+ *   --empty-page-delay <ms> Delay when a page has 0 broken members (default: same as --page-delay)
  *   --workflow-delay <ms> Milliseconds to wait after each workflow start (default: 0)
  *
  * Environment Variables Required:
@@ -63,6 +64,7 @@ interface ScriptOptions {
   dryRun: boolean
   limit: number | null
   maxPages: number | null
+  emptyPageDelayMs: number | null
 }
 
 function parseArgs(): ScriptOptions {
@@ -76,10 +78,17 @@ function parseArgs(): ScriptOptions {
 
   const pageSize = parseInt(getArg('--page-size') ?? '100', 10)
   const concurrency = parseInt(getArg('--concurrency') ?? '20', 10)
-  const pageDelayMs = parseInt(getArg('--page-delay') ?? '5000', 10)
+  const pageDelayMs = parseInt(getArg('--page-delay') ?? '2000', 10)
   const workflowDelayMs = parseInt(getArg('--workflow-delay') ?? '0', 10)
   const startAfter = getArg('--start-after') ?? null
   const dryRun = args.includes('--dry-run')
+  const emptyPageDelayRaw = getArg('--empty-page-delay')
+  const emptyPageDelayMs = emptyPageDelayRaw !== undefined ? parseInt(emptyPageDelayRaw, 10) : null
+
+  if (emptyPageDelayMs !== null && (isNaN(emptyPageDelayMs) || emptyPageDelayMs < 0)) {
+    log.error('--empty-page-delay must be a non-negative integer')
+    process.exit(1)
+  }
   const limitRaw = getArg('--limit')
   const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : null
   const maxPagesRaw = getArg('--max-pages')
@@ -110,7 +119,7 @@ function parseArgs(): ScriptOptions {
     process.exit(1)
   }
 
-  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit, maxPages }
+  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit, maxPages, emptyPageDelayMs }
 }
 
 // Returns a page of distinct memberIds from memberOrganizations, cursor-based.
@@ -239,6 +248,7 @@ async function main() {
   log.info(`Mode:            ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
   log.info(`Limit:           ${opts.limit ?? '(none)'}`)
   log.info(`Max pages:       ${opts.maxPages ?? '(none)'}`)
+  log.info(`Empty page delay: ${opts.emptyPageDelayMs !== null ? `${opts.emptyPageDelayMs}ms` : `same as page-delay (${opts.pageDelayMs}ms)`}`)
   log.info('='.repeat(80))
 
   const dbConnection = await getDbConnection(WRITE_DB_CONFIG())
@@ -350,8 +360,11 @@ async function main() {
       hasMore = false
     }
 
-    if (opts.pageDelayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, opts.pageDelayMs))
+    const delayMs = brokenMembers.length === 0 && opts.emptyPageDelayMs !== null
+      ? opts.emptyPageDelayMs
+      : opts.pageDelayMs
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
   }
 

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -1,45 +1,3 @@
-/**
- * Recalculate All Affiliations Script
- *
- * PROBLEM:
- * activityRelations.organizationId may be stale for members who have activities
- * attributed to an organization they no longer have an active work experience for
- * (no matching memberOrganizations row with deletedAt IS NULL). This can happen
- * regardless of the source of the work experience change (enrichment, manual, etc.).
- *
- * SOLUTION:
- * Paginates over distinct memberIds from memberOrganizations. For each batch,
- * detects members with stale org attributions by checking activityRelations via
- * ix_activityRelations_memberId (no full table scan). Triggers a memberUpdate
- * Temporal workflow only for affected members.
- *
- * Usage:
- *   pnpm run recalculate-all-affiliations -- [options]
- *   npx tsx src/bin/recalculate-all-affiliations.ts [options]
- *
- * Options:
- *   --page-size <n>       Number of memberIds per page (default: 100)
- *                         Kept small intentionally: each page triggers an
- *                         activityRelations lookup per member via memberId index.
- *   --concurrency <n>     Max concurrent Temporal workflow starts per page (default: 20)
- *   --page-delay <ms>     Milliseconds to wait between pages (default: 2000)
- *   --start-after <id>    Resume from a specific memberId (exclusive, for restarts)
- *   --dry-run             Log what would be processed without starting workflows
- *   --limit <n>           Stop after triggering at most N workflows (for testing)
- *   --max-pages <n>       Stop after processing at most N pages (useful for dry-run testing)
- *   --empty-page-delay <ms> Delay when a page has 0 broken members (default: same as --page-delay)
- *   --workflow-delay <ms> Milliseconds to wait after each workflow start (default: 0)
- *
- * Environment Variables Required:
- *   CROWD_DB_WRITE_HOST        - Postgres write host
- *   CROWD_DB_PORT              - Postgres port
- *   CROWD_DB_USERNAME          - Postgres username
- *   CROWD_DB_PASSWORD          - Postgres password
- *   CROWD_DB_DATABASE          - Postgres database name
- *   CROWD_TEMPORAL_SERVER_URL  - Temporal server URL
- *   CROWD_TEMPORAL_NAMESPACE   - Temporal namespace
- *   SERVICE                    - Service identifier (used by Temporal client)
- */
 import { WorkflowIdReusePolicy } from '@temporalio/client'
 
 import { DEFAULT_TENANT_ID } from '@crowd/common'
@@ -85,11 +43,6 @@ function parseArgs(): ScriptOptions {
   const dryRun = args.includes('--dry-run')
   const emptyPageDelayRaw = getArg('--empty-page-delay')
   const emptyPageDelayMs = emptyPageDelayRaw !== undefined ? parseInt(emptyPageDelayRaw, 10) : null
-
-  if (emptyPageDelayMs !== null && (isNaN(emptyPageDelayMs) || emptyPageDelayMs < 0)) {
-    log.error('--empty-page-delay must be a non-negative integer')
-    process.exit(1)
-  }
   const limitRaw = getArg('--limit')
   const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : null
   const maxPagesRaw = getArg('--max-pages')
@@ -109,6 +62,10 @@ function parseArgs(): ScriptOptions {
   }
   if (isNaN(workflowDelayMs) || workflowDelayMs < 0) {
     log.error('--workflow-delay must be a non-negative integer')
+    process.exit(1)
+  }
+  if (emptyPageDelayMs !== null && (isNaN(emptyPageDelayMs) || emptyPageDelayMs < 0)) {
+    log.error('--empty-page-delay must be a non-negative integer')
     process.exit(1)
   }
   if (limit !== null && (isNaN(limit) || limit <= 0)) {
@@ -133,7 +90,6 @@ function parseArgs(): ScriptOptions {
   }
 }
 
-// Returns a page of distinct memberIds from memberOrganizations, cursor-based.
 async function fetchMemberIdPage(
   qx: ReturnType<typeof pgpQx>,
   afterMemberId: string | null,
@@ -156,16 +112,12 @@ async function fetchMemberIdPage(
   return rows.map((r: Record<string, unknown>) => r.memberId as string)
 }
 
-// Finds members in the batch whose activityRelations.organizationId is stale —
-// i.e. attributed to an org they no longer have an active memberOrganization for.
-// Uses ix_activityRelations_memberId for the activityRelations lookup (no seq scan).
 async function findBrokenMembers(
   qx: ReturnType<typeof pgpQx>,
   memberIds: string[],
 ): Promise<BrokenMember[]> {
-  // First reduce to distinct (memberId, organizationId) pairs — a member may have
-  // thousands of activities but only a handful of distinct org attributions.
-  // The NOT EXISTS then runs on the small deduplicated set, not on every activity row.
+  // Deduplicate to (memberId, organizationId) pairs first — a member may have thousands
+  // of activities but only a handful of distinct org attributions.
   const staleRows = await qx.select(
     `
     WITH pairs AS (
@@ -199,7 +151,6 @@ async function findBrokenMembers(
 
   const brokenMemberIds = [...staleMap.keys()]
 
-  // Fetch currently active org IDs to pass to memberUpdate
   const orgRows = await qx.select(
     `
     SELECT "memberId", array_agg(DISTINCT "organizationId") AS "activeOrgIds"
@@ -225,52 +176,23 @@ async function findBrokenMembers(
   }))
 }
 
-async function runWithConcurrency<T>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T) => Promise<void>,
-): Promise<{ succeeded: number; failed: number }> {
-  let succeeded = 0
-  let failed = 0
-  let index = 0
-
-  async function worker() {
-    while (index < items.length) {
-      const item = items[index++]
-      try {
-        await fn(item)
-        succeeded++
-      } catch (err) {
-        failed++
-        log.error({ err }, 'Failed to process member')
-      }
-    }
-  }
-
-  const workers = Array.from({ length: Math.min(concurrency, items.length) }, worker)
-  await Promise.all(workers)
-
-  return { succeeded, failed }
-}
-
 async function main() {
   const opts = parseArgs()
 
-  log.info('='.repeat(80))
-  log.info('Recalculate All Affiliations Script')
-  log.info('='.repeat(80))
-  log.info(`Page size:       ${opts.pageSize}`)
-  log.info(`Concurrency:     ${opts.concurrency}`)
-  log.info(`Page delay:      ${opts.pageDelayMs}ms`)
-  log.info(`Workflow delay:  ${opts.workflowDelayMs}ms`)
-  log.info(`Start after:     ${opts.startAfter ?? '(beginning)'}`)
-  log.info(`Mode:            ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
-  log.info(`Limit:           ${opts.limit ?? '(none)'}`)
-  log.info(`Max pages:       ${opts.maxPages ?? '(none)'}`)
   log.info(
-    `Empty page delay: ${opts.emptyPageDelayMs !== null ? `${opts.emptyPageDelayMs}ms` : `same as page-delay (${opts.pageDelayMs}ms)`}`,
+    {
+      pageSize: opts.pageSize,
+      concurrency: opts.concurrency,
+      pageDelayMs: opts.pageDelayMs,
+      workflowDelayMs: opts.workflowDelayMs,
+      startAfter: opts.startAfter,
+      dryRun: opts.dryRun,
+      limit: opts.limit,
+      maxPages: opts.maxPages,
+      emptyPageDelayMs: opts.emptyPageDelayMs,
+    },
+    'Starting recalculate-all-affiliations',
   )
-  log.info('='.repeat(80))
 
   const dbConnection = await getDbConnection(WRITE_DB_CONFIG())
   const qx = pgpQx(dbConnection)
@@ -331,37 +253,43 @@ async function main() {
         }
 
         const toProcess = brokenMembers.slice(0, remaining)
-        const { succeeded, failed } = await runWithConcurrency(
-          toProcess,
-          opts.concurrency,
-          async ({ memberId, activeOrgIds, staleOrgIds }) => {
-            log.info(
-              `Triggering memberUpdate for broken member: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
-            )
-            await temporal.workflow.start('memberUpdate', {
-              taskQueue: 'profiles',
-              workflowId: `member-update/${DEFAULT_TENANT_ID}/${memberId}`,
-              workflowIdReusePolicy:
-                WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
-              retry: { maximumAttempts: 10 },
-              args: [
-                {
-                  member: { id: memberId },
-                  memberOrganizationIds: activeOrgIds,
-                  syncToOpensearch: true,
-                },
-              ],
-              searchAttributes: { TenantId: [DEFAULT_TENANT_ID] },
-            })
-            if (opts.workflowDelayMs > 0) {
-              await new Promise((resolve) => setTimeout(resolve, opts.workflowDelayMs))
-            }
-          },
-        )
 
-        totalSucceeded += succeeded
-        totalFailed += failed
-        log.info(`Page ${pageNum} done: ${succeeded} ok, ${failed} failed`)
+        let index = 0
+        const worker = async () => {
+          while (index < toProcess.length) {
+            const { memberId, activeOrgIds, staleOrgIds } = toProcess[index++]
+            try {
+              log.info(
+                `Triggering memberUpdate: ${memberId} | stale orgs: [${staleOrgIds.join(', ')}] | active orgs: ${activeOrgIds.length}`,
+              )
+              await temporal.workflow.start('memberUpdate', {
+                taskQueue: 'profiles',
+                workflowId: `member-update/${DEFAULT_TENANT_ID}/${memberId}`,
+                workflowIdReusePolicy:
+                  WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+                retry: { maximumAttempts: 10 },
+                args: [
+                  {
+                    member: { id: memberId },
+                    memberOrganizationIds: activeOrgIds,
+                    syncToOpensearch: true,
+                  },
+                ],
+                searchAttributes: { TenantId: [DEFAULT_TENANT_ID] },
+              })
+              if (opts.workflowDelayMs > 0) {
+                await new Promise((resolve) => setTimeout(resolve, opts.workflowDelayMs))
+              }
+              totalSucceeded++
+            } catch (err) {
+              totalFailed++
+              log.error({ err }, 'Failed to process member')
+            }
+          }
+        }
+
+        await Promise.all(Array.from({ length: Math.min(opts.concurrency, toProcess.length) }, worker))
+        log.info(`Page ${pageNum} done: ${totalSucceeded} ok, ${totalFailed} failed`)
 
         if (opts.limit !== null && totalSucceeded + totalFailed >= opts.limit) {
           log.info(`Limit of ${opts.limit} workflows reached.`)
@@ -392,17 +320,16 @@ async function main() {
     }
   }
 
-  log.info('='.repeat(80))
-  log.info('Summary')
-  log.info('='.repeat(80))
   const brokenPct = totalScanned > 0 ? ((totalBroken / totalScanned) * 100).toFixed(2) : '0.00'
-  log.info(`Pages processed:     ${pageNum}`)
-  log.info(`Members scanned:     ${totalScanned}`)
-  log.info(`Members broken:      ${totalBroken} (${brokenPct}%)`)
-  if (!opts.dryRun) {
-    log.info(`Workflows succeeded: ${totalSucceeded}`)
-    log.info(`Workflows failed:    ${totalFailed}`)
-  }
+  log.info(
+    {
+      pagesProcessed: pageNum,
+      membersScanned: totalScanned,
+      membersBroken: `${totalBroken} (${brokenPct}%)`,
+      ...(opts.dryRun ? {} : { workflowsSucceeded: totalSucceeded, workflowsFailed: totalFailed }),
+    },
+    'Done',
+  )
 
   process.exit(totalFailed > 0 ? 1 : 0)
 }

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -1,0 +1,353 @@
+/**
+ * Recalculate All Affiliations Script
+ *
+ * PROBLEM:
+ * activityRelations.organizationId may be stale for members who have activities
+ * attributed to an organization they no longer have an active work experience for
+ * (no matching memberOrganizations row with deletedAt IS NULL). This can happen
+ * regardless of the source of the work experience change (enrichment, manual, etc.).
+ *
+ * SOLUTION:
+ * Paginates over distinct memberIds from memberOrganizations. For each batch,
+ * detects members with stale org attributions by checking activityRelations via
+ * ix_activityRelations_memberId (no full table scan). Triggers a memberUpdate
+ * Temporal workflow only for affected members.
+ *
+ * Usage:
+ *   pnpm run recalculate-all-affiliations -- [options]
+ *   npx tsx src/bin/recalculate-all-affiliations.ts [options]
+ *
+ * Options:
+ *   --page-size <n>       Number of memberIds per page (default: 100)
+ *                         Kept small intentionally: each page triggers an
+ *                         activityRelations lookup per member via memberId index.
+ *   --concurrency <n>     Max concurrent Temporal workflow starts per page (default: 20)
+ *   --page-delay <ms>     Milliseconds to wait between pages (default: 5000)
+ *   --start-after <id>    Resume from a specific memberId (exclusive, for restarts)
+ *   --dry-run             Log what would be processed without starting workflows
+ *   --limit <n>           Stop after triggering at most N workflows (for testing)
+ *   --workflow-delay <ms> Milliseconds to wait after each workflow start (default: 0)
+ *
+ * Environment Variables Required:
+ *   CROWD_DB_WRITE_HOST        - Postgres write host
+ *   CROWD_DB_PORT              - Postgres port
+ *   CROWD_DB_USERNAME          - Postgres username
+ *   CROWD_DB_PASSWORD          - Postgres password
+ *   CROWD_DB_DATABASE          - Postgres database name
+ *   CROWD_TEMPORAL_SERVER_URL  - Temporal server URL
+ *   CROWD_TEMPORAL_NAMESPACE   - Temporal namespace
+ *   SERVICE                    - Service identifier (used by Temporal client)
+ */
+import { WorkflowIdReusePolicy } from '@temporalio/client'
+
+import { DEFAULT_TENANT_ID } from '@crowd/common'
+import { WRITE_DB_CONFIG, getDbConnection } from '@crowd/data-access-layer/src/database'
+import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
+import { getServiceChildLogger } from '@crowd/logging'
+import { TEMPORAL_CONFIG, getTemporalClient } from '@crowd/temporal'
+
+const log = getServiceChildLogger('recalculate-all-affiliations')
+
+interface MemberWithActiveOrgs {
+  memberId: string
+  activeOrgIds: string[]
+}
+
+interface ScriptOptions {
+  pageSize: number
+  concurrency: number
+  pageDelayMs: number
+  workflowDelayMs: number
+  startAfter: string | null
+  dryRun: boolean
+  limit: number | null
+}
+
+function parseArgs(): ScriptOptions {
+  const args = process.argv.slice(2)
+
+  const getArg = (flag: string): string | undefined => {
+    const idx = args.indexOf(flag)
+    if (idx !== -1 && idx + 1 < args.length) return args[idx + 1]
+    return undefined
+  }
+
+  const pageSize = parseInt(getArg('--page-size') ?? '100', 10)
+  const concurrency = parseInt(getArg('--concurrency') ?? '20', 10)
+  const pageDelayMs = parseInt(getArg('--page-delay') ?? '5000', 10)
+  const workflowDelayMs = parseInt(getArg('--workflow-delay') ?? '0', 10)
+  const startAfter = getArg('--start-after') ?? null
+  const dryRun = args.includes('--dry-run')
+  const limitRaw = getArg('--limit')
+  const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : null
+
+  if (isNaN(pageSize) || pageSize <= 0) {
+    log.error('--page-size must be a positive integer')
+    process.exit(1)
+  }
+  if (isNaN(concurrency) || concurrency <= 0) {
+    log.error('--concurrency must be a positive integer')
+    process.exit(1)
+  }
+  if (isNaN(pageDelayMs) || pageDelayMs < 0) {
+    log.error('--page-delay must be a non-negative integer')
+    process.exit(1)
+  }
+  if (isNaN(workflowDelayMs) || workflowDelayMs < 0) {
+    log.error('--workflow-delay must be a non-negative integer')
+    process.exit(1)
+  }
+  if (limit !== null && (isNaN(limit) || limit <= 0)) {
+    log.error('--limit must be a positive integer')
+    process.exit(1)
+  }
+
+  return { pageSize, concurrency, pageDelayMs, workflowDelayMs, startAfter, dryRun, limit }
+}
+
+// Returns a page of distinct memberIds from memberOrganizations, cursor-based.
+async function fetchMemberIdPage(
+  qx: ReturnType<typeof pgpQx>,
+  afterMemberId: string | null,
+  pageSize: number,
+): Promise<string[]> {
+  const cursorClause = afterMemberId ? `AND "memberId" > $(afterMemberId)` : ''
+
+  const rows = await qx.select(
+    `
+    SELECT "memberId"
+    FROM "memberOrganizations"
+    WHERE TRUE ${cursorClause}
+    GROUP BY "memberId"
+    ORDER BY "memberId"
+    LIMIT $(pageSize)
+    `,
+    { afterMemberId, pageSize },
+  )
+
+  return rows.map((r: Record<string, unknown>) => r.memberId as string)
+}
+
+// Finds members in the batch whose activityRelations.organizationId is stale —
+// i.e. attributed to an org they no longer have an active memberOrganization for.
+// Uses ix_activityRelations_memberId for the activityRelations lookup (no seq scan).
+async function findBrokenMembers(
+  qx: ReturnType<typeof pgpQx>,
+  memberIds: string[],
+): Promise<MemberWithActiveOrgs[]> {
+  // First reduce to distinct (memberId, organizationId) pairs — a member may have
+  // thousands of activities but only a handful of distinct org attributions.
+  // The NOT EXISTS then runs on the small deduplicated set, not on every activity row.
+  const brokenRows = await qx.select(
+    `
+    WITH pairs AS (
+      SELECT DISTINCT "memberId", "organizationId"
+      FROM "activityRelations"
+      WHERE "memberId" = ANY($(memberIds))
+        AND "organizationId" IS NOT NULL
+    )
+    SELECT DISTINCT p."memberId"
+    FROM pairs p
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "memberOrganizations" mo
+      WHERE mo."memberId" = p."memberId"
+        AND mo."organizationId" = p."organizationId"
+        AND mo."deletedAt" IS NULL
+    )
+    `,
+    { memberIds },
+  )
+
+  if (brokenRows.length === 0) {
+    return []
+  }
+
+  const brokenMemberIds = brokenRows.map((r: Record<string, unknown>) => r.memberId as string)
+
+  // Fetch currently active org IDs to pass to memberUpdate
+  const orgRows = await qx.select(
+    `
+    SELECT "memberId", array_agg(DISTINCT "organizationId") AS "activeOrgIds"
+    FROM "memberOrganizations"
+    WHERE "memberId" = ANY($(brokenMemberIds))
+      AND "deletedAt" IS NULL
+    GROUP BY "memberId"
+    `,
+    { brokenMemberIds },
+  )
+
+  const orgMap = new Map<string, string[]>(
+    orgRows.map((r: Record<string, unknown>) => [
+      r.memberId as string,
+      (r.activeOrgIds as string[] | null) ?? [],
+    ]),
+  )
+
+  return brokenMemberIds.map((memberId: string) => ({
+    memberId,
+    activeOrgIds: orgMap.get(memberId) ?? [],
+  }))
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<{ succeeded: number; failed: number }> {
+  let succeeded = 0
+  let failed = 0
+  let index = 0
+
+  async function worker() {
+    while (index < items.length) {
+      const item = items[index++]
+      try {
+        await fn(item)
+        succeeded++
+      } catch (err) {
+        failed++
+        log.error({ err }, 'Failed to process member')
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, worker)
+  await Promise.all(workers)
+
+  return { succeeded, failed }
+}
+
+async function main() {
+  const opts = parseArgs()
+
+  log.info('='.repeat(80))
+  log.info('Recalculate All Affiliations Script')
+  log.info('='.repeat(80))
+  log.info(`Page size:       ${opts.pageSize}`)
+  log.info(`Concurrency:     ${opts.concurrency}`)
+  log.info(`Page delay:      ${opts.pageDelayMs}ms`)
+  log.info(`Workflow delay:  ${opts.workflowDelayMs}ms`)
+  log.info(`Start after:     ${opts.startAfter ?? '(beginning)'}`)
+  log.info(`Mode:            ${opts.dryRun ? 'DRY RUN' : 'LIVE'}`)
+  log.info(`Limit:           ${opts.limit ?? '(none)'}`)
+  log.info('='.repeat(80))
+
+  const dbConnection = await getDbConnection(WRITE_DB_CONFIG())
+  const qx = pgpQx(dbConnection)
+  const temporal = await getTemporalClient(TEMPORAL_CONFIG())
+
+  let cursor: string | null = opts.startAfter
+  let pageNum = 0
+  let totalScanned = 0
+  let totalBroken = 0
+  let totalSucceeded = 0
+  let totalFailed = 0
+
+  let hasMore = true
+  while (hasMore) {
+    pageNum++
+
+    const memberIds = await fetchMemberIdPage(qx, cursor, opts.pageSize)
+
+    if (memberIds.length === 0) {
+      log.info('No more members to process.')
+      hasMore = false
+      continue
+    }
+
+    const lastMemberId = memberIds[memberIds.length - 1]
+    totalScanned += memberIds.length
+
+    const brokenMembers = await findBrokenMembers(qx, memberIds)
+    totalBroken += brokenMembers.length
+
+    log.info(
+      `Page ${pageNum}: scanned ${memberIds.length} | broken: ${brokenMembers.length} | cursor: ${lastMemberId}`,
+    )
+
+    if (brokenMembers.length > 0) {
+      if (opts.dryRun) {
+        for (const { memberId, activeOrgIds } of brokenMembers) {
+          log.info(
+            `[DRY RUN] memberUpdate | memberId: ${memberId} | activeOrgs: ${activeOrgIds.length}`,
+          )
+        }
+      } else {
+        const triggeredSoFar = totalSucceeded + totalFailed
+        const remaining = opts.limit !== null ? opts.limit - triggeredSoFar : brokenMembers.length
+        if (remaining <= 0) {
+          log.info(`Limit of ${opts.limit} workflows reached.`)
+          hasMore = false
+          continue
+        }
+
+        const toProcess = brokenMembers.slice(0, remaining)
+        const { succeeded, failed } = await runWithConcurrency(
+          toProcess,
+          opts.concurrency,
+          async ({ memberId, activeOrgIds }) => {
+            log.info({ memberId, activeOrgs: activeOrgIds.length }, 'Triggering memberUpdate workflow')
+            await temporal.workflow.start('memberUpdate', {
+              taskQueue: 'profiles',
+              workflowId: `member-update/${DEFAULT_TENANT_ID}/${memberId}`,
+              workflowIdReusePolicy:
+                WorkflowIdReusePolicy.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
+              retry: { maximumAttempts: 10 },
+              args: [
+                {
+                  member: { id: memberId },
+                  memberOrganizationIds: activeOrgIds,
+                  syncToOpensearch: true,
+                },
+              ],
+              searchAttributes: { TenantId: [DEFAULT_TENANT_ID] },
+            })
+            if (opts.workflowDelayMs > 0) {
+              await new Promise((resolve) => setTimeout(resolve, opts.workflowDelayMs))
+            }
+          },
+        )
+
+        totalSucceeded += succeeded
+        totalFailed += failed
+        log.info(`Page ${pageNum} done: ${succeeded} ok, ${failed} failed`)
+
+        if (opts.limit !== null && totalSucceeded + totalFailed >= opts.limit) {
+          log.info(`Limit of ${opts.limit} workflows reached.`)
+          hasMore = false
+          continue
+        }
+      }
+    }
+
+    log.info(`Resume with: --start-after ${lastMemberId}`)
+    cursor = lastMemberId
+
+    if (memberIds.length < opts.pageSize) {
+      hasMore = false
+    }
+
+    if (opts.pageDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, opts.pageDelayMs))
+    }
+  }
+
+  log.info('='.repeat(80))
+  log.info('Summary')
+  log.info('='.repeat(80))
+  const brokenPct = totalScanned > 0 ? ((totalBroken / totalScanned) * 100).toFixed(2) : '0.00'
+  log.info(`Pages processed:     ${pageNum}`)
+  log.info(`Members scanned:     ${totalScanned}`)
+  log.info(`Members broken:      ${totalBroken} (${brokenPct}%)`)
+  if (!opts.dryRun) {
+    log.info(`Workflows succeeded: ${totalSucceeded}`)
+    log.info(`Workflows failed:    ${totalFailed}`)
+  }
+
+  process.exit(totalFailed > 0 ? 1 : 0)
+}
+
+main().catch((err) => {
+  log.error({ err }, 'Unexpected error')
+  process.exit(1)
+})

--- a/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
+++ b/services/apps/script_executor_worker/src/bin/recalculate-all-affiliations.ts
@@ -288,7 +288,9 @@ async function main() {
           }
         }
 
-        await Promise.all(Array.from({ length: Math.min(opts.concurrency, toProcess.length) }, worker))
+        await Promise.all(
+          Array.from({ length: Math.min(opts.concurrency, toProcess.length) }, worker),
+        )
         log.info(`Page ${pageNum} done: ${totalSucceeded} ok, ${totalFailed} failed`)
 
         if (opts.limit !== null && totalSucceeded + totalFailed >= opts.limit) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new maintenance script that scans production tables and can mass-trigger `memberUpdate` Temporal workflows (terminating any running ones), so misconfiguration of limits/concurrency could create significant DB/Temporal/OpenSearch load.
> 
> **Overview**
> Adds a new `recalculate-all-affiliations` script to the script executor worker to detect members whose `activityRelations.organizationId` references no longer exist in active `memberOrganizations`, and then trigger `memberUpdate` workflows to recompute affiliations (with paging, concurrency, resume cursor, delays, and `--dry-run`/limit/max-pages controls).
> 
> Exposes the script via `package.json` so it can be run from the worker package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e39b57c1e826e58115c48d6b80fe2593914df83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->