### PR TITLE
fix: recalculate affiliations on update member orgs (IN-1083)

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -876,7 +876,6 @@ class MemberRepository {
       data.organizationsReplace,
       options.currentSegments.map((s) => s.id),
       options,
-      false, // MemberService.update triggers startAffiliationRecalculation after commit
     )
 
     if (data.noMerge) {

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -876,6 +876,7 @@ class MemberRepository {
       data.organizationsReplace,
       options.currentSegments.map((s) => s.id),
       options,
+      false, // MemberService.update triggers startAffiliationRecalculation after commit
     )
 
     if (data.noMerge) {

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -20,6 +20,7 @@ import {
   insertMemberSegmentAggregates,
   queryMembersAdvanced,
 } from '@crowd/data-access-layer/src/members'
+import { fetchMemberOrganizations } from '@crowd/data-access-layer/src/members/organizations'
 import { QueryExecutor, optionsQx } from '@crowd/data-access-layer/src/queryExecutor'
 import { fetchManySegments } from '@crowd/data-access-layer/src/segments'
 import { LoggerBase } from '@crowd/logging'
@@ -276,6 +277,12 @@ export default class MemberService extends LoggerBase {
       data.displayName = data.username[data.platform].username
     }
 
+    const existingOrgIds = existing && data.organizations
+      ? (await fetchMemberOrganizations(optionsQx(this.options), existing.id)).map(
+          (o) => o.organizationId,
+        )
+      : []
+
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
     try {
@@ -504,6 +511,17 @@ export default class MemberService extends LoggerBase {
       )
 
       await SequelizeRepository.commitTransaction(transaction)
+
+      if (data.organizations) {
+        const commonMemberService = new CommonMemberService(
+          optionsQx(this.options),
+          this.options.temporal,
+          this.options.log,
+        )
+        const newOrgIds = data.organizations.map((o) => o.id)
+        const allAffectedOrgIds = [...new Set([...existingOrgIds, ...newOrgIds])]
+        await commonMemberService.startAffiliationRecalculation(record.id, allAffectedOrgIds, false)
+      }
 
       if (syncToOpensearch) {
         await searchSyncService.triggerMemberSync(record.id)
@@ -800,6 +818,12 @@ export default class MemberService extends LoggerBase {
   ) {
     let transaction
     try {
+      const existingOrgIds = data.organizations
+        ? (await fetchMemberOrganizations(optionsQx(this.options), id)).map(
+            (o) => o.organizationId,
+          )
+        : []
+
       const repoOptions = await SequelizeRepository.createTransactionalRepositoryOptions(
         this.options,
       )
@@ -824,9 +848,11 @@ export default class MemberService extends LoggerBase {
         this.options.temporal,
         this.options.log,
       )
+      const newOrgIds = (data.organizations || []).map((o) => o.id)
+      const allAffectedOrgIds = [...new Set([...existingOrgIds, ...newOrgIds])]
       await commonMemberService.startAffiliationRecalculation(
         id,
-        (data.organizations || []).map((o) => o.id),
+        allAffectedOrgIds,
         syncToOpensearch,
       )
 

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -277,12 +277,7 @@ export default class MemberService extends LoggerBase {
       data.displayName = data.username[data.platform].username
     }
 
-    const existingOrgIds =
-      existing && data.organizations
-        ? (await fetchMemberOrganizations(optionsQx(this.options), existing.id)).map(
-            (o) => o.organizationId,
-          )
-        : []
+    let existingOrgIds: string[] = []
 
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
@@ -444,6 +439,13 @@ export default class MemberService extends LoggerBase {
       let record
       if (existing) {
         const { id } = existing
+
+        if (data.organizations) {
+          existingOrgIds = (await fetchMemberOrganizations(optionsQx(this.options), id)).map(
+            (o) => o.organizationId,
+          )
+        }
+
         delete existing.id
         const toUpdate = CommonMemberService.membersMerge(existing, data)
 
@@ -521,7 +523,11 @@ export default class MemberService extends LoggerBase {
         )
         const newOrgIds = data.organizations.map((o) => o.id)
         const allAffectedOrgIds = [...new Set([...existingOrgIds, ...newOrgIds])]
-        await commonMemberService.startAffiliationRecalculation(record.id, allAffectedOrgIds, false)
+        await commonMemberService.startAffiliationRecalculation(
+          record.id,
+          allAffectedOrgIds,
+          syncToOpensearch,
+        )
       }
 
       if (syncToOpensearch) {

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -277,11 +277,12 @@ export default class MemberService extends LoggerBase {
       data.displayName = data.username[data.platform].username
     }
 
-    const existingOrgIds = existing && data.organizations
-      ? (await fetchMemberOrganizations(optionsQx(this.options), existing.id)).map(
-          (o) => o.organizationId,
-        )
-      : []
+    const existingOrgIds =
+      existing && data.organizations
+        ? (await fetchMemberOrganizations(optionsQx(this.options), existing.id)).map(
+            (o) => o.organizationId,
+          )
+        : []
 
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
@@ -819,9 +820,7 @@ export default class MemberService extends LoggerBase {
     let transaction
     try {
       const existingOrgIds = data.organizations
-        ? (await fetchMemberOrganizations(optionsQx(this.options), id)).map(
-            (o) => o.organizationId,
-          )
+        ? (await fetchMemberOrganizations(optionsQx(this.options), id)).map((o) => o.organizationId)
         : []
 
       const repoOptions = await SequelizeRepository.createTransactionalRepositoryOptions(

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -481,6 +481,17 @@ export default class MemberService extends LoggerBase {
                 this.log,
                 'memberService -> create -> addToMember',
               )
+
+              const commonMemberService = new CommonMemberService(
+                dbStoreQx(this.store),
+                this.temporal,
+                this.log,
+              )
+              await commonMemberService.startAffiliationRecalculation(
+                id,
+                orgsToAdd.map((o) => o.id),
+                false,
+              )
             }
           }
 
@@ -716,6 +727,17 @@ export default class MemberService extends LoggerBase {
                 () => orgService.addToMember([segmentId], id, orgsToAdd),
                 this.log,
                 'memberService -> update -> addToMember',
+              )
+
+              const commonMemberService = new CommonMemberService(
+                dbStoreQx(this.store),
+                this.temporal,
+                this.log,
+              )
+              await commonMemberService.startAffiliationRecalculation(
+                id,
+                orgsToAdd.map((o) => o.id),
+                false,
               )
             }
           }

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -75,6 +75,7 @@ export class CommonMemberService extends LoggerBase {
     replace: any,
     segmentIds: string[],
     options?: any,
+    triggerRecalc = true,
   ): Promise<void> {
     if (!organizations) {
       return
@@ -168,7 +169,7 @@ export class CommonMemberService extends LoggerBase {
       }),
     )
 
-    if (affectedOrgIds.size > 0) {
+    if (triggerRecalc && affectedOrgIds.size > 0) {
       await this.startAffiliationRecalculation(memberId, [...affectedOrgIds], true)
     }
   }

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -116,7 +116,6 @@ export class CommonMemberService extends LoggerBase {
         }
 
         for (const org of normalizedOrgs) {
-
           // we don't need to touch exactly same existing work experiences
           if (
             !originalOrgs.some(

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -84,6 +84,8 @@ export class CommonMemberService extends LoggerBase {
       return moment(v).toISOString()
     }
 
+    const affectedOrgIds = new Set<string>()
+
     await captureApiChange(
       options,
       memberEditOrganizationsAction(memberId, async (captureOldState, captureNewState) => {
@@ -108,6 +110,7 @@ export class CommonMemberService extends LoggerBase {
           for (const item of toDelete) {
             await deleteMemberOrganizations(this.qx, memberId, [item.id])
             ;(item as any).delete = true
+            affectedOrgIds.add(item.organizationId)
           }
         }
 
@@ -157,12 +160,17 @@ export class CommonMemberService extends LoggerBase {
 
             await addOrgsToSegments(this.qx, segmentIds, [org.id])
             newOrgs.push(newOrg)
+            affectedOrgIds.add(org.id)
           }
         }
 
         captureNewState(newOrgs)
       }),
     )
+
+    if (affectedOrgIds.size > 0) {
+      await this.startAffiliationRecalculation(memberId, [...affectedOrgIds], true)
+    }
   }
 
   public async findAffiliation(

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -75,7 +75,6 @@ export class CommonMemberService extends LoggerBase {
     replace: any,
     segmentIds: string[],
     options?: any,
-    triggerRecalc = true,
   ): Promise<void> {
     if (!organizations) {
       return
@@ -84,8 +83,6 @@ export class CommonMemberService extends LoggerBase {
     function iso(v) {
       return moment(v).toISOString()
     }
-
-    const affectedOrgIds = new Set<string>()
 
     await captureApiChange(
       options,
@@ -111,7 +108,6 @@ export class CommonMemberService extends LoggerBase {
           for (const item of toDelete) {
             await deleteMemberOrganizations(this.qx, memberId, [item.id])
             ;(item as any).delete = true
-            affectedOrgIds.add(item.organizationId)
           }
         }
 
@@ -122,10 +118,10 @@ export class CommonMemberService extends LoggerBase {
           if (
             !originalOrgs.some(
               (w) =>
-                w.organizationId === item.id &&
-                w.title === (item.title || null) &&
-                w.dateStart === (item.startDate || null) &&
-                w.dateEnd === (item.endDate || null),
+                w.organizationId === org.id &&
+                w.title === (org.title || null) &&
+                w.dateStart === (org.startDate || null) &&
+                w.dateEnd === (org.endDate || null),
             )
           ) {
             const newOrg = {
@@ -161,26 +157,12 @@ export class CommonMemberService extends LoggerBase {
 
             await addOrgsToSegments(this.qx, segmentIds, [org.id])
             newOrgs.push(newOrg)
-            affectedOrgIds.add(org.id)
           }
         }
 
         captureNewState(newOrgs)
       }),
     )
-
-    if (triggerRecalc && affectedOrgIds.size > 0) {
-      this.log.info(
-        { memberId, affectedOrgIds: [...affectedOrgIds] },
-        'Member organizations updated — triggering affiliation recalculation',
-      )
-      await this.startAffiliationRecalculation(memberId, [...affectedOrgIds], true)
-    } else {
-      this.log.info(
-        { memberId, affectedOrgIds: [...affectedOrgIds], triggerRecalc },
-        'Member organizations updated — skipping affiliation recalculation',
-      )
-    }
   }
 
   public async findAffiliation(

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -259,7 +259,10 @@ export class CommonMemberService extends LoggerBase {
     organizationIds: string[],
     syncToOpensearch = false,
   ): Promise<void> {
-    this.log.info({ memberId, organizationIds, syncToOpensearch }, 'Starting affiliation recalculation workflow')
+    this.log.info(
+      { memberId, organizationIds, syncToOpensearch },
+      'Starting affiliation recalculation workflow',
+    )
     await this.temporal.workflow.start('memberUpdate', {
       taskQueue: 'profiles',
       workflowId: `${TemporalWorkflowId.MEMBER_UPDATE}/${DEFAULT_TENANT_ID}/${memberId}`,

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -170,7 +170,16 @@ export class CommonMemberService extends LoggerBase {
     )
 
     if (triggerRecalc && affectedOrgIds.size > 0) {
+      this.log.info(
+        { memberId, affectedOrgIds: [...affectedOrgIds] },
+        'Member organizations updated — triggering affiliation recalculation',
+      )
       await this.startAffiliationRecalculation(memberId, [...affectedOrgIds], true)
+    } else {
+      this.log.info(
+        { memberId, affectedOrgIds: [...affectedOrgIds], triggerRecalc },
+        'Member organizations updated — skipping affiliation recalculation',
+      )
     }
   }
 
@@ -250,6 +259,7 @@ export class CommonMemberService extends LoggerBase {
     organizationIds: string[],
     syncToOpensearch = false,
   ): Promise<void> {
+    this.log.info({ memberId, organizationIds, syncToOpensearch }, 'Starting affiliation recalculation workflow')
     await this.temporal.workflow.start('memberUpdate', {
       taskQueue: 'profiles',
       workflowId: `${TemporalWorkflowId.MEMBER_UPDATE}/${DEFAULT_TENANT_ID}/${memberId}`,

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -84,6 +84,10 @@ export class CommonMemberService extends LoggerBase {
       return moment(v).toISOString()
     }
 
+    const normalizedOrgs = organizations.map((item) =>
+      typeof item === 'string' ? { id: item } : item,
+    )
+
     await captureApiChange(
       options,
       memberEditOrganizationsAction(memberId, async (captureOldState, captureNewState) => {
@@ -95,7 +99,7 @@ export class CommonMemberService extends LoggerBase {
         if (replace) {
           const toDelete = originalOrgs.filter(
             (originalOrg: any) =>
-              !organizations.find(
+              !normalizedOrgs.find(
                 (newOrg) =>
                   originalOrg.organizationId === newOrg.id &&
                   (originalOrg.title === (newOrg.title || null) ||
@@ -111,8 +115,7 @@ export class CommonMemberService extends LoggerBase {
           }
         }
 
-        for (const item of organizations) {
-          const org = typeof item === 'string' ? { id: item } : item
+        for (const org of normalizedOrgs) {
 
           // we don't need to touch exactly same existing work experiences
           if (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes workflow triggering and the set of organization IDs used for affiliation recomputation, which can affect correctness/performance of affiliation data if mis-scoped or called too often.
> 
> **Overview**
> Ensures member affiliation data is recalculated whenever a member’s organizations are added/updated.
> 
> On backend member `upsert`/`update`, the code now fetches existing organization IDs and triggers `CommonMemberService.startAffiliationRecalculation` with the union of *old + new* org IDs so removals and additions are both covered. The data sink worker also triggers the recalculation workflow after it adds organizations to a member, and `updateMemberOrganizations` now normalizes org inputs consistently; `startAffiliationRecalculation` adds structured logging before starting the Temporal workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b65c266e017d465173caa12660b3b5f9c94a8bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->