### PR TITLE
fix: skip records without email

### DIFF
--- a/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/buildSourceQuery.ts
+++ b/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/buildSourceQuery.ts
@@ -55,7 +55,8 @@ export const buildSourceQuery = (sinceTimestamp?: string): string => {
     AND u.lf_username IS NOT NULL
   LEFT JOIN org_accounts org
     ON er.account_id = org.account_id
-  WHERE ${LFID_COALESCE} IS NOT NULL`
+  WHERE er.email IS NOT NULL
+    AND ${LFID_COALESCE} IS NOT NULL`
 
   // Limit to a single project in non-prod to avoid exporting all projects data
   if (!IS_PROD_ENV) {

--- a/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/transformer.ts
+++ b/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/transformer.ts
@@ -23,6 +23,13 @@ export class CventTransformer extends TransformerBase {
     const firstName = (row.FIRST_NAME as string | null)?.trim() || null
     const lastName = (row.LAST_NAME as string | null)?.trim() || null
     const email = (row.EMAIL as string).trim()
+    if (!email) {
+      log.warn(
+        { registrationId: row.REGISTRATION_ID, userName, lfUsername },
+        'Skipping row: empty email',
+      )
+      return null
+    }
 
     const registrationId = (row.REGISTRATION_ID as string)?.trim()
     const sourceId = (row.USER_ID as string | null) || undefined

--- a/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/transformer.ts
+++ b/services/apps/snowflake_connectors/src/integrations/cvent/event-registrations/transformer.ts
@@ -22,14 +22,7 @@ export class CventTransformer extends TransformerBase {
     const fullName = (row.FULL_NAME as string | null)?.trim() || null
     const firstName = (row.FIRST_NAME as string | null)?.trim() || null
     const lastName = (row.LAST_NAME as string | null)?.trim() || null
-    const email = (row.EMAIL as string | null)?.trim() || null
-    if (!email) {
-      log.debug(
-        { registrationId: row.REGISTRATION_ID, userName, lfUsername },
-        'Skipping row: missing email',
-      )
-      return null
-    }
+    const email = (row.EMAIL as string).trim()
 
     const registrationId = (row.REGISTRATION_ID as string)?.trim()
     const sourceId = (row.USER_ID as string | null) || undefined


### PR DESCRIPTION
This pull request updates the event registration integration for Cvent to ensure that only rows with valid emails are processed, both at the data source and transformation stages. The changes improve data integrity by filtering out records without email addresses earlier in the pipeline and simplifying the transformation logic.

**Data filtering improvements:**

* The SQL query in `buildSourceQuery.ts` now explicitly filters out rows where `er.email` is null, preventing records without email addresses from being exported.

**Transformation logic simplification:**

* The `CventTransformer` no longer checks for missing emails or skips rows in the transformation step, as the query now guarantees that all rows have an email. The code for trimming and validating the email field is simplified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized data-quality filter and transformer assumption change; main risk is inadvertently dropping edge-case registrations where email is null/blank.
> 
> **Overview**
> Cvent event registration ingestion now **filters out records without emails earlier** by adding `er.email IS NOT NULL` to the Snowflake source query (`buildSourceQuery.ts`) alongside the existing LFID requirement.
> 
> The transformer (`CventTransformer`) now assumes `EMAIL` is present (non-null) and switches its skip condition to only guard against *empty* strings, logging a warning when encountered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1c975bd79dedc5b431063b620c3c449bea093c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->