### PR TITLE
fix: organization query (CM-1129)

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1296,6 +1296,25 @@ class OrganizationRepository {
     return { lfxMembershipFilter, updatedfilter }
   }
 
+  private static handleSearchFilter(filter: any): {
+    searchTerm: string | null
+    updatedFilter: any
+  } {
+    if (!filter || typeof filter !== 'object') {
+      return { searchTerm: null, updatedFilter: filter }
+    }
+
+    const updatedFilter = { ...filter }
+    let searchTerm: string | null = null
+
+    if (typeof updatedFilter.search === 'string' && updatedFilter.search.trim()) {
+      searchTerm = updatedFilter.search.trim()
+    }
+    delete updatedFilter.search
+
+    return { searchTerm, updatedFilter }
+  }
+
   static async findAndCountAll(
     {
       countOnly = false,
@@ -1428,6 +1447,10 @@ class OrganizationRepository {
 
     const withAggregates = include.aggregates
 
+    const { searchTerm, updatedFilter: filterWithoutSearch } =
+      OrganizationRepository.handleSearchFilter(filter)
+    filter = filterWithoutSearch
+
     const { lfxMembershipFilter, updatedfilter } =
       OrganizationRepository.handleLfxMembershipFilter(filter)
     filter = updatedfilter // updated filter without lfxMembershipFilter
@@ -1458,11 +1481,17 @@ class OrganizationRepository {
       segmentId = segment.id
     }
 
-    const params = {
+    const params: Record<string, any> = {
       limit,
       offset,
       segmentId,
       tenantId: options.currentTenant.id,
+    }
+
+    let searchWhereClause = ''
+    if (searchTerm) {
+      params.searchTerm = `%${searchTerm}%`
+      searchWhereClause = `AND o."displayName" ILIKE $(searchTerm)`
     }
 
     const filterString = RawQueryParser.parseFilters(
@@ -1498,6 +1527,7 @@ class OrganizationRepository {
       WHERE 1=1
         AND o."tenantId" = $(tenantId)
         ${lfxMembershipFilterWhereClause}
+        ${searchWhereClause}
         AND (${filterString})
     `
     const countQuery = createQuery('COUNT(*)')

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -1296,25 +1296,6 @@ class OrganizationRepository {
     return { lfxMembershipFilter, updatedfilter }
   }
 
-  private static handleSearchFilter(filter: any): {
-    searchTerm: string | null
-    updatedFilter: any
-  } {
-    if (!filter || typeof filter !== 'object') {
-      return { searchTerm: null, updatedFilter: filter }
-    }
-
-    const updatedFilter = { ...filter }
-    let searchTerm: string | null = null
-
-    if (typeof updatedFilter.search === 'string' && updatedFilter.search.trim()) {
-      searchTerm = updatedFilter.search.trim()
-    }
-    delete updatedFilter.search
-
-    return { searchTerm, updatedFilter }
-  }
-
   static async findAndCountAll(
     {
       countOnly = false,
@@ -1335,6 +1316,7 @@ class OrganizationRepository {
       limit = 20,
       offset = 0,
       orderBy = undefined,
+      search = undefined as string | undefined,
       segmentId = undefined,
     },
     options: IRepositoryOptions,
@@ -1351,6 +1333,7 @@ class OrganizationRepository {
       limit,
       offset,
       orderBy,
+      search,
       segmentId,
     })
 
@@ -1364,6 +1347,7 @@ class OrganizationRepository {
         cacheKey,
         {
           filter,
+          search,
           limit,
           offset,
           orderBy,
@@ -1385,6 +1369,7 @@ class OrganizationRepository {
         cacheKey,
         {
           filter,
+          search,
           segmentId,
           include,
         },
@@ -1405,6 +1390,7 @@ class OrganizationRepository {
       cacheKey,
       {
         filter,
+        search,
         limit,
         offset,
         orderBy,
@@ -1422,6 +1408,7 @@ class OrganizationRepository {
     cacheKey: string,
     {
       filter = {} as any,
+      search = undefined as string | undefined,
       limit = 20,
       offset = 0,
       orderBy = undefined,
@@ -1446,10 +1433,6 @@ class OrganizationRepository {
     const qx = SequelizeRepository.getQueryExecutor(options)
 
     const withAggregates = include.aggregates
-
-    const { searchTerm, updatedFilter: filterWithoutSearch } =
-      OrganizationRepository.handleSearchFilter(filter)
-    filter = filterWithoutSearch
 
     const { lfxMembershipFilter, updatedfilter } =
       OrganizationRepository.handleLfxMembershipFilter(filter)
@@ -1489,8 +1472,8 @@ class OrganizationRepository {
     }
 
     let searchWhereClause = ''
-    if (searchTerm) {
-      params.searchTerm = `%${searchTerm}%`
+    if (search) {
+      params.searchTerm = `%${search}%`
       searchWhereClause = `AND o."displayName" ILIKE $(searchTerm)`
     }
 
@@ -1679,6 +1662,7 @@ class OrganizationRepository {
     params: {
       // TODO: REMOVE this any
       filter?: any
+      search?: string
       limit: number
       offset: number
       orderBy?: string
@@ -1701,6 +1685,7 @@ class OrganizationRepository {
     cacheKey: string,
     params: {
       filter?: any
+      search?: string
       segmentId?: string
       include: any
     },

--- a/backend/src/database/repositories/organizationsQueryCache.ts
+++ b/backend/src/database/repositories/organizationsQueryCache.ts
@@ -38,6 +38,7 @@ export class OrganizationQueryCache {
     limit: number
     offset: number
     orderBy?: string
+    search?: string
     segmentId?: string
   }): string {
     const cleanParams = Object.fromEntries(
@@ -49,6 +50,7 @@ export class OrganizationQueryCache {
         limit: params.limit,
         offset: params.offset,
         orderBy: params.orderBy,
+        search: params.search,
         segmentId: params.segmentId,
       }).filter(([, value]) => value !== null && value !== undefined),
     )

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -1163,10 +1163,13 @@ export default class OrganizationService extends LoggerBase {
   }
 
   async query(data) {
-    const { filter, orderBy, limit, offset, segments } = data
+    const { filter: rawFilter, orderBy, limit, offset, segments } = data
+    const { search, ...filter } = rawFilter ?? {}
+    const searchTerm = typeof search === 'string' && search.trim() ? search.trim() : undefined
     return OrganizationRepository.findAndCountAll(
       {
         filter,
+        search: searchTerm,
         orderBy,
         limit,
         offset,

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -1163,9 +1163,8 @@ export default class OrganizationService extends LoggerBase {
   }
 
   async query(data) {
-    const { filter: rawFilter, orderBy, limit, offset, segments } = data
-    const { search, ...filter } = rawFilter ?? {}
-    const searchTerm = typeof search === 'string' && search.trim() ? search.trim() : undefined
+    const { filter, orderBy, limit, offset, segments, search: rawSearch } = data
+    const searchTerm = typeof rawSearch === 'string' && rawSearch.trim() ? rawSearch.trim() : undefined
     return OrganizationRepository.findAndCountAll(
       {
         filter,

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -1163,8 +1163,15 @@ export default class OrganizationService extends LoggerBase {
   }
 
   async query(data) {
-    const { filter, orderBy, limit, offset, segments, search: rawSearch } = data
-    const searchTerm = typeof rawSearch === 'string' && rawSearch.trim() ? rawSearch.trim() : undefined
+    const { filter: rawFilter, orderBy, limit, offset, segments, search: rawSearch } = data
+    const searchTerm =
+      typeof rawSearch === 'string' && rawSearch.trim() ? rawSearch.trim() : undefined
+
+    // Strip frontend-state keys that are never valid filter columns or operators.
+    // These can appear when the raw Pinia filter state is sent instead of the
+    // processed output of buildApiFilter.
+    const { search: _s, relation: _r, order: _o, settings: _st, ...filter } = rawFilter ?? {}
+
     return OrganizationRepository.findAndCountAll(
       {
         filter,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core organizations listing query and its Redis caching, which can affect result correctness and cache hit rates/performance if the new `search` handling is wrong or poorly indexed.
> 
> **Overview**
> Adds an optional `search` term to the organizations advanced query, applying a `displayName` `ILIKE` filter and including the term in the Redis cache key and background refresh params so cached results/counts remain consistent.
> 
> Hardens `OrganizationService.query` by trimming/validating `search` and stripping UI-only keys (`search`, `relation`, `order`, `settings`) from incoming filter payloads before building the repository query.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9accb2536c52ad7b48b9fcf1b06da76830e580cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->