### PR TITLE
fix: validate LLM work experience squash result

### DIFF
--- a/services/apps/members_enrichment_worker/src/activities/llm.ts
+++ b/services/apps/members_enrichment_worker/src/activities/llm.ts
@@ -327,7 +327,7 @@ export async function squashWorkExperiencesWithLLM(
             "startDate": "2020-06-01",
             "endDate": "2021-12-31",
             "source": "LinkedIn"
-          }
+          },
           {
             "name": "Company Y",
             "title": "Manager",
@@ -338,8 +338,7 @@ export async function squashWorkExperiencesWithLLM(
         ]
   
         Ensure the response is a **valid and complete JSON**.
-        DO NOT output anything else.
-        Output ONLY valid JSON
+        Output ONLY valid JSON array. DO NOT output anything else.
     `
 
   const llmService = new LlmService(
@@ -351,8 +350,15 @@ export async function squashWorkExperiencesWithLLM(
     svc.log,
   )
 
-  const result = await llmService.squashWorkExperiencesFromMultipleSources<
+  const res = await llmService.squashWorkExperiencesFromMultipleSources<
     IMemberEnrichmentDataNormalizedOrganization[]
   >(memberId, prompt)
-  return result.result
+
+  if (!Array.isArray(res?.result)) {
+    const errorMessage = 'LLM returned invalid work experiences payload shape!'
+    svc.log.warn({ memberId, result: res?.result }, errorMessage)
+    throw new Error(errorMessage)
+  }
+
+  return res.result
 }


### PR DESCRIPTION
## Summary

- Ensure LLM work experience squashing returns a top-level JSON array.
- Throw on invalid response shape so Temporal retries instead of failing later with `.forEach is not a function`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity change, but it alters failure behavior in the enrichment workflow by throwing earlier and triggering Temporal retries when the LLM returns malformed JSON.
> 
> **Overview**
> Updates the work-experience squashing prompt to explicitly require a **top-level JSON array** response.
> 
> Adds a runtime shape check in `squashWorkExperiencesWithLLM` to verify `res.result` is an array, logging a warning and throwing an error when invalid to avoid downstream `.forEach`-style crashes and let Temporal retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f50bc35be51e0f6a02c09f822186e6a24566fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->