### PR TITLE
fix: return conflict for duplicate verified member identities (CM-1133)

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -319,6 +319,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpError'
+        '409':
+          description: Identity is already verified on another member.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HttpError'
 
   # ──────────────────────────────────────────────
   # Maintainer Roles

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -325,6 +325,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HttpError'
+              example:
+                error:
+                  code: CONFLICT
+                  message: Identity already verified on another member
 
   # ──────────────────────────────────────────────
   # Maintainer Roles

--- a/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
@@ -15,7 +15,6 @@ import {
 } from '@crowd/common_services'
 import {
   MemberField,
-  checkMemberIdentityExistence,
   deleteMemberIdentity,
   findMemberById,
   findMemberIdentityById,
@@ -86,23 +85,21 @@ export async function verifyMemberIdentity(req: Request, res: Response): Promise
       captureOldState(identity)
 
       await qx.tx(async (tx) => {
-        if (verified) {
-          const existingIdentities = await checkMemberIdentityExistence(
-            tx,
-            identity.value,
-            identity.platform,
-            identity.type,
-          )
+        try {
+          updatedIdentity = await updateMemberIdentity(tx, memberId, identityId, {
+            verified,
+            verifiedBy,
+          })
+        } catch (error) {
+          const constraint =
+            error.constraint ?? error.original?.constraint ?? error.parent?.constraint
 
-          if (existingIdentities.some((i) => i.memberId !== memberId && i.verified)) {
+          if (verified && constraint === 'uix_memberIdentities_platform_value_type_verified') {
             throw new ConflictError('Identity already verified on another member')
           }
-        }
 
-        updatedIdentity = await updateMemberIdentity(tx, memberId, identityId, {
-          verified,
-          verifiedBy,
-        })
+          throw error
+        }
 
         if (!updatedIdentity) {
           throw new InternalError('Failed to update member identity')

--- a/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
@@ -6,7 +6,7 @@ import {
   memberUnmergeAction,
   memberVerifyIdentityAction,
 } from '@crowd/audit-logs'
-import { InternalError, NotFoundError } from '@crowd/common'
+import { ConflictError, InternalError, NotFoundError } from '@crowd/common'
 import {
   invalidateMemberQueryCache,
   prepareMemberUnmerge,
@@ -15,6 +15,7 @@ import {
 } from '@crowd/common_services'
 import {
   MemberField,
+  checkMemberIdentityExistence,
   deleteMemberIdentity,
   findMemberById,
   findMemberIdentityById,
@@ -85,6 +86,19 @@ export async function verifyMemberIdentity(req: Request, res: Response): Promise
       captureOldState(identity)
 
       await qx.tx(async (tx) => {
+        if (verified) {
+          const existingIdentities = await checkMemberIdentityExistence(
+            tx,
+            identity.value,
+            identity.platform,
+            identity.type,
+          )
+
+          if (existingIdentities.some((i) => i.memberId !== memberId && i.verified)) {
+            throw new ConflictError('Identity already verified on another member')
+          }
+        }
+
         updatedIdentity = await updateMemberIdentity(tx, memberId, identityId, {
           verified,
           verifiedBy,


### PR DESCRIPTION
## Summary
- Return `409 Conflict` when verifying a member identity that is already verified on another member.
- Preserve the db uniqueness invariant while avoiding public API `500` responses for expected identity conflicts.
- Document the new `409` response in the public OpenAPI spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to member identity verification error handling and OpenAPI documentation, with no schema or workflow changes beyond mapping a known DB uniqueness violation to a 409 response.
> 
> **Overview**
> Prevents expected duplicate-verified identity collisions from surfacing as `500` errors by catching the DB unique-constraint violation during `verifyMemberIdentity` and returning a `409 Conflict` (`ConflictError`) when an identity is already verified on another member.
> 
> Updates the public `openapi.yaml` spec for `PATCH /members/{memberId}/identities/{identityId}` to document the new `409` response and example payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b93a59879b4faab528166458b208784d9aa8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->