### PR TITLE
fix: handle member identity unique constraint conflicts

### DIFF
--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -5,7 +5,6 @@ import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
 import { ConflictError, NotFoundError } from '@crowd/common'
 import {
   MemberField,
-  checkMemberIdentityExistence,
   findMemberById,
   createMemberIdentity as insertMemberIdentity,
   optionsQx,
@@ -53,37 +52,35 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
       captureOldState({})
 
       await qx.tx(async (tx) => {
-        const existing = await checkMemberIdentityExistence(
-          tx,
-          data.value,
-          data.platform,
-          data.type,
-        )
+        try {
+          result = await insertMemberIdentity(
+            tx,
+            {
+              memberId,
+              platform: data.platform,
+              value: data.value,
+              type: data.type,
+              source: data.source,
+              verified: data.verified,
+              verifiedBy: data.verifiedBy,
+            },
+            true,
+            true,
+          )
+        } catch (error) {
+          const constraint =
+            error.constraint ?? error.original?.constraint ?? error.parent?.constraint
 
-        for (const identity of existing) {
-          if (identity.memberId === memberId) {
+          if (constraint === 'uix_memberIdentities_memberId_platform_value_type') {
             throw new ConflictError('Identity already exists on this member')
           }
 
-          if (identity.verified) {
+          if (constraint === 'uix_memberIdentities_platform_value_type_verified') {
             throw new ConflictError('Identity already verified on another member')
           }
-        }
 
-        result = await insertMemberIdentity(
-          tx,
-          {
-            memberId,
-            platform: data.platform,
-            value: data.value,
-            type: data.type,
-            source: data.source,
-            verified: data.verified,
-            verifiedBy: data.verifiedBy,
-          },
-          true,
-          true,
-        )
+          throw error
+        }
 
         // touch member updated at to trigger merge suggestion
         await touchMemberUpdatedAt(tx, memberId)


### PR DESCRIPTION
## Summary
- Handle unique constraint conflicts when creating member identities in the public API.
- Convert duplicate identity DB errors into `409 Conflict` responses instead of unhandled `500` errors.
- Remove the redundant pre-insert identity existence check and rely on DB constraints as the source of truth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to the public member identity create endpoint that maps known DB uniqueness violations to `409 Conflict` instead of surfacing `500` errors.
> 
> **Overview**
> Updates the public `POST` member identity creation flow to rely on DB uniqueness constraints rather than a pre-insert existence check.
> 
> On insert, it now catches specific unique-index violations (duplicate identity on the same member, or an identity already verified on another member) and returns `409 Conflict` with clearer messages, while rethrowing unexpected errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018bd12a1dadf1cc03ef06fbc2dd2dc9d1c24947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->