### PR TITLE
fix: early return for empty segments (CM-1136)

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -294,7 +294,12 @@ class MemberRepository {
     if (segmentIds.length === 0) {
       return args.countOnly
         ? { count: 0 }
-        : { rows: [], count: 0, limit: args.limit, offset: args.offset }
+        : {
+            rows: [{ members: [], similarity: 0 }],
+            count: 0,
+            limit: args.limit,
+            offset: args.offset,
+          }
     }
 
     let similarityFilter = ''

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -293,7 +293,7 @@ class MemberRepository {
 
     if (segmentIds.length === 0) {
       return args.countOnly
-        ? { count: 0 }
+        ? { count: '0' }
         : {
             rows: [{ members: [], similarity: 0 }],
             count: 0,

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -291,6 +291,12 @@ class MemberRepository {
       await new SegmentRepository(options).getSegmentSubprojects(currentSegments)
     ).map((s) => s.id)
 
+    if (segmentIds.length === 0) {
+      return args.countOnly
+        ? { count: 0 }
+        : { rows: [], count: 0, limit: args.limit, offset: args.offset }
+    }
+
     let similarityFilter = ''
     const similarityConditions = []
 

--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -296,6 +296,8 @@ class SegmentRepository extends RepositoryBase<
   }
 
   async getSegmentSubprojects(segments: string[]) {
+    if (segments.length === 0) return []
+
     const transaction = this.transaction
 
     const records = await this.options.database.sequelize.query(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk control-flow change that avoids running SQL queries when no segments/subprojects are selected; main risk is slight response-shape differences for callers expecting query execution on empty input.
> 
> **Overview**
> Prevents merge-suggestion lookups from querying the database when the current segment selection resolves to no subprojects by adding an early return in `MemberRepository.findMembersWithMergeSuggestions` (returns zero count / empty rows).
> 
> Adds a guard in `SegmentRepository.getSegmentSubprojects` to immediately return `[]` when called with an empty segment list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209cd957f9ffb5f9608d11b6ebd0f38944f3ef7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->