### PR TITLE
fix: soft-delete undated duplicate member organization rows

### DIFF
--- a/services/apps/cron_service/src/jobs/inferMemberOrganizationStintChanges.job.ts
+++ b/services/apps/cron_service/src/jobs/inferMemberOrganizationStintChanges.job.ts
@@ -10,6 +10,7 @@ import {
   changeMemberOrganizationAffiliationOverrides,
   checkOrganizationAffiliationPolicy,
   createMemberOrganization,
+  deleteUndatedMemberOrganizations,
   fetchMemberOrganizationsBySource,
   updateMemberOrganization,
 } from '@crowd/data-access-layer'
@@ -136,6 +137,10 @@ async function applyStintChanges(qx: QueryExecutor, changes: MemberOrgStintChang
       })
     }
   }
+
+  await deleteUndatedMemberOrganizations(qx, changes[0].memberId, [
+    ...new Set(changes.map((c) => c.organizationId)),
+  ])
 }
 
 export default job

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -482,6 +482,29 @@ export async function deleteMemberOrganizations(
   })
 }
 
+export async function deleteUndatedMemberOrganizations(
+  qx: QueryExecutor,
+  memberId: string,
+  organizationIds: string[],
+): Promise<void> {
+  if (organizationIds.length === 0) {
+    return
+  }
+
+  await qx.result(
+    `
+      UPDATE "memberOrganizations"
+      SET "deletedAt" = NOW()
+      WHERE "memberId" = $(memberId)
+        AND "organizationId" IN ($(organizationIds:csv))
+        AND "dateStart" IS NULL
+        AND "dateEnd" IS NULL
+        AND "deletedAt" IS NULL
+    `,
+    { memberId, organizationIds },
+  )
+}
+
 export async function cleanSoftDeletedMemberOrganization(
   qx: QueryExecutor,
   memberId: string,

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -491,18 +491,36 @@ export async function deleteUndatedMemberOrganizations(
     return
   }
 
-  await qx.result(
-    `
-      UPDATE "memberOrganizations"
-      SET "deletedAt" = NOW()
-      WHERE "memberId" = $(memberId)
-        AND "organizationId" IN ($(organizationIds:csv))
-        AND "dateStart" IS NULL
-        AND "dateEnd" IS NULL
-        AND "deletedAt" IS NULL
-    `,
-    { memberId, organizationIds },
-  )
+  const whereClause = `
+    "memberId" = $(memberId)
+    AND "organizationId" IN ($(organizationIds:csv))
+    AND "dateStart" IS NULL
+    AND "dateEnd" IS NULL
+    AND "deletedAt" IS NULL
+  `
+
+  const params = { memberId, organizationIds }
+
+  await qx.tx(async (tx) => {
+    await tx.result(
+      `
+        DELETE FROM "memberOrganizationAffiliationOverrides"
+        WHERE "memberOrganizationId" IN (
+          SELECT "id" FROM "memberOrganizations" WHERE ${whereClause}
+        )
+      `,
+      params,
+    )
+
+    await tx.result(
+      `
+        UPDATE "memberOrganizations"
+        SET "deletedAt" = NOW()
+        WHERE ${whereClause}
+      `,
+      params,
+    )
+  })
 }
 
 export async function cleanSoftDeletedMemberOrganization(


### PR DESCRIPTION
## Summary

This PR prevents duplicate "Unknown" work-history rows after email-domain stint inference.

When the cron job infers a dated `email-domain` row for a `(memberId, organizationId)`, it now also soft-deletes any active undated rows for the same pair (`dateStart IS NULL` and `dateEnd IS NULL`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches work-history persistence by soft-deleting rows (and related affiliation overrides), so a bug could remove legitimate undated records for affected orgs; scope is limited to inferred members/orgs with null dates.
> 
> **Overview**
> Prevents duplicate "unknown date" work-history rows after email-domain stint inference by cleaning up any active `memberOrganizations` for the same member/org where both `dateStart` and `dateEnd` are `NULL`.
> 
> Adds `deleteUndatedMemberOrganizations` in the data-access layer to transactional soft-delete those undated rows and remove their `memberOrganizationAffiliationOverrides`, and invokes it at the end of `inferMemberOrganizationStintChanges` processing for the orgs affected in the current batch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b0d264852fbbcc1c89bbdc558b38266b5530c9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->