### PR TITLE
fix: prevent overlapping orgs from splitting inferred stints (CM-1143)

### DIFF
--- a/services/libs/common_services/src/services/member-organization.ts
+++ b/services/libs/common_services/src/services/member-organization.ts
@@ -201,23 +201,26 @@ export function inferMemberOrganizationStintChanges(
       continue
     }
 
-    // 5. Determine the gap window between neighbor and targetDate, then check if another org
-    // holds a significant (>= 30 day) dated stint that overlaps that window (multi-stint guard)
+    // Only split when another org clearly sits between this stint and the new date.
+    // Overlapping orgs are treated as concurrent evidence, not a break in the stint.
     const isForward = targetDate > neighbor.dateEnd
-    const gapStart = isForward ? neighbor.dateEnd : targetDate
-    const gapEnd = isForward ? targetDate : neighbor.dateStart
-    const hasConflict = stints.some(
-      (s) =>
-        s.organizationId !== organizationId &&
-        s.dateStart &&
-        s.dateEnd &&
-        s.dateStart < gapEnd &&
-        s.dateEnd > gapStart &&
-        diff(s.dateStart, s.dateEnd) >= 30,
-    )
+    const hasSeparator = stints.some((s) => {
+      if (
+        s.organizationId === organizationId ||
+        !s.dateStart ||
+        !s.dateEnd ||
+        diff(s.dateStart, s.dateEnd) < 30
+      ) {
+        return false
+      }
 
-    if (hasConflict) {
-      // 6a. Another org owns the gap — start a fresh stint rather than bridging
+      return isForward
+        ? s.dateStart > neighbor.dateEnd && s.dateStart <= targetDate
+        : s.dateEnd < neighbor.dateStart && s.dateEnd >= targetDate
+    })
+
+    if (hasSeparator) {
+      // 6a. Another org clearly sits in between — start a fresh stint rather than bridging
       stints.push({
         id: null,
         organizationId,

--- a/services/libs/common_services/src/services/member-organization.ts
+++ b/services/libs/common_services/src/services/member-organization.ts
@@ -201,7 +201,7 @@ export function inferMemberOrganizationStintChanges(
       continue
     }
 
-    // Only split when another org clearly sits between this stint and the new date.
+    // 5. Only split when another org clearly sits between this stint and the new date.
     // Overlapping orgs are treated as concurrent evidence, not a break in the stint.
     const isForward = targetDate > neighbor.dateEnd
     const hasSeparator = stints.some((s) => {

--- a/services/libs/common_services/src/services/member-organization.ts
+++ b/services/libs/common_services/src/services/member-organization.ts
@@ -214,9 +214,17 @@ export function inferMemberOrganizationStintChanges(
         return false
       }
 
-      return isForward
-        ? s.dateStart > neighbor.dateEnd && s.dateStart <= targetDate
-        : s.dateEnd < neighbor.dateStart && s.dateEnd >= targetDate
+      if (isForward) {
+        return (
+          (s.dateStart > neighbor.dateEnd && s.dateStart <= targetDate) ||
+          (s.dateEnd > neighbor.dateEnd && s.dateEnd <= targetDate)
+        )
+      }
+
+      return (
+        (s.dateStart >= targetDate && s.dateStart < neighbor.dateStart) ||
+        (s.dateEnd >= targetDate && s.dateEnd < neighbor.dateStart)
+      )
     })
 
     if (hasSeparator) {


### PR DESCRIPTION
## Summary

This PR fixes a stint-inference bug in the email-domain cron flow that could generate many one-day `memberOrganizations` rows for the same `(member, organization)`.

The root cause was the multi-stint guard: it treated any long overlap from another org as a break, which made the job insert new stints repeatedly instead of extending the existing one.

The logic now treats another org as a separator only when one of its date boundaries falls between the nearest same-org stint and the incoming activity date. Fully overlapping/concurrent rows stay on the normal debounce/extend path. This preserves intended multi-stint behavior (A → B → A) while preventing overlap-driven row explosion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stint-inference splitting logic, which can affect how `memberOrganizations` rows are inserted/extended and therefore impacts historical data shape. While scoped to a small block, edge cases in date-boundary detection could still alter multi-stint outcomes.
> 
> **Overview**
> Prevents inferred `memberOrganizations` stints from being split just because another organization has a long overlapping stint.
> 
> Replaces the previous “gap overlap” conflict check with a stricter *separator* rule that only starts a new stint when another org’s `dateStart`/`dateEnd` falls between the nearest same-org stint and the incoming `targetDate`; otherwise the existing stint continues to use the normal debounce/extend path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4461a9a12f20a0f774155bfb2975ee8db422ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->