### PR TITLE
fix: prevent 500 on contributor identity update by filtering non-updatable fields

### DIFF
--- a/frontend/src/modules/contributor/components/edit/identity/contributor-identity-edit.vue
+++ b/frontend/src/modules/contributor/components/edit/identity/contributor-identity-edit.vue
@@ -129,12 +129,13 @@ const updateIdentity = () => {
   sending.value = true;
 
   updateContributorIdentity(props.contributor.id, props.modelValue.id, {
-    ...form,
+    value: form.value,
+    type: form.type,
+    platform: form.type === 'email' ? 'custom' : form.platform,
     verified: false,
     source: 'ui',
-    integrationId: null,
     sourceId: null,
-    platform: form.type === 'email' ? 'custom' : form.platform,
+    integrationId: null,
   })
     .then(() => {
       ToastStore.success('Identity updated successfully');

--- a/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
+++ b/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
@@ -36,6 +36,11 @@ export class ContributorIdentitiesApiService {
     return authAxios.patch(
       `/member/${memberId}/identity/${id}`,
       payload,
+      {
+        params: {
+          segments: getSegments(),
+        },
+      },
     ).then(({ data }) => Promise.resolve(data));
   }
 

--- a/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
+++ b/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
@@ -1,5 +1,5 @@
 import authAxios from '@/shared/axios/auth-axios';
-import { ContributorIdentity } from '@/modules/contributor/types/Contributor';
+import { ContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
 import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 
@@ -32,13 +32,10 @@ export class ContributorIdentitiesApiService {
     ).then(({ data }) => Promise.resolve(data));
   }
 
-  static async update(memberId: string, id: string, identity: Partial<ContributorIdentity>) {
+  static async update(memberId: string, id: string, payload: UpdateContributorIdentityPayload) {
     return authAxios.patch(
       `/member/${memberId}/identity/${id}`,
-      {
-        ...identity,
-        segments: getSegments(),
-      },
+      payload,
     ).then(({ data }) => Promise.resolve(data));
   }
 

--- a/frontend/src/modules/contributor/store/contributor.actions.ts
+++ b/frontend/src/modules/contributor/store/contributor.actions.ts
@@ -1,7 +1,7 @@
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { storeToRefs } from 'pinia';
 import { ContributorApiService } from '@/modules/contributor/services/contributor.api.service';
-import { Contributor, ContributorAffiliation, ContributorIdentity } from '@/modules/contributor/types/Contributor';
+import { Contributor, ContributorAffiliation, ContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
 import { ContributorIdentitiesApiService } from '@/modules/contributor/services/contributor.identities.api.service';
 import { MergeActionsService } from '@/shared/modules/merge/services/merge-actions.service';
 import { MergeAction } from '@/shared/modules/merge/types/MemberActions';
@@ -72,7 +72,7 @@ export default {
     return ContributorIdentitiesApiService.createMultiple(memberId, identities)
       .then(this.setIdentities);
   },
-  updateContributorIdentity(memberId: string, id: string, identity: Partial<ContributorIdentity>): Promise<ContributorIdentity[]> {
+  updateContributorIdentity(memberId: string, id: string, identity: UpdateContributorIdentityPayload): Promise<ContributorIdentity[]> {
     return ContributorIdentitiesApiService.update(memberId, id, identity)
       .then(this.setIdentities);
   },

--- a/frontend/src/modules/contributor/store/contributor.actions.ts
+++ b/frontend/src/modules/contributor/store/contributor.actions.ts
@@ -1,7 +1,9 @@
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { storeToRefs } from 'pinia';
 import { ContributorApiService } from '@/modules/contributor/services/contributor.api.service';
-import { Contributor, ContributorAffiliation, ContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
+import {
+  Contributor, ContributorAffiliation, ContributorIdentity, UpdateContributorIdentityPayload,
+} from '@/modules/contributor/types/Contributor';
 import { ContributorIdentitiesApiService } from '@/modules/contributor/services/contributor.identities.api.service';
 import { MergeActionsService } from '@/shared/modules/merge/services/merge-actions.service';
 import { MergeAction } from '@/shared/modules/merge/types/MemberActions';

--- a/frontend/src/modules/contributor/types/Contributor.ts
+++ b/frontend/src/modules/contributor/types/Contributor.ts
@@ -73,6 +73,16 @@ export interface ContributorIdentity {
   duplicatedIdentities?: ContributorIdentity[];
 }
 
+export interface UpdateContributorIdentityPayload {
+  value?: string;
+  type?: string;
+  platform?: string;
+  verified?: boolean;
+  source?: string | null;
+  sourceId?: string | null;
+  integrationId?: string | null;
+}
+
 export interface Contributor {
   activeDaysCount: string;
   activeOn: string[] | null;

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -113,18 +113,35 @@ export async function findMemberIdentitiesByValue(
   )
 }
 
+const UPDATABLE_IDENTITY_FIELDS: ReadonlyArray<keyof UpdateMemberIdentity> = [
+  'platform',
+  'value',
+  'type',
+  'verified',
+  'verifiedBy',
+  'source',
+  'sourceId',
+  'integrationId',
+]
+
 export async function updateMemberIdentity(
   qx: QueryExecutor,
   memberId: string,
   id: string,
   data: Partial<UpdateMemberIdentity>,
 ): Promise<IMemberIdentity> {
-  if (Object.keys(data).length === 0) return null
+  const filtered = Object.fromEntries(
+    Object.entries(data).filter(
+      ([k, v]) => (UPDATABLE_IDENTITY_FIELDS as readonly string[]).includes(k) && v !== undefined,
+    ),
+  )
 
-  const setClause = Object.keys(data).map((key) => `"${key}" = $(${key})`)
+  if (Object.keys(filtered).length === 0) return null
+
+  const setClause = Object.keys(filtered).map((key) => `"${key}" = $(${key})`)
   setClause.push('"updatedAt" = now()')
 
-  const params = { memberId, id, ...data }
+  const params = { memberId, id, ...filtered }
 
   const query = `
     UPDATE "memberIdentities"


### PR DESCRIPTION
## Issue

Updating a contributor identity from the UI returned a 500 from the backend.

The frontend was spreading the full identity object into the PATCH payload, so fields that aren't updatable (e.g. `createdAt`, `memberId`, `id`) were sent to the API. The backend's `updateMemberIdentity` then built a SQL `UPDATE` from every key it received, which produced an invalid statement and crashed the request.

## Fix

**Frontend** — only send fields the API is meant to accept.

- Introduced `UpdateContributorIdentityPayload` type with the updatable fields only (`value`, `type`, `platform`, `verified`, `source`, `sourceId`, `integrationId`).
- `contributor-identity-edit.vue` now picks `value` and `type` explicitly instead of spreading `form`.
- `ContributorIdentitiesApiService.update` and the `updateContributorIdentity` store action are typed against the new payload.

**Backend** — defense-in-depth so an unexpected field can't break the query again.

- `updateMemberIdentity` (`services/libs/data-access-layer/src/members/identities.ts`) now filters the incoming `data` against an allowlist (`UPDATABLE_IDENTITY_FIELDS`: `platform`, `value`, `type`, `verified`, `verifiedBy`, `source`, `sourceId`, `integrationId`) and drops `undefined` values before building the `SET` clause.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contributor identity update flow end-to-end (UI payload, API client, and SQL update builder); mistakes could prevent legitimate identity updates or silently drop fields.
> 
> **Overview**
> Prevents contributor identity updates from triggering backend 500s by **sending only allowed fields** from the UI and tightening types via a new `UpdateContributorIdentityPayload` used by the store action and `ContributorIdentitiesApiService.update`.
> 
> Adds **defense-in-depth** in `updateMemberIdentity` by allowlisting updatable columns and dropping `undefined` values before building the SQL `SET` clause, avoiding invalid updates when unexpected fields are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df4b7385f46b02afe20cf508a6c78d719f72737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->