### PR TITLE
fix: issue while merging member organizations (CM-1109)

### DIFF
--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -18,6 +18,9 @@ import { EmailDomainMemberOrganizationActivityDate } from './types'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+const toIsoString = (v: Date | string): string =>
+  v instanceof Date ? v.toISOString() : new Date(v).toISOString()
+
 export async function fetchMemberOrganizations(
   qx: QueryExecutor,
   memberId: string,
@@ -689,14 +692,14 @@ export async function removeMemberRole(qx: QueryExecutor, role: IMemberOrganizat
     conditions.push('"dateStart" IS NULL')
   } else {
     conditions.push('"dateStart" = $(dateStart)')
-    replacements.dateStart = (role.dateStart as Date).toISOString()
+    replacements.dateStart = toIsoString(role.dateStart)
   }
 
   if (role.dateEnd === null) {
     conditions.push('"dateEnd" IS NULL')
   } else {
     conditions.push('"dateEnd" = $(dateEnd)')
-    replacements.dateEnd = (role.dateEnd as Date).toISOString()
+    replacements.dateEnd = toIsoString(role.dateEnd)
   }
 
   const whereClause = conditions.join(' AND ')
@@ -991,7 +994,7 @@ export async function mergeRoles(
         if (new Date(memberOrganization.dateStart) <= new Date(currentRoles[0].dateStart)) {
           addRoles.push({
             id: currentRole.id,
-            dateStart: (memberOrganization.dateStart as Date).toISOString(),
+            dateStart: toIsoString(memberOrganization.dateStart as Date | string),
             dateEnd: null,
             memberId: currentRole.memberId,
             organizationId: currentRole.organizationId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches member-organization merge/delete logic used to reconcile work experiences; incorrect date normalization could change which rows are matched for removal or merging.
> 
> **Overview**
> Fixes member-organization merging/removal when `dateStart`/`dateEnd` values are sometimes strings instead of `Date` objects.
> 
> Adds a small `toIsoString` helper and uses it when building SQL predicates and merged role payloads, avoiding invalid casts/`toISOString()` calls during merge operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e100018bb8f6a938952d3be626b1c5ec39f659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->