### PR TITLE
fix: correct role removal and merge strategy in moveRoles

### DIFF
--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -949,13 +949,12 @@ function areDatesEqual(dateA: Date | string | null, dateB: Date | string | null)
 }
 
 function isSamePrimaryRole(a: IMemberOrganization, b: IMemberOrganization): boolean {
-  const isSameMember = a.memberId === b.memberId
-  const isSameOrganization = a.organizationId === b.organizationId
-  const isSameTitle = a.title === b.title
-  const hasSameStartDate = areDatesEqual(a.dateStart, b.dateStart)
-  const hasSameEndDate = areDatesEqual(a.dateEnd, b.dateEnd)
-
-  return isSameMember && isSameOrganization && isSameTitle && hasSameStartDate && hasSameEndDate
+  return (
+    a.memberId === b.memberId &&
+    a.organizationId === b.organizationId &&
+    areDatesEqual(a.dateStart, b.dateStart) &&
+    areDatesEqual(a.dateEnd, b.dateEnd)
+  )
 }
 
 export async function mergeRoles(

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -578,7 +578,7 @@ export interface IMergeStrat {
   targetOrganizationId(role: IMemberOrganization): string
 }
 
-type RoleToAdd = IMemberOrganization & { originalRoleIds?: string[] }
+type RoleToAdd = IMemberOrganization & { originalRoleIds: string[] }
 
 const MemberMergeStrat = (primaryMemberId: string): IMergeStrat => ({
   entityIdField: EntityField.memberId,
@@ -958,7 +958,7 @@ export async function mergeRoles(
     memberId: mergeStrat.targetMemberId(role),
     organizationId: mergeStrat.targetOrganizationId(role),
     source: role.source,
-    originalRoleIds: role.id ? [role.id] : undefined,
+    originalRoleIds: role.id ? [role.id] : [],
   })
 
   let shouldRecalculateAffiliations = false
@@ -1032,13 +1032,13 @@ export async function mergeRoles(
           if (new Date(secondary.dateStart) < new Date(existingCurrentAdd.dateStart)) {
             existingCurrentAdd.dateStart = new Date(secondary.dateStart).toISOString()
           }
-          if (secondary.id) existingCurrentAdd.originalRoleIds?.push(secondary.id)
+          if (secondary.id) existingCurrentAdd.originalRoleIds.push(secondary.id)
         } else {
           addRoles.push(toTargetEntity(secondary))
         }
       } else {
         const existingAdd = addRoles.find((r) =>
-          currentPrimaries.some((p) => p.id && r.originalRoleIds?.includes(p.id)),
+          currentPrimaries.some((p) => p.id && r.originalRoleIds.includes(p.id)),
         )
 
         const earliestStart = new Date(
@@ -1049,10 +1049,10 @@ export async function mergeRoles(
           if (!existingAdd.dateStart || new Date(earliestStart) < new Date(existingAdd.dateStart)) {
             existingAdd.dateStart = earliestStart
           }
-          if (secondary.id) existingAdd.originalRoleIds?.push(secondary.id)
+          if (secondary.id) existingAdd.originalRoleIds.push(secondary.id)
           for (const p of currentPrimaries) {
-            if (p.id && !existingAdd.originalRoleIds?.includes(p.id)) {
-              existingAdd.originalRoleIds?.push(p.id)
+            if (p.id && !existingAdd.originalRoleIds.includes(p.id)) {
+              existingAdd.originalRoleIds.push(p.id)
               queueRoleRemoval(p)
             }
           }
@@ -1096,7 +1096,7 @@ export async function mergeRoles(
         existingAdd.dateStart = new Date(minStart).toISOString()
         existingAdd.dateEnd = new Date(maxEnd).toISOString()
         for (const r of allNew) {
-          if (r.id) existingAdd.originalRoleIds?.push(r.id)
+          if (r.id) existingAdd.originalRoleIds.push(r.id)
         }
       } else {
         const allMatching = [...intersecting, secondary]
@@ -1139,7 +1139,7 @@ export async function mergeRoles(
     if (!targetRoleId) continue
 
     const relevant = overridesToRecreate.filter((item) =>
-      item.role.id ? addData.originalRoleIds?.includes(item.role.id) : false,
+      item.role.id ? addData.originalRoleIds.includes(item.role.id) : false,
     )
     const targetOrgBlocked = orgAffiliationPolicyById.get(addData.organizationId) ?? false
 

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -1028,7 +1028,7 @@ export async function mergeRoles(
 
         queueRoleRemoval(memberOrganization)
       } else {
-        throw new Error(`Member ${memberOrganization.memberId} has more than one current roles.`)
+        throw new Error(`Member ${memberOrganization.memberId} has more than one current role.`)
       }
     } else if (memberOrganization.dateStart === null && memberOrganization.dateEnd !== null) {
       throw new Error(`Member organization with dateEnd and without dateStart!`)

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -1043,12 +1043,12 @@ export async function mergeRoles(
           mergeStrat.intersectBasedOn(mo) === mergeStrat.intersectBasedOn(memberOrganization) &&
           mo.dateStart !== null &&
           mo.dateEnd !== null &&
-          ((secondaryStart < primaryStart && secondaryEnd > primaryStart) ||
-            (primaryStart < secondaryStart && secondaryEnd < primaryEnd) ||
-            (secondaryStart < primaryStart && secondaryEnd > primaryEnd) ||
-            (primaryStart < secondaryStart &&
+          ((secondaryStart <= primaryStart && secondaryEnd > primaryStart) ||
+            (primaryStart <= secondaryStart && secondaryEnd <= primaryEnd) ||
+            (secondaryStart <= primaryStart && secondaryEnd >= primaryEnd) ||
+            (primaryStart <= secondaryStart &&
               secondaryStart < primaryEnd &&
-              secondaryEnd > primaryEnd))
+              secondaryEnd >= primaryEnd))
         )
       })
 

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -578,6 +578,8 @@ export interface IMergeStrat {
   targetOrganizationId(role: IMemberOrganization): string
 }
 
+type RoleToAdd = IMemberOrganization & { originalRoleIds?: string[] }
+
 const MemberMergeStrat = (primaryMemberId: string): IMergeStrat => ({
   entityIdField: EntityField.memberId,
   intersectBasedOnField: EntityField.organizationId,
@@ -588,7 +590,7 @@ const MemberMergeStrat = (primaryMemberId: string): IMergeStrat => ({
     return role.organizationId
   },
   worthMerging(a: IMemberOrganization, b: IMemberOrganization): boolean {
-    return a.memberId === b.memberId
+    return a.organizationId === b.organizationId
   },
   targetMemberId(): string {
     return primaryMemberId
@@ -608,7 +610,7 @@ const OrgMergeStrat = (primaryOrganizationId: string): IMergeStrat => ({
     return role.memberId
   },
   worthMerging(a: IMemberOrganization, b: IMemberOrganization): boolean {
-    return a.organizationId === b.organizationId
+    return a.memberId === b.memberId
   },
   targetMemberId(role: IMemberOrganization): string {
     return role.memberId
@@ -928,7 +930,7 @@ export async function moveOrgsBetweenMembers(
 function transformRoleToTargetEntity(
   role: IMemberOrganization,
   mergeStrat: IMergeStrat,
-): IMemberOrganization & { originalRoleId?: string } {
+): RoleToAdd {
   return {
     title: role.title,
     dateStart: role.dateStart,
@@ -936,7 +938,7 @@ function transformRoleToTargetEntity(
     memberId: mergeStrat.targetMemberId(role),
     organizationId: mergeStrat.targetOrganizationId(role),
     source: role.source,
-    originalRoleId: role.id,
+    originalRoleIds: role.id ? [role.id] : undefined,
   }
 }
 
@@ -968,16 +970,23 @@ export async function mergeRoles(
   let shouldRecalculateAffiliations = false
   const allExistingOverrides = [...primaryAffiliationOverrides, ...secondaryAffiliationOverrides]
   const removeRoles: IMemberOrganization[] = []
-  const addRoles: (IMemberOrganization & { originalRoleId?: string })[] = []
+  const addRoles: RoleToAdd[] = []
   const affiliationOverridesToRecreate: {
     role: IMemberOrganization
     override: IMemberOrganizationAffiliationOverride
   }[] = []
+  const queueRoleRemoval = (role: IMemberOrganization) => {
+    if (role.id && removeRoles.some((r) => r.id === role.id)) {
+      return
+    }
+
+    removeRoles.push(role)
+  }
 
   // Phase 1: Analyze all secondary roles and build the complete plan
   for (const memberOrganization of secondaryRoles) {
     if (memberOrganization.dateStart === null && memberOrganization.dateEnd === null) {
-      removeRoles.push(memberOrganization)
+      queueRoleRemoval(memberOrganization)
     } else if (memberOrganization.dateStart !== null && memberOrganization.dateEnd === null) {
       const currentRoles = primaryRoles.filter(
         (mo) =>
@@ -988,7 +997,7 @@ export async function mergeRoles(
 
       if (currentRoles.length === 0) {
         addRoles.push(transformRoleToTargetEntity(memberOrganization, mergeStrat))
-        removeRoles.push(memberOrganization)
+        queueRoleRemoval(memberOrganization)
       } else if (currentRoles.length === 1) {
         const currentRole = currentRoles[0]
         if (new Date(memberOrganization.dateStart) <= new Date(currentRoles[0].dateStart)) {
@@ -1000,12 +1009,13 @@ export async function mergeRoles(
             organizationId: currentRole.organizationId,
             title: currentRole.title,
             source: currentRole.source,
+            originalRoleIds: [currentRole.id, memberOrganization.id].filter(Boolean),
           })
 
-          removeRoles.push(currentRole)
+          queueRoleRemoval(currentRole)
         }
 
-        removeRoles.push(memberOrganization)
+        queueRoleRemoval(memberOrganization)
       } else {
         throw new Error(`Member ${memberOrganization.memberId} has more than one current roles.`)
       }
@@ -1019,7 +1029,7 @@ export async function mergeRoles(
         const secondaryEnd = new Date(memberOrganization.dateEnd)
 
         return (
-          mo.memberId === memberOrganization.memberId &&
+          mergeStrat.intersectBasedOn(mo) === mergeStrat.intersectBasedOn(memberOrganization) &&
           mo.dateStart !== null &&
           mo.dateEnd !== null &&
           ((secondaryStart < primaryStart && secondaryEnd > primaryStart) ||
@@ -1049,11 +1059,15 @@ export async function mergeRoles(
           foundIntersectingRoles.length > 0
             ? foundIntersectingRoles[0].source
             : memberOrganization.source,
+        originalRoleIds: [...foundIntersectingRoles.map((r) => r.id), memberOrganization.id].filter(
+          Boolean,
+        ),
       })
 
       for (const r of foundIntersectingRoles) {
-        removeRoles.push(r)
+        queueRoleRemoval(r)
       }
+      queueRoleRemoval(memberOrganization)
     }
   }
 
@@ -1089,8 +1103,8 @@ export async function mergeRoles(
 
     // 1. Gather all overrides relevant to this specific role merge
     const relevantOverrides = affiliationOverridesToRecreate.filter((item) => {
-      return addRole.originalRoleId
-        ? item.role.id === addRole.originalRoleId
+      return addRole.originalRoleIds?.length
+        ? !!item.role.id && addRole.originalRoleIds.includes(item.role.id)
         : item.role.memberId === addRole.memberId && item.role.title === addRole.title
     })
 
@@ -1104,34 +1118,6 @@ export async function mergeRoles(
     const incomingSecondaries = relevantOverrides.filter((r) =>
       secondaryAffiliationOverrides.some((s) => s.memberOrganizationId === r.role.id),
     )
-    if (!newRoleId) {
-      // Use targetOrganizationId so the comparison works in both member-merge
-      // (org unchanged) and org-merge (secondary org -> primary org) contexts.
-      const directSecondaryRole = secondaryRoles.find((role) =>
-        secondaryAffiliationOverrides.some(
-          (override) =>
-            override.memberOrganizationId === role.id &&
-            mergeStrat.targetOrganizationId(role) === addRole.organizationId &&
-            role.title === addRole.title,
-        ),
-      )
-      const directSecondaryOverride = directSecondaryRole
-        ? secondaryAffiliationOverrides.find(
-            (override) => override.memberOrganizationId === directSecondaryRole.id,
-          )
-        : undefined
-
-      if (
-        directSecondaryRole &&
-        directSecondaryOverride &&
-        !incomingSecondaries.some((item) => item.role.id === directSecondaryRole.id)
-      ) {
-        incomingSecondaries.push({
-          role: directSecondaryRole,
-          override: directSecondaryOverride,
-        })
-      }
-    }
 
     // 2. Resolve "Primary Work Experience"
     // Keep it if the primary had it, or if a secondary had it and no other primary role claims it.

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -1012,6 +1012,18 @@ export async function mergeRoles(
           })
 
           queueRoleRemoval(currentRole)
+        } else {
+          // Primary started earlier — keep it, but track secondary for override transfer.
+          // Insert is a no-op (ON CONFLICT), Phase 3 resolves via isSamePrimaryRole.
+          addRoles.push({
+            dateStart: toIsoString(currentRole.dateStart as Date | string),
+            dateEnd: null,
+            memberId: currentRole.memberId,
+            organizationId: currentRole.organizationId,
+            title: currentRole.title,
+            source: currentRole.source,
+            originalRoleIds: [currentRole.id, memberOrganization.id].filter(Boolean),
+          })
         }
 
         queueRoleRemoval(memberOrganization)
@@ -1034,7 +1046,9 @@ export async function mergeRoles(
           ((secondaryStart < primaryStart && secondaryEnd > primaryStart) ||
             (primaryStart < secondaryStart && secondaryEnd < primaryEnd) ||
             (secondaryStart < primaryStart && secondaryEnd > primaryEnd) ||
-            (primaryStart < secondaryStart && secondaryEnd > primaryEnd))
+            (primaryStart < secondaryStart &&
+              secondaryStart < primaryEnd &&
+              secondaryEnd > primaryEnd))
         )
       })
 

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -927,36 +927,6 @@ export async function moveOrgsBetweenMembers(
   )
 }
 
-function transformRoleToTargetEntity(
-  role: IMemberOrganization,
-  mergeStrat: IMergeStrat,
-): RoleToAdd {
-  return {
-    title: role.title,
-    dateStart: role.dateStart,
-    dateEnd: role.dateEnd,
-    memberId: mergeStrat.targetMemberId(role),
-    organizationId: mergeStrat.targetOrganizationId(role),
-    source: role.source,
-    originalRoleIds: role.id ? [role.id] : undefined,
-  }
-}
-
-function areDatesEqual(dateA: Date | string | null, dateB: Date | string | null): boolean {
-  if (dateA === null && dateB === null) return true
-  if (dateA === null || dateB === null) return false
-  return new Date(dateA).getTime() === new Date(dateB).getTime()
-}
-
-function isSamePrimaryRole(a: IMemberOrganization, b: IMemberOrganization): boolean {
-  return (
-    a.memberId === b.memberId &&
-    a.organizationId === b.organizationId &&
-    areDatesEqual(a.dateStart, b.dateStart) &&
-    areDatesEqual(a.dateEnd, b.dateEnd)
-  )
-}
-
 export async function mergeRoles(
   qx: QueryExecutor,
   primaryRoles: IMemberOrganization[],
@@ -966,175 +936,225 @@ export async function mergeRoles(
   mergeStrat: IMergeStrat,
   orgAffiliationPolicyById: Map<string, boolean>,
 ): Promise<{ shouldRecalculateAffiliations: boolean }> {
+  const isDefinedId = (id: string | undefined): id is string => !!id
+
+  const areDatesEqual = (a: Date | string | null, b: Date | string | null): boolean => {
+    if (a === null && b === null) return true
+    if (a === null || b === null) return false
+    return new Date(a).getTime() === new Date(b).getTime()
+  }
+
+  // matches the db unique key — title excluded because ON CONFLICT ignores it
+  const isSameRole = (a: IMemberOrganization, b: IMemberOrganization): boolean =>
+    a.memberId === b.memberId &&
+    a.organizationId === b.organizationId &&
+    areDatesEqual(a.dateStart, b.dateStart) &&
+    areDatesEqual(a.dateEnd, b.dateEnd)
+
+  const toTargetEntity = (role: IMemberOrganization): RoleToAdd => ({
+    title: role.title,
+    dateStart: role.dateStart,
+    dateEnd: role.dateEnd,
+    memberId: mergeStrat.targetMemberId(role),
+    organizationId: mergeStrat.targetOrganizationId(role),
+    source: role.source,
+    originalRoleIds: role.id ? [role.id] : undefined,
+  })
+
   let shouldRecalculateAffiliations = false
-  const allExistingOverrides = [...primaryAffiliationOverrides, ...secondaryAffiliationOverrides]
+  const removedIds = new Set<string>()
   const removeRoles: IMemberOrganization[] = []
   const addRoles: RoleToAdd[] = []
-  const affiliationOverridesToRecreate: {
+  const overridesToRecreate: {
     role: IMemberOrganization
     override: IMemberOrganizationAffiliationOverride
   }[] = []
+
+  const allExistingOverrides = [...primaryAffiliationOverrides, ...secondaryAffiliationOverrides]
+
   const queueRoleRemoval = (role: IMemberOrganization) => {
-    if (role.id && removeRoles.some((r) => r.id === role.id)) {
-      return
+    if (role.id && !removedIds.has(role.id)) {
+      removedIds.add(role.id)
+      removeRoles.push(role)
     }
-
-    removeRoles.push(role)
   }
 
-  // Phase 1: Analyze all secondary roles and build the complete plan
-  for (const memberOrganization of secondaryRoles) {
-    if (memberOrganization.dateStart === null && memberOrganization.dateEnd === null) {
-      queueRoleRemoval(memberOrganization)
-    } else if (memberOrganization.dateStart !== null && memberOrganization.dateEnd === null) {
-      const currentRoles = primaryRoles.filter(
-        (mo) =>
-          mergeStrat.worthMerging(mo, memberOrganization) &&
-          mo.dateStart !== null &&
-          mo.dateEnd === null,
+  // finds primary dated roles overlapping with a secondary, skipping already-removed ones
+  const getOverlaps = (secondary: IMemberOrganization) => {
+    if (!secondary.dateStart || !secondary.dateEnd) return []
+
+    const sStart = new Date(secondary.dateStart)
+    const sEnd = new Date(secondary.dateEnd)
+
+    return primaryRoles.filter((p) => {
+      if ((p.id && removedIds.has(p.id)) || !p.dateStart || !p.dateEnd) return false
+      if (mergeStrat.intersectBasedOn(p) !== mergeStrat.intersectBasedOn(secondary)) return false
+      return sStart < new Date(p.dateEnd) && new Date(p.dateStart) < sEnd
+    })
+  }
+
+  // Phase 1: planning — decide which roles to remove and what to add
+  for (const secondary of secondaryRoles) {
+    const { dateStart, dateEnd } = secondary
+
+    // Case A: undated — no-op insert just to carry overrides to primary's existing role
+    if (!dateStart && !dateEnd) {
+      const match = primaryRoles.find(
+        (p) => mergeStrat.worthMerging(p, secondary) && !p.dateStart && !p.dateEnd,
+      )
+      if (match) {
+        addRoles.push({
+          ...toTargetEntity(match),
+          originalRoleIds: [match.id, secondary.id].filter(isDefinedId),
+        })
+      }
+      queueRoleRemoval(secondary)
+    }
+
+    // Case B: current / ongoing roles (start date, no end date) — keep earliest start date
+    else if (dateStart && !dateEnd) {
+      const currentPrimaries = primaryRoles.filter(
+        (p) =>
+          mergeStrat.worthMerging(p, secondary) &&
+          p.dateStart &&
+          !p.dateEnd &&
+          !(p.id && removedIds.has(p.id)),
       )
 
-      if (currentRoles.length === 0) {
-        addRoles.push(transformRoleToTargetEntity(memberOrganization, mergeStrat))
-        queueRoleRemoval(memberOrganization)
-      } else if (currentRoles.length === 1) {
-        const currentRole = currentRoles[0]
-        if (new Date(memberOrganization.dateStart) <= new Date(currentRoles[0].dateStart)) {
-          addRoles.push({
-            id: currentRole.id,
-            dateStart: toIsoString(memberOrganization.dateStart as Date | string),
-            dateEnd: null,
-            memberId: currentRole.memberId,
-            organizationId: currentRole.organizationId,
-            title: currentRole.title,
-            source: currentRole.source,
-            originalRoleIds: [currentRole.id, memberOrganization.id].filter(Boolean),
-          })
-
-          queueRoleRemoval(currentRole)
-        } else {
-          // Primary started earlier — keep it, but track secondary for override transfer.
-          // Insert is a no-op (ON CONFLICT), Phase 3 resolves via isSamePrimaryRole.
-          addRoles.push({
-            dateStart: toIsoString(currentRole.dateStart as Date | string),
-            dateEnd: null,
-            memberId: currentRole.memberId,
-            organizationId: currentRole.organizationId,
-            title: currentRole.title,
-            source: currentRole.source,
-            originalRoleIds: [currentRole.id, memberOrganization.id].filter(Boolean),
-          })
-        }
-
-        queueRoleRemoval(memberOrganization)
-      } else {
-        throw new Error(`Member ${memberOrganization.memberId} has more than one current role.`)
-      }
-    } else if (memberOrganization.dateStart === null && memberOrganization.dateEnd !== null) {
-      throw new Error(`Member organization with dateEnd and without dateStart!`)
-    } else {
-      const foundIntersectingRoles = primaryRoles.filter((mo) => {
-        const primaryStart = new Date(mo.dateStart)
-        const primaryEnd = new Date(mo.dateEnd)
-        const secondaryStart = new Date(memberOrganization.dateStart)
-        const secondaryEnd = new Date(memberOrganization.dateEnd)
-
-        return (
-          mergeStrat.intersectBasedOn(mo) === mergeStrat.intersectBasedOn(memberOrganization) &&
-          mo.dateStart !== null &&
-          mo.dateEnd !== null &&
-          ((secondaryStart <= primaryStart && secondaryEnd > primaryStart) ||
-            (primaryStart <= secondaryStart && secondaryEnd <= primaryEnd) ||
-            (secondaryStart <= primaryStart && secondaryEnd >= primaryEnd) ||
-            (primaryStart <= secondaryStart &&
-              secondaryStart < primaryEnd &&
-              secondaryEnd >= primaryEnd))
+      if (currentPrimaries.length === 0) {
+        const existingCurrentAdd = addRoles.find(
+          (r) =>
+            r.dateStart &&
+            !r.dateEnd &&
+            mergeStrat.intersectBasedOn(r) === mergeStrat.intersectBasedOn(secondary),
         )
-      })
+        if (existingCurrentAdd) {
+          if (new Date(secondary.dateStart) < new Date(existingCurrentAdd.dateStart)) {
+            existingCurrentAdd.dateStart = new Date(secondary.dateStart).toISOString()
+          }
+          if (secondary.id) existingCurrentAdd.originalRoleIds?.push(secondary.id)
+        } else {
+          addRoles.push(toTargetEntity(secondary))
+        }
+      } else {
+        const existingAdd = addRoles.find((r) =>
+          currentPrimaries.some((p) => p.id && r.originalRoleIds?.includes(p.id)),
+        )
 
-      const startDates = [...foundIntersectingRoles, memberOrganization].map((org) =>
-        new Date(org.dateStart).getTime(),
-      )
-      const endDates = [...foundIntersectingRoles, memberOrganization].map((org) =>
-        new Date(org.dateEnd).getTime(),
-      )
+        const earliestStart = new Date(
+          Math.min(...[...currentPrimaries, secondary].map((r) => new Date(r.dateStart).getTime())),
+        ).toISOString()
 
-      addRoles.push({
-        dateStart: new Date(Math.min.apply(null, startDates)).toISOString(),
-        dateEnd: new Date(Math.max.apply(null, endDates)).toISOString(),
-        memberId: mergeStrat.targetMemberId(memberOrganization),
-        organizationId: mergeStrat.targetOrganizationId(memberOrganization),
-        title:
-          foundIntersectingRoles.length > 0
-            ? foundIntersectingRoles[0].title
-            : memberOrganization.title,
-        source:
-          foundIntersectingRoles.length > 0
-            ? foundIntersectingRoles[0].source
-            : memberOrganization.source,
-        originalRoleIds: [...foundIntersectingRoles.map((r) => r.id), memberOrganization.id].filter(
-          Boolean,
-        ),
-      })
-
-      for (const r of foundIntersectingRoles) {
-        queueRoleRemoval(r)
+        if (existingAdd) {
+          if (!existingAdd.dateStart || new Date(earliestStart) < new Date(existingAdd.dateStart)) {
+            existingAdd.dateStart = earliestStart
+          }
+          if (secondary.id) existingAdd.originalRoleIds?.push(secondary.id)
+          for (const p of currentPrimaries) {
+            if (p.id && !existingAdd.originalRoleIds?.includes(p.id)) {
+              existingAdd.originalRoleIds?.push(p.id)
+              queueRoleRemoval(p)
+            }
+          }
+        } else {
+          addRoles.push({
+            ...toTargetEntity(currentPrimaries[0]),
+            dateStart: earliestStart,
+            originalRoleIds: [...currentPrimaries.map((p) => p.id), secondary.id].filter(
+              isDefinedId,
+            ),
+          })
+          currentPrimaries.forEach(queueRoleRemoval)
+        }
       }
-      queueRoleRemoval(memberOrganization)
+      queueRoleRemoval(secondary)
+    }
+
+    // Case C: dated / historical roles — merge overlapping ranges into one
+    else if (dateStart && dateEnd) {
+      const intersecting = getOverlaps(secondary)
+
+      const existingAdd = addRoles.find(
+        (r) =>
+          r.dateStart &&
+          r.dateEnd &&
+          mergeStrat.intersectBasedOn(r) === mergeStrat.intersectBasedOn(secondary) &&
+          new Date(secondary.dateStart) < new Date(r.dateEnd) &&
+          new Date(r.dateStart) < new Date(secondary.dateEnd),
+      )
+
+      if (existingAdd) {
+        const allNew = [...intersecting, secondary]
+        const minStart = Math.min(
+          new Date(existingAdd.dateStart).getTime(),
+          ...allNew.map((r) => new Date(r.dateStart as Date | string).getTime()),
+        )
+        const maxEnd = Math.max(
+          new Date(existingAdd.dateEnd).getTime(),
+          ...allNew.map((r) => new Date(r.dateEnd as Date | string).getTime()),
+        )
+        existingAdd.dateStart = new Date(minStart).toISOString()
+        existingAdd.dateEnd = new Date(maxEnd).toISOString()
+        for (const r of allNew) {
+          if (r.id) existingAdd.originalRoleIds?.push(r.id)
+        }
+      } else {
+        const allMatching = [...intersecting, secondary]
+        const base = intersecting[0] || secondary
+        addRoles.push({
+          ...toTargetEntity(base),
+          dateStart: new Date(
+            Math.min(...allMatching.map((r) => new Date(r.dateStart as Date | string).getTime())),
+          ).toISOString(),
+          dateEnd: new Date(
+            Math.max(...allMatching.map((r) => new Date(r.dateEnd as Date | string).getTime())),
+          ).toISOString(),
+          originalRoleIds: allMatching.map((r) => r.id).filter(isDefinedId),
+        })
+      }
+
+      intersecting.forEach(queueRoleRemoval)
+      queueRoleRemoval(secondary)
+    }
+
+    // Case D: invalid data (dateEnd without dateStart) — just clean up
+    else {
+      queueRoleRemoval(secondary)
     }
   }
 
-  // Phase 2: Execute batch removal of roles
-  for (const removeRole of removeRoles) {
-    const existingOverride = allExistingOverrides.find(
-      (o) => o.memberOrganizationId === removeRole.id,
-    )
-
-    if (existingOverride) {
-      affiliationOverridesToRecreate.push({
-        role: removeRole,
-        override: existingOverride,
-      })
-    }
-
-    await removeMemberRole(qx, removeRole)
+  // Phase 2: execute removals, saving any overrides so they can be re-applied
+  for (const role of removeRoles) {
+    const override = allExistingOverrides.find((o) => o.memberOrganizationId === role.id)
+    if (override) overridesToRecreate.push({ role, override })
+    await removeMemberRole(qx, role)
   }
 
-  // Phase 3: Execute additions and resolve overrides
-  for (const addRole of addRoles) {
-    const newRoleId = await addMemberRole(qx, addRole)
-    const targetOrgId = mergeStrat.targetOrganizationId(addRole)
-    const isTargetBlocked = orgAffiliationPolicyById.get(targetOrgId) ?? false
-
-    // Identify the target ID: either the new one or the existing primary it merged into
-    const existingPrimaryRole = !newRoleId
-      ? primaryRoles.find((pr) => isSamePrimaryRole(pr, addRole))
-      : null
-    const targetRoleId = newRoleId || existingPrimaryRole?.id
+  // Phase 3: insert new roles and resolve override policies
+  for (const addData of addRoles) {
+    const newId = await addMemberRole(qx, addData)
+    const primaryMatch = !newId ? primaryRoles.find((p) => isSameRole(p, addData)) : null
+    const targetRoleId = newId || primaryMatch?.id
 
     if (!targetRoleId) continue
 
-    // 1. Gather all overrides relevant to this specific role merge
-    const relevantOverrides = affiliationOverridesToRecreate.filter((item) => {
-      return addRole.originalRoleIds?.length
-        ? !!item.role.id && addRole.originalRoleIds.includes(item.role.id)
-        : item.role.memberId === addRole.memberId && item.role.title === addRole.title
-    })
-
-    const removedPrimaryOverride = relevantOverrides.find((item) =>
-      primaryAffiliationOverrides.some((o) => o.memberOrganizationId === item.role.id),
-    )?.override
-    const existingPrimaryOverride = primaryAffiliationOverrides.find(
-      (o) => o.memberOrganizationId === targetRoleId,
+    const relevant = overridesToRecreate.filter((item) =>
+      item.role.id ? addData.originalRoleIds?.includes(item.role.id) : false,
     )
-    const primaryOverride = existingPrimaryOverride ?? removedPrimaryOverride
-    const incomingSecondaries = relevantOverrides.filter((r) =>
-      secondaryAffiliationOverrides.some((s) => s.memberOrganizationId === r.role.id),
-    )
+    const targetOrgBlocked = orgAffiliationPolicyById.get(addData.organizationId) ?? false
 
-    // 2. Resolve "Primary Work Experience"
-    // Keep it if the primary had it, or if a secondary had it and no other primary role claims it.
-    const secondaryHasExp = incomingSecondaries.some((s) => s.override.isPrimaryWorkExperience)
+    // keep isPrimaryWorkExperience if primary had it, or adopt from secondary when vacant
+    const primaryOverride =
+      primaryAffiliationOverrides.find((o) => o.memberOrganizationId === targetRoleId) ??
+      relevant.find((item) =>
+        primaryAffiliationOverrides.some((o) => o.memberOrganizationId === item.role.id),
+      )?.override
+
+    const secondaryHasExp = relevant.some(
+      (r) =>
+        r.override.isPrimaryWorkExperience &&
+        secondaryAffiliationOverrides.some((s) => s.memberOrganizationId === r.role.id),
+    )
     const otherPrimaryHasExp = primaryAffiliationOverrides.some(
       (o) => o.isPrimaryWorkExperience && o.memberOrganizationId !== targetRoleId,
     )
@@ -1143,51 +1163,45 @@ export async function mergeRoles(
       (secondaryHasExp && !otherPrimaryHasExp)
     )
 
-    // 3. Resolve "Allow Affiliation"
-    // Block if the target org is blocked, or preserve row-level manual blocks.
-    let finalAllowAffiliation: boolean | undefined = undefined
-    const secondaryManualBlock = incomingSecondaries.some(
-      (s) =>
-        s.override.allowAffiliation === false &&
-        !(orgAffiliationPolicyById.get(s.role.organizationId) ?? false),
+    // block if target org is blocked, primary was blocked, or secondary had a manual block
+    const secondaryManualBlock = relevant.some(
+      (r) =>
+        r.override.allowAffiliation === false &&
+        !orgAffiliationPolicyById.get(r.role.organizationId),
     )
+    const finalAllowAffiliation =
+      targetOrgBlocked || primaryOverride?.allowAffiliation === false || secondaryManualBlock
+        ? false
+        : undefined
 
-    if (isTargetBlocked || primaryOverride?.allowAffiliation === false || secondaryManualBlock) {
-      finalAllowAffiliation = false
-    }
-
-    // 4. Update db
-    const needsUpdate =
-      isTargetBlocked ||
+    if (
+      targetOrgBlocked ||
       primaryOverride?.allowAffiliation === false ||
       secondaryManualBlock ||
       finalIsPrimaryWorkExp
-
-    if (needsUpdate) {
-      const effectiveAllowAffiliation = finalAllowAffiliation
-
+    ) {
       await changeMemberOrganizationAffiliationOverrides(qx, [
         {
-          memberId: mergeStrat.targetMemberId(addRole),
+          memberId: addData.memberId,
           memberOrganizationId: targetRoleId,
-          allowAffiliation: effectiveAllowAffiliation,
+          allowAffiliation: finalAllowAffiliation,
           isPrimaryWorkExperience: finalIsPrimaryWorkExp || undefined,
         },
       ])
       shouldRecalculateAffiliations = true
     }
 
-    // 5. Recalculate if we intentionally dropped a stale block from a blocked source org.
-    if (!shouldRecalculateAffiliations && !isTargetBlocked) {
-      if (
-        incomingSecondaries.some(
-          (s) =>
-            s.override.allowAffiliation === false &&
-            (orgAffiliationPolicyById.get(s.role.organizationId) ?? false),
-        )
-      ) {
-        shouldRecalculateAffiliations = true
-      }
+    // secondary had allowAffiliation=false from an org-level block (not manual) —
+    // that block doesn't carry over, but affiliations need recalculation since the
+    // previously suppressed affiliation may now be valid
+    if (!shouldRecalculateAffiliations && !targetOrgBlocked) {
+      const hadOrgLevelBlock = relevant.some(
+        (r) =>
+          r.override.allowAffiliation === false &&
+          secondaryAffiliationOverrides.some((s) => s.memberOrganizationId === r.role.id) &&
+          (orgAffiliationPolicyById.get(r.role.organizationId) ?? false),
+      )
+      if (hadOrgLevelBlock) shouldRecalculateAffiliations = true
     }
   }
 


### PR DESCRIPTION
## What

Fixes a FK violation (`memberOrganizationAffiliationOverrides_memberId_fkey`) that caused `finishMemberMerging` workflows to fail on the final member deletion step, and fixes several related bugs in `mergeRoles` that were silently producing wrong merge results.

## Why it broke

`mergeRoles` was never removing secondary `memberOrganizations` rows in the fully-dated path. When the secondary had a matching role on the primary, the code merged the primary side but left the secondary row alive — along with its `memberOrganizationAffiliationOverrides` still pointing at the secondary member. `DELETE FROM members` then hit the FK.

Two other bugs made things worse:

- `worthMerging` was inverted in both strategies — comparing the entity field instead of the cross-entity field. This made the current-role merge path dead code for member merges; current roles were always duplicated instead of merged.
- The dated overlap filter hardcoded `mo.memberId` instead of using `mergeStrat.intersectBasedOn()`, so overlapping dated roles were never detected during member merges.

## Changes

- Every secondary role is now queued for removal regardless of path. `removeMemberRole` deletes overrides first (in a transaction), so nothing dangles.
- `worthMerging` fixed: `organizationId` for member merge, `memberId` for org merge.
- Overlap detection replaced with standard interval test (`sStart < pEnd && pStart < sEnd`) via `getOverlaps`, which also skips already-removed primaries to avoid stale-snapshot issues.
- `originalRoleId` → `originalRoleIds[]` so overrides from multiple source roles are all tracked and correctly recreated.
- `isSameRole` (renamed from `isSamePrimaryRole`) no longer compares `title` — matches the DB unique key exactly.
- `directSecondaryRole` workaround removed — redundant now that all secondaries are properly removed and tracked via `originalRoleIds`.
- Helpers (`areDatesEqual`, `isSameRole`, `toTargetEntity`, `getOverlaps`, `queueRoleRemoval`) moved inside `mergeRoles` since they're only used there.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core merge/delete logic for `memberOrganizations` and affiliation overrides; mistakes could drop or mis-merge work experience history, but changes are localized and aimed at preventing FK violations and duplicate roles.
> 
> **Overview**
> Fixes merge strategy predicates (`worthMerging`) so member merges merge by `organizationId` and org merges merge by `memberId`, restoring the intended behavior for current-role merging.
> 
> Reworks `mergeRoles` to *plan* removals/additions across undated, current, and dated roles, including proper overlap detection for historical ranges and tracking merged sources via `originalRoleIds[]`. Secondary roles (and any intersecting primaries being consolidated) are now consistently queued for deletion, preventing leftover rows/overrides that caused FK violations.
> 
> Updates override recreation logic to reapply `allowAffiliation`/`isPrimaryWorkExperience` based on all merged source roles, removes the prior direct-secondary workaround, and triggers affiliation recalculation when org-level blocks are dropped during the merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8094b6912aa4927d4e1ad046f3e37c7e9e4aa12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->