### PR TITLE
feat: add maturity field to tinybird project data IN-1098

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 dist
 
+.claude
+*.local.md
+
 # local env files
 .env*
 .env.local

--- a/services/libs/tinybird/datasources/insights_projects_populated_ds.datasource
+++ b/services/libs/tinybird/datasources/insights_projects_populated_ds.datasource
@@ -23,6 +23,7 @@ DESCRIPTION >
     - `contributorCount` and `organizationCount` are computed contributor and organization statistics (UInt64).
     - `healthScore` is the overall project health score (Float64).
     - `status` is the status of the project ex: active or archived
+    - `maturity` is the project maturity stage (e.g. Sandbox, Incubating, Graduated). Empty string when not set.
     - `lastVulnerabilityScanStatus` is the aggregated vulnerability scan status across all project repositories (`LowCardinality(Nullable(String))`). Possible values: `'success'` (all scans passed), `'no_packages_found'` (no dependency packages detected), `'failure'` (at least one scan failed), `'running'` (scan in progress). NULL when no scan records exist for the project's repositories.
 
 TAGS "Project metadata", "Analytics enrichment"
@@ -63,7 +64,8 @@ SCHEMA >
     `communityKeywords` Array(String),
     `communityLanguages` Array(String),
     `status` String,
-    `lastVulnerabilityScanStatus` LowCardinality(Nullable(String))
+    `maturity` LowCardinality(String),
+    `lastVulnerabilityScanStatus` Nullable(String)
 
 ENGINE MergeTree
 ENGINE_PARTITION_KEY toYear(createdAt)

--- a/services/libs/tinybird/datasources/segments.datasource
+++ b/services/libs/tinybird/datasources/segments.datasource
@@ -37,6 +37,7 @@ SCHEMA >
     `description` String `json:$.record.description` DEFAULT '',
     `sourceId` String `json:$.record.sourceId` DEFAULT '',
     `sourceParentId` String `json:$.record.sourceParentId` DEFAULT '',
+    `maturity` LowCardinality(String) `json:$.record.maturity` DEFAULT '',
     `createdAt` DateTime64(3) `json:$.record.createdAt`,
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`
 

--- a/services/libs/tinybird/pipes/insightsProjects_filtered.pipe
+++ b/services/libs/tinybird/pipes/insightsProjects_filtered.pipe
@@ -34,6 +34,7 @@ SQL >
         insights_projects_populated_ds.communityKeywords,
         insights_projects_populated_ds.communityLanguages,
         insights_projects_populated_ds.status,
+        insights_projects_populated_ds.maturity,
         insights_projects_populated_ds.lastVulnerabilityScanStatus
     FROM insights_projects_populated_ds
     where

--- a/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
@@ -231,6 +231,7 @@ SQL >
         any (insights_projects_populated_copy_mentions.communityKeywords) as communityKeywords,
         any (insights_projects_populated_copy_mentions.communityLanguages) as communityLanguages,
         any (segments.status) as status,
+        any (segments.maturity) as maturity,
         any (last_vulnerability_scan_status.lastVulnerabilityScanStatus) as lastVulnerabilityScanStatus
     FROM insightsProjects FINAL
     LEFT JOIN


### PR DESCRIPTION
Summary                                                                         
                                               
  - Add maturity column to segments.datasource — picks up the new maturity text field from Postgres via Sequin CDC ($.record.maturity, defaults to empty string)
  - Add maturity LowCardinality(String) to insights_projects_populated_ds.datasource output schema
  - Select any(segments.maturity) as maturity in the final node of insights_projects_populated_copy.pipe — reuses the existing segments join, no new join added
                                                                                                                                                                                                                                                                                                                          
  Changes
                                                                                                                                                                                                                                                                                                                          
  - services/libs/tinybird/datasources/segments.datasource — new maturity column  
  - services/libs/tinybird/datasources/insights_projects_populated_ds.datasource — new maturity column in schema + description
  - services/libs/tinybird/pipes/insights_projects_populated_copy.pipe — select maturity in final results node
  - frontend/.gitignore — housekeeping: add .claude / *.local.md, fix trailing newline                                                                                                                                                                                                                                    
   
  Ticket: https://linuxfoundation.atlassian.net/browse/IN-1098      

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Tinybird datasource schemas and pipe outputs, which can break downstream queries or consumers if not deployed/migrated in sync; logic changes are additive and straightforward.
> 
> **Overview**
> Adds a new `maturity` field to Tinybird’s segment and project datasets so project maturity stage flows from `segments.datasource` into `insights_projects_populated_ds`.
> 
> Updates the project copy/filtered pipes to select and expose `maturity` in final results, and makes minor housekeeping tweaks to `frontend/.gitignore` (ignore `.claude`/`*.local.md`, fix `cython_debug/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb06b2500b2ed688fa65a2fce7dfabde39558ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->