### PR TITLE
fix: measure separator gap presence in stint inference (CM-1143)

### DIFF
--- a/services/libs/common_services/src/services/member-organization.ts
+++ b/services/libs/common_services/src/services/member-organization.ts
@@ -201,30 +201,27 @@ export function inferMemberOrganizationStintChanges(
       continue
     }
 
-    // 5. Only split when another org clearly sits between this stint and the new date.
-    // Overlapping orgs are treated as concurrent evidence, not a break in the stint.
+    // 5. Only split when another org has meaningful exclusive presence in the gap
+    // between the closest same-org stint and the new date (>30 days).
+    // Concurrent/overlapping orgs that barely extend into the gap are not career breaks.
     const isForward = targetDate > neighbor.dateEnd
+    const gapStart = isForward ? neighbor.dateEnd : targetDate
+    const gapEnd = isForward ? targetDate : neighbor.dateStart
+
     const hasSeparator = stints.some((s) => {
-      if (
-        s.organizationId === organizationId ||
-        !s.dateStart ||
-        !s.dateEnd ||
-        diff(s.dateStart, s.dateEnd) < 30
-      ) {
+      if (s.organizationId === organizationId || !s.dateStart || !s.dateEnd) {
         return false
       }
 
-      if (isForward) {
-        return (
-          (s.dateStart > neighbor.dateEnd && s.dateStart <= targetDate) ||
-          (s.dateEnd > neighbor.dateEnd && s.dateEnd <= targetDate)
-        )
+      // Wide umbrella orgs that fully wrap the neighbor are concurrent, not career breaks
+      if (s.dateStart <= neighbor.dateStart && s.dateEnd >= neighbor.dateEnd) {
+        return false
       }
 
-      return (
-        (s.dateStart >= targetDate && s.dateStart < neighbor.dateStart) ||
-        (s.dateEnd >= targetDate && s.dateEnd < neighbor.dateStart)
-      )
+      const overlapStart = s.dateStart > gapStart ? s.dateStart : gapStart
+      const overlapEnd = s.dateEnd < gapEnd ? s.dateEnd : gapEnd
+
+      return overlapStart < overlapEnd && diff(overlapStart, overlapEnd) > 30
     })
 
     if (hasSeparator) {


### PR DESCRIPTION
## Summary

Fixed an edge case in member organization stint inference where long-running concurrent orgs could incorrectly split an existing email-domain stint.

Previously, the separator check looked at whether another org's start or end date landed in the gap between the closest same-org stint and the new activity date. That caused false splits when a concurrent org overlapped the same-org stint for a long time but ended shortly after it.

The new logic treats another org as a separator only when it has meaningful presence in the gap. It also ignores umbrella/concurrent orgs that fully wrap the closest same-org stint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the stint-splitting heuristic used by the cron-driven inference, which can alter generated member-organization date ranges and downstream reporting. Logic is localized but affects data updates/inserts based on historical activity gaps.
> 
> **Overview**
> Updates `inferMemberOrganizationStintChanges` separator detection to split stints only when another organization has **>30 days of actual overlap within the gap** between the closest same-org stint and the new activity date.
> 
> Ignores concurrent "umbrella" org stints that fully wrap the neighbor stint and replaces the prior boundary-date check (start/end landing in the gap) with an explicit gap-overlap calculation, reducing false splits from long-running overlapping orgs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e2bd6ed6994ce42899483c2b087111bf2cbb400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->