### PR TITLE
fix: deduplicate jira key warning comment on PRs

### DIFF
--- a/.github/workflows/pr-title-jira-key-lint.yml
+++ b/.github/workflows/pr-title-jira-key-lint.yml
@@ -26,57 +26,63 @@ jobs:
 
             console.log(`PR Title: ${prTitle}`);
 
-            const existingComment = await (async () => {
-              const perPage = 100;
-              for (let page = 1; ; page += 1) {
-                const { data: comments } = await github.rest.issues.listComments({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                  per_page: perPage,
-                  page,
-                });
+            const matchingComments = [];
+            const perPage = 100;
+            for (let page = 1; ; page += 1) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: perPage,
+                page,
+              });
 
-                const found = comments.find(
-                  (c) => c.user?.type === 'Bot' && c.body?.includes(COMMENT_MARKER),
-                );
-                if (found) return found;
-                if (comments.length < perPage) return null;
+              for (const c of comments) {
+                if (c.user?.type === 'Bot' && c.body?.includes(COMMENT_MARKER)) {
+                  matchingComments.push(c);
+                }
               }
-            })();
+              if (comments.length < perPage) break;
+            }
 
             if (!jiraKeyRegex.test(prTitle)) {
-              const warningMessage = `${COMMENT_MARKER}
-            ⚠️ **Jira Issue Key Missing**
+              const warningMessage = [
+                COMMENT_MARKER,
+                '⚠️ **Jira Issue Key Missing**',
+                '',
+                "Your PR title doesn't contain a Jira issue key. Consider adding it for better traceability.",
+                '',
+                '**Example:**',
+                '- `feat: add user authentication (CM-123)`',
+                '- `feat: add user authentication (IN-123)`',
+                '',
+                '**Projects:**',
+                '- CM: Community Data Platform',
+                '- IN: Insights',
+                '',
+                'Please add a Jira issue key to your PR title.',
+              ].join('\n');
 
-            Your PR title doesn't contain a Jira issue key. Consider adding it for better traceability.
-
-            **Example:**
-            - \`feat: add user authentication (CM-123)\`
-            - \`feat: add user authentication (IN-123)\`
-
-            **Projects:**
-            - CM: Community Data Platform
-            - IN: Insights
-
-            Please add a Jira issue key to your PR title.`;
-
-              if (existingComment) {
-                if (existingComment.body !== warningMessage) {
-                  await github.rest.issues.updateComment({
-                    owner,
-                    repo,
-                    comment_id: existingComment.id,
-                    body: warningMessage,
-                  });
-                }
-              } else {
+              if (matchingComments.length === 0) {
                 await github.rest.issues.createComment({
                   owner,
                   repo,
                   issue_number: prNumber,
                   body: warningMessage,
                 });
+              } else {
+                const [keep, ...extras] = matchingComments;
+                if (keep.body !== warningMessage) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: keep.id,
+                    body: warningMessage,
+                  });
+                }
+                for (const extra of extras) {
+                  await github.rest.issues.deleteComment({ owner, repo, comment_id: extra.id });
+                }
               }
 
               await github.rest.checks.create({
@@ -95,12 +101,8 @@ jobs:
               const match = prTitle.match(jiraKeyRegex);
               console.log(`✅ Found Jira issue key: ${match[0]}`);
 
-              if (existingComment) {
-                await github.rest.issues.deleteComment({
-                  owner,
-                  repo,
-                  comment_id: existingComment.id,
-                });
+              for (const c of matchingComments) {
+                await github.rest.issues.deleteComment({ owner, repo, comment_id: c.id });
               }
 
               await github.rest.checks.create({

--- a/.github/workflows/pr-title-jira-key-lint.yml
+++ b/.github/workflows/pr-title-jira-key-lint.yml
@@ -17,62 +17,99 @@ jobs:
         with:
           script: |
             const prTitle = context.payload.pull_request.title;
-            console.log(`PR Title: ${prTitle}`);
-            
-            // Regex to match Jira issue keys (CM-123 format)
-            // Supports conventional commits format: type(CM-123): description
+            const prNumber = context.issue.number;
+            const { owner, repo } = context.repo;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const COMMENT_MARKER = '<!-- jira-key-validation-comment -->';
             const jiraKeyRegex = /\b[A-Z]+-\d+\b/;
-            
-            if (!jiraKeyRegex.test(prTitle)) {
-              const warningMessage = `⚠️ **Jira Issue Key Missing**
-              
-              Your PR title doesn't contain a Jira issue key. Consider adding it for better traceability.
-              
-              **Example:**
-              - \`feat: add user authentication (CM-123)\`
-              - \`feat: add user authentication (IN-123)\`
 
-              **Projects:**
-              - CM: Community Data Platform
-              - IN: Insights
+            console.log(`PR Title: ${prTitle}`);
 
-              Please add a Jira issue key to your PR title.`;
-              
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: warningMessage
+            const existingComment = await (async () => {
+              const iterator = github.paginate.iterator(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: prNumber,
+                per_page: 100,
               });
-              
-              // Create check run with failure conclusion
-              github.rest.checks.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head_sha: context.payload.pull_request.head.sha,
+              for await (const { data: comments } of iterator) {
+                const found = comments.find(
+                  (c) => c.user?.type === 'Bot' && c.body?.includes(COMMENT_MARKER),
+                );
+                if (found) return found;
+              }
+              return null;
+            })();
+
+            if (!jiraKeyRegex.test(prTitle)) {
+              const warningMessage = `${COMMENT_MARKER}
+            ⚠️ **Jira Issue Key Missing**
+
+            Your PR title doesn't contain a Jira issue key. Consider adding it for better traceability.
+
+            **Example:**
+            - \`feat: add user authentication (CM-123)\`
+            - \`feat: add user authentication (IN-123)\`
+
+            **Projects:**
+            - CM: Community Data Platform
+            - IN: Insights
+
+            Please add a Jira issue key to your PR title.`;
+
+              if (existingComment) {
+                if (existingComment.body !== warningMessage) {
+                  await github.rest.issues.updateComment({
+                    owner,
+                    repo,
+                    comment_id: existingComment.id,
+                    body: warningMessage,
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: warningMessage,
+                });
+              }
+
+              await github.rest.checks.create({
+                owner,
+                repo,
+                head_sha: headSha,
                 name: 'Jira PR Validation',
                 status: 'completed',
                 conclusion: 'neutral',
                 output: {
                   title: 'Jira Issue Key Missing',
-                  summary: 'PR title does not contain a Jira issue key'
-                }
+                  summary: 'PR title does not contain a Jira issue key',
+                },
               });
             } else {
               const match = prTitle.match(jiraKeyRegex);
               console.log(`✅ Found Jira issue key: ${match[0]}`);
-              
-              // Create check run with success conclusion
-              github.rest.checks.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head_sha: context.payload.pull_request.head.sha,
+
+              if (existingComment) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: existingComment.id,
+                });
+              }
+
+              await github.rest.checks.create({
+                owner,
+                repo,
+                head_sha: headSha,
                 name: 'Jira PR Validation',
                 status: 'completed',
                 conclusion: 'success',
                 output: {
                   title: 'Jira Issue Key Found',
-                  summary: `Found Jira issue key: ${match[0]}`
-                }
+                  summary: `Found Jira issue key: ${match[0]}`,
+                },
               });
             }

--- a/.github/workflows/pr-title-jira-key-lint.yml
+++ b/.github/workflows/pr-title-jira-key-lint.yml
@@ -27,19 +27,22 @@ jobs:
             console.log(`PR Title: ${prTitle}`);
 
             const existingComment = await (async () => {
-              const iterator = github.paginate.iterator(github.rest.issues.listComments, {
-                owner,
-                repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
-              for await (const { data: comments } of iterator) {
+              const perPage = 100;
+              for (let page = 1; ; page += 1) {
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  per_page: perPage,
+                  page,
+                });
+
                 const found = comments.find(
                   (c) => c.user?.type === 'Bot' && c.body?.includes(COMMENT_MARKER),
                 );
                 if (found) return found;
+                if (comments.length < perPage) return null;
               }
-              return null;
             })();
 
             if (!jiraKeyRegex.test(prTitle)) {


### PR DESCRIPTION
## Summary

Fixes the Jira key PR title workflow posting duplicate warning comments on every PR event.

- Makes the warning comment idempotent using a hidden HTML marker to find/update existing comments
- Cleans up any pre-existing duplicate warnings from previous runs
- Fixes markdown rendering (was showing as code block due to leading indentation)
- Awaits all API calls and avoids `github.paginate.iterator()` (broken in github-script v7)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that tweaks PR comment/check behavior; main risk is noisy/incorrect bot commenting if the marker logic or pagination misses cases.
> 
> **Overview**
> Makes the Jira-key PR-title GitHub Action **idempotent** by tagging its warning with a hidden `COMMENT_MARKER`, then finding/updating an existing bot comment (and deleting any duplicates) instead of posting a new one on every event.
> 
> Also fixes the warning message formatting (builds markdown via `join('\n')`), awaits all GitHub API calls, and ensures the check run uses the resolved `headSha`/repo metadata consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342bdae7b73cafdb65853c028515c13b4f143c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->