### PR TITLE
fix: reduce bedrock throttling in member enrichment llm activities (CM-1155)

### DIFF
--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -10,8 +10,6 @@ const {
   normalizeEnrichmentData,
   fetchMemberDataForLLMSquashing,
   findWhichLinkedinProfileToUseAmongScraperResult,
-  squashMultipleValueAttributesWithLLM,
-  squashWorkExperiencesWithLLM,
   updateMemberUsingSquashedPayload,
   cleanAttributeValue,
   touchMemberEnrichmentLastTriedAt,
@@ -22,6 +20,18 @@ const {
     backoffCoefficient: 2.0,
     maximumInterval: '60s',
     maximumAttempts: 4,
+  },
+})
+
+const { squashMultipleValueAttributesWithLLM, squashWorkExperiencesWithLLM } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: '10 minutes',
+  retry: {
+    initialInterval: '30s',
+    backoffCoefficient: 2.0,
+    maximumInterval: '5 minutes',
+    maximumAttempts: 6,
   },
 })
 

--- a/services/libs/types/src/llm.ts
+++ b/services/libs/types/src/llm.ts
@@ -79,7 +79,7 @@ export const LLM_SETTINGS: Record<LlmQueryType, ILlmSettings> = {
   [LlmQueryType.MEMBER_ENRICHMENT_SQUASH_MULTIPLE_VALUE_ATTRIBUTES]: {
     modelId: LlmModelType.CLAUDE_SONNET_4,
     arguments: {
-      max_tokens: 40000,
+      max_tokens: 2000,
       anthropic_version: 'bedrock-2023-05-31',
       temperature: 0,
     },
@@ -87,7 +87,7 @@ export const LLM_SETTINGS: Record<LlmQueryType, ILlmSettings> = {
   [LlmQueryType.MEMBER_ENRICHMENT_SQUASH_WORK_EXPERIENCES_FROM_MULTIPLE_SOURCES]: {
     modelId: LlmModelType.CLAUDE_SONNET_4,
     arguments: {
-      max_tokens: 40000,
+      max_tokens: 8000,
       anthropic_version: 'bedrock-2023-05-31',
       temperature: 0,
     },


### PR DESCRIPTION
## Summary

The `processMemberSources` workflow was failing with `ThrottlingException: Too many tokens` from AWS Bedrock, exhausting all retry attempts permanently.

**Oversized `max_tokens` inflating Bedrock's rate limit budget** — Bedrock reserves TPM capacity based on `max_tokens`, not actual output. Both squash activities had `max_tokens: 40000`, but production data (230K+ calls) shows actual usage is far lower:

| Query Type | p99 output | `max_tokens` before → after |
|---|---|---|
| squash attributes | 590 | 40,000 → 2,000 |
| squash work experiences | 3,573 | 40,000 → 8,000 |

**Retry policy too tight for throttling** — LLM activities shared the same retry config as cache lookups (4 attempts, 60s max interval). They now have their own policy: 6 attempts with intervals up to 5 minutes, enough to ride out a throttle window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM `max_tokens` limits and Temporal retry/timeouts for enrichment squashing, which could affect output completeness and workflow latency if limits are too low or retries too long.
> 
> **Overview**
> Reduces AWS Bedrock throttling in member enrichment by **lowering `max_tokens`** for the two squash queries (multiple-value attributes to `2000`, work-experience squashing to `8000`).
> 
> Separates the Temporal activity configuration so the two LLM squash activities run with **longer timeouts and a more tolerant retry policy** (`10m` timeout; up to 6 attempts with backoff to `5m`), while keeping the existing shorter retry settings for the non-LLM enrichment activities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff4f1a6d7a06f5df639934e95b0225d3f3603d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->