### PR TITLE
feat: fetch and store repo license via licensee IN-1105

### DIFF
--- a/backend/src/database/migrations/U1778154987__addLicenseToRepositories.sql
+++ b/backend/src/database/migrations/U1778154987__addLicenseToRepositories.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.repositories DROP COLUMN license;

--- a/backend/src/database/migrations/V1778154987__addLicenseToRepositories.sql
+++ b/backend/src/database/migrations/V1778154987__addLicenseToRepositories.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.repositories ADD COLUMN license VARCHAR(255);

--- a/scripts/services/docker/Dockerfile.git_integration
+++ b/scripts/services/docker/Dockerfile.git_integration
@@ -83,10 +83,13 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     git \
     ripgrep \
+    ruby \
+    ruby-dev \
+    build-essential \
     --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean \
-    && apt-get autoremove -y
+    && gem install licensee -v '10.0.0' --no-document \
+    && apt-get remove --autoremove -y ruby-dev build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/scripts/services/docker/Dockerfile.git_integration
+++ b/scripts/services/docker/Dockerfile.git_integration
@@ -84,11 +84,15 @@ RUN apt-get update && apt-get install -y \
     git \
     ripgrep \
     ruby \
+    libgit2-1.1 \
     ruby-dev \
     build-essential \
+    libgit2-dev \
+    cmake \
+    pkg-config \
     --no-install-recommends \
-    && gem install licensee -v '10.0.0' --no-document \
-    && apt-get remove --autoremove -y ruby-dev build-essential \
+    && gem install licensee -v '9.15.3' --no-document \
+    && apt-get remove --autoremove -y ruby-dev build-essential libgit2-dev cmake pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONUNBUFFERED=1 \

--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -286,10 +286,10 @@ async def update_last_processed_commit(repo_id: str, commit_hash: str, branch: s
 async def update_repository_license(repository_id: str, license_spdx: str | None) -> None:
     sql_query = """
     UPDATE public.repositories
-        SET license = $1,
+        SET license = $1::varchar,
         "updatedAt" = NOW()
     WHERE id = $2
-      AND ($1 IS NOT NULL OR license IS NULL)
+      AND ($1::varchar IS NOT NULL OR license IS NULL)
     """
     await execute(sql_query, (license_spdx, repository_id))
 

--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -283,6 +283,17 @@ async def update_last_processed_commit(repo_id: str, commit_hash: str, branch: s
     return str(result)
 
 
+async def update_repository_license(repository_id: str, license_spdx: str | None) -> None:
+    sql_query = """
+    UPDATE public.repositories
+        SET license = $1,
+        "updatedAt" = NOW()
+    WHERE id = $2
+      AND ($1 IS NOT NULL OR license IS NULL)
+    """
+    await execute(sql_query, (license_spdx, repository_id))
+
+
 async def mark_repo_as_processed(repo_id: str, repo_state: RepositoryState):
     sql_query = """
     UPDATE git."repositoryProcessing"

--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -289,7 +289,7 @@ async def update_repository_license(repository_id: str, license_spdx: str | None
         SET license = $1::varchar,
         "updatedAt" = NOW()
     WHERE id = $2
-      AND ($1::varchar IS NOT NULL OR license IS NULL)
+      AND license IS DISTINCT FROM $1::varchar
     """
     await execute(sql_query, (license_spdx, repository_id))
 

--- a/services/apps/git_integration/src/crowdgit/server.py
+++ b/services/apps/git_integration/src/crowdgit/server.py
@@ -8,6 +8,7 @@ from loguru import logger
 from crowdgit.services import (
     CloneService,
     CommitService,
+    LicenseService,
     MaintainerService,
     QueueService,
     SoftwareValueService,
@@ -28,6 +29,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     software_value_service = SoftwareValueService()
     vulnerability_scanner_service = VulnerabilityScannerService()
     maintainer_service = MaintainerService()
+    license_service = LicenseService()
 
     worker_task = None
     worker = RepositoryWorker(
@@ -36,6 +38,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         software_value_service=software_value_service,
         vulnerability_scanner_service=vulnerability_scanner_service,
         maintainer_service=maintainer_service,
+        license_service=license_service,
         queue_service=queue_service,
     )
     logger.info("Repo worker initialized")

--- a/services/apps/git_integration/src/crowdgit/services/__init__.py
+++ b/services/apps/git_integration/src/crowdgit/services/__init__.py
@@ -1,6 +1,7 @@
 from crowdgit.services.base.base_service import BaseService
 from crowdgit.services.clone.clone_service import CloneService
 from crowdgit.services.commit.commit_service import CommitService
+from crowdgit.services.license.license_service import LicenseService
 from crowdgit.services.maintainer.maintainer_service import MaintainerService
 from crowdgit.services.queue.queue_service import QueueService
 from crowdgit.services.software_value.software_value_service import SoftwareValueService
@@ -12,6 +13,7 @@ __all__ = [
     "BaseService",
     "CloneService",
     "CommitService",
+    "LicenseService",
     "SoftwareValueService",
     "VulnerabilityScannerService",
     "MaintainerService",

--- a/services/apps/git_integration/src/crowdgit/services/license/__init__.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/__init__.py
@@ -1,0 +1,3 @@
+from crowdgit.services.license.license_service import LicenseService
+
+__all__ = ["LicenseService"]

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -31,10 +31,14 @@ class LicenseService(BaseService):
             matched_files = data.get("matched_files") or []
             spdx_id = licenses[0].get("spdx_id") if licenses else None
             confidence = (
-                (matched_files[0].get("matcher") or {}).get("confidence") if matched_files else None
+                (matched_files[0].get("matcher") or {}).get("confidence")
+                if matched_files
+                else None
             )
             if spdx_id:
-                self.logger.info(f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}")
+                self.logger.info(
+                    f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}"
+                )
             else:
                 self.logger.info(f"No SPDX license matched in {repo_path}")
             return spdx_id

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -1,0 +1,40 @@
+import json
+
+from crowdgit.errors import CommandExecutionError, CommandTimeoutError
+from crowdgit.services.base.base_service import BaseService
+from crowdgit.services.utils import run_shell_command
+
+
+class LicenseService(BaseService):
+    """Detects SPDX license from a cloned repository using the licensee gem."""
+
+    async def detect(self, repo_path: str) -> str | None:
+        """Run licensee against repo_path and return the SPDX identifier, or None."""
+        try:
+            output = await run_shell_command(["licensee", "detect", "--json", repo_path])
+        except CommandExecutionError:
+            self.logger.info(f"licensee found no license in {repo_path}")
+            return None
+        except CommandTimeoutError as e:
+            self.logger.warning(f"licensee timed out: {repr(e)}")
+            return None
+        except FileNotFoundError as e:
+            self.logger.warning(f"licensee binary not found in PATH: {repr(e)}")
+            return None
+        except Exception as e:
+            self.logger.warning(f"licensee failed: {repr(e)}")
+            return None
+
+        try:
+            data = json.loads(output)
+            matched = data.get("matched_license") or {}
+            spdx_id = matched.get("spdx_id")
+            confidence = matched.get("confidence")
+            if spdx_id:
+                self.logger.info(f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}")
+            else:
+                self.logger.info(f"No SPDX license matched in {repo_path}")
+            return spdx_id
+        except Exception as e:
+            self.logger.warning(f"Failed to parse licensee output: {repr(e)}")
+            return None

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -11,7 +11,9 @@ class LicenseService(BaseService):
     async def detect(self, repo_path: str) -> str | None:
         """Run licensee against repo_path and return the SPDX identifier, or None."""
         try:
-            output = await run_shell_command(["licensee", "detect", "--json", repo_path], timeout=60)
+            output = await run_shell_command(
+                ["licensee", "detect", "--json", repo_path], timeout=60
+            )
         except CommandExecutionError:
             self.logger.info(f"licensee found no license in {repo_path}")
             return None

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -11,7 +11,7 @@ class LicenseService(BaseService):
     async def detect(self, repo_path: str) -> str | None:
         """Run licensee against repo_path and return the SPDX identifier, or None."""
         try:
-            output = await run_shell_command(["licensee", "detect", "--json", repo_path])
+            output = await run_shell_command(["licensee", "detect", "--json", repo_path], timeout=60)
         except CommandExecutionError:
             self.logger.info(f"licensee found no license in {repo_path}")
             return None

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -27,9 +27,10 @@ class LicenseService(BaseService):
 
         try:
             data = json.loads(output)
-            matched = data.get("matched_license") or {}
-            spdx_id = matched.get("spdx_id")
-            confidence = matched.get("confidence")
+            licenses = data.get("licenses") or []
+            matched_files = data.get("matched_files") or []
+            spdx_id = licenses[0].get("spdx_id") if licenses else None
+            confidence = (matched_files[0].get("matcher") or {}).get("confidence") if matched_files else None
             if spdx_id:
                 self.logger.info(f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}")
             else:

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -30,7 +30,9 @@ class LicenseService(BaseService):
             licenses = data.get("licenses") or []
             matched_files = data.get("matched_files") or []
             spdx_id = licenses[0].get("spdx_id") if licenses else None
-            confidence = (matched_files[0].get("matcher") or {}).get("confidence") if matched_files else None
+            confidence = (
+                (matched_files[0].get("matcher") or {}).get("confidence") if matched_files else None
+            )
             if spdx_id:
                 self.logger.info(f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}")
             else:

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -7,6 +7,7 @@ from crowdgit.database.crud import (
     mark_repo_as_processed,
     release_repo,
     update_last_processed_commit,
+    update_repository_license,
 )
 from crowdgit.enums import RepositoryState
 from crowdgit.errors import (
@@ -22,6 +23,7 @@ from crowdgit.models import Repository
 from crowdgit.services import (
     CloneService,
     CommitService,
+    LicenseService,
     MaintainerService,
     QueueService,
     SoftwareValueService,
@@ -46,6 +48,7 @@ class RepositoryWorker:
         software_value_service: SoftwareValueService,
         vulnerability_scanner_service: VulnerabilityScannerService,
         maintainer_service: MaintainerService,
+        license_service: LicenseService,
         queue_service: QueueService,
     ):
         self.clone_service = clone_service
@@ -53,6 +56,7 @@ class RepositoryWorker:
         self.software_value_service = software_value_service
         self.vulnerability_scanner_service = vulnerability_scanner_service
         self.maintainer_service = maintainer_service
+        self.license_service = license_service
         self.queue_service = queue_service
         self._shutdown = False
 
@@ -236,6 +240,8 @@ class RepositoryWorker:
                         repository.id, batch_info.repo_path, repository.url
                     )
                     await self.maintainer_service.process_maintainers(repository, batch_info)
+                    license_spdx = await self.license_service.detect(batch_info.repo_path)
+                    await update_repository_license(repository.id, license_spdx)
                 await self.commit_service.process_single_batch_commits(
                     repository,
                     batch_info,

--- a/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
+++ b/services/apps/git_integration/src/crowdgit/worker/repository_worker.py
@@ -163,6 +163,7 @@ class RepositoryWorker:
             (self.maintainer_service, "maintainer_processing"),
             (self.software_value_service, "software_value_processing"),
             (self.vulnerability_scanner_service, "vulnerability_scan_processing"),
+            (self.license_service, "license_detection"),
             (self.queue_service, "queue_service"),
         ]
 
@@ -178,6 +179,7 @@ class RepositoryWorker:
             self.maintainer_service,
             self.software_value_service,
             self.vulnerability_scanner_service,
+            self.license_service,
             self.queue_service,
         ]
 

--- a/services/apps/members_enrichment_worker/src/activities/member.ts
+++ b/services/apps/members_enrichment_worker/src/activities/member.ts
@@ -77,15 +77,8 @@ export async function getIdentitiesExistInOtherMembers(
   excludeMemberId: string,
   identities: IMemberIdentity[],
 ): Promise<IMemberIdentity[]> {
-  let rows: IMemberIdentity[] = []
-
-  try {
-    const db = svc.postgres.reader
-    rows = await getIdentitiesExistInOthers(db, excludeMemberId, identities)
-  } catch (err) {
-    throw err
-  }
-
+  const db = svc.postgres.reader
+  const rows = await getIdentitiesExistInOthers(db, excludeMemberId, identities)
   return rows
 }
 
@@ -94,25 +87,21 @@ export async function updateMemberWithEnrichmentData(
   identities: IMemberIdentity[],
   attributes?: IAttributes,
 ): Promise<void> {
-  try {
-    await svc.postgres.writer.connection().tx(async (tx) => {
-      for (const identity of identities) {
-        await createMemberIdentity(new PgPromiseQueryExecutor(tx), {
-          memberId,
-          platform: identity.platform,
-          value: identity.value,
-          type: identity.type,
-          verified: identity.verified || false,
-          source: 'enrichment',
-        })
-      }
-      if (attributes) {
-        await updateMemberAttributes(tx, memberId, attributes)
-      }
-    })
-  } catch (err) {
-    throw err
-  }
+  await svc.postgres.writer.connection().tx(async (tx) => {
+    for (const identity of identities) {
+      await createMemberIdentity(new PgPromiseQueryExecutor(tx), {
+        memberId,
+        platform: identity.platform,
+        value: identity.value,
+        type: identity.type,
+        verified: identity.verified || false,
+        source: 'enrichment',
+      })
+    }
+    if (attributes) {
+      await updateMemberAttributes(tx, memberId, attributes)
+    }
+  })
 }
 
 export async function mergeMembers(

--- a/services/libs/data-access-layer/src/repositories/index.ts
+++ b/services/libs/data-access-layer/src/repositories/index.ts
@@ -149,7 +149,8 @@ export async function getRepositoriesBySourceIntegrationId(
       "createdAt",
       "updatedAt",
       "deletedAt",
-      "lastArchivedCheckAt"
+      "lastArchivedCheckAt",
+      license
     FROM public.repositories
     WHERE "sourceIntegrationId" = $(sourceIntegrationId)
       AND "deletedAt" IS NULL
@@ -191,7 +192,8 @@ export async function getRepositoriesByUrl(
       "createdAt",
       "updatedAt",
       "deletedAt",
-      "lastArchivedCheckAt"
+      "lastArchivedCheckAt",
+      license
     FROM public.repositories
     WHERE url IN ($(repoUrls:csv))
     ${deletedFilter}

--- a/services/libs/data-access-layer/src/repositories/index.ts
+++ b/services/libs/data-access-layer/src/repositories/index.ts
@@ -21,6 +21,7 @@ export interface IRepository {
   updatedAt: string
   deletedAt: string | null
   lastArchivedCheckAt: string | null
+  license: string | null
 }
 
 export interface ICreateRepository {


### PR DESCRIPTION
## Summary

- Adds `license` column (`VARCHAR(255)`) to `public.repositories` via a new migration
- Installs the `licensee` Ruby gem (v9.15.3, the last version compatible with Ruby 2.7 on Debian Bullseye) in the git integration Docker image, along with `libgit2` build and runtime deps required by the `rugged` gem
- Implements `LicenseService` that runs `licensee detect --json <repo_path>` and extracts the SPDX identifier from the JSON output
- Wires the service into the repository worker's first-batch hook, alongside the existing software-value and vulnerability-scanner calls
- Persists the detected SPDX ID (e.g. `MIT`, `Apache-2.0`, `BSD-3-Clause`) to `public.repositories.license` via a new `update_repository_license` CRUD helper

## Changes

- `backend/src/database/migrations/V1778154987__addLicenseToRepositories.sql` — add `license` column
- `backend/src/database/migrations/U1778154987__addLicenseToRepositories.sql` — undo migration
- `scripts/services/docker/Dockerfile.git_integration` — install licensee v9.15.3 + libgit2 deps
- `services/apps/git_integration/src/crowdgit/services/license/license_service.py` — new service
- `services/apps/git_integration/src/crowdgit/services/license/__init__.py` — module init
- `services/apps/git_integration/src/crowdgit/services/__init__.py` — export LicenseService
- `services/apps/git_integration/src/crowdgit/worker/repository_worker.py` — wire service
- `services/apps/git_integration/src/crowdgit/database/crud.py` — add update_repository_license

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `license` column and a new external dependency (`licensee` Ruby gem) executed during repository processing, which may impact worker runtime and database migrations if detection is slow or the tool behaves unexpectedly.
> 
> **Overview**
> Adds a new `public.repositories.license` (`VARCHAR(255)`) column with forward/undo migrations and updates the data-access layer to select this field.
> 
> Extends the git-integration worker to run a new `LicenseService` on the first clone batch, using the `licensee` gem to detect an SPDX ID and persist it via a new `update_repository_license` DB helper.
> 
> Updates the git-integration Docker image to install Ruby + `licensee` (and required `libgit2` build/runtime deps) so license detection can run in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef58578f22140649dc3e2054906a93a9e81ca39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->