### PR TITLE
chore: add type to identity public api payload

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -1014,6 +1014,7 @@ components:
         - id
         - value
         - platform
+        - type
         - verified
         - verifiedBy
         - source
@@ -1029,6 +1030,12 @@ components:
         platform:
           type: string
           description: Platform name (e.g. github, linkedin, lfid).
+        type:
+          type: string
+          enum:
+            - username
+            - email
+          description: Identity type.
         verified:
           type: boolean
         verifiedBy:

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -94,6 +94,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     id: result.id,
     value: result.value,
     platform: result.platform,
+    type: result.type,
     verified: result.verified,
     verifiedBy: result.verifiedBy ?? null,
     source: result.source ?? null,

--- a/backend/src/api/public/v1/members/identities/getMemberIdentities.ts
+++ b/backend/src/api/public/v1/members/identities/getMemberIdentities.ts
@@ -27,10 +27,11 @@ export async function getMemberIdentities(req: Request, res: Response): Promise<
   const rawIdentities = await fetchMemberIdentities(qx, memberId)
 
   const identities = rawIdentities.map(
-    ({ id, value, platform, verified, verifiedBy, source, createdAt, updatedAt }) => ({
+    ({ id, value, platform, type, verified, verifiedBy, source, createdAt, updatedAt }) => ({
       id,
       value,
       platform,
+      type,
       verified,
       verifiedBy: verifiedBy ?? null,
       source,

--- a/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
@@ -53,6 +53,7 @@ function toReturn(identity: IMemberIdentity) {
     id: identity.id,
     value: identity.value,
     platform: identity.platform,
+    type: identity.type,
     verified: identity.verified,
     verifiedBy: identity.verifiedBy ?? null,
     source: identity.source,


### PR DESCRIPTION
This pull request adds support for a new identity attribute, type, to member identities. The type distinguishes between different forms of identity (such as username or email) and is now included in the API schema, as well as in the relevant API responses.

Schema and API changes:

**OpenAPI schema updates:**
- Added a required type field to the identity schema in `openapi.yaml`, with allowed values username and email, and included it in the list of required fields. [[1]](diffhunk://#diff-20ca6d563381c176fcd9fb479aa03d6ded0e7bb7c4f54d1dea0963a910ec8d7eR1017) [[2]](diffhunk://#diff-20ca6d563381c176fcd9fb479aa03d6ded0e7bb7c4f54d1dea0963a910ec8d7eR1033-R1038)

**API response updates:**
- Updated the response objects in `createMemberIdentity.ts`, `getMemberIdentities.ts`, and `verifyMemberIdentity.ts` to include the new type field in their returned data. [[1]](diffhunk://#diff-07c2ff7e7df008201585a7215a90d1352acc08397051ea72d504966ac832d447R97) [[2]](diffhunk://#diff-076b259714e163e4636f5a0b3176cf9083f0fe2bb8635a3383080477a972a5b8L30-R34) [[3]](diffhunk://#diff-5f543b30d23cd6dbfeb8c42c2d0d817ddb08080497e7e29364e8733b1dcbee57R56)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API contract changes by adding a new required `type` field to `MemberIdentity`, which can break existing clients that assume the older response schema.
> 
> **Overview**
> Adds a new required `type` attribute to the public `MemberIdentity` schema (enum `username`/`email`) in `openapi.yaml`.
> 
> Updates member identity endpoints to include `type` in responses for create (`POST /members/{memberId}/identities`), list (`GET /members/{memberId}/identities`), and verify/reject (`PATCH /members/{memberId}/identities/{identityId}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d244ab43f585f26669b0b9b7f650d249f36de239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->