### PR TITLE
fix: apply 98% confidence threshold and NOASSERTION semantics in license detection IN-1105

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -46,7 +46,12 @@ class LicenseService(BaseService):
             #   NULL         = licensee didn't run, timed out, or found no license file
             #   NOASSERTION  = found a license file but couldn't reliably identify it
             # The UI should display NOASSERTION as "Other".
-            if spdx_id and spdx_id != "NOASSERTION" and confidence is not None and confidence < LICENSE_CONFIDENCE_THRESHOLD:
+            if (
+                spdx_id
+                and spdx_id != "NOASSERTION"
+                and confidence is not None
+                and confidence < LICENSE_CONFIDENCE_THRESHOLD
+            ):
                 self.logger.info(
                     f"License downgraded to NOASSERTION: confidence {confidence}% below threshold in {repo_path}"
                 )

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -37,6 +37,18 @@ class LicenseService(BaseService):
                 if matched_files
                 else None
             )
+
+            # Mirror GitHub's threshold — below 98% similarity the match is unreliable.
+            # Downgrade low-confidence matches to NOASSERTION so the distinction is clean:
+            #   NULL         = no license file found
+            #   NOASSERTION  = found a license file but couldn't reliably identify it
+            # The UI should display NOASSERTION as "Other".
+            if spdx_id and spdx_id != "NOASSERTION" and confidence is not None and confidence < 98:
+                self.logger.info(
+                    f"License downgraded to NOASSERTION: confidence {confidence}% below threshold in {repo_path}"
+                )
+                return "NOASSERTION"
+
             if spdx_id:
                 self.logger.info(
                     f"License detected: {spdx_id} (confidence={confidence}) in {repo_path}"

--- a/services/apps/git_integration/src/crowdgit/services/license/license_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/license/license_service.py
@@ -4,6 +4,9 @@ from crowdgit.errors import CommandExecutionError, CommandTimeoutError
 from crowdgit.services.base.base_service import BaseService
 from crowdgit.services.utils import run_shell_command
 
+# Mirrors GitHub's internal licensee threshold — matches below this are too uncertain.
+LICENSE_CONFIDENCE_THRESHOLD = 98
+
 
 class LicenseService(BaseService):
     """Detects SPDX license from a cloned repository using the licensee gem."""
@@ -38,12 +41,12 @@ class LicenseService(BaseService):
                 else None
             )
 
-            # Mirror GitHub's threshold — below 98% similarity the match is unreliable.
+            # Mirror GitHub's threshold — below LICENSE_CONFIDENCE_THRESHOLD the match is unreliable.
             # Downgrade low-confidence matches to NOASSERTION so the distinction is clean:
-            #   NULL         = no license file found
+            #   NULL         = licensee didn't run, timed out, or found no license file
             #   NOASSERTION  = found a license file but couldn't reliably identify it
             # The UI should display NOASSERTION as "Other".
-            if spdx_id and spdx_id != "NOASSERTION" and confidence is not None and confidence < 98:
+            if spdx_id and spdx_id != "NOASSERTION" and confidence is not None and confidence < LICENSE_CONFIDENCE_THRESHOLD:
                 self.logger.info(
                     f"License downgraded to NOASSERTION: confidence {confidence}% below threshold in {repo_path}"
                 )


### PR DESCRIPTION
## Summary

- Add a 98% confidence threshold to license detection (mirrors GitHub's internal threshold for licensee)
- Low-confidence matches are downgraded to `NOASSERTION` instead of storing a potentially incorrect SPDX identifier
- Establish clear `NULL` vs `NOASSERTION` semantics:
  - `NULL` = no license file found in the repo
  - `NOASSERTION` = license file found but could not be reliably identified (UI should display as "Other")

## Changes

- `services/apps/git_integration/src/crowdgit/services/license/license_service.py` — confidence threshold check and NOASSERTION downgrade logic

## Ticket

https://linuxfoundation.atlassian.net/browse/IN-1105

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted license identification behavior by converting low-confidence SPDX matches to `NOASSERTION`, which may impact downstream reporting/UI expectations. Logic is localized but affects how license data is interpreted and stored.
> 
> **Overview**
> Updates `LicenseService.detect` to apply a GitHub-aligned `LICENSE_CONFIDENCE_THRESHOLD` (98%) when interpreting `licensee` results.
> 
> If `licensee` returns an SPDX id with confidence below the threshold, the service now logs the downgrade and returns `NOASSERTION` instead of a potentially incorrect SPDX identifier, clarifying `None` (no result/failed) vs `NOASSERTION` (unreliable match).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d97f54f800acf9a6b5ce8a3d1aafa0a8749976. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->