### PR TITLE
fix: keep LFX organizations as primary in merge suggestions

### DIFF
--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -347,15 +347,21 @@ export async function getOrganizationMergeSuggestions(
       continue
     }
 
+    const secondaryOrg = opensearchToFullOrg(organizationToMerge._source)
+
     // Calculate similarity score between organizations
     const similarityConfidenceScore = OrganizationSimilarityCalculator.calculateSimilarity(
       fullOrg,
-      opensearchToFullOrg(organizationToMerge._source),
+      secondaryOrg,
     )
 
-    // Sort organizations: primary has more identities/activity, secondary is the one to merge
-    const organizationsSorted = [fullOrg, opensearchToFullOrg(organizationToMerge._source)].sort(
-      (a, b) => {
+    let organizationsSorted: IOrganizationFullAggregatesOpensearch[]
+    if (secondaryOrgWithLfxMembership && !primaryOrgWithLfxMembership) {
+      // LFX membership organizations can't be merged as secondary.
+      organizationsSorted = [secondaryOrg, fullOrg]
+    } else {
+      // Sort organizations: primary has more identities/activity, secondary is the one to merge
+      organizationsSorted = [fullOrg, secondaryOrg].sort((a, b) => {
         if (
           a.identities.length > b.identities.length ||
           (a.identities.length === b.identities.length && a.activityCount > b.activityCount)
@@ -368,8 +374,8 @@ export async function getOrganizationMergeSuggestions(
           return 1
         }
         return 0
-      },
-    )
+      })
+    }
 
     mergeSuggestions.push({
       similarity: similarityConfidenceScore,

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -357,10 +357,13 @@ export async function getOrganizationMergeSuggestions(
 
     let organizationsSorted: IOrganizationFullAggregatesOpensearch[]
     if (secondaryOrgWithLfxMembership && !primaryOrgWithLfxMembership) {
-      // LFX membership organizations can't be merged as secondary.
+      // Secondary is LFX — swap so LFX org is always primary.
       organizationsSorted = [secondaryOrg, fullOrg]
+    } else if (primaryOrgWithLfxMembership && !secondaryOrgWithLfxMembership) {
+      // Primary is LFX — keep order as-is to prevent sort from pushing it into secondary.
+      organizationsSorted = [fullOrg, secondaryOrg]
     } else {
-      // Sort organizations: primary has more identities/activity, secondary is the one to merge
+      // Neither has LFX — sort by identity count and activity.
       organizationsSorted = [fullOrg, secondaryOrg].sort((a, b) => {
         if (
           a.identities.length > b.identities.length ||

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -349,15 +349,18 @@ export async function getOrganizationMergeSuggestions(
 
     const secondaryOrg = opensearchToFullOrg(organizationToMerge._source)
 
+    const similarityConfidenceScore = OrganizationSimilarityCalculator.calculateSimilarity(
+      fullOrg,
+      secondaryOrg,
+    )
+
     let organizationsSorted: IOrganizationFullAggregatesOpensearch[]
     if (secondaryOrgWithLfxMembership && !primaryOrgWithLfxMembership) {
-      // Secondary is LFX — swap so LFX org is always primary.
       organizationsSorted = [secondaryOrg, fullOrg]
     } else if (primaryOrgWithLfxMembership && !secondaryOrgWithLfxMembership) {
-      // Primary is LFX — keep order as-is to prevent sort from pushing it into secondary.
       organizationsSorted = [fullOrg, secondaryOrg]
     } else {
-      // Neither has LFX — sort by identity count and activity.
+      // Sort organizations: primary has more identities/activity, secondary is the one to merge
       organizationsSorted = [fullOrg, secondaryOrg].sort((a, b) => {
         if (
           a.identities.length > b.identities.length ||
@@ -373,11 +376,6 @@ export async function getOrganizationMergeSuggestions(
         return 0
       })
     }
-
-    const similarityConfidenceScore = OrganizationSimilarityCalculator.calculateSimilarity(
-      organizationsSorted[0],
-      organizationsSorted[1],
-    )
 
     mergeSuggestions.push({
       similarity: similarityConfidenceScore,

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -349,12 +349,6 @@ export async function getOrganizationMergeSuggestions(
 
     const secondaryOrg = opensearchToFullOrg(organizationToMerge._source)
 
-    // Calculate similarity score between organizations
-    const similarityConfidenceScore = OrganizationSimilarityCalculator.calculateSimilarity(
-      fullOrg,
-      secondaryOrg,
-    )
-
     let organizationsSorted: IOrganizationFullAggregatesOpensearch[]
     if (secondaryOrgWithLfxMembership && !primaryOrgWithLfxMembership) {
       // Secondary is LFX — swap so LFX org is always primary.
@@ -379,6 +373,11 @@ export async function getOrganizationMergeSuggestions(
         return 0
       })
     }
+
+    const similarityConfidenceScore = OrganizationSimilarityCalculator.calculateSimilarity(
+      organizationsSorted[0],
+      organizationsSorted[1],
+    )
 
     mergeSuggestions.push({
       similarity: similarityConfidenceScore,


### PR DESCRIPTION
## What changed

In `getOrganizationMergeSuggestions`, when generating organization merge suggestions, if the secondary candidate has an LFX membership and the primary does not, the two are now swapped so the LFX org becomes primary.

## Why

LFX membership organizations cannot be merged as secondary, and the merge API hard-rejects these cases at runtime. By ensuring they’re always set as primary during suggestion creation, we prevent invalid ordering from entering the pipeline and avoid silently failed merges caused by this constraint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-suggestion ordering logic, which can affect which organization is treated as the merge primary/secondary and therefore downstream merge behavior. Risk is limited to suggestion generation but could alter merge outcomes for LFX-related candidates.
> 
> **Overview**
> Updates `getOrganizationMergeSuggestions` to **force LFX-member organizations to be the primary** when building merge suggestions: if only one side has LFX membership, the pair is ordered so the LFX org comes first; otherwise it falls back to the existing identities/activity-based sort. Also avoids repeated `opensearchToFullOrg` conversions by materializing the secondary org once before scoring and ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 359a056f8c9bda2691f00c2d1c674cc8ed8f72b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->