### PR TITLE
fix: increase updateMemberAffiliations timeout to 3 hours

### DIFF
--- a/services/apps/profiles_worker/src/workflows/member/memberUpdate.ts
+++ b/services/apps/profiles_worker/src/workflows/member/memberUpdate.ts
@@ -10,10 +10,12 @@ import {
 import * as activities from '../../activities'
 import { MemberUpdateInput } from '../../types/member'
 
-const { updateMemberAffiliations, syncOrganization, syncMember } = proxyActivities<
-  typeof activities
->({
+const { syncOrganization, syncMember } = proxyActivities<typeof activities>({
   startToCloseTimeout: '60 minutes',
+})
+
+const { updateMemberAffiliations } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '3 hours',
 })
 
 export const refreshAffiliationsSignal = defineSignal<[MemberUpdateInput]>('refreshAffiliations')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change that only adjusts Temporal activity timeout configuration; primary impact is allowing `updateMemberAffiliations` to run longer before timing out.
> 
> **Overview**
> Updates the `memberUpdate` Temporal workflow to configure `updateMemberAffiliations` with a longer `startToCloseTimeout` (**3 hours**) by moving it into a separate `proxyActivities` block.
> 
> Keeps `syncMember`/`syncOrganization` on the existing **60-minute** timeout, limiting the longer timeout scope to the affiliation refresh step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265e28e3433eabf82c0498798facf62d5de94493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->