### PR TITLE
chore: enhance 409 alerts

### DIFF
--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -75,7 +75,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
             throw new ConflictError('Identity already exists on this member', {
               platform: data.platform,
               value: data.value,
-              type: data.type
+              type: data.type,
             })
           }
 

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -72,11 +72,19 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
             error.constraint ?? error.original?.constraint ?? error.parent?.constraint
 
           if (constraint === 'uix_memberIdentities_memberId_platform_value_type') {
-            throw new ConflictError('Identity already exists on this member')
+            throw new ConflictError('Identity already exists on this member', {
+              platform: data.platform,
+              value: data.value,
+              type: data.type
+            })
           }
 
           if (constraint === 'uix_memberIdentities_platform_value_type_verified') {
-            throw new ConflictError('Identity already verified on another member')
+            throw new ConflictError('Identity already verified on another member', {
+              platform: data.platform,
+              value: data.value,
+              type: data.type,
+            })
           }
 
           throw error

--- a/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
@@ -96,7 +96,11 @@ export async function verifyMemberIdentity(req: Request, res: Response): Promise
             error.constraint ?? error.original?.constraint ?? error.parent?.constraint
 
           if (verified && constraint === 'uix_memberIdentities_platform_value_type_verified') {
-            throw new ConflictError('Identity already verified on another member')
+            throw new ConflictError('Identity already verified on another member', {
+              platform: identity.platform,
+              value: identity.value,
+              type: identity.type,
+            })
           }
 
           throw error


### PR DESCRIPTION
This pull request enhances error handling in the member identity API endpoints by providing additional context in conflict error responses. Now, when a conflict occurs due to a duplicate or already verified identity, the error includes relevant identity details, making it easier for clients to understand the cause.

**Improved error context in identity endpoints:**

* [`createMemberIdentity.ts`](diffhunk://#diff-07c2ff7e7df008201585a7215a90d1352acc08397051ea72d504966ac832d447L75-R87): Updated conflict errors to include `platform`, `value`, and `type` in the error details when an identity already exists for a member or is already verified on another member.
* [`verifyMemberIdentity.ts`](diffhunk://#diff-5f543b30d23cd6dbfeb8c42c2d0d817ddb08080497e7e29364e8733b1dcbee57L99-R103): Enhanced conflict error to return `platform`, `value`, and `type` when an identity is already verified on another member.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only enriches `409 Conflict` error payloads for member identity create/verify flows, without changing persistence or authorization logic.
> 
> **Overview**
> Improves `409 Conflict` responses in member identity endpoints by attaching the conflicting identity context (`platform`, `value`, `type`).
> 
> On `createMemberIdentity`, conflicts for "already exists on this member" and "already verified on another member" now include these fields; on `verifyMemberIdentity`, the "already verified on another member" conflict does the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e12b17d0378229640d9740a8cc125a8ca83268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->