### PR TITLE
fix: refactor project table (CM-1165)

### DIFF
--- a/backend/src/database/migrations/V1778749030__refactor-projects-catalog.sql
+++ b/backend/src/database/migrations/V1778749030__refactor-projects-catalog.sql
@@ -1,0 +1,16 @@
+-- Drop evaluatedProjects table (data migrated into projectCatalog)
+DROP TABLE IF EXISTS "evaluatedProjects";
+
+-- Remove ossfCriticalityScore from projectCatalog
+ALTER TABLE "projectCatalog" DROP COLUMN IF EXISTS "ossfCriticalityScore";
+DROP INDEX IF EXISTS "ix_projectCatalog_ossfCriticalityScore";
+
+-- Add new columns to projectCatalog
+ALTER TABLE "projectCatalog"
+    ADD COLUMN IF NOT EXISTS "source" VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS "action" VARCHAR(16) NOT NULL DEFAULT 'auto',
+    ADD COLUMN IF NOT EXISTS "evaluatedAt" TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN IF NOT EXISTS "onboardedAt" TIMESTAMP WITH TIME ZONE;
+
+CREATE INDEX "ix_projectCatalog_source" ON "projectCatalog" ("source");
+CREATE INDEX "ix_projectCatalog_action" ON "projectCatalog" ("action");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it drops the `evaluatedProjects` table and removes the `ossfCriticalityScore` column/index, which can cause irreversible data loss and break any code or queries still depending on them.
> 
> **Overview**
> This migration removes legacy project evaluation storage by dropping the `evaluatedProjects` table and deleting the `projectCatalog.ossfCriticalityScore` column (and its index).
> 
> It extends `projectCatalog` with new metadata fields (`source`, `action`, `evaluatedAt`, `onboardedAt`) and adds indexes on `source` and `action` to support the updated querying model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4a8f4f1127b7feb47c8974dd112f631d6a119e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->