### PR TITLE
fix: add defaults to mentions datasource fields and fix licenses json path

### DIFF
--- a/services/libs/tinybird/datasources/mentions.datasource
+++ b/services/libs/tinybird/datasources/mentions.datasource
@@ -46,7 +46,7 @@ SCHEMA >
     `createdAt` DateTime64(3) `json:$.createdAt` DEFAULT now64(3),
     `bookmarked` UInt8 `json:$.bookmarked` DEFAULT 0,
     `keywords` Array(String) `json:$.keywords[:]` DEFAULT [],
-    `authorFollowerCount` Nullable(Int32) `json:$.authorFollowerCount` DEFAULT NULL,
+    `authorFollowerCount` Nullable(Int32) `json:$.authorFollowerCount`,
     `tags` Array(Nullable(String)) `json:$.tags[:]` DEFAULT []
 
 ENGINE ReplacingMergeTree

--- a/services/libs/tinybird/datasources/mentions.datasource
+++ b/services/libs/tinybird/datasources/mentions.datasource
@@ -44,10 +44,10 @@ SCHEMA >
     `language` String `json:$.language` DEFAULT '',
     `projectSlug` LowCardinality(String) `json:$.projectSlug` DEFAULT '',
     `createdAt` DateTime64(3) `json:$.createdAt` DEFAULT now64(3),
-    `bookmarked` UInt8 `json:$.bookmarked`,
-    `keywords` Array(String) `json:$.keywords[:]`,
-    `authorFollowerCount` Nullable(Int32) `json:$.authorFollowerCount`,
-    `tags` Array(Nullable(String)) `json:$.tags[:]`
+    `bookmarked` UInt8 `json:$.bookmarked` DEFAULT 0,
+    `keywords` Array(String) `json:$.keywords[:]` DEFAULT [],
+    `authorFollowerCount` Nullable(Int32) `json:$.authorFollowerCount` DEFAULT NULL,
+    `tags` Array(Nullable(String)) `json:$.tags[:]` DEFAULT []
 
 ENGINE ReplacingMergeTree
 ENGINE_PARTITION_KEY toYear(timestamp)

--- a/services/libs/tinybird/datasources/repositories.datasource
+++ b/services/libs/tinybird/datasources/repositories.datasource
@@ -32,7 +32,7 @@ SCHEMA >
     `updatedAt` DateTime64(3) `json:$.record.updatedAt`,
     `deletedAt` Nullable(DateTime64(3)) `json:$.record.deletedAt`,
     `lastArchivedCheckAt` Nullable(DateTime64(3)) `json:$.record.lastArchivedCheckAt`,
-    `licenses` Array(String) `json:$.record.licenses` DEFAULT []
+    `licenses` Array(String) `json:$.record.licenses[:]` DEFAULT []
 
 ENGINE ReplacingMergeTree
 ENGINE_PARTITION_KEY toYear(createdAt)


### PR DESCRIPTION
## Summary

- Add explicit `DEFAULT` values to fields in `mentions.datasource` that previously had none (`bookmarked`, `keywords`, `authorFollowerCount`, `tags`) — prevents ingestion errors when these fields are absent in incoming JSON
- Fix `licenses` JSON path in `repositories.datasource` from `json:$.record.licenses` to `json:$.record.licenses[:]` so array elements are correctly extracted

## Changes

- `services/libs/tinybird/datasources/mentions.datasource` — added defaults for 4 trailing schema fields
- `services/libs/tinybird/datasources/repositories.datasource` — corrected licenses JSON path to use array accessor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema tweaks to Tinybird datasources; main impact is on ingestion behavior when optional fields are missing or when parsing `licenses` as an array.
> 
> **Overview**
> Prevents Tinybird ingestion failures by adding explicit `DEFAULT` values for optional fields in `mentions.datasource` (e.g., `bookmarked`, `keywords`, `tags`).
> 
> Fixes `repositories.datasource` parsing of `licenses` by switching the JSON path to the array accessor (`json:$.record.licenses[:]`) so elements are extracted correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d90f91aae7d85f534ac946e70d90ff9f813f0cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->