### PR TITLE
fix: improve member merge suggestions for split git email profiles (CM-1137)

### DIFF
--- a/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import uniqBy from 'lodash.uniqby'
 
-import { parseGitHubNoreplyEmail } from '@crowd/common'
+import { parseGitHubNoreplyEmail, parseGitLabNoreplyEmail } from '@crowd/common'
 import { addMemberNoMerge } from '@crowd/data-access-layer/src/member_merge'
 import { MemberField, queryMembers } from '@crowd/data-access-layer/src/members'
 import MemberMergeSuggestionsRepository from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker/memberMergeSuggestions.repo'
@@ -119,6 +119,10 @@ export async function getMemberMergeSuggestions(
       if (ghUsername) {
         noreplyEmailUsernameMatches.push({ value: ghUsername, platform: PlatformType.GITHUB })
       }
+      const glUsername = parseGitLabNoreplyEmail(value)
+      if (glUsername) {
+        noreplyEmailUsernameMatches.push({ value: glUsername, platform: PlatformType.GITLAB })
+      }
     }
 
     // Fuzzy matches (only for verified & non-numeric)
@@ -213,8 +217,8 @@ export async function getMemberMergeSuggestions(
       }),
     },
     {
-      // Query 8: Noreply/private email -> username (verified or unverified)
-      matches: uniqBy(noreplyEmailUsernameMatches, 'value'),
+      // Query 8: Noreply email -> platform username (verified identities only)
+      matches: uniqBy(noreplyEmailUsernameMatches, (m) => `${m.platform}:${m.value}`),
       builder: ({ value, platform }) => ({
         bool: {
           must: [

--- a/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
@@ -1,6 +1,12 @@
 import { get as getLevenshteinDistance } from 'fast-levenshtein'
 
-import { parseGitHubNoreplyEmail } from '@crowd/common'
+import {
+  getEmailLocalPart,
+  isKnownBot,
+  isLocalMachineEmail,
+  parseGitHubNoreplyEmail,
+  parseGitLabNoreplyEmail,
+} from '@crowd/common'
 import {
   IMemberIdentity,
   IMemberOpensearch,
@@ -14,6 +20,7 @@ import {
 
 import { EMAIL_AS_USERNAME_PLATFORMS } from './enums'
 import { MemberAttributeOpensearch } from './enums'
+import { isOsReservedName } from './utils'
 
 class MemberSimilarityCalculator {
   static HIGH_CONFIDENCE_SCORE = 0.9
@@ -194,28 +201,84 @@ class MemberSimilarityCalculator {
   ): boolean {
     if (member.identities && member.identities.length > 0) {
       for (const identity of member.identities.filter(
-        (i) => i.type === MemberIdentityType.USERNAME,
+        (i) => i.type === MemberIdentityType.USERNAME && i.verified,
       )) {
+        const clashingIdentities = similarMember.nested_identities.filter(
+          (i) =>
+            i.keyword_type === MemberIdentityType.USERNAME &&
+            i.bool_verified === true &&
+            i.string_platform === identity.platform &&
+            i.keyword_value !== identity.value,
+        )
+
+        if (clashingIdentities.length === 0) continue
+
+        // git "usernames" are commit-author emails — a single person commits from many addresses
+        // (work, personal, noreply, machine-local). Different values don't mean different people.
+        // Relax only when ALL clashes are email-like and the displayName is a real identity.
         if (
-          similarMember.nested_identities.some(
-            (i) =>
-              i.keyword_type === MemberIdentityType.USERNAME &&
-              i.string_platform === identity.platform &&
-              i.keyword_value !== identity.value,
-          )
+          identity.platform === PlatformType.GIT &&
+          identity.value.includes('@') &&
+          clashingIdentities.every((c) => c.keyword_value?.includes('@')) &&
+          !this.isNonIdentityBearingDisplayName(member, similarMember)
         ) {
-          return true
+          continue
         }
+
+        return true
       }
     }
 
     return false
   }
 
-  /**
-   * Checks bidirectionally if a noreply address on one member resolves to a platform username on the other.
-   * No identity type filter — git ingest stores noreply addresses as type=username, not type=email.
-   */
+  // Returns true when either member's displayName is a bot or a generic placeholder rather than
+  // a real person's name — we keep conservative clash detection for these to avoid merging
+  // distinct entities that share the same non-identity string.
+  private static isNonIdentityBearingDisplayName(
+    member: IMemberWithAggregatesForMergeSuggestions,
+    similarMember: IMemberOpensearch,
+  ): boolean {
+    if (member.attributes?.[MemberAttributeName.IS_BOT]?.default === true) return true
+    // obj_isBot is a boolean attribute indexed under obj_attributes but not in the typed enum
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((similarMember.obj_attributes as any)?.obj_isBot?.bool_default === true) return true
+    if (isKnownBot(member.displayName ?? '') || isKnownBot(similarMember.keyword_displayName ?? ''))
+      return true
+
+    const primaryDn = (member.displayName ?? '').toLowerCase().trim()
+    const similarDn = (similarMember.keyword_displayName ?? '').toLowerCase().trim()
+
+    if (isOsReservedName(primaryDn) || isOsReservedName(similarDn)) return true
+
+    // When a git/username local-part equals the displayName, the name is just the commit-time
+    // default (e.g. user.name="user", user.email="user@laptop.local").
+    for (const id of member.identities) {
+      if (
+        id.platform === PlatformType.GIT &&
+        id.type === MemberIdentityType.USERNAME &&
+        id.value.includes('@')
+      ) {
+        const lp = getEmailLocalPart(id.value)
+        if (lp === primaryDn || lp === similarDn) return true
+      }
+    }
+    for (const id of similarMember.nested_identities) {
+      if (
+        id.string_platform === PlatformType.GIT &&
+        id.keyword_type === MemberIdentityType.USERNAME &&
+        id.string_value?.includes('@')
+      ) {
+        const lp = getEmailLocalPart(id.string_value)
+        if (lp === primaryDn || lp === similarDn) return true
+      }
+    }
+
+    return false
+  }
+
+  // Checks if a noreply address on either member resolves to the other's platform username.
+  // Noreply identities can be ingested as type=email or type=username depending on the source.
   static hasMatchingUsernameFromNoreplyEmail(
     primaryMember: IMemberWithAggregatesForMergeSuggestions,
     similarMember: IMemberOpensearch,
@@ -231,6 +294,15 @@ class MemberSimilarityCalculator {
           )
           .map((i) => i.string_value?.toLowerCase()),
       ),
+      [PlatformType.GITLAB]: new Set(
+        similarMember.nested_identities
+          .filter(
+            (i) =>
+              i.string_platform === PlatformType.GITLAB &&
+              i.keyword_type === MemberIdentityType.USERNAME,
+          )
+          .map((i) => i.string_value?.toLowerCase()),
+      ),
     }
 
     for (const identity of primaryMember.identities) {
@@ -238,6 +310,11 @@ class MemberSimilarityCalculator {
 
       const ghUsername = parseGitHubNoreplyEmail(identity.value)
       if (ghUsername && similarUsernamesByPlatform[PlatformType.GITHUB].has(ghUsername)) {
+        return true
+      }
+
+      const glUsername = parseGitLabNoreplyEmail(identity.value)
+      if (glUsername && similarUsernamesByPlatform[PlatformType.GITLAB].has(glUsername)) {
         return true
       }
     }
@@ -251,6 +328,13 @@ class MemberSimilarityCalculator {
           )
           .map((i) => i.value?.toLowerCase()),
       ),
+      [PlatformType.GITLAB]: new Set(
+        primaryMember.identities
+          .filter(
+            (i) => i.platform === PlatformType.GITLAB && i.type === MemberIdentityType.USERNAME,
+          )
+          .map((i) => i.value?.toLowerCase()),
+      ),
     }
 
     for (const identity of similarMember.nested_identities) {
@@ -258,6 +342,11 @@ class MemberSimilarityCalculator {
 
       const ghUsername = parseGitHubNoreplyEmail(identity.string_value)
       if (ghUsername && primaryUsernamesByPlatform[PlatformType.GITHUB].has(ghUsername)) {
+        return true
+      }
+
+      const glUsername = parseGitLabNoreplyEmail(identity.string_value)
+      if (glUsername && primaryUsernamesByPlatform[PlatformType.GITLAB].has(glUsername)) {
         return true
       }
     }
@@ -379,10 +468,15 @@ class MemberSimilarityCalculator {
     similarMember: IMemberOpensearch,
     startingScore?: number,
   ): number {
-    let isHighConfidence = false
-    let confidenceScore = startingScore || this.HIGH_CONFIDENCE_SCORE
+    // displayName equality (startingScore omitted) is itself a high-confidence signal — don't
+    // gate on metadata. Edit-distance callers pass a score and must have at least one signal.
+    let isHighConfidence = startingScore === undefined
+    let confidenceScore =
+      startingScore != null && Number.isFinite(startingScore)
+        ? startingScore
+        : this.HIGH_CONFIDENCE_SCORE
 
-    const bumpFactor = Math.floor((1 - confidenceScore) / 5)
+    const bumpFactor = (1 - confidenceScore) / 6
 
     if (this.hasSameLocation(member, similarMember)) {
       isHighConfidence = true
@@ -409,11 +503,58 @@ class MemberSimilarityCalculator {
       confidenceScore = this.bumpConfidenceScore(confidenceScore, bumpFactor)
     }
 
+    // Catches contributors whose only identity is commits from an unconfigured machine —
+    // same local-part across *.local / *.lan addresses is a strong hint they're the same person.
+    if (this.hasSameLocalPartInGitUsername(member, similarMember)) {
+      isHighConfidence = true
+      confidenceScore = this.bumpConfidenceScore(confidenceScore, bumpFactor)
+    }
+
     if (!isHighConfidence) {
       return this.LOW_CONFIDENCE_SCORE
     }
 
     return confidenceScore
+  }
+
+  static hasSameLocalPartInGitUsername(
+    member: IMemberWithAggregatesForMergeSuggestions,
+    similarMember: IMemberOpensearch,
+  ): boolean {
+    const primaryDn = (member.displayName ?? '').toLowerCase().trim()
+    const similarDn = (similarMember.keyword_displayName ?? '').toLowerCase().trim()
+    const isUsable = (lp: string) =>
+      lp.length > 0 &&
+      lp !== primaryDn &&
+      lp !== similarDn &&
+      !isKnownBot(lp) &&
+      !isOsReservedName(lp)
+
+    const primaryLocalParts = member.identities
+      .filter(
+        (i) =>
+          i.platform === PlatformType.GIT &&
+          i.type === MemberIdentityType.USERNAME &&
+          isLocalMachineEmail(i.value),
+      )
+      .map((i) => getEmailLocalPart(i.value))
+      .filter(isUsable)
+
+    if (primaryLocalParts.length === 0) return false
+
+    const similarLocalParts = new Set(
+      similarMember.nested_identities
+        .filter(
+          (i) =>
+            i.string_platform === PlatformType.GIT &&
+            i.keyword_type === MemberIdentityType.USERNAME &&
+            isLocalMachineEmail(i.string_value ?? ''),
+        )
+        .map((i) => getEmailLocalPart(i.string_value ?? ''))
+        .filter(isUsable),
+    )
+
+    return primaryLocalParts.some((lp) => similarLocalParts.has(lp))
   }
 
   static bumpConfidenceScore(confidenceScore: number, bump: number): number {

--- a/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
@@ -200,6 +200,8 @@ class MemberSimilarityCalculator {
     similarMember: IMemberOpensearch,
   ): boolean {
     if (member.identities && member.identities.length > 0) {
+      // Only verified usernames are authoritative enough to veto merges; unverified social
+      // slugs mostly come from enrichment and should not block stronger identity evidence.
       for (const identity of member.identities.filter(
         (i) => i.type === MemberIdentityType.USERNAME && i.verified,
       )) {
@@ -468,8 +470,8 @@ class MemberSimilarityCalculator {
     similarMember: IMemberOpensearch,
     startingScore?: number,
   ): number {
-    // displayName equality (startingScore omitted) is itself a high-confidence signal — don't
-    // gate on metadata. Edit-distance callers pass a score and must have at least one signal.
+    // Exact displayName widens the candidate funnel for sparse git-only profiles.
+    // The LLM prompt still rejects display-name-only matches before merging.
     let isHighConfidence = startingScore === undefined
     let confidenceScore =
       startingScore != null && Number.isFinite(startingScore)

--- a/services/apps/merge_suggestions_worker/src/utils.ts
+++ b/services/apps/merge_suggestions_worker/src/utils.ts
@@ -2,6 +2,13 @@ import { ILLMConsumableMember, PlatformType } from '@crowd/types'
 
 import { EMAIL_AS_USERNAME_PLATFORMS } from './enums'
 
+const NOREPLY_SUFFIXES = ['@users.noreply.github.com', '@users.noreply.gitlab.com']
+
+function isNoreplyEmail(value: string): boolean {
+  const lower = value.toLowerCase()
+  return NOREPLY_SUFFIXES.some((s) => lower.endsWith(s))
+}
+
 export const prefixLength = (string: string) => {
   if (string.length > 5 && string.length < 8) {
     return 6
@@ -21,15 +28,12 @@ export function chunkArray<T>(array: T[], chunkSize: number): T[][] {
 export const removeEmailLikeIdentitiesFromMember = (
   member: ILLMConsumableMember,
 ): ILLMConsumableMember => {
-  const nonEmailIdentities: { platform: string; value: string }[] = []
-  for (const identity of member.identities) {
-    if (identity.value.indexOf('@') === -1) {
-      // remove found identity from member.identities
-      nonEmailIdentities.push(identity)
-    }
-  }
-
-  member.identities = nonEmailIdentities
+  // Strip plain emails to avoid the LLM making false matches via shared domain suffixes.
+  // Noreply addresses are kept — their local-part is a provider-authoritative username and
+  // gives the LLM a meaningful identity signal.
+  member.identities = member.identities.filter(
+    (identity) => !identity.value.includes('@') || isNoreplyEmail(identity.value),
+  )
 
   return member
 }
@@ -44,4 +48,12 @@ export function isEmailAsUsernamePlatform(platform: PlatformType) {
 
 export function stripProtocol(value: string) {
   return value.replace(/^https?:\/\//, '')
+}
+
+// Generic git user.name placeholders and OS account names that are never a real human
+// identity — shared across unrelated machines and meaningless as a merge signal.
+const OS_RESERVED_NAMES = new Set(['unknown', 'root', 'ubuntu', 'admin', 'user', 'guest'])
+
+export function isOsReservedName(name: string): boolean {
+  return OS_RESERVED_NAMES.has(name.trim().toLowerCase())
 }

--- a/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
@@ -42,9 +42,10 @@ export async function mergeMembersWithLLM(
                   3. Attributes and other fields: If one member have a specific field and other member doesn't, skip that field when deciding similarity. 
                   Checking semantically instead of literally is important for such fields. Important fields here are: location, timezone, languages, programming languages. 
                   For example one member might have Berlin in location, while other can have Germany - consider such members have same location.  
-                  4. Display Name: Tokenize using both character and word tokenization. When the display name is more than one word, and the difference is a few edit distances consider it a strong indication of similarity. 
-                  When one display name is contained by the other, check other fields for the final decision. The same members on different platforms might have different display names. 
-                  Display names can be multiple words and might be sorted in different order in different platforms for the same member.
+                  4. Display Name: Tokenize using both character and word tokenization. When the display name is more than one word, and the difference is a few edit distances consider it a strong indication of similarity.
+                  When one display name is contained by the other, check other fields for the final decision. The same members on different platforms might have different display names.
+                  Display names can be multiple words and might be sorted in different order in different platforms for the same member. Display name is a supporting signal only — it is never sufficient on its own. 
+                  If display name is the only thing that matches and there are no corroborating signals from identities, organizations, or attributes, return 'false'.
                   CRITICAL RULE - NEVER MERGE IF SAME PLATFORM WITH DIFFERENT VALUES:
                   Before making any decision, you MUST check if both members have identities on the same platform.
                   If member1.identities[x].platform === member2.identities[y].platform (they share a platform), then:

--- a/services/libs/common/src/constants/email-providers.ts
+++ b/services/libs/common/src/constants/email-providers.ts
@@ -1,4 +1,10 @@
+export const noreplyEmailProviders = {
+  github: '@users.noreply.github.com',
+  gitlab: '@users.noreply.gitlab.com',
+} as const
+
 export const emailProviders = new Set([
+  'users.noreply.gitlab.com',
   'gmail.com',
   'gmail.co.uk',
   'gmail.com.au',

--- a/services/libs/common/src/email.ts
+++ b/services/libs/common/src/email.ts
@@ -1,10 +1,10 @@
 import validator from 'validator'
 
+import { noreplyEmailProviders } from './constants'
+
 export const isValidEmail = (value: string): boolean => {
   return validator.isEmail(value)
 }
-
-const GITHUB_NOREPLY_EMAIL_SUFFIX = '@users.noreply.github.com'
 
 /**
  * Extracts username from a GitHub noreply email.
@@ -14,13 +14,56 @@ export const parseGitHubNoreplyEmail = (email?: string | null): string | null =>
   if (!email) return null
 
   const lower = email.toLowerCase()
-  if (!lower.endsWith(GITHUB_NOREPLY_EMAIL_SUFFIX)) return null
+  if (!lower.endsWith(noreplyEmailProviders.github)) return null
 
-  const local = lower.slice(0, -GITHUB_NOREPLY_EMAIL_SUFFIX.length)
+  const local = lower.slice(0, -noreplyEmailProviders.github.length)
   if (!local) return null
 
   const plusIndex = local.indexOf('+')
   const username = plusIndex >= 0 ? local.slice(plusIndex + 1) : local
 
   return username || null
+}
+
+/**
+ * Extracts username from a GitLab noreply email.
+ * @see https://docs.gitlab.com/user/profile/#use-an-automatically-generated-private-commit-email
+ */
+export const parseGitLabNoreplyEmail = (email?: string | null): string | null => {
+  if (!email) return null
+
+  const lower = email.toLowerCase()
+  if (!lower.endsWith(noreplyEmailProviders.gitlab)) return null
+
+  const local = lower.slice(0, -noreplyEmailProviders.gitlab.length)
+  if (!local) return null
+
+  // Strip numeric ID prefix (e.g. "12345-username" → "username")
+  const username = /^\d+-/.test(local) ? local.slice(local.indexOf('-') + 1) : local
+  return username || null
+}
+
+/**
+ * Returns true if the email host indicates a local machine (not a real mail server).
+ * Git commits from unconfigured machines often produce addresses like user@hostname.local.
+ */
+export const isLocalMachineEmail = (value: string): boolean => {
+  const atIndex = value.indexOf('@')
+  if (atIndex < 0) return false
+  const host = value.slice(atIndex + 1).toLowerCase()
+  return (
+    host === 'localhost' ||
+    host.endsWith('.local') ||
+    host.endsWith('.lan') ||
+    host.endsWith('.localdomain')
+  )
+}
+
+/**
+ * Returns the local-part of an email (before '@'), lower-cased.
+ * Returns the full value lower-cased when there is no '@'.
+ */
+export const getEmailLocalPart = (value: string): string => {
+  const atIndex = value.indexOf('@')
+  return (atIndex >= 0 ? value.slice(0, atIndex) : value).toLowerCase()
 }


### PR DESCRIPTION
## Summary

Improves member merge suggestions for contributors split across multiple Git commit emails.

Git ingest stores commit-author emails as `git/username`, but merge scoring treated those values like stable platform handles. That caused profiles for the same person to hard-clash and score `0.2` before noreply, display-name, or metadata checks could run.

## Changes

- Relax `git/username` clashes when both values are email-like, while keeping real platform username clashes intact.
- Only use verified usernames as hard clash signals, so enrichment-derived social slugs do not veto stronger identity evidence.
- Add guardrails for bots, placeholder names, and local-machine default identities.
- Add GitLab noreply parsing and include GitLab/GitHub noreply-to-username matches in candidate generation and scoring.
- Fix confidence score bumps so metadata signals actually increase similarity.
- Add a local-machine email local-part signal for `*.local` / `*.lan` commit identities.
- Preserve noreply identities in the LLM payload while continuing to strip normal emails.
- Tighten the LLM prompt so display name alone is not enough to approve a merge.

## Validation

- Ran focused member similarity checks against real DB-derived cases.
- Verified positive cases for split Git email profiles and negative cases for clashing real platform usernames / placeholder names.
- Ran merge worker typecheck and lint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core member-merge candidate generation and similarity scoring (clash detection, confidence bumping, new identity heuristics), which can meaningfully alter merge decisions and may cause false merges/splits if edge cases are missed.
> 
> **Overview**
> Improves member merge suggestions for contributors split across multiple git commit emails by **relaxing clash detection** to only consider *verified* username conflicts and by exempting `git/username` email-like clashes when display names look non-placeholder/non-bot.
> 
> Expands matching and scoring signals: adds `parseGitLabNoreplyEmail` support and uses noreply→username matches in both OpenSearch candidate queries and similarity checks; fixes noreply deduping to key on `platform:value`; fixes confidence bumping (previously no-op) and adds a new boost for shared local-part across local-machine git emails.
> 
> Tightens LLM merging behavior by preserving noreply emails (while stripping other emails) and updating the prompt to treat display name as a supporting-only signal that cannot alone justify a merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33411aea560fb1563637e24510ad5482335d660a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


