### PR TITLE
fix: member enrichment schedule timeout

### DIFF
--- a/services/apps/members_enrichment_worker/src/schedules/membersEnrichment.ts
+++ b/services/apps/members_enrichment_worker/src/schedules/membersEnrichment.ts
@@ -57,7 +57,7 @@ export const scheduleMembersEnrichment = async () => {
         type: 'startWorkflow',
         workflowType: triggerMembersEnrichment,
         taskQueue: 'members-enrichment',
-        workflowExecutionTimeout: '3 hours',
+        workflowExecutionTimeout: '2 hours',
         retry: {
           initialInterval: '15 seconds',
           backoffCoefficient: 2,

--- a/services/apps/members_enrichment_worker/src/workflows/triggerMembersEnrichment.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/triggerMembersEnrichment.ts
@@ -1,7 +1,6 @@
 import {
   ChildWorkflowCancellationType,
   ParentClosePolicy,
-  continueAsNew,
   executeChild,
   proxyActivities,
 } from '@temporalio/workflow'
@@ -53,6 +52,4 @@ export async function triggerMembersEnrichment(): Promise<void> {
       ),
     )
   }
-
-  await continueAsNew<typeof triggerMembersEnrichment>()
 }


### PR DESCRIPTION
## Summary

We initially treated the member enrichment timeout as a sign that a 500-member batch might not finish within the workflow timeout. After checking the Temporal run history, the 500-member batches were completing, but each run immediately continued as new and started another batch. The scheduled execution eventually timed out because it kept draining work instead of completing after one batch.

This changes member enrichment to process one bounded batch per schedule run. The hourly schedule now controls pacing, and `overlap: SKIP` still prevents concurrent runs if a batch takes longer than expected.

## Changes

- Removed the unconditional `continueAsNew()` from `triggerMembersEnrichment`
- Restored the schedule timeout from `3 hours` to `2 hours`
- Kept the batch size at 500 members per run

## Expected throughput

With a 500-member batch taking roughly 50 minutes on average, the hourly schedule should complete most runs before the next tick. This gives an expected throughput of:

- Best/average case: ~12,000 members/day (24 runs × 500 members)
- Conservative case: ~10,000-11,000 members/day (accounting for occasional slower runs or retries)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Temporal workflow execution behavior by removing `continueAsNew`, which can affect enrichment throughput and scheduling/timeout characteristics if assumptions about batch sizing or pacing are wrong.
> 
> **Overview**
> Member enrichment scheduled runs are now *bounded to a single batch* by removing the unconditional `continueAsNew()` from `triggerMembersEnrichment`, so each hourly tick completes after processing up to 500 members.
> 
> The `members-enrichment-multiple-sources` schedule workflow execution timeout is reduced from `3 hours` to `2 hours` to match the intended per-run workload and avoid long-running schedule executions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810847d23062a827f85ca7338cfdcfba195dbe34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->