### PR TITLE
fix: reduce false-positive merge suggestions from single-word display names (CM-1137)

### DIFF
--- a/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/memberSimilarityCalculator.ts
@@ -178,7 +178,18 @@ class MemberSimilarityCalculator {
     if (
       similarMember.keyword_displayName.toLowerCase() === primaryMember.displayName.toLowerCase()
     ) {
-      return this.decideMemberSimilarityUsingAdditionalChecks(primaryMember, similarMember)
+      const dn = primaryMember.displayName.toLowerCase().trim()
+      if (isOsReservedName(dn)) {
+        return this.LOW_CONFIDENCE_SCORE
+      }
+      // Single-word names (first-name-only, handles) are too ambiguous without a corroborating
+      // signal. Multi-word names (full names) are treated as high-confidence on their own.
+      const isFullName = dn.includes(' ')
+      return this.decideMemberSimilarityUsingAdditionalChecks(
+        primaryMember,
+        similarMember,
+        isFullName ? undefined : this.HIGH_CONFIDENCE_SCORE,
+      )
     }
 
     // calculate similarity percentage

--- a/services/apps/merge_suggestions_worker/src/utils.ts
+++ b/services/apps/merge_suggestions_worker/src/utils.ts
@@ -52,7 +52,16 @@ export function stripProtocol(value: string) {
 
 // Generic git user.name placeholders and OS account names that are never a real human
 // identity — shared across unrelated machines and meaningless as a merge signal.
-const OS_RESERVED_NAMES = new Set(['unknown', 'root', 'ubuntu', 'admin', 'user', 'guest'])
+const OS_RESERVED_NAMES = new Set([
+  'unknown',
+  'root',
+  'ubuntu',
+  'admin',
+  'user',
+  'guest',
+  '[[unknown]] [not provided]',
+  'deleted user',
+])
 
 export function isOsReservedName(name: string): boolean {
   return OS_RESERVED_NAMES.has(name.trim().toLowerCase())


### PR DESCRIPTION
## Summary

Follow-up to #4115.

The first production run surfaced:

- ~21k single-word first-name collisions (`Alex`, `David`, `Scott`, etc.) scoring `0.9` with no corroborating signal.
- ~259 placeholder-name pairs (`[[Unknown]] [Not Provided]`, `Deleted User`) incorrectly treated as valid merge candidates.

## Changes

- Single-word display names now require at least one corroborating signal (`location`, `org`, `timezone`, or `local-part`).
- Only full names (i.e. names containing a space) are treated as high-confidence on their own.
- Added `[[Unknown]] [Not Provided]` and `Deleted User` to the placeholder-name blocklist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts merge-similarity scoring logic used to propose member merges; mistakes could reduce recall or still allow some false positives, but changes are localized to heuristics.
> 
> **Overview**
> Reduces false-positive merge suggestions when members share the same `displayName`.
> 
> Exact `displayName` matches now return *low confidence* for OS/placeholder names via `isOsReservedName`, and treat *single-word* names as requiring corroborating signals by starting `decideMemberSimilarityUsingAdditionalChecks` at `HIGH_CONFIDENCE_SCORE` (only multi-word “full names” remain high-confidence on display name alone).
> 
> Expands the `OS_RESERVED_NAMES` blocklist in `utils.ts` to include `[[Unknown]] [Not Provided]` and `Deleted User`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a878584554a0f5666e3cabb5fdbb05d4bd8d85b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->