### PR TITLE
feat: first implementation of the evaluation job (CM-1167)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1425,9 +1425,6 @@ importers:
       '@crowd/logging':
         specifier: workspace:*
         version: link:../../libs/logging
-      '@crowd/redis':
-        specifier: workspace:*
-        version: link:../../libs/redis
       '@crowd/temporal':
         specifier: workspace:*
         version: link:../../libs/temporal

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1413,12 +1413,6 @@ importers:
       '@crowd/archetype-worker':
         specifier: workspace:*
         version: link:../../archetypes/worker
-      '@crowd/common':
-        specifier: workspace:*
-        version: link:../../libs/common
-      '@crowd/common_services':
-        specifier: workspace:*
-        version: link:../../libs/common_services
       '@crowd/data-access-layer':
         specifier: workspace:*
         version: link:../../libs/data-access-layer
@@ -1428,12 +1422,6 @@ importers:
       '@crowd/temporal':
         specifier: workspace:*
         version: link:../../libs/temporal
-      '@crowd/types':
-        specifier: workspace:*
-        version: link:../../libs/types
-      '@temporalio/activity':
-        specifier: ~1.11.8
-        version: 1.11.8
       '@temporalio/client':
         specifier: ~1.11.8
         version: 1.11.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1405,6 +1405,58 @@ importers:
         specifier: ^3.0.1
         version: 3.1.0
 
+  services/apps/projects_evaluation_worker:
+    dependencies:
+      '@crowd/archetype-standard':
+        specifier: workspace:*
+        version: link:../../archetypes/standard
+      '@crowd/archetype-worker':
+        specifier: workspace:*
+        version: link:../../archetypes/worker
+      '@crowd/common':
+        specifier: workspace:*
+        version: link:../../libs/common
+      '@crowd/common_services':
+        specifier: workspace:*
+        version: link:../../libs/common_services
+      '@crowd/data-access-layer':
+        specifier: workspace:*
+        version: link:../../libs/data-access-layer
+      '@crowd/logging':
+        specifier: workspace:*
+        version: link:../../libs/logging
+      '@crowd/redis':
+        specifier: workspace:*
+        version: link:../../libs/redis
+      '@crowd/temporal':
+        specifier: workspace:*
+        version: link:../../libs/temporal
+      '@crowd/types':
+        specifier: workspace:*
+        version: link:../../libs/types
+      '@temporalio/activity':
+        specifier: ~1.11.8
+        version: 1.11.8
+      '@temporalio/client':
+        specifier: ~1.11.8
+        version: 1.11.8
+      '@temporalio/workflow':
+        specifier: ~1.11.8
+        version: 1.11.8
+      tsx:
+        specifier: ^4.7.1
+        version: 4.7.3
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
+    devDependencies:
+      '@types/node':
+        specifier: ^20.8.2
+        version: 20.12.7
+      nodemon:
+        specifier: ^3.0.1
+        version: 3.1.0
+
   services/apps/script_executor_worker:
     dependencies:
       '@crowd/archetype-standard':

--- a/scripts/builders/projects-evaluation-worker.env
+++ b/scripts/builders/projects-evaluation-worker.env
@@ -1,0 +1,4 @@
+DOCKERFILE="./services/docker/Dockerfile.projects_evaluation_worker"
+CONTEXT="../"
+REPO="sjc.ocir.io/axbydjxa5zuh/projects-evaluation-worker"
+SERVICES="projects-evaluation-worker"

--- a/scripts/cli
+++ b/scripts/cli
@@ -1013,7 +1013,7 @@ while test $# -gt 0; do
         exit
         ;;
     clean-start-dev)
-        IGNORED_SERVICES=("python-worker" "job-generator" "discord-ws" "webhook-api" "profiles-worker" "organizations-enrichment-worker" "merge-suggestions-worker" "members-enrichment-worker" "exports-worker" "entity-merging-worker")
+        # IGNORED_SERVICES=("python-worker" "job-generator" "discord-ws" "webhook-api" "profiles-worker" "organizations-enrichment-worker" "merge-suggestions-worker" "members-enrichment-worker" "exports-worker" "entity-merging-worker")
         CLEAN_START=1
         DEV=1
         start

--- a/scripts/cli
+++ b/scripts/cli
@@ -1013,7 +1013,7 @@ while test $# -gt 0; do
         exit
         ;;
     clean-start-dev)
-        # IGNORED_SERVICES=("python-worker" "job-generator" "discord-ws" "webhook-api" "profiles-worker" "organizations-enrichment-worker" "merge-suggestions-worker" "members-enrichment-worker" "exports-worker" "entity-merging-worker")
+        IGNORED_SERVICES=("python-worker" "job-generator" "discord-ws" "webhook-api" "profiles-worker" "organizations-enrichment-worker" "merge-suggestions-worker" "members-enrichment-worker" "exports-worker" "entity-merging-worker")
         CLEAN_START=1
         DEV=1
         start

--- a/scripts/services/docker/Dockerfile.projects_evaluation_worker
+++ b/scripts/services/docker/Dockerfile.projects_evaluation_worker
@@ -1,0 +1,23 @@
+FROM node:20-alpine as builder
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /usr/crowd/app
+RUN npm install -g corepack@latest && corepack enable pnpm && corepack prepare pnpm@9.15.0 --activate
+
+COPY ./pnpm-workspace.yaml ./pnpm-lock.yaml ./
+RUN pnpm fetch
+
+COPY ./services ./services
+RUN pnpm i --frozen-lockfile
+
+FROM node:20-bookworm-slim as runner
+
+WORKDIR /usr/crowd/app
+RUN npm install -g corepack@latest && corepack enable pnpm && corepack prepare pnpm@9.15.0 --activate  && apt update && apt install -y ca-certificates --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/crowd/app/node_modules ./node_modules
+COPY --from=builder /usr/crowd/app/services/base.tsconfig.json ./services/base.tsconfig.json
+COPY --from=builder /usr/crowd/app/services/libs ./services/libs
+COPY --from=builder /usr/crowd/app/services/archetypes/ ./services/archetypes
+COPY --from=builder /usr/crowd/app/services/apps/projects_evaluation_worker/ ./services/apps/projects_evaluation_worker

--- a/scripts/services/projects-evaluation-worker.yaml
+++ b/scripts/services/projects-evaluation-worker.yaml
@@ -1,0 +1,64 @@
+version: '3.1'
+
+x-env-args: &env-args
+  DOCKER_BUILDKIT: 1
+  NODE_ENV: docker
+  SERVICE: projects-evaluation-worker
+  CROWD_TEMPORAL_TASKQUEUE: projects-evaluation
+  SHELL: /bin/sh
+
+services:
+  projects-evaluation-worker:
+    build:
+      context: ../../
+      dockerfile: ./scripts/services/docker/Dockerfile.projects_evaluation_worker
+    command: 'pnpm run start'
+    working_dir: /usr/crowd/app/services/apps/projects_evaluation_worker
+    env_file:
+      - ../../backend/.env.dist.local
+      - ../../backend/.env.dist.composed
+      - ../../backend/.env.override.local
+      - ../../backend/.env.override.composed
+    environment:
+      <<: *env-args
+    restart: always
+    networks:
+      - crowd-bridge
+
+  projects-evaluation-worker-dev:
+    build:
+      context: ../../
+      dockerfile: ./scripts/services/docker/Dockerfile.projects_evaluation_worker
+    command: 'pnpm run dev'
+    working_dir: /usr/crowd/app/services/apps/projects_evaluation_worker
+    env_file:
+      - ../../backend/.env.dist.local
+      - ../../backend/.env.dist.composed
+      - ../../backend/.env.override.local
+      - ../../backend/.env.override.composed
+    environment:
+      <<: *env-args
+    hostname: projects-evaluation-worker
+    networks:
+      - crowd-bridge
+    volumes:
+      - ../../services/libs/audit-logs/src:/usr/crowd/app/services/libs/audit-logs/src
+      - ../../services/libs/common/src:/usr/crowd/app/services/libs/common/src
+      - ../../services/libs/common_services/src:/usr/crowd/app/services/libs/common_services/src
+      - ../../services/libs/data-access-layer/src:/usr/crowd/app/services/libs/data-access-layer/src
+      - ../../services/libs/database/src:/usr/crowd/app/services/libs/database/src
+      - ../../services/libs/integrations/src:/usr/crowd/app/services/libs/integrations/src
+      - ../../services/libs/logging/src:/usr/crowd/app/services/libs/logging/src
+      - ../../services/libs/nango/src:/usr/crowd/app/services/libs/nango/src
+      - ../../services/libs/opensearch/src:/usr/crowd/app/services/libs/opensearch/src
+      - ../../services/libs/queue/src:/usr/crowd/app/services/libs/queue/src
+      - ../../services/libs/redis/src:/usr/crowd/app/services/libs/redis/src
+      - ../../services/libs/snowflake/src:/usr/crowd/app/services/libs/snowflake/src
+      - ../../services/libs/telemetry/src:/usr/crowd/app/services/libs/telemetry/src
+      - ../../services/libs/temporal/src:/usr/crowd/app/services/libs/temporal/src
+      - ../../services/libs/types/src:/usr/crowd/app/services/libs/types/src
+      - ../../services/apps/projects_evaluation_worker/src:/usr/crowd/app/services/apps/projects_evaluation_worker/src
+
+networks:
+  crowd-bridge:
+    external: true

--- a/services/apps/projects_evaluation_worker/package.json
+++ b/services/apps/projects_evaluation_worker/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@crowd/projects-evaluation-worker",
+  "private": true,
+  "scripts": {
+    "start": "CROWD_TEMPORAL_TASKQUEUE=projects-evaluation SERVICE=projects-evaluation-worker tsx src/main.ts",
+    "start:debug:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && CROWD_TEMPORAL_TASKQUEUE=projects-evaluation SERVICE=projects-evaluation-worker tsx --inspect=0.0.0.0:9233 src/main.ts",
+    "start:debug": "CROWD_TEMPORAL_TASKQUEUE=projects-evaluation SERVICE=projects-evaluation-worker LOG_LEVEL=trace tsx --inspect=0.0.0.0:9233 src/main.ts",
+    "dev:local": "nodemon --watch src --watch ../../libs --ext ts --exec pnpm run start:debug:local",
+    "dev": "nodemon --watch src --watch ../../libs --ext ts --exec pnpm run start:debug",
+    "lint": "npx eslint --ext .ts src --max-warnings=0",
+    "format": "npx prettier --write \"src/**/*.ts\"",
+    "format-check": "npx prettier --check .",
+    "tsc-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@crowd/archetype-standard": "workspace:*",
+    "@crowd/archetype-worker": "workspace:*",
+    "@crowd/common": "workspace:*",
+    "@crowd/common_services": "workspace:*",
+    "@crowd/data-access-layer": "workspace:*",
+    "@crowd/logging": "workspace:*",
+    "@crowd/redis": "workspace:*",
+    "@crowd/temporal": "workspace:*",
+    "@crowd/types": "workspace:*",
+    "@temporalio/activity": "~1.11.8",
+    "@temporalio/client": "~1.11.8",
+    "@temporalio/workflow": "~1.11.8",
+    "tsx": "^4.7.1",
+    "typescript": "^5.6.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.2",
+    "nodemon": "^3.0.1"
+  }
+}

--- a/services/apps/projects_evaluation_worker/package.json
+++ b/services/apps/projects_evaluation_worker/package.json
@@ -19,7 +19,6 @@
     "@crowd/common_services": "workspace:*",
     "@crowd/data-access-layer": "workspace:*",
     "@crowd/logging": "workspace:*",
-    "@crowd/redis": "workspace:*",
     "@crowd/temporal": "workspace:*",
     "@crowd/types": "workspace:*",
     "@temporalio/activity": "~1.11.8",

--- a/services/apps/projects_evaluation_worker/package.json
+++ b/services/apps/projects_evaluation_worker/package.json
@@ -15,13 +15,9 @@
   "dependencies": {
     "@crowd/archetype-standard": "workspace:*",
     "@crowd/archetype-worker": "workspace:*",
-    "@crowd/common": "workspace:*",
-    "@crowd/common_services": "workspace:*",
     "@crowd/data-access-layer": "workspace:*",
     "@crowd/logging": "workspace:*",
     "@crowd/temporal": "workspace:*",
-    "@crowd/types": "workspace:*",
-    "@temporalio/activity": "~1.11.8",
     "@temporalio/client": "~1.11.8",
     "@temporalio/workflow": "~1.11.8",
     "tsx": "^4.7.1",

--- a/services/apps/projects_evaluation_worker/src/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities.ts
@@ -1,0 +1,1 @@
+export * from './activities/activities'

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -9,8 +9,8 @@ import { svc } from '../main'
 const log = getServiceLogger()
 
 export async function fetchPendingProjects(batchSize: number): Promise<IDbProjectCatalog[]> {
-  const qx = pgpQx(svc.postgres.writer.connection())
-
+  const qx = pgpQx(svc.postgres.reader.connection())
+  
   const projects = await findProjectCatalogPendingEvaluation(qx, { limit: batchSize })
 
   log.info({ count: projects.length, batchSize }, 'Fetched projects pending evaluation.')

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -10,7 +10,7 @@ const log = getServiceLogger()
 
 export async function fetchPendingProjects(batchSize: number): Promise<IDbProjectCatalog[]> {
   const qx = pgpQx(svc.postgres.reader.connection())
-  
+
   const projects = await findProjectCatalogPendingEvaluation(qx, { limit: batchSize })
 
   log.info({ count: projects.length, batchSize }, 'Fetched projects pending evaluation.')

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,7 +1,4 @@
-import {
-  findProjectCatalogPendingEvaluation,
-  updateProjectCatalog,
-} from '@crowd/data-access-layer'
+import { findProjectCatalogPendingEvaluation, updateProjectCatalog } from '@crowd/data-access-layer'
 import { IDbProjectCatalog } from '@crowd/data-access-layer/src/project-catalog/types'
 import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceLogger } from '@crowd/logging'

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,0 +1,56 @@
+import {
+  findProjectCatalogPendingEvaluation,
+  updateProjectCatalog,
+} from '@crowd/data-access-layer'
+import { IDbProjectCatalog } from '@crowd/data-access-layer/src/project-catalog/types'
+import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
+import { getServiceLogger } from '@crowd/logging'
+
+import { evaluateProject } from '../evaluator/evaluator'
+import { svc } from '../main'
+
+const log = getServiceLogger()
+
+export async function fetchPendingProjects(batchSize: number): Promise<IDbProjectCatalog[]> {
+  const qx = pgpQx(svc.postgres.writer.connection())
+
+  const projects = await findProjectCatalogPendingEvaluation(qx, { limit: batchSize })
+
+  log.info({ count: projects.length, batchSize }, 'Fetched projects pending evaluation.')
+
+  return projects
+}
+
+export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Promise<void> {
+  const qx = pgpQx(svc.postgres.writer.connection())
+  const startTime = Date.now()
+
+  log.info({ id: project.id, repoUrl: project.repoUrl }, 'Starting evaluation.')
+
+  const result = await evaluateProject({
+    id: project.id,
+    repoUrl: project.repoUrl,
+    repoName: project.repoName,
+    projectSlug: project.projectSlug,
+    lfCriticalityScore: project.lfCriticalityScore,
+    source: project.source,
+  })
+
+  await updateProjectCatalog(qx, project.id, {
+    action: result.outcome,
+    evaluatedAt: new Date().toISOString(),
+  })
+
+  const elapsedSeconds = ((Date.now() - startTime) / 1000).toFixed(1)
+
+  log.info(
+    {
+      id: project.id,
+      repoUrl: project.repoUrl,
+      outcome: result.outcome,
+      reason: result.reason,
+      elapsedSeconds,
+    },
+    'Evaluation complete.',
+  )
+}

--- a/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
@@ -1,0 +1,11 @@
+import { IEvaluationInput, IEvaluationResult } from './types'
+
+// TODO: Replace with the actual AI evaluation algorithm once the external repo is integrated.
+// The algorithm is described in the technical spec and currently takes ~30-40s per project
+// at ~$0.15/project. Reference: https://github.com/... (link TBD).
+export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluationResult> {
+  throw new Error(
+    `evaluateProject is not implemented yet. ` +
+      `Integrate the AI evaluation algorithm for repo: ${input.repoUrl}`,
+  )
+}

--- a/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
@@ -4,8 +4,6 @@ import { IEvaluationInput, IEvaluationResult } from './types'
 // The algorithm is described in the technical spec and currently takes ~30-40s per project
 // at ~$0.15/project. Reference: https://github.com/... (link TBD).
 export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluationResult> {
-  throw new Error(
-    `evaluateProject is not implemented yet. ` +
-      `Integrate the AI evaluation algorithm for repo: ${input.repoUrl}`,
-  )
+  console.error(`evaluateProject is not implemented yet for repo: ${input.repoUrl}`)
+  return { outcome: 'unsure', reason: 'evaluator not implemented' }
 }

--- a/services/apps/projects_evaluation_worker/src/evaluator/types.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/types.ts
@@ -1,0 +1,18 @@
+import { ProjectCatalogAction } from '@crowd/data-access-layer/src/project-catalog/types'
+
+export interface IEvaluationInput {
+  id: string
+  repoUrl: string
+  repoName: string
+  projectSlug: string
+  lfCriticalityScore: number | null
+  source: string | null
+}
+
+// Evaluation can only resolve to 'onboard' or 'unsure' — never back to 'evaluate' or 'auto'.
+export type EvaluationOutcome = Extract<ProjectCatalogAction, 'onboard' | 'unsure'>
+
+export interface IEvaluationResult {
+  outcome: EvaluationOutcome
+  reason: string
+}

--- a/services/apps/projects_evaluation_worker/src/main.ts
+++ b/services/apps/projects_evaluation_worker/src/main.ts
@@ -1,0 +1,40 @@
+import { Config } from '@crowd/archetype-standard'
+import { Options, ServiceWorker } from '@crowd/archetype-worker'
+
+import { scheduleProjectsEvaluation } from './schedules/scheduleProjectsEvaluation'
+
+const config: Config = {
+  envvars: [],
+  producer: {
+    enabled: false,
+  },
+  temporal: {
+    enabled: true,
+  },
+  redis: {
+    enabled: false,
+  },
+}
+
+const options: Options = {
+  postgres: {
+    enabled: true,
+  },
+  opensearch: {
+    enabled: false,
+  },
+}
+
+export const svc = new ServiceWorker(config, options)
+
+setImmediate(async () => {
+  await svc.init()
+
+  svc.log.info('Projects evaluation worker starting up.')
+
+  await scheduleProjectsEvaluation()
+
+  svc.log.info('Projects evaluation worker running — schedule registered, waiting for Temporal.')
+
+  await svc.start()
+})

--- a/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
+++ b/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
@@ -1,0 +1,42 @@
+import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/client'
+
+import { svc } from '../main'
+import { evaluateProjects } from '../workflows'
+
+export const scheduleProjectsEvaluation = async () => {
+  svc.log.info('Scheduling projects evaluation')
+
+  try {
+    await svc.temporal.schedule.create({
+      scheduleId: 'projectsEvaluation',
+      spec: {
+        // Run every Monday at 02:00 UTC — gives time after the weekly discovery run.
+        cronExpressions: ['0 2 * * 1'],
+      },
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: '1 minute',
+      },
+      action: {
+        type: 'startWorkflow',
+        workflowType: evaluateProjects,
+        taskQueue: 'projects-evaluation',
+        args: [{ batchSize: 100 }],
+        // 100 projects × ~3min each = ~5h worst case; set ceiling with margin.
+        workflowExecutionTimeout: '6 hours',
+        retry: {
+          initialInterval: '30 seconds',
+          backoffCoefficient: 2,
+          maximumAttempts: 3,
+        },
+      },
+    })
+  } catch (err) {
+    if (err instanceof ScheduleAlreadyRunning) {
+      svc.log.info('Schedule already registered in Temporal.')
+      svc.log.info('Configuration may have changed since. Please make sure they are in sync.')
+    } else {
+      throw new Error(err)
+    }
+  }
+}

--- a/services/apps/projects_evaluation_worker/src/workflows.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows.ts
@@ -1,0 +1,3 @@
+import { evaluateProjects } from './workflows/evaluateProjects'
+
+export { evaluateProjects }

--- a/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
@@ -1,0 +1,53 @@
+import { log, proxyActivities } from '@temporalio/workflow'
+
+import type * as activities from '../activities'
+
+// Short timeout: just a DB read.
+const fetchActivities = proxyActivities<typeof activities>({
+  startToCloseTimeout: '2 minutes',
+  retry: { maximumAttempts: 3 },
+})
+
+// Each AI evaluation call takes ~30-40s; give generous headroom per project.
+const evaluateActivities = proxyActivities<typeof activities>({
+  startToCloseTimeout: '3 minutes',
+  retry: { maximumAttempts: 2 },
+})
+
+const DEFAULT_BATCH_SIZE = 100
+
+export async function evaluateProjects(
+  input: { batchSize?: number } = {},
+): Promise<void> {
+  const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE
+
+  log.info('evaluateProjects workflow started.')
+
+  const projects = await fetchActivities.fetchPendingProjects(batchSize)
+
+  if (projects.length === 0) {
+    log.info('No projects pending evaluation. Nothing to do.')
+    return
+  }
+
+  log.info(`Evaluating ${projects.length} project(s) (batch size: ${batchSize}).`)
+
+  let succeeded = 0
+  let failed = 0
+
+  for (let i = 0; i < projects.length; i++) {
+    const project = projects[i]
+    log.info(`[${i + 1}/${projects.length}] Evaluating: ${project.repoUrl}`)
+
+    try {
+      await evaluateActivities.evaluateAndUpdateProject(project)
+      succeeded++
+    } catch (err) {
+      // Log and continue — a single failure should not abort the whole batch.
+      failed++
+      log.error(`Evaluation failed for project id=${project.id} repoUrl=${project.repoUrl}: ${String(err)}`)
+    }
+  }
+
+  log.info(`Batch evaluation complete. total=${projects.length} succeeded=${succeeded} failed=${failed}`)
+}

--- a/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
@@ -16,9 +16,7 @@ const evaluateActivities = proxyActivities<typeof activities>({
 
 const DEFAULT_BATCH_SIZE = 100
 
-export async function evaluateProjects(
-  input: { batchSize?: number } = {},
-): Promise<void> {
+export async function evaluateProjects(input: { batchSize?: number } = {}): Promise<void> {
   const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE
 
   log.info('evaluateProjects workflow started.')
@@ -45,9 +43,13 @@ export async function evaluateProjects(
     } catch (err) {
       // Log and continue — a single failure should not abort the whole batch.
       failed++
-      log.error(`Evaluation failed for project id=${project.id} repoUrl=${project.repoUrl}: ${String(err)}`)
+      log.error(
+        `Evaluation failed for project id=${project.id} repoUrl=${project.repoUrl}: ${String(err)}`,
+      )
     }
   }
 
-  log.info(`Batch evaluation complete. total=${projects.length} succeeded=${succeeded} failed=${failed}`)
+  log.info(
+    `Batch evaluation complete. total=${projects.length} succeeded=${succeeded} failed=${failed}`,
+  )
 }

--- a/services/apps/projects_evaluation_worker/tsconfig.json
+++ b/services/apps/projects_evaluation_worker/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../base.tsconfig.json",
+  "include": ["src/**/*"]
+}

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -79,6 +79,25 @@ export async function findAllProjectCatalog(
   )
 }
 
+export async function findProjectCatalogPendingEvaluation(
+  qx: QueryExecutor,
+  options: { limit?: number; offset?: number } = {},
+): Promise<IDbProjectCatalog[]> {
+  const { limit, offset } = options
+
+  return qx.select(
+    `
+    SELECT ${prepareSelectColumns(PROJECT_CATALOG_COLUMNS)}
+    FROM "projectCatalog"
+    WHERE action = 'evaluate'
+    ORDER BY "lfCriticalityScore" DESC NULLS LAST, "createdAt" ASC
+    ${limit !== undefined ? 'LIMIT $(limit)' : ''}
+    ${offset !== undefined ? 'OFFSET $(offset)' : ''}
+    `,
+    { limit, offset },
+  )
+}
+
 export async function countProjectCatalog(qx: QueryExecutor): Promise<number> {
   const result = await qx.selectOne(
     `


### PR DESCRIPTION
## Summary
Introduces the skeleton of the projects_evaluation_worker, the second phase of the auto-onboarding pipeline. The worker picks up projects marked action = 'evaluate' in the projectCatalog table, runs an AI-based evaluation on each one, and updates the action to onboard or unsure along with evaluatedAt. The evaluator itself is a stub — the actual AI algorithm integration is tracked separately.

## Changes
- New Temporal worker projects_evaluation_worker with workflow, activities, schedule (every Monday 02:00 UTC), Dockerfile and docker-compose YAML
- Added findProjectCatalogPendingEvaluation to the DAL — filters by action = 'evaluate', ordered by lfCriticalityScore DESC then createdAt ASC (highest score first, FIFO within same score)
- Evaluator stub in src/evaluator/evaluator.ts throws explicitly until the algorithm is wired

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
https://linuxfoundation.atlassian.net/browse/CM-1167

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Temporal-scheduled worker that reads and updates `projectCatalog` rows, so misconfiguration or the current stubbed evaluator could incorrectly mark projects as `unsure` at scale. Changes are otherwise additive (new service, new DAL query) with limited impact on existing flows.
> 
> **Overview**
> Adds an initial `projects_evaluation_worker` Temporal worker that runs on a weekly schedule, fetches `projectCatalog` entries with `action = 'evaluate'`, evaluates them, and persists the resulting `action` plus `evaluatedAt`.
> 
> Includes new Docker build/compose setup for the worker and a new DAL helper `findProjectCatalogPendingEvaluation` that selects evaluable projects ordered by *highest* `lfCriticalityScore` then oldest `createdAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de405aa5f75be0b80e0d4bf92249ae262a816d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->