### PR TITLE
feat: evaluation priority logic (CM-1166)

### DIFF
--- a/services/apps/automatic_projects_discovery_worker/src/sources/insights-discussions/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/insights-discussions/source.ts
@@ -261,7 +261,6 @@ export class InsightsDiscussionsSource implements IDiscoverySource {
       projectSlug,
       repoName,
       repoUrl,
-      action: 'evaluate',
     }
   }
 }

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,12 +1,47 @@
-import { findProjectCatalogPendingEvaluation, updateProjectCatalog } from '@crowd/data-access-layer'
+import {
+  countProjectCatalogByAction,
+  findProjectCatalogPendingEvaluation,
+  promoteProjectsToEvaluate,
+  updateProjectCatalog,
+} from '@crowd/data-access-layer'
 import { IDbProjectCatalog } from '@crowd/data-access-layer/src/project-catalog/types'
 import { pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceLogger } from '@crowd/logging'
 
 import { evaluateProject } from '../evaluator/evaluator'
 import { svc } from '../main'
+import { IPriorityConfig } from '../types'
 
 const log = getServiceLogger()
+
+/**
+ * Promotes 'auto' projects to 'evaluate' up to the configured limit,
+ * respecting source priority and criticality score ordering.
+ */
+export async function promoteProjectsForEvaluation(config: IPriorityConfig): Promise<void> {
+  const { evaluateLimit, sourcePriority } = config
+  const qx = pgpQx(svc.postgres.writer.connection())
+
+  const currentEvaluateCount = await countProjectCatalogByAction(qx, 'evaluate')
+  const slotsAvailable = Math.max(0, evaluateLimit - currentEvaluateCount)
+
+  log.info(
+    { evaluateLimit, currentEvaluateCount, slotsAvailable, sourcePriority },
+    'Priority promotion: computing slots.',
+  )
+
+  if (slotsAvailable === 0) {
+    log.info('Priority promotion: queue is full, skipping promotion.')
+    return
+  }
+
+  const promoted = await promoteProjectsToEvaluate(qx, {
+    limit: slotsAvailable,
+    sourcePriority,
+  })
+
+  log.info({ promoted, slotsAvailable }, 'Priority promotion: complete.')
+}
 
 export async function fetchPendingProjects(batchSize: number): Promise<IDbProjectCatalog[]> {
   const qx = pgpQx(svc.postgres.reader.connection())

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,5 +1,4 @@
 import {
-  countProjectCatalogByAction,
   findProjectCatalogPendingEvaluation,
   promoteProjectsToEvaluate,
   updateProjectCatalog,
@@ -15,32 +14,19 @@ import { IPriorityConfig } from '../types'
 const log = getServiceLogger()
 
 /**
- * Promotes 'auto' projects to 'evaluate' up to the configured limit,
- * respecting source priority and criticality score ordering.
+ * Promotes 'auto' projects to 'evaluate' up to the configured limit.
+ * Count, slot computation, locking, and update are all done atomically
+ * inside a single SQL statement — see promoteProjectsToEvaluate in the DAL.
  */
 export async function promoteProjectsForEvaluation(config: IPriorityConfig): Promise<void> {
   const { evaluateLimit, sourcePriority } = config
   const qx = pgpQx(svc.postgres.writer.connection())
 
-  const currentEvaluateCount = await countProjectCatalogByAction(qx, 'evaluate')
-  const slotsAvailable = Math.max(0, evaluateLimit - currentEvaluateCount)
+  log.info({ evaluateLimit, sourcePriority }, 'Priority promotion: starting.')
 
-  log.info(
-    { evaluateLimit, currentEvaluateCount, slotsAvailable, sourcePriority },
-    'Priority promotion: computing slots.',
-  )
+  const promoted = await promoteProjectsToEvaluate(qx, { evaluateLimit, sourcePriority })
 
-  if (slotsAvailable === 0) {
-    log.info('Priority promotion: queue is full, skipping promotion.')
-    return
-  }
-
-  const promoted = await promoteProjectsToEvaluate(qx, {
-    limit: slotsAvailable,
-    sourcePriority,
-  })
-
-  log.info({ promoted, slotsAvailable }, 'Priority promotion: complete.')
+  log.info({ promoted }, 'Priority promotion: complete.')
 }
 
 export async function fetchPendingProjects(batchSize: number): Promise<IDbProjectCatalog[]> {

--- a/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
+++ b/services/apps/projects_evaluation_worker/src/schedules/scheduleProjectsEvaluation.ts
@@ -1,7 +1,18 @@
 import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/client'
 
 import { svc } from '../main'
-import { evaluateProjects } from '../workflows'
+import { IEvaluateProjectsInput, evaluateProjects } from '../workflows'
+
+// Priority configuration for the evaluation queue.
+// - evaluateLimit: maximum number of projects in 'evaluate' state at any time.
+// - sourcePriority: ordered list of sources; earlier = higher priority; unlisted sources rank last.
+const EVALUATION_ARGS: IEvaluateProjectsInput = {
+  batchSize: 50,
+  priorityConfig: {
+    evaluateLimit: 50,
+    sourcePriority: ['insights-discussions'],
+  },
+}
 
 export const scheduleProjectsEvaluation = async () => {
   svc.log.info('Scheduling projects evaluation')
@@ -21,8 +32,8 @@ export const scheduleProjectsEvaluation = async () => {
         type: 'startWorkflow',
         workflowType: evaluateProjects,
         taskQueue: 'projects-evaluation',
-        args: [{ batchSize: 100 }],
-        // 100 projects × ~3min each = ~5h worst case; set ceiling with margin.
+        args: [EVALUATION_ARGS],
+        // 50 projects × ~3min each = ~2.5h worst case; set ceiling with margin.
         workflowExecutionTimeout: '6 hours',
         retry: {
           initialInterval: '30 seconds',

--- a/services/apps/projects_evaluation_worker/src/types.ts
+++ b/services/apps/projects_evaluation_worker/src/types.ts
@@ -1,0 +1,14 @@
+export interface IPriorityConfig {
+  /** Maximum number of projects in the 'evaluate' queue at any time. */
+  evaluateLimit: number
+  /**
+   * Ordered list of source names by descending priority.
+   * Sources not in this list rank below all listed ones.
+   */
+  sourcePriority: string[]
+}
+
+export interface IEvaluateProjectsInput {
+  batchSize?: number
+  priorityConfig?: IPriorityConfig
+}

--- a/services/apps/projects_evaluation_worker/src/workflows.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows.ts
@@ -1,5 +1,5 @@
-import { evaluateProjects } from './workflows/evaluateProjects'
 import type { IEvaluateProjectsInput } from './types'
+import { evaluateProjects } from './workflows/evaluateProjects'
 
 export { evaluateProjects }
 export type { IEvaluateProjectsInput }

--- a/services/apps/projects_evaluation_worker/src/workflows.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows.ts
@@ -1,3 +1,5 @@
 import { evaluateProjects } from './workflows/evaluateProjects'
+import type { IEvaluateProjectsInput } from './types'
 
 export { evaluateProjects }
+export type { IEvaluateProjectsInput }

--- a/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
+++ b/services/apps/projects_evaluation_worker/src/workflows/evaluateProjects.ts
@@ -1,6 +1,13 @@
 import { log, proxyActivities } from '@temporalio/workflow'
 
 import type * as activities from '../activities'
+import type { IEvaluateProjectsInput, IPriorityConfig } from '../types'
+
+// Quick DB write — promote auto → evaluate.
+const promotionActivities = proxyActivities<typeof activities>({
+  startToCloseTimeout: '1 minute',
+  retry: { maximumAttempts: 3 },
+})
 
 // Short timeout: just a DB read.
 const fetchActivities = proxyActivities<typeof activities>({
@@ -14,13 +21,20 @@ const evaluateActivities = proxyActivities<typeof activities>({
   retry: { maximumAttempts: 2 },
 })
 
-const DEFAULT_BATCH_SIZE = 100
+const DEFAULT_PRIORITY_CONFIG: IPriorityConfig = {
+  evaluateLimit: 50,
+  sourcePriority: ['insights-discussions'],
+}
 
-export async function evaluateProjects(input: { batchSize?: number } = {}): Promise<void> {
-  const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE
+export async function evaluateProjects(input: IEvaluateProjectsInput = {}): Promise<void> {
+  const { batchSize = 50, priorityConfig = DEFAULT_PRIORITY_CONFIG } = input
 
   log.info('evaluateProjects workflow started.')
 
+  // Step 1: promote 'auto' projects to 'evaluate' according to priority config.
+  await promotionActivities.promoteProjectsForEvaluation(priorityConfig)
+
+  // Step 2: fetch the evaluation queue (includes any leftovers from prior runs).
   const projects = await fetchActivities.fetchPendingProjects(batchSize)
 
   if (projects.length === 0) {

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -1,7 +1,12 @@
 import { QueryExecutor } from '../queryExecutor'
 import { prepareSelectColumns } from '../utils'
 
-import { IDbProjectCatalog, IDbProjectCatalogCreate, IDbProjectCatalogUpdate } from './types'
+import {
+  IDbProjectCatalog,
+  IDbProjectCatalogCreate,
+  IDbProjectCatalogUpdate,
+  ProjectCatalogAction,
+} from './types'
 
 const PROJECT_CATALOG_COLUMNS = [
   'id',
@@ -106,6 +111,62 @@ export async function countProjectCatalog(qx: QueryExecutor): Promise<number> {
     `,
   )
   return parseInt(result.count, 10)
+}
+
+export async function countProjectCatalogByAction(
+  qx: QueryExecutor,
+  action: ProjectCatalogAction,
+): Promise<number> {
+  const result = await qx.selectOne(
+    `
+    SELECT COUNT(*) AS count
+    FROM "projectCatalog"
+    WHERE action = $(action)
+    `,
+    { action },
+  )
+  return parseInt(result.count, 10)
+}
+
+/**
+ * Promotes up to `limit` projects from action='auto' to action='evaluate'.
+ *
+ * Ordering (all configurable via `sourcePriority`):
+ *   1. Source priority — earlier position in the array = higher priority (NULLS/unknown = lowest)
+ *   2. lfCriticalityScore DESC (higher score = higher priority, NULLs last)
+ *   3. createdAt ASC (older entries first as a stable tie-breaker)
+ *
+ * Returns the number of rows actually promoted.
+ */
+export async function promoteProjectsToEvaluate(
+  qx: QueryExecutor,
+  options: { limit: number; sourcePriority: string[] },
+): Promise<number> {
+  const { limit, sourcePriority } = options
+
+  if (limit <= 0) {
+    return 0
+  }
+
+  const result = await qx.result(
+    `
+    UPDATE "projectCatalog"
+    SET action = 'evaluate', "updatedAt" = NOW()
+    WHERE id IN (
+      SELECT id
+      FROM "projectCatalog"
+      WHERE action = 'auto'
+      ORDER BY
+        COALESCE(ARRAY_POSITION($(sourcePriority)::text[], source), 2147483647) ASC,
+        "lfCriticalityScore" DESC NULLS LAST,
+        "createdAt" ASC
+      LIMIT $(limit)
+    )
+    `,
+    { sourcePriority, limit },
+  )
+
+  return result
 }
 
 export async function insertProjectCatalog(

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -129,15 +129,16 @@ export async function countProjectCatalogByAction(
 }
 
 /**
- * Promotes 'auto' projects to 'evaluate', enforcing a hard cap on the total
- * queue size in a single atomic statement.
+ * Promotes 'auto' projects to 'evaluate', targeting a soft cap on the queue size.
  *
  * Uses a CTE to:
- *   1. Compute available slots (evaluateLimit − current 'evaluate' count) inline,
- *      so two concurrent calls observe the same baseline and each picks a
- *      disjoint set of rows.
- *   2. Lock candidates with FOR UPDATE SKIP LOCKED — concurrent transactions
- *      skip already-locked rows, preventing double-promotion.
+ *   1. Compute available slots (evaluateLimit − current 'evaluate' count) inline.
+ *   2. Lock candidates with FOR UPDATE SKIP LOCKED — prevents double-promotion
+ *      if two transactions run concurrently (e.g. simultaneous manual triggers).
+ *      Note: concurrent calls can each compute the same slot count and promote
+ *      up to evaluateLimit disjoint rows, so the cap is soft — the queue can
+ *      overshoot by at most evaluateLimit per extra concurrent caller. In practice
+ *      this doesn't happen: the schedule uses ScheduleOverlapPolicy.SKIP.
  *   3. Re-check action = 'auto' in the outer UPDATE to guard against rows whose
  *      state changed after the subquery snapshot (e.g. manual updates).
  *

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -129,44 +129,60 @@ export async function countProjectCatalogByAction(
 }
 
 /**
- * Promotes up to `limit` projects from action='auto' to action='evaluate'.
+ * Promotes 'auto' projects to 'evaluate', enforcing a hard cap on the total
+ * queue size in a single atomic statement.
  *
- * Ordering (all configurable via `sourcePriority`):
- *   1. Source priority — earlier position in the array = higher priority (NULLS/unknown = lowest)
- *   2. lfCriticalityScore DESC (higher score = higher priority, NULLs last)
- *   3. createdAt ASC (older entries first as a stable tie-breaker)
+ * Uses a CTE to:
+ *   1. Compute available slots (evaluateLimit − current 'evaluate' count) inline,
+ *      so two concurrent calls observe the same baseline and each picks a
+ *      disjoint set of rows.
+ *   2. Lock candidates with FOR UPDATE SKIP LOCKED — concurrent transactions
+ *      skip already-locked rows, preventing double-promotion.
+ *   3. Re-check action = 'auto' in the outer UPDATE to guard against rows whose
+ *      state changed after the subquery snapshot (e.g. manual updates).
+ *
+ * Ordering (configurable via `sourcePriority`):
+ *   1. Source priority — earlier position in the array = higher priority (unlisted = lowest)
+ *   2. lfCriticalityScore DESC (NULLs last)
+ *   3. createdAt ASC (stable tie-breaker)
  *
  * Returns the number of rows actually promoted.
  */
 export async function promoteProjectsToEvaluate(
   qx: QueryExecutor,
-  options: { limit: number; sourcePriority: string[] },
+  options: { evaluateLimit: number; sourcePriority: string[] },
 ): Promise<number> {
-  const { limit, sourcePriority } = options
+  const { evaluateLimit, sourcePriority } = options
 
-  if (limit <= 0) {
-    return 0
-  }
-
-  const result = await qx.result(
+  return qx.result(
     `
+    WITH
+      slots AS (
+        SELECT GREATEST(0, $(evaluateLimit) - COUNT(*)) AS available
+        FROM "projectCatalog"
+        WHERE action = 'evaluate'
+      ),
+      candidates AS (
+        SELECT pc.id
+        FROM "projectCatalog" pc
+        CROSS JOIN slots
+        WHERE pc.action = 'auto'
+          AND slots.available > 0
+        ORDER BY
+          COALESCE(ARRAY_POSITION($(sourcePriority)::text[], pc.source), 2147483647) ASC,
+          pc."lfCriticalityScore" DESC NULLS LAST,
+          pc."createdAt" ASC
+        LIMIT (SELECT available FROM slots)
+        FOR UPDATE SKIP LOCKED
+      )
     UPDATE "projectCatalog"
     SET action = 'evaluate', "updatedAt" = NOW()
-    WHERE id IN (
-      SELECT id
-      FROM "projectCatalog"
-      WHERE action = 'auto'
-      ORDER BY
-        COALESCE(ARRAY_POSITION($(sourcePriority)::text[], source), 2147483647) ASC,
-        "lfCriticalityScore" DESC NULLS LAST,
-        "createdAt" ASC
-      LIMIT $(limit)
-    )
+    FROM candidates
+    WHERE "projectCatalog".id = candidates.id
+      AND "projectCatalog".action = 'auto'
     `,
-    { sourcePriority, limit },
+    { evaluateLimit, sourcePriority },
   )
-
-  return result
 }
 
 export async function insertProjectCatalog(


### PR DESCRIPTION
## Summary
Implements the priority promotion logic for the auto-onboarding pipeline. Projects enter the catalog as `auto` from all sources. The evaluation worker now runs a promotion step before each AI evaluation batch: it selects up to N projects from `auto` → `evaluate` according to a configurable priority order (source priority + criticality score), enforcing a hard cap on the queue size.

## Changes
- **`projects_evaluation_worker`**: added `promoteProjectsForEvaluation` as the first step of the `evaluateProjects` workflow, before fetching and calling the AI evaluation API
- **`projects_evaluation_worker`**: introduced `IPriorityConfig` and `IEvaluateProjectsInput` types; schedule now exposes `evaluateLimit: 50` and `sourcePriority: ['insights-discussions']` as explicit, editable config
- **DAL** (`promoteProjectsToEvaluate`): single atomic CTE — computes available slots, locks candidates with `FOR UPDATE SKIP LOCKED`, and re-checks `action = 'auto'` in the outer UPDATE; prevents double-promotion and `onboard`/`unsure` overwrites under concurrent runs
- **`insights-discussions` source**: removed hardcoded `action: 'evaluate'` from `parseRow` — all sources now enter as `auto`, priority logic is the single promotion gate

  ## Type of change
  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor / cleanup
  - [ ] Performance improvement
  - [ ] Chore / dependency update
  - [ ] Documentation

  ## JIRA ticket
  https://linuxfoundation.atlassian.net/browse/CM-1166

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new database promotion logic and changes the Temporal evaluation workflow to mutate `projectCatalog.action` based on configurable priorities, which could affect queue sizing/order if misconfigured or if the SQL has edge-case concurrency behavior.
> 
> **Overview**
> Adds a **priority-based promotion step** to the projects evaluation pipeline: before each evaluation batch, the workflow now atomically promotes up to a configured limit of `projectCatalog` rows from `auto` → `evaluate` using source/criticality ordering.
> 
> The evaluation schedule is updated to pass explicit `IEvaluateProjectsInput` (defaulting to `batchSize: 50`, `evaluateLimit: 50`, `sourcePriority: ['insights-discussions']`), and the Insights Discussions discovery source no longer hardcodes `action: 'evaluate'` so new entries flow through the shared promotion gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e065bcf4070b78ea36e1dfd559af5dec0143cfda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->