### PR TITLE
fix: rate limiting api call (CM-1138)

### DIFF
--- a/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/activities/activities.ts
@@ -1,3 +1,4 @@
+import { Context } from '@temporalio/activity'
 import { parse } from 'csv-parse'
 
 import { bulkUpsertProjectCatalog } from '@crowd/data-access-layer'
@@ -102,6 +103,7 @@ export async function processDataset(
       totalProcessed += batch.length
       batch = []
 
+      Context.current().heartbeat({ totalProcessed, batchNumber })
       log.info({ totalProcessed, batchNumber, datasetId: dataset.id }, 'Batch upserted.')
     }
   }

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -13,13 +13,20 @@ const DEFAULT_API_HOST = 'lf-criticality-score-api.example.com'
 const DEFAULT_API_PORT = 443
 const PAGE_SIZE = 100
 
+function parseEnvInt(value: string | undefined, defaultValue: number, min: number, max: number): number {
+  const parsed = parseInt(value ?? '', 10)
+  return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : defaultValue
+}
+
 // Requests per second sent to the LF Criticality Score API (throttle between pages).
-const REQUESTS_PER_SECOND = parseInt(
-  process.env.LF_CRITICALITY_SCORE_REQUESTS_PER_SECOND ?? '5',
-  10,
+const REQUESTS_PER_SECOND = parseEnvInt(
+  process.env.LF_CRITICALITY_SCORE_REQUESTS_PER_SECOND,
+  5,
+  1,
+  100,
 )
-// Max per-page retry attempts on 429 or 5xx before giving up and letting Temporal retry.
-const MAX_RETRIES = parseInt(process.env.LF_CRITICALITY_SCORE_MAX_RETRIES ?? '7', 10)
+// Max per-page attempts (initial + retries) on 429 or 5xx before giving up.
+const MAX_ATTEMPTS = parseEnvInt(process.env.LF_CRITICALITY_SCORE_MAX_ATTEMPTS ?? process.env.LF_CRITICALITY_SCORE_MAX_RETRIES, 7, 1, 20)
 
 interface LfApiResponse {
   page: number
@@ -55,15 +62,24 @@ function getApiBaseUrl(): string {
   return `${scheme}://${host}:${port}`
 }
 
-function httpGet(url: string): Promise<{ statusCode: number; retryAfter: string | null; body: string }> {
+function parseRetryAfterMs(header: string | string[] | undefined): number | null {
+  const raw = Array.isArray(header) ? header[0] : header
+  if (!raw) return null
+  const secs = parseFloat(raw.trim())
+  return Number.isFinite(secs) && secs > 0 ? secs * 1000 : null
+}
+
+function httpGet(url: string): Promise<{ statusCode: number; retryAfterMs: number | null; body: string }> {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https://') ? https : http
     const req = client.get(url, (res) => {
       const statusCode = res.statusCode ?? 0
-      const retryAfter = res.headers['retry-after'] ?? null
+      const retryAfterMs = parseRetryAfterMs(res.headers['retry-after'])
       const chunks: Uint8Array[] = []
       res.on('data', (chunk: Uint8Array) => chunks.push(chunk))
-      res.on('end', () => resolve({ statusCode, retryAfter: retryAfter as string | null, body: Buffer.concat(chunks).toString('utf8') }))
+      res.on('end', () =>
+        resolve({ statusCode, retryAfterMs, body: Buffer.concat(chunks).toString('utf8') }),
+      )
       res.on('error', reject)
     })
     req.on('error', reject)
@@ -80,8 +96,8 @@ async function fetchPage(
   if (scoredAfter) params.set('scoredAfter', scoredAfter)
   const url = `${baseUrl}/projects?${params.toString()}`
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const { statusCode, retryAfter, body } = await httpGet(url)
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const { statusCode, retryAfterMs, body } = await httpGet(url)
 
     if (statusCode === 200) {
       try {
@@ -92,27 +108,21 @@ async function fetchPage(
     }
 
     const isRetryable = statusCode === 429 || statusCode >= 500
-    if (!isRetryable || attempt === MAX_RETRIES) {
+    if (!isRetryable || attempt === MAX_ATTEMPTS - 1) {
       throw new Error(`LF Criticality Score API returned status ${statusCode} for ${url}`)
     }
 
-    let delayMs: number
-    const retryAfterSecs = retryAfter ? parseFloat(retryAfter) : NaN
-    if (!Number.isNaN(retryAfterSecs) && retryAfterSecs > 0) {
-      delayMs = retryAfterSecs * 1000
-    } else {
-      delayMs = Math.min(Math.pow(2, attempt) * 1000, 60_000)
-    }
+    const delayMs = retryAfterMs ?? Math.min(Math.pow(2, attempt) * 1000, 60_000)
 
     log.warn(
-      { page, attempt: attempt + 1, maxRetries: MAX_RETRIES, statusCode, delayMs },
+      { page, attempt: attempt + 1, maxAttempts: MAX_ATTEMPTS, statusCode, delayMs },
       'LF Criticality Score: rate limited or server error, retrying...',
     )
     await timeout(delayMs)
   }
 
   // Unreachable, but satisfies TypeScript.
-  throw new Error(`LF Criticality Score API failed for ${url} after ${MAX_RETRIES} retries`)
+  throw new Error(`LF Criticality Score API failed for ${url} after ${MAX_ATTEMPTS} attempts`)
 }
 
 export class LfCriticalityScoreSource implements IDiscoverySource {

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -2,6 +2,7 @@ import http from 'http'
 import https from 'https'
 import { Readable } from 'stream'
 
+import { timeout } from '@crowd/common'
 import { getServiceLogger } from '@crowd/logging'
 
 import { IDatasetDescriptor, IDiscoverySource, IDiscoverySourceRow } from '../types'
@@ -11,6 +12,14 @@ const log = getServiceLogger()
 const DEFAULT_API_HOST = 'lf-criticality-score-api.example.com'
 const DEFAULT_API_PORT = 443
 const PAGE_SIZE = 100
+
+// Requests per second sent to the LF Criticality Score API (throttle between pages).
+const REQUESTS_PER_SECOND = parseInt(
+  process.env.LF_CRITICALITY_SCORE_REQUESTS_PER_SECOND ?? '5',
+  10,
+)
+// Max per-page retry attempts on 429 or 5xx before giving up and letting Temporal retry.
+const MAX_RETRIES = parseInt(process.env.LF_CRITICALITY_SCORE_MAX_RETRIES ?? '7', 10)
 
 interface LfApiResponse {
   page: number
@@ -46,6 +55,22 @@ function getApiBaseUrl(): string {
   return `${scheme}://${host}:${port}`
 }
 
+function httpGet(url: string): Promise<{ statusCode: number; retryAfter: string | null; body: string }> {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https://') ? https : http
+    const req = client.get(url, (res) => {
+      const statusCode = res.statusCode ?? 0
+      const retryAfter = res.headers['retry-after'] ?? null
+      const chunks: Uint8Array[] = []
+      res.on('data', (chunk: Uint8Array) => chunks.push(chunk))
+      res.on('end', () => resolve({ statusCode, retryAfter: retryAfter as string | null, body: Buffer.concat(chunks).toString('utf8') }))
+      res.on('error', reject)
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
 async function fetchPage(
   baseUrl: string,
   page: number,
@@ -55,31 +80,39 @@ async function fetchPage(
   if (scoredAfter) params.set('scoredAfter', scoredAfter)
   const url = `${baseUrl}/projects?${params.toString()}`
 
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https://') ? https : http
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const { statusCode, retryAfter, body } = await httpGet(url)
 
-    const req = client.get(url, (res) => {
-      if (res.statusCode !== 200) {
-        reject(new Error(`LF Criticality Score API returned status ${res.statusCode} for ${url}`))
-        res.resume()
-        return
+    if (statusCode === 200) {
+      try {
+        return JSON.parse(body) as LfApiResponse
+      } catch (err) {
+        throw new Error(`Failed to parse LF Criticality Score API response: ${err}`)
       }
+    }
 
-      const chunks: Uint8Array[] = []
-      res.on('data', (chunk: Uint8Array) => chunks.push(chunk))
-      res.on('end', () => {
-        try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as LfApiResponse)
-        } catch (err) {
-          reject(new Error(`Failed to parse LF Criticality Score API response: ${err}`))
-        }
-      })
-      res.on('error', reject)
-    })
+    const isRetryable = statusCode === 429 || statusCode >= 500
+    if (!isRetryable || attempt === MAX_RETRIES) {
+      throw new Error(`LF Criticality Score API returned status ${statusCode} for ${url}`)
+    }
 
-    req.on('error', reject)
-    req.end()
-  })
+    let delayMs: number
+    const retryAfterSecs = retryAfter ? parseFloat(retryAfter) : NaN
+    if (!Number.isNaN(retryAfterSecs) && retryAfterSecs > 0) {
+      delayMs = retryAfterSecs * 1000
+    } else {
+      delayMs = Math.min(Math.pow(2, attempt) * 1000, 60_000)
+    }
+
+    log.warn(
+      { page, attempt: attempt + 1, maxRetries: MAX_RETRIES, statusCode, delayMs },
+      'LF Criticality Score: rate limited or server error, retrying...',
+    )
+    await timeout(delayMs)
+  }
+
+  // Unreachable, but satisfies TypeScript.
+  throw new Error(`LF Criticality Score API failed for ${url} after ${MAX_RETRIES} retries`)
 }
 
 export class LfCriticalityScoreSource implements IDiscoverySource {
@@ -113,11 +146,17 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
       'LF Criticality Score: starting stream fetch.',
     )
 
+    const throttleIntervalMs = Math.round(1000 / REQUESTS_PER_SECOND)
+
     async function* pages() {
       let page = 1
       let totalPages = 1
 
       do {
+        if (page > 1) {
+          await timeout(throttleIntervalMs)
+        }
+
         log.info(
           { datasetId: dataset.id, page, totalPages },
           'LF Criticality Score: fetching page...',

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -72,6 +72,12 @@ function getApiBaseUrl(): string {
   return `${scheme}://${host}:${port}`
 }
 
+interface HttpGetResult {
+  statusCode: number
+  retryAfterMs: number | null
+  body: string
+}
+
 function parseRetryAfterMs(header: string | string[] | undefined): number | null {
   const raw = Array.isArray(header) ? header[0] : header
   if (!raw) return null
@@ -79,7 +85,7 @@ function parseRetryAfterMs(header: string | string[] | undefined): number | null
   return Number.isFinite(secs) && secs > 0 ? secs * 1000 : null
 }
 
-function httpGet(url: string): Promise {
+function httpGet(url: string): Promise<HttpGetResult> {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https://') ? https : http
     const req = client.get(url, (res) => {
@@ -97,13 +103,34 @@ function httpGet(url: string): Promise {
   })
 }
 
-async function fetchPage(baseUrl: string, page: number, scoredAfter?: string): Promise {
+async function fetchPage(
+  baseUrl: string,
+  page: number,
+  scoredAfter?: string,
+): Promise<LfApiResponse> {
   const params = new URLSearchParams({ page: String(page), pageSize: String(PAGE_SIZE) })
   if (scoredAfter) params.set('scoredAfter', scoredAfter)
   const url = `${baseUrl}/projects?${params.toString()}`
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const { statusCode, retryAfterMs, body } = await httpGet(url)
+    let result: HttpGetResult | null = null
+
+    try {
+      result = await httpGet(url)
+    } catch (networkErr) {
+      if (attempt === MAX_ATTEMPTS - 1) {
+        throw new Error(`LF Criticality Score API network error for ${url}: ${networkErr}`)
+      }
+      const delayMs = Math.min(Math.pow(2, attempt) * 1000, 60_000)
+      log.warn(
+        { page, attempt: attempt + 1, maxAttempts: MAX_ATTEMPTS, delayMs, err: String(networkErr) },
+        'LF Criticality Score: network error, retrying...',
+      )
+      await timeout(delayMs)
+      continue
+    }
+
+    const { statusCode, retryAfterMs, body } = result
 
     if (statusCode === 200) {
       try {
@@ -135,7 +162,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
   public readonly name = 'lf-criticality-score'
   public readonly format = 'json' as const
 
-  async listAvailableDatasets(options?: { scoredAfter?: string }): Promise {
+  async listAvailableDatasets(options?: { scoredAfter?: string }): Promise<IDatasetDescriptor[]> {
     const baseUrl = getApiBaseUrl()
     const today = new Date().toISOString().slice(0, 10)
     const { scoredAfter } = options ?? {}
@@ -153,7 +180,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
     ]
   }
 
-  async fetchDatasetStream(dataset: IDatasetDescriptor): Promise {
+  async fetchDatasetStream(dataset: IDatasetDescriptor): Promise<Readable> {
     const baseUrl = getApiBaseUrl()
     const scoredAfter = new URL(dataset.url).searchParams.get('scoredAfter') ?? undefined
 
@@ -202,7 +229,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
     return Readable.from(pages(), { objectMode: true })
   }
 
-  parseRow(rawRow: Record): IDiscoverySourceRow | null {
+  parseRow(rawRow: Record<string, unknown>): IDiscoverySourceRow | null {
     const repoUrl = (rawRow['repourl'] ?? rawRow['repoUrl']) as string | undefined
     if (!repoUrl) {
       return null

--- a/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/lf-criticality-score/source.ts
@@ -13,7 +13,12 @@ const DEFAULT_API_HOST = 'lf-criticality-score-api.example.com'
 const DEFAULT_API_PORT = 443
 const PAGE_SIZE = 100
 
-function parseEnvInt(value: string | undefined, defaultValue: number, min: number, max: number): number {
+function parseEnvInt(
+  value: string | undefined,
+  defaultValue: number,
+  min: number,
+  max: number,
+): number {
   const parsed = parseInt(value ?? '', 10)
   return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : defaultValue
 }
@@ -26,7 +31,12 @@ const REQUESTS_PER_SECOND = parseEnvInt(
   100,
 )
 // Max per-page attempts (initial + retries) on 429 or 5xx before giving up.
-const MAX_ATTEMPTS = parseEnvInt(process.env.LF_CRITICALITY_SCORE_MAX_ATTEMPTS ?? process.env.LF_CRITICALITY_SCORE_MAX_RETRIES, 7, 1, 20)
+const MAX_ATTEMPTS = parseEnvInt(
+  process.env.LF_CRITICALITY_SCORE_MAX_ATTEMPTS ?? process.env.LF_CRITICALITY_SCORE_MAX_RETRIES,
+  7,
+  1,
+  20,
+)
 
 interface LfApiResponse {
   page: number
@@ -69,7 +79,7 @@ function parseRetryAfterMs(header: string | string[] | undefined): number | null
   return Number.isFinite(secs) && secs > 0 ? secs * 1000 : null
 }
 
-function httpGet(url: string): Promise<{ statusCode: number; retryAfterMs: number | null; body: string }> {
+function httpGet(url: string): Promise {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https://') ? https : http
     const req = client.get(url, (res) => {
@@ -87,11 +97,7 @@ function httpGet(url: string): Promise<{ statusCode: number; retryAfterMs: numbe
   })
 }
 
-async function fetchPage(
-  baseUrl: string,
-  page: number,
-  scoredAfter?: string,
-): Promise<LfApiResponse> {
+async function fetchPage(baseUrl: string, page: number, scoredAfter?: string): Promise {
   const params = new URLSearchParams({ page: String(page), pageSize: String(PAGE_SIZE) })
   if (scoredAfter) params.set('scoredAfter', scoredAfter)
   const url = `${baseUrl}/projects?${params.toString()}`
@@ -129,7 +135,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
   public readonly name = 'lf-criticality-score'
   public readonly format = 'json' as const
 
-  async listAvailableDatasets(options?: { scoredAfter?: string }): Promise<IDatasetDescriptor[]> {
+  async listAvailableDatasets(options?: { scoredAfter?: string }): Promise {
     const baseUrl = getApiBaseUrl()
     const today = new Date().toISOString().slice(0, 10)
     const { scoredAfter } = options ?? {}
@@ -147,7 +153,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
     ]
   }
 
-  async fetchDatasetStream(dataset: IDatasetDescriptor): Promise<Readable> {
+  async fetchDatasetStream(dataset: IDatasetDescriptor): Promise {
     const baseUrl = getApiBaseUrl()
     const scoredAfter = new URL(dataset.url).searchParams.get('scoredAfter') ?? undefined
 
@@ -159,32 +165,26 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
     const throttleIntervalMs = Math.round(1000 / REQUESTS_PER_SECOND)
 
     async function* pages() {
-      let page = 1
-      let totalPages = 1
+      const firstPage = await fetchPage(baseUrl, 1, scoredAfter)
+      const { totalPages } = firstPage
 
-      do {
-        if (page > 1) {
-          await timeout(throttleIntervalMs)
-        }
+      log.info(
+        { datasetId: dataset.id, total: firstPage.total, totalPages, pageSize: firstPage.pageSize },
+        'LF Criticality Score: first page received — total records available.',
+      )
+
+      for (const row of firstPage.data) {
+        yield row
+      }
+
+      for (let page = 2; page <= totalPages; page++) {
+        await timeout(throttleIntervalMs)
 
         log.info(
           { datasetId: dataset.id, page, totalPages },
           'LF Criticality Score: fetching page...',
         )
         const response = await fetchPage(baseUrl, page, scoredAfter)
-        totalPages = response.totalPages
-
-        if (page === 1) {
-          log.info(
-            {
-              datasetId: dataset.id,
-              total: response.total,
-              totalPages,
-              pageSize: response.pageSize,
-            },
-            'LF Criticality Score: first page received — total records available.',
-          )
-        }
 
         for (const row of response.data) {
           yield row
@@ -194,9 +194,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
           { datasetId: dataset.id, page, totalPages, rowsInPage: response.data.length },
           'LF Criticality Score: page fetched.',
         )
-
-        page++
-      } while (page <= totalPages)
+      }
 
       log.info({ datasetId: dataset.id, totalPages }, 'LF Criticality Score: all pages fetched.')
     }
@@ -204,7 +202,7 @@ export class LfCriticalityScoreSource implements IDiscoverySource {
     return Readable.from(pages(), { objectMode: true })
   }
 
-  parseRow(rawRow: Record<string, unknown>): IDiscoverySourceRow | null {
+  parseRow(rawRow: Record): IDiscoverySourceRow | null {
     const repoUrl = (rawRow['repourl'] ?? rawRow['repoUrl']) as string | undefined
     if (!repoUrl) {
       return null

--- a/services/apps/automatic_projects_discovery_worker/src/workflows/discoverProjects.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/workflows/discoverProjects.ts
@@ -7,9 +7,10 @@ const listActivities = proxyActivities<typeof activities>({
   retry: { maximumAttempts: 3 },
 })
 
-// processDataset is long-running (10-20 min for ~119MB / ~750K rows).
+// processDataset is long-running: ~119MB / ~750K rows + inter-page throttle can exceed 60 min.
 const processActivities = proxyActivities<typeof activities>({
-  startToCloseTimeout: '30 minutes',
+  startToCloseTimeout: '90 minutes',
+  heartbeatTimeout: '5 minutes',
   retry: { maximumAttempts: 3 },
 })
 


### PR DESCRIPTION
## Summary
Adds throttling and per-page retry logic to the LF Criticality Score source to prevent 429 failures during full dataset fetches (~7,500 sequential pages for ~750K rows).

## Changes
- Added `httpGet()` helper in `source.ts` to separate the raw HTTP call from error handling, returning `statusCode`, `Retry-After` header, and body without rejecting on non-200
- Replaced the bare `fetchPage()` rejection on non-200 with a retry loop: retries up to 7 times on 429 or 5xx, respecting the `Retry-After` header when present, falling back to exponential backoff (`2^attempt` seconds, capped at 60s)
- Added a configurable inter-page throttle delay (default 200ms = 5 req/s) between pages in the `pages()` generator prevents hitting the rate limit proactively rather than only reacting to 429s
- Both limits are tunable via env vars: `LF_CRITICALITY_SCORE_REQUESTS_PER_SECOND` (default `5`) and `LF_CRITICALITY_SCORE_MAX_RETRIES` (default `7`)

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes long-running Temporal activity behavior (timeouts/heartbeats) and introduces new retry/throttling paths that could affect runtime and failure modes during full syncs.
> 
> **Overview**
> **Improves reliability of LF Criticality Score ingestion under rate limits.** The source now throttles requests between pages (configurable req/s) and adds per-page retry logic on network errors, `429`, and `5xx`, honoring `Retry-After` when present with exponential backoff fallback.
> 
> **Aligns Temporal execution settings with the longer fetch.** `processDataset` now heartbeats after each DB upsert batch, and the workflow increases the `processDataset` activity timeout to `90 minutes` with a `5 minute` heartbeat timeout to prevent activity timeouts during throttled full syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfabfd329b4a63b66dd37f0cb33204bad5b41165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->