### PR TITLE
chore: create new organizations datasource with inferred slug (IN-1174)

### DIFF
--- a/services/libs/tinybird/datasources/organizations_populated_slug.datasource
+++ b/services/libs/tinybird/datasources/organizations_populated_slug.datasource
@@ -1,0 +1,39 @@
+DESCRIPTION >
+    Denormalized organizations datasource: every column from organizations FINAL plus a
+    deterministic globally unique slug derived from displayName and a total contributionCount
+    across all segments.
+
+    Only includes organizations that have at least one contribution
+    (isCodeContribution = 1 OR isCollaboration = 1).
+
+    Slug rules:
+      - slug = lowerUTF8(displayName) with non-alphanumeric runs collapsed to '-' and
+        leading/trailing dashes trimmed.
+      - If two or more organizations produce the same baseSlug, the one with the highest
+        contributionCount keeps the bare slug; the rest get '-1', '-2', ... suffixes
+        ordered by descending contributionCount, with id ASC as the deterministic tiebreaker.
+      - If the derived slug would be empty (displayName contains only non-ASCII or special
+        characters), the slug falls back to id.
+
+    Refreshed daily at 01:15 UTC by organizations_slugged_copy.pipe.
+
+SCHEMA >
+    `id` String,
+    `displayName` String,
+    `location` String DEFAULT '',
+    `logo` String DEFAULT '',
+    `tags` Array(String) DEFAULT [],
+    `employees` UInt32 DEFAULT 0,
+    `createdAt` DateTime64(3),
+    `updatedAt` DateTime64(3),
+    `isTeamOrganization` UInt8 DEFAULT 0,
+    `type` String DEFAULT '',
+    `size` String DEFAULT '',
+    `headline` String DEFAULT '',
+    `industry` String DEFAULT '',
+    `founded` UInt16 DEFAULT 0,
+    `slug` String,
+    `contributionCount` UInt64
+
+ENGINE MergeTree
+ENGINE_SORTING_KEY id

--- a/services/libs/tinybird/datasources/organizations_populated_slug.datasource
+++ b/services/libs/tinybird/datasources/organizations_populated_slug.datasource
@@ -2,19 +2,16 @@ DESCRIPTION >
     Denormalized organizations datasource: every column from organizations FINAL plus a
     deterministic globally unique slug derived from displayName and a total contributionCount
     across all segments.
-
     Only includes organizations that have at least one contribution
     (isCodeContribution = 1 OR isCollaboration = 1).
-
     Slug rules:
-      - slug = lowerUTF8(displayName) with non-alphanumeric runs collapsed to '-' and
-        leading/trailing dashes trimmed.
-      - If two or more organizations produce the same baseSlug, the one with the highest
-        contributionCount keeps the bare slug; the rest get '-1', '-2', ... suffixes
-        ordered by descending contributionCount, with id ASC as the deterministic tiebreaker.
-      - If the derived slug would be empty (displayName contains only non-ASCII or special
-        characters), the slug falls back to id.
-
+    - slug = lowerUTF8(displayName) with non-alphanumeric runs collapsed to '-' and
+    leading/trailing dashes trimmed.
+    - If two or more organizations produce the same baseSlug, the one with the highest
+    contributionCount keeps the bare slug; the rest get '-1', '-2', ... suffixes
+    ordered by descending contributionCount, with id ASC as the deterministic tiebreaker.
+    - If the derived slug would be empty (displayName contains only non-ASCII or special
+    characters), the slug falls back to id.
     Refreshed daily at 01:15 UTC by organizations_slugged_copy.pipe.
 
 SCHEMA >

--- a/services/libs/tinybird/datasources/organizations_populated_slug.datasource
+++ b/services/libs/tinybird/datasources/organizations_populated_slug.datasource
@@ -2,17 +2,19 @@ DESCRIPTION >
     Denormalized organizations datasource: every column from organizations FINAL plus a
     deterministic globally unique slug derived from displayName and a total contributionCount
     across all segments.
-    Only includes organizations that have at least one contribution
-    (isCodeContribution = 1 OR isCollaboration = 1).
+    Only includes organizations that have at least one activity recorded in
+    cdp_organization_segment_aggregates_ds (activityCountState > 0).
     Slug rules:
     - slug = lowerUTF8(displayName) with non-alphanumeric runs collapsed to '-' and
     leading/trailing dashes trimmed.
     - If two or more organizations produce the same baseSlug, the one with the highest
-    contributionCount keeps the bare slug; the rest get '-1', '-2', ... suffixes
-    ordered by descending contributionCount, with id ASC as the deterministic tiebreaker.
+    contributionCount keeps the bare slug; the rest get '--1', '--2', ... suffixes
+    (double-dash) ordered by descending contributionCount, with id ASC as the
+    deterministic tiebreaker. Double-dash prevents collisions with natural slugs that
+    end in a digit or word (e.g. 'dark-1' vs 'dark--1').
     - If the derived slug would be empty (displayName contains only non-ASCII or special
     characters), the slug falls back to id.
-    Refreshed daily at 01:15 UTC by organizations_slugged_copy.pipe.
+    Refreshed hourly at :35 by organizations_populate_slug.pipe.
 
 SCHEMA >
     `id` String,

--- a/services/libs/tinybird/pipes/organizations_populate_slug.pipe
+++ b/services/libs/tinybird/pipes/organizations_populate_slug.pipe
@@ -1,0 +1,127 @@
+DESCRIPTION >
+    Populates organizations_populated_slug with one row per organization that has contributions.
+    Carries all columns from organizations FINAL and adds a deterministic globally unique
+    slug and a total activityCount (sourced from cdp_organization_segment_aggregates_ds).
+
+NODE organizations_slugged_contribution_counts
+DESCRIPTION >
+    Total activity count per organization summed across all segments, read from the
+    pre-aggregated AggregatingMergeTree. Much faster than scanning the bucket union.
+SQL >
+    SELECT
+        organizationId,
+        countMerge(activityCountState) AS contributionCount
+    FROM cdp_organization_segment_aggregates_ds
+    WHERE organizationId != ''
+    GROUP BY organizationId
+
+NODE organizations_slugged_enriched
+DESCRIPTION >
+    Join contribution counts with full org metadata and compute the base slug candidate.
+SQL >
+    SELECT
+        org.id AS id,
+        org.displayName AS displayName,
+        org.location AS location,
+        org.logo AS logo,
+        org.tags AS tags,
+        org.employees AS employees,
+        org.createdAt AS createdAt,
+        org.updatedAt AS updatedAt,
+        org.isTeamOrganization AS isTeamOrganization,
+        org.type AS type,
+        org.size AS size,
+        org.headline AS headline,
+        org.industry AS industry,
+        org.founded AS founded,
+        c.contributionCount AS contributionCount,
+        replaceRegexpAll(
+            replaceRegexpAll(lowerUTF8(org.displayName), '[^a-z0-9]+', '-'),
+            '(^-+)|(-+$)',
+            ''
+        ) AS generatedSlug
+    FROM organizations_slugged_contribution_counts c
+    INNER JOIN organizations org FINAL ON org.id = c.organizationId
+
+NODE organizations_slugged_base_slug
+DESCRIPTION >
+    Apply empty-slug fallback: if generatedSlug is empty, use the org id as baseSlug.
+SQL >
+    SELECT
+        id,
+        displayName,
+        location,
+        logo,
+        tags,
+        employees,
+        createdAt,
+        updatedAt,
+        isTeamOrganization,
+        type,
+        size,
+        headline,
+        industry,
+        founded,
+        contributionCount,
+        if(length(generatedSlug) > 0, generatedSlug, id) AS baseSlug
+    FROM organizations_slugged_enriched
+
+NODE organizations_slugged_ranked
+DESCRIPTION >
+    Assign final globally unique slugs. Orgs with a unique baseSlug keep it as-is.
+    Orgs in a collision group (>=2 share the same baseSlug) all get a '--N' suffix
+    ordered by descending contributionCount (id ASC tiebreaker). Double-dash is used
+    so synthetic suffixes never collide with natural slugs that end in a number or word
+    (e.g. 'dark-1' from 'Dark-1' vs 'dark--1' from 'Dark++' in a collision group).
+SQL >
+    SELECT
+        id,
+        displayName,
+        location,
+        logo,
+        tags,
+        employees,
+        createdAt,
+        updatedAt,
+        isTeamOrganization,
+        type,
+        size,
+        headline,
+        industry,
+        founded,
+        if(
+            groupSize = 1 OR slugRank = 1,
+            baseSlug,
+            concat(baseSlug, '--', toString(slugRank))
+        ) AS slug,
+        contributionCount
+    FROM (
+        SELECT
+            id,
+            displayName,
+            location,
+            logo,
+            tags,
+            employees,
+            createdAt,
+            updatedAt,
+            isTeamOrganization,
+            type,
+            size,
+            headline,
+            industry,
+            founded,
+            contributionCount,
+            baseSlug,
+            count() OVER (PARTITION BY baseSlug) AS groupSize,
+            row_number() OVER (
+                PARTITION BY baseSlug
+                ORDER BY contributionCount DESC, id ASC
+            ) AS slugRank
+        FROM organizations_slugged_base_slug
+    )
+
+TYPE COPY
+TARGET_DATASOURCE organizations_populated_slug
+COPY_MODE replace
+COPY_SCHEDULE 35 * * * *

--- a/services/libs/tinybird/pipes/organizations_populate_slug.pipe
+++ b/services/libs/tinybird/pipes/organizations_populate_slug.pipe
@@ -1,16 +1,15 @@
 DESCRIPTION >
     Populates organizations_populated_slug with one row per organization that has contributions.
     Carries all columns from organizations FINAL and adds a deterministic globally unique
-    slug and a total activityCount (sourced from cdp_organization_segment_aggregates_ds).
+    slug and a total contributionCount (sourced from cdp_organization_segment_aggregates_ds).
 
 NODE organizations_slugged_contribution_counts
 DESCRIPTION >
     Total activity count per organization summed across all segments, read from the
     pre-aggregated AggregatingMergeTree. Much faster than scanning the bucket union.
+
 SQL >
-    SELECT
-        organizationId,
-        countMerge(activityCountState) AS contributionCount
+    SELECT organizationId, countMerge(activityCountState) AS contributionCount
     FROM cdp_organization_segment_aggregates_ds
     WHERE organizationId != ''
     GROUP BY organizationId
@@ -18,6 +17,7 @@ SQL >
 NODE organizations_slugged_enriched
 DESCRIPTION >
     Join contribution counts with full org metadata and compute the base slug candidate.
+
 SQL >
     SELECT
         org.id AS id,
@@ -36,9 +36,7 @@ SQL >
         org.founded AS founded,
         c.contributionCount AS contributionCount,
         replaceRegexpAll(
-            replaceRegexpAll(lowerUTF8(org.displayName), '[^a-z0-9]+', '-'),
-            '(^-+)|(-+$)',
-            ''
+            replaceRegexpAll(lowerUTF8(org.displayName), '[^a-z0-9]+', '-'), '(^-+)|(-+$)', ''
         ) AS generatedSlug
     FROM organizations_slugged_contribution_counts c
     INNER JOIN organizations org FINAL ON org.id = c.organizationId
@@ -46,6 +44,7 @@ SQL >
 NODE organizations_slugged_base_slug
 DESCRIPTION >
     Apply empty-slug fallback: if generatedSlug is empty, use the org id as baseSlug.
+
 SQL >
     SELECT
         id,
@@ -73,6 +72,7 @@ DESCRIPTION >
     ordered by descending contributionCount (id ASC tiebreaker). Double-dash is used
     so synthetic suffixes never collide with natural slugs that end in a number or word
     (e.g. 'dark-1' from 'Dark-1' vs 'dark--1' from 'Dark++' in a collision group).
+
 SQL >
     SELECT
         id,
@@ -89,37 +89,33 @@ SQL >
         headline,
         industry,
         founded,
-        if(
-            groupSize = 1 OR slugRank = 1,
-            baseSlug,
-            concat(baseSlug, '--', toString(slugRank))
-        ) AS slug,
+        if(groupSize = 1 OR slugRank = 1, baseSlug, concat(baseSlug, '--', toString(slugRank))) AS slug,
         contributionCount
-    FROM (
-        SELECT
-            id,
-            displayName,
-            location,
-            logo,
-            tags,
-            employees,
-            createdAt,
-            updatedAt,
-            isTeamOrganization,
-            type,
-            size,
-            headline,
-            industry,
-            founded,
-            contributionCount,
-            baseSlug,
-            count() OVER (PARTITION BY baseSlug) AS groupSize,
-            row_number() OVER (
-                PARTITION BY baseSlug
-                ORDER BY contributionCount DESC, id ASC
-            ) AS slugRank
-        FROM organizations_slugged_base_slug
-    )
+    FROM
+        (
+            SELECT
+                id,
+                displayName,
+                location,
+                logo,
+                tags,
+                employees,
+                createdAt,
+                updatedAt,
+                isTeamOrganization,
+                type,
+                size,
+                headline,
+                industry,
+                founded,
+                contributionCount,
+                baseSlug,
+                count() OVER (PARTITION BY baseSlug) AS groupSize,
+                row_number() OVER (
+                    PARTITION BY baseSlug ORDER BY contributionCount DESC, id ASC
+                ) AS slugRank
+            FROM organizations_slugged_base_slug
+        )
 
 TYPE COPY
 TARGET_DATASOURCE organizations_populated_slug


### PR DESCRIPTION
## Summary
Adds a new denormalized Tinybird datasource `organizations_populated_slug` that mirrors every column from the `organizations` table and adds two derived columns: a deterministic, globally unique `slug` inferred from `displayName`, and a total `contributionCount` summed across all segments. Only organizations with at least one contribution are included.

The datasource is populated hourly (at :35) by a COPY pipe and is intended to back URL-friendly organization lookups without runtime slug computation.

## Why COPY pipe instead of a Materialized View
Slug assignment is inherently global: a row's final slug depends on every other row that shares the same base slug (collision rank = `row_number() OVER (PARTITION BY baseSlug ORDER BY contributionCount DESC, id ASC)`). MVs in ClickHouse/Tinybird only see the newly inserted block, so they can't recompute ranks or collision counts across the rest of the partition when a new org appears. The pipe also relies on `JOIN organizations FINAL`, which an MV can't refresh when existing org rows are updated. A scheduled COPY rebuilds the full table so global ranks and the latest org metadata stay consistent on every refresh.

## Changes
- New datasource `services/libs/tinybird/datasources/organizations_populated_slug.datasource` — full org schema plus `slug: String` and `contributionCount: UInt64`, MergeTree sorted by `id`
- New COPY pipe `services/libs/tinybird/pipes/organizations_populate_slug.pipe` that:
  - Sums `activityCountState` per organization from `cdp_organization_segment_aggregates_ds` (uses the pre-aggregated AMT instead of scanning raw buckets)
  - Joins with `organizations FINAL` for metadata
  - Computes a base slug via `lowerUTF8` + `replaceRegexpAll` to collapse non-alphanumerics into `-` and trim edges
  - Falls back to `id` when the base slug would be empty (e.g. non-ASCII displayName)
  - Resolves collisions deterministically: highest `contributionCount` keeps the bare slug; the rest get `--1`, `--2`, … suffixes ordered by `contributionCount DESC, id ASC`. Double-dash is used so synthetic suffixes never collide with natural slugs ending in `-N`.

## Type of change
- [x] Chore / dependency update

## JIRA ticket
https://linuxfoundation.atlassian.net/browse/IN-1174

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new scheduled Tinybird COPY pipeline that rebuilds a denormalized organizations table hourly; risk is mainly around data correctness (slug collision ranking) and query/performance impact during refreshes.
> 
> **Overview**
> Introduces a new Tinybird datasource, `organizations_populated_slug`, which mirrors `organizations FINAL` and adds derived `slug` and `contributionCount` columns, limited to orgs with recorded activity.
> 
> Adds the scheduled COPY pipe `organizations_populate_slug.pipe` to compute total contribution counts from `cdp_organization_segment_aggregates_ds`, generate a normalized base slug from `displayName` (fallback to `id` when empty), and deterministically resolve slug collisions via `row_number()` ordering by `contributionCount DESC, id ASC` with a `--N` suffix. The table is rebuilt hourly at `:35` using `COPY_MODE replace`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf1bee35be46fc2c9dd4a1e171d6e43efd4ea98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->