### PR TITLE
feat: add evaluations fields on projectCatalog table (CM-1168)

### DIFF
--- a/backend/src/database/migrations/V1779280838__exclusion-reason-to-project-catalog.sql
+++ b/backend/src/database/migrations/V1779280838__exclusion-reason-to-project-catalog.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "projectCatalog"
+  ADD COLUMN IF NOT EXISTS "evaluationResult" TEXT,
+  ADD COLUMN IF NOT EXISTS "evaluationReason" TEXT;

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -16,6 +16,8 @@ const PROJECT_CATALOG_COLUMNS = [
   'source',
   'action',
   'lfCriticalityScore',
+  'evaluationResult',
+  'evaluationReason',
   'evaluatedAt',
   'onboardedAt',
   'syncedAt',
@@ -430,6 +432,14 @@ export async function updateProjectCatalog(
   if (data.lfCriticalityScore !== undefined) {
     setClauses.push('"lfCriticalityScore" = $(lfCriticalityScore)')
     params.lfCriticalityScore = data.lfCriticalityScore
+  }
+  if (data.evaluationResult !== undefined) {
+    setClauses.push('"evaluationResult" = $(evaluationResult)')
+    params.evaluationResult = data.evaluationResult
+  }
+  if (data.evaluationReason !== undefined) {
+    setClauses.push('"evaluationReason" = $(evaluationReason)')
+    params.evaluationReason = data.evaluationReason
   }
   if (data.syncedAt !== undefined) {
     setClauses.push('"syncedAt" = $(syncedAt)')

--- a/services/libs/data-access-layer/src/project-catalog/types.ts
+++ b/services/libs/data-access-layer/src/project-catalog/types.ts
@@ -8,6 +8,8 @@ export interface IDbProjectCatalog {
   source: string | null
   action: ProjectCatalogAction
   lfCriticalityScore: number | null
+  evaluationResult: string | null
+  evaluationReason: string | null
   evaluatedAt: string | null
   onboardedAt: string | null
   syncedAt: string | null
@@ -17,7 +19,14 @@ export interface IDbProjectCatalog {
 
 type ProjectCatalogWritable = Pick<
   IDbProjectCatalog,
-  'projectSlug' | 'repoName' | 'repoUrl' | 'source' | 'action' | 'lfCriticalityScore'
+  | 'projectSlug'
+  | 'repoName'
+  | 'repoUrl'
+  | 'source'
+  | 'action'
+  | 'lfCriticalityScore'
+  | 'evaluationResult'
+  | 'evaluationReason'
 >
 
 export type IDbProjectCatalogCreate = Omit<

--- a/services/libs/data-access-layer/src/project-catalog/types.ts
+++ b/services/libs/data-access-layer/src/project-catalog/types.ts
@@ -31,11 +31,13 @@ type ProjectCatalogWritable = Pick<
 
 export type IDbProjectCatalogCreate = Omit<
   ProjectCatalogWritable,
-  'source' | 'action' | 'lfCriticalityScore'
+  'source' | 'action' | 'lfCriticalityScore' | 'evaluationResult' | 'evaluationReason'
 > & {
   source?: string | null
   action?: ProjectCatalogAction
   lfCriticalityScore?: number
+  evaluationResult?: string | null
+  evaluationReason?: string | null
 }
 
 export type IDbProjectCatalogUpdate = Partial<ProjectCatalogWritable> & {


### PR DESCRIPTION
## Summary
Adds evaluationResult and evaluationReason TEXT columns to the projectCatalog table to store the outcome and rationale of the evaluation step for projects that are not onboarded.

## Changes
- Migration V1779280838 adds evaluationResult and evaluationReason (nullable TEXT) to projectCatalog; undo migration drops them
- IDbProjectCatalog and ProjectCatalogWritable updated with the two new fields
- PROJECT_CATALOG_COLUMNS and updateProjectCatalog in projectCatalog.ts updated to read and write the new columns

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[JIRA ticket](https://linuxfoundation.atlassian.net/browse/CM-1168)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces two nullable columns and wires them through the data-access layer, with no behavioral changes beyond reading/writing the new fields.
> 
> **Overview**
> Adds `evaluationResult` and `evaluationReason` (nullable `TEXT`) to the `projectCatalog` table via a new migration.
> 
> Updates the project-catalog data-access layer/types to include these fields in selects (`PROJECT_CATALOG_COLUMNS`) and allow them to be set via `updateProjectCatalog` / create/update typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6ede23c1c57c15586176538c811b118d4d9cb5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->