### PR TITLE
feat: add evaluation api call (CM-1168)

### DIFF
--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -45,8 +45,8 @@ export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Prom
   const startTime = Date.now()
 
   // Guard: fetch fresh state to ensure the API is called at most once per project.
-  // If evaluatedAt is already set, a previous run completed this project — skip.
-  const fresh = await findProjectCatalogById(pgpQx(svc.postgres.reader.connection()), project.id)
+  // Uses the writer connection to avoid replica lag missing a just-written evaluatedAt.
+  const fresh = await findProjectCatalogById(qx, project.id)
   if (fresh?.evaluatedAt) {
     log.info(
       { id: project.id, repoUrl: project.repoUrl, evaluatedAt: fresh.evaluatedAt },

--- a/services/apps/projects_evaluation_worker/src/activities/activities.ts
+++ b/services/apps/projects_evaluation_worker/src/activities/activities.ts
@@ -1,4 +1,5 @@
 import {
+  findProjectCatalogById,
   findProjectCatalogPendingEvaluation,
   promoteProjectsToEvaluate,
   updateProjectCatalog,
@@ -43,6 +44,17 @@ export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Prom
   const qx = pgpQx(svc.postgres.writer.connection())
   const startTime = Date.now()
 
+  // Guard: fetch fresh state to ensure the API is called at most once per project.
+  // If evaluatedAt is already set, a previous run completed this project — skip.
+  const fresh = await findProjectCatalogById(pgpQx(svc.postgres.reader.connection()), project.id)
+  if (fresh?.evaluatedAt) {
+    log.info(
+      { id: project.id, repoUrl: project.repoUrl, evaluatedAt: fresh.evaluatedAt },
+      'Project already evaluated, skipping API call.',
+    )
+    return
+  }
+
   log.info({ id: project.id, repoUrl: project.repoUrl }, 'Starting evaluation.')
 
   const result = await evaluateProject({
@@ -56,6 +68,8 @@ export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Prom
 
   await updateProjectCatalog(qx, project.id, {
     action: result.outcome,
+    evaluationResult: result.evaluationResult,
+    evaluationReason: result.evaluationReason,
     evaluatedAt: new Date().toISOString(),
   })
 
@@ -66,7 +80,8 @@ export async function evaluateAndUpdateProject(project: IDbProjectCatalog): Prom
       id: project.id,
       repoUrl: project.repoUrl,
       outcome: result.outcome,
-      reason: result.reason,
+      evaluationResult: result.evaluationResult,
+      evaluationReason: result.evaluationReason,
       elapsedSeconds,
     },
     'Evaluation complete.',

--- a/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
@@ -5,10 +5,6 @@ interface IApiResponseContent {
   non_onboard_reason?: string
 }
 
-interface IApiResponse {
-  content: IApiResponseContent
-}
-
 export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluationResult> {
   const endpoint = process.env.CROWD_PROJECT_EVALUATION_API_ENDPOINT
   const userId = process.env.CROWD_PROJECT_EVALUATION_API_USER_ID
@@ -18,7 +14,8 @@ export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluat
     return {
       outcome: 'unsure',
       evaluationResult: 'error',
-      evaluationReason: 'Missing API configuration: CROWD_PROJECT_EVALUATION_API_ENDPOINT, CROWD_PROJECT_EVALUATION_API_USER_ID, or CROWD_PROJECT_EVALUATION_API_SECRET',
+      evaluationReason:
+        'Missing API configuration: CROWD_PROJECT_EVALUATION_API_ENDPOINT, CROWD_PROJECT_EVALUATION_API_USER_ID, or CROWD_PROJECT_EVALUATION_API_SECRET',
     }
   }
 
@@ -54,9 +51,9 @@ export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluat
     }
   }
 
-  let responseBody: IApiResponse
+  let responseBody: unknown
   try {
-    responseBody = (await response.json()) as IApiResponse
+    responseBody = await response.json()
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return {
@@ -66,11 +63,24 @@ export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluat
     }
   }
 
-  const { onboard, non_onboard_reason } = responseBody.content
+  const content = (responseBody as { content?: unknown } | null)?.content
+  if (
+    !content ||
+    typeof content !== 'object' ||
+    typeof (content as IApiResponseContent).onboard !== 'boolean'
+  ) {
+    return {
+      outcome: 'unsure',
+      evaluationResult: 'error',
+      evaluationReason: `Unexpected API response shape: ${JSON.stringify(responseBody)}`,
+    }
+  }
+
+  const { onboard, non_onboard_reason } = content as IApiResponseContent
 
   return {
     outcome: onboard ? 'onboard' : 'skip',
     evaluationResult: String(onboard),
-    evaluationReason: non_onboard_reason ?? '',
+    evaluationReason: non_onboard_reason ?? null,
   }
 }

--- a/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/evaluator.ts
@@ -1,9 +1,76 @@
 import { IEvaluationInput, IEvaluationResult } from './types'
 
-// TODO: Replace with the actual AI evaluation algorithm once the external repo is integrated.
-// The algorithm is described in the technical spec and currently takes ~30-40s per project
-// at ~$0.15/project. Reference: https://github.com/... (link TBD).
+interface IApiResponseContent {
+  onboard: boolean
+  non_onboard_reason?: string
+}
+
+interface IApiResponse {
+  content: IApiResponseContent
+}
+
 export async function evaluateProject(input: IEvaluationInput): Promise<IEvaluationResult> {
-  console.error(`evaluateProject is not implemented yet for repo: ${input.repoUrl}`)
-  return { outcome: 'unsure', reason: 'evaluator not implemented' }
+  const endpoint = process.env.CROWD_PROJECT_EVALUATION_API_ENDPOINT
+  const userId = process.env.CROWD_PROJECT_EVALUATION_API_USER_ID
+  const secret = process.env.CROWD_PROJECT_EVALUATION_API_SECRET
+
+  if (!endpoint || !userId || !secret) {
+    return {
+      outcome: 'unsure',
+      evaluationResult: 'error',
+      evaluationReason: 'Missing API configuration: CROWD_PROJECT_EVALUATION_API_ENDPOINT, CROWD_PROJECT_EVALUATION_API_USER_ID, or CROWD_PROJECT_EVALUATION_API_SECRET',
+    }
+  }
+
+  const body = new URLSearchParams()
+  body.append('message', JSON.stringify({ repo_url: input.repoUrl }))
+  body.append('stream', 'false')
+  body.append('user_id', userId)
+
+  let response: Response
+  try {
+    response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Bearer ${secret}`,
+      },
+      body,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      outcome: 'unsure',
+      evaluationResult: 'error',
+      evaluationReason: `API request failed: ${message}`,
+    }
+  }
+
+  if (!response.ok) {
+    return {
+      outcome: 'unsure',
+      evaluationResult: 'error',
+      evaluationReason: `API returned HTTP ${response.status}: ${response.statusText}`,
+    }
+  }
+
+  let responseBody: IApiResponse
+  try {
+    responseBody = (await response.json()) as IApiResponse
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return {
+      outcome: 'unsure',
+      evaluationResult: 'error',
+      evaluationReason: `Failed to parse API response: ${message}`,
+    }
+  }
+
+  const { onboard, non_onboard_reason } = responseBody.content
+
+  return {
+    outcome: onboard ? 'onboard' : 'skip',
+    evaluationResult: String(onboard),
+    evaluationReason: non_onboard_reason ?? '',
+  }
 }

--- a/services/apps/projects_evaluation_worker/src/evaluator/types.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/types.ts
@@ -9,10 +9,11 @@ export interface IEvaluationInput {
   source: string | null
 }
 
-// Evaluation can only resolve to 'onboard' or 'unsure' — never back to 'evaluate' or 'auto'.
-export type EvaluationOutcome = Extract<ProjectCatalogAction, 'onboard' | 'unsure'>
+// Evaluation can only resolve to 'onboard', 'skip', or 'unsure' — never back to 'evaluate' or 'auto'.
+export type EvaluationOutcome = Extract<ProjectCatalogAction, 'onboard' | 'skip' | 'unsure'>
 
 export interface IEvaluationResult {
   outcome: EvaluationOutcome
-  reason: string
+  evaluationResult: string
+  evaluationReason: string
 }

--- a/services/apps/projects_evaluation_worker/src/evaluator/types.ts
+++ b/services/apps/projects_evaluation_worker/src/evaluator/types.ts
@@ -15,5 +15,5 @@ export type EvaluationOutcome = Extract<ProjectCatalogAction, 'onboard' | 'skip'
 export interface IEvaluationResult {
   outcome: EvaluationOutcome
   evaluationResult: string
-  evaluationReason: string
+  evaluationReason: string | null
 }

--- a/services/apps/projects_evaluation_worker/src/main.ts
+++ b/services/apps/projects_evaluation_worker/src/main.ts
@@ -4,7 +4,11 @@ import { Options, ServiceWorker } from '@crowd/archetype-worker'
 import { scheduleProjectsEvaluation } from './schedules/scheduleProjectsEvaluation'
 
 const config: Config = {
-  envvars: [],
+  envvars: [
+    'CROWD_PROJECT_EVALUATION_API_ENDPOINT',
+    'CROWD_PROJECT_EVALUATION_API_USER_ID',
+    'CROWD_PROJECT_EVALUATION_API_SECRET',
+  ],
   producer: {
     enabled: false,
   },

--- a/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
+++ b/services/libs/data-access-layer/src/project-catalog/projectCatalog.ts
@@ -316,7 +316,7 @@ export async function upsertProjectCatalog(
       "repoName" = EXCLUDED."repoName",
       "source" = COALESCE(EXCLUDED."source", "projectCatalog"."source"),
       "action" = CASE
-        WHEN "projectCatalog"."action" IN ('onboard', 'unsure') THEN "projectCatalog"."action"
+        WHEN "projectCatalog"."action" IN ('onboard', 'skip', 'unsure') THEN "projectCatalog"."action"
         WHEN EXCLUDED.action = 'evaluate' THEN 'evaluate'
         ELSE "projectCatalog"."action"
       END,
@@ -389,7 +389,7 @@ export async function bulkUpsertProjectCatalog(
       "repoName" = EXCLUDED."repoName",
       "source" = COALESCE(EXCLUDED."source", "projectCatalog"."source"),
       "action" = CASE
-        WHEN "projectCatalog"."action" IN ('onboard', 'unsure') THEN "projectCatalog"."action"
+        WHEN "projectCatalog"."action" IN ('onboard', 'skip', 'unsure') THEN "projectCatalog"."action"
         WHEN EXCLUDED.action = 'evaluate' THEN 'evaluate'
         ELSE "projectCatalog"."action"
       END,

--- a/services/libs/data-access-layer/src/project-catalog/types.ts
+++ b/services/libs/data-access-layer/src/project-catalog/types.ts
@@ -1,4 +1,4 @@
-export type ProjectCatalogAction = 'auto' | 'evaluate' | 'onboard' | 'unsure'
+export type ProjectCatalogAction = 'auto' | 'evaluate' | 'onboard' | 'skip' | 'unsure'
 
 export interface IDbProjectCatalog {
   id: string


### PR DESCRIPTION
## Summary
Wires the projects evaluation worker to the external LFX AI onboarding-evaluation API, replacing the placeholder evaluator. Each pending project in `projectCatalog` is sent to the API, and the response is persisted as the project's `action`, `evaluationResult`, and `evaluationReason`.

## Changes
- **Evaluator implementation** (`evaluator/evaluator.ts`): real HTTP call to `CROWD_PROJECT_EVALUATION_API_ENDPOINT` with `Bearer` auth, `application/x-www-form-urlencoded` body (`message`, `stream=false`, `user_id`). All failure modes (missing config, network error, non-2xx, JSON parse error) resolve to `outcome: 'unsure'` with `evaluationResult: 'error'` and a descriptive `evaluationReason`, so a single bad call never crashes the workflow.
- **New `skip` outcome**: extended `EvaluationOutcome` and `ProjectCatalogAction` to include `'skip'` (when the API returns `onboard: false`). `'onboard' | 'skip' | 'unsure'` are now treated as terminal in `upsertProjectCatalog` / `bulkUpsertProjectCatalog`  a re-discovered project will not be moved back to `evaluate`.
- **Result shape**: `IEvaluationResult` now carries `evaluationResult` (stringified `onboard` flag) and `evaluationReason` (the API's `non_onboard_reason`) instead of a single `reason` field, matching the new columns persisted on `projectCatalog`.
- **Idempotency guard** (`activities/activities.ts`): before calling the API, refetch the project via `findProjectCatalogById` and short-circuit if `evaluatedAt` is already set. Protects against double-billing if Temporal retries an activity after a successful API call but a failed DB write.
- **Worker config** (`main.ts`): declares the three required env vars (`CROWD_PROJECT_EVALUATION_API_ENDPOINT`, `CROWD_PROJECT_EVALUATION_API_USER_ID`, `CROWD_PROJECT_EVALUATION_API_SECRET`) so the service fails fast on boot if any are missing.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[ticket](https://linuxfoundation.atlassian.net/browse/CM-1168)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces paid external API calls and changes project catalog action semantics (new skip terminal state); failures are contained to unsure/error outcomes but misconfiguration or API issues affect onboarding decisions at scale.
> 
> **Overview**
> Replaces the projects evaluation worker **placeholder** with a real call to the external LFX AI onboarding-evaluation API and persists outcomes on `projectCatalog`.
> 
> The evaluator posts `repo_url` to `CROWD_PROJECT_EVALUATION_API_ENDPOINT` with Bearer auth and maps `content.onboard` to **`onboard`** or new terminal action **`skip`**, storing `evaluationResult` / `evaluationReason` (and `action: unsure` with `evaluationResult: error` on config, network, HTTP, or parse failures so the workflow does not throw). **`evaluateAndUpdateProject`** refetches via the writer and skips the API if `evaluatedAt` is already set (retry/idempotency). Catalog **upserts** treat **`skip`** like **`onboard`** / **`unsure`** so rediscovery does not reset terminal decisions. The worker now requires the three API env vars at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be91ffc4c6dd6495f3cfd73b5825237b064aff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->