### PR TITLE
chore: update downloads schema for tier 2/3 granularity

### DIFF
--- a/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
+++ b/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
@@ -7,7 +7,10 @@ CREATE TABLE packages_universe (
     ecosystem text NOT NULL,
     namespace text,
     name text NOT NULL,
-    downloads_30d bigint,
+    -- To be validated later on: Cached latest-month snapshot written by the same weekly ranking worker that populates
+    -- downloads_monthly. Used directly by rank_packages_universe() to avoid a join.
+    -- For monthly history across runs, see downloads_monthly (keyed by purl).
+    downloads_last_30d bigint,
     dependent_packages_count int,
     dependent_repos_count int,
     criticality_score numeric(10, 4),
@@ -54,7 +57,6 @@ CREATE TABLE packages (
     latest_release_at timestamptz,
     dependent_packages_count int,
     dependent_repos_count int,
-    downloads_last_month bigint,
     -- has_critical_vulnerability bool NOT NULL DEFAULT FALSE,
     -- Deferred: semantics undecided between (a) any advisory with no fixed_version vs
     -- (b) latest_version falls inside an affected semver range. Lateral join against
@@ -78,10 +80,6 @@ CREATE INDEX ON packages (is_critical) WHERE is_critical;
 CREATE INDEX ON packages (ecosystem, name);
 
 CREATE INDEX ON packages USING gin (keywords);
-
-CREATE INDEX ON packages (downloads_last_month DESC)
-WHERE
-    status = 'active';
 
 -- INDEX on has_critical_vulnerability removed — column is commented out above.
 -- Uncomment both when semantics are decided.
@@ -126,7 +124,6 @@ CREATE TABLE versions (
     is_yanked bool,
     is_prerelease bool NOT NULL DEFAULT FALSE,
     license text, -- SPDX where available; can differ per version
-    download_count bigint, -- per-version where available (npm, crates)
     last_synced_at timestamptz NOT NULL DEFAULT NOW(),
     PRIMARY KEY (id, package_id),
     UNIQUE (package_id, number)
@@ -646,9 +643,27 @@ CREATE TABLE package_maintainers (
 );
 
 -- ============================================================
--- DOWNLOADS (time-series, partitioned by month via pg_partman)
+-- DOWNLOADS
 --
--- pg_partman MUST be enabled in OCI config before this migration runs:
+-- Two tables track download volume at different tiers and granularities:
+--
+--   downloads_daily   (tier 2 — packages)
+--     Source of truth for daily download counts. One row per package per day.
+--     No denormalized rollup on the packages table — consumers SUM over this
+--     table when they need a window (e.g. last 30 days).
+--
+--   downloads_monthly (tier 3 — packages_universe)
+--     Monthly download timeline keyed by purl. Stable across the weekly
+--     packages_universe truncation, which is why it uses purl as identifier
+--     rather than a FK to packages_universe. The per-package latest-month
+--     snapshot is also cached in packages_universe.downloads_last_30d for fast
+--     access by the criticality-ranking function (no join needed).
+--
+-- ============================================================
+-- DOWNLOADS DAILY (tier 2 — packages, daily granularity)
+--
+-- Partitioned by month via pg_partman. pg_partman MUST be enabled in OCI
+-- config before this migration runs:
 --   OCI Console → Database → Configuration → Extensions → enable pg_partman
 --
 -- After enabling, run the setup below (once, outside Flyway or in a
@@ -676,13 +691,34 @@ CREATE TABLE package_maintainers (
 -- ============================================================
 CREATE TABLE downloads_daily (
     id bigserial,
-    package_id bigint NOT NULL,
+    package_id bigint NOT NULL REFERENCES packages (id),
     date date NOT NULL,
     count bigint NOT NULL,
     PRIMARY KEY (id, date),
     UNIQUE (package_id, date)
 )
 PARTITION BY RANGE (date);
+
+-- ============================================================
+-- DOWNLOADS MONTHLY (tier 3 — packages_universe, monthly granularity)
+--
+-- Historical timeline of monthly download counts, keyed by purl.
+-- Keyed by purl (not packages_universe.id) so rows survive the weekly
+-- truncation of packages_universe. The latest-month value is also written
+-- to packages_universe.downloads_last_30d for fast access by the ranking function.
+--
+-- month stores the first day of the month (e.g. 2025-01-01 for Jan 2025).
+-- Writers should upsert: INSERT ... ON CONFLICT (purl, month) DO UPDATE SET count = EXCLUDED.count
+-- ============================================================
+CREATE TABLE downloads_monthly (
+    id bigserial PRIMARY KEY,
+    purl text NOT NULL,
+    date date NOT NULL,
+    count bigint NOT NULL,
+    UNIQUE (purl, month)
+);
+
+CREATE INDEX ON downloads_monthly (purl, month DESC);
 
 -- ============================================================
 -- CRITICALITY RANKING FUNCTION
@@ -707,7 +743,7 @@ BEGIN
     -- and to compress the gap between small and large values (e.g. LN(1)=0
     -- vs LN(2)≈0.69 gives a gentler floor than LN(0)=-∞). Typically 1.0.
     --
-    -- Until the npm-registry / Maven downloads enricher runs, downloads_30d
+    -- Until the npm-registry / Maven downloads enricher runs, downloads_last_30d
     -- is NULL on every row. weight_downloads contributes 0 to the score;
     -- ranking effectively reduces to:
     --   LN(1 + dependent_repos_count)     * weight_dependent_repos
@@ -717,7 +753,7 @@ BEGIN
     WITH new_scores AS (
         SELECT
             id,
-            ( LN(log_smoothing + COALESCE(downloads_30d, 0))            * weight_downloads
+            ( LN(log_smoothing + COALESCE(downloads_last_30d, 0))            * weight_downloads
             + LN(log_smoothing + COALESCE(dependent_repos_count, 0))    * weight_dependent_repos
             + LN(log_smoothing + COALESCE(dependent_packages_count, 0)) * weight_dependent_packages
             )::numeric(10, 4) AS new_score

--- a/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
+++ b/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
@@ -7,9 +7,9 @@ CREATE TABLE packages_universe (
     ecosystem text NOT NULL,
     namespace text,
     name text NOT NULL,
-    -- To be validated later on: Cached latest-month snapshot written by the same weekly ranking worker that populates
-    -- downloads_monthly. Used directly by rank_packages_universe() to avoid a join.
-    -- For monthly history across runs, see downloads_monthly (keyed by purl).
+    -- To be validated later on: Cached latest 30-day window count written by the same weekly ranking worker that populates
+    -- downloads_last_30d. Used directly by rank_packages_universe() to avoid a join.
+    -- For the full rolling-window history, see downloads_last_30d (keyed by purl).
     downloads_last_30d bigint,
     dependent_packages_count int,
     dependent_repos_count int,
@@ -652,12 +652,12 @@ CREATE TABLE package_maintainers (
 --     No denormalized rollup on the packages table — consumers SUM over this
 --     table when they need a window (e.g. last 30 days).
 --
---   downloads_monthly (tier 3 — packages_universe)
---     Monthly download timeline keyed by purl. Stable across the weekly
---     packages_universe truncation, which is why it uses purl as identifier
---     rather than a FK to packages_universe. The per-package latest-month
---     snapshot is also cached in packages_universe.downloads_last_30d for fast
---     access by the criticality-ranking function (no join needed).
+--   downloads_last_30d (tier 3 — packages_universe)
+--     Rolling 30-day download timeline keyed by purl. Each row represents one
+--     30-day window (start_date..end_date). Keyed by purl so rows survive the
+--     weekly truncation of packages_universe. The latest window's count is also
+--     cached in packages_universe.downloads_last_30d for fast access by the
+--     criticality-ranking function (no join needed).
 --
 -- ============================================================
 -- DOWNLOADS DAILY (tier 2 — packages, daily granularity)
@@ -700,25 +700,30 @@ CREATE TABLE downloads_daily (
 PARTITION BY RANGE (date);
 
 -- ============================================================
--- DOWNLOADS MONTHLY (tier 3 — packages_universe, monthly granularity)
+-- DOWNLOADS LAST 30D (tier 3 — packages_universe, rolling 30-day granularity)
 --
--- Historical timeline of monthly download counts, keyed by purl.
+-- Historical timeline of rolling 30-day download counts, keyed by purl.
+-- Each row captures one window: downloads from start_date to end_date (inclusive).
 -- Keyed by purl (not packages_universe.id) so rows survive the weekly
--- truncation of packages_universe. The latest-month value is also written
+-- truncation of packages_universe. The latest window is also written
 -- to packages_universe.downloads_last_30d for fast access by the ranking function.
 --
--- month stores the first day of the month (e.g. 2025-01-01 for Jan 2025).
--- Writers should upsert: INSERT ... ON CONFLICT (purl, month) DO UPDATE SET count = EXCLUDED.count
+-- Writers should upsert: INSERT ... ON CONFLICT (purl, end_date) DO UPDATE SET count = EXCLUDED.count, start_date = EXCLUDED.start_date
+-- PK includes end_date because Postgres requires the partition key to be
+-- part of the primary key on range-partitioned tables.
 -- ============================================================
-CREATE TABLE downloads_monthly (
-    id bigserial PRIMARY KEY,
+CREATE TABLE downloads_last_30d (
+    id bigserial,
     purl text NOT NULL,
-    date date NOT NULL,
+    start_date date NOT NULL,
+    end_date date NOT NULL,
     count bigint NOT NULL,
-    UNIQUE (purl, month)
-);
+    PRIMARY KEY (id, end_date),
+    UNIQUE (purl, end_date)
+)
+PARTITION BY RANGE (end_date);
 
-CREATE INDEX ON downloads_monthly (purl, month DESC);
+CREATE INDEX ON downloads_last_30d (purl, end_date DESC);
 
 -- ============================================================
 -- CRITICALITY RANKING FUNCTION

--- a/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
+++ b/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
@@ -7,9 +7,10 @@ CREATE TABLE packages_universe (
     ecosystem text NOT NULL,
     namespace text,
     name text NOT NULL,
-    -- To be validated later on: Cached latest 30-day window count written by the same weekly ranking worker that populates
-    -- downloads_last_30d. Used directly by rank_packages_universe() to avoid a join.
-    -- For the full rolling-window history, see downloads_last_30d (keyed by purl).
+    -- Cached latest 30-day window count. Written by the same weekly ranking worker that upserts rows into
+    -- the downloads_last_30d table (keyed by purl/end_date). This column is the denormalized latest value
+    -- used directly by rank_packages_universe() to avoid a join; the downloads_last_30d table holds the
+    -- full rolling-window timeline.
     downloads_last_30d bigint,
     dependent_packages_count int,
     dependent_repos_count int,
@@ -706,11 +707,36 @@ PARTITION BY RANGE (date);
 -- Each row captures one window: downloads from start_date to end_date (inclusive).
 -- Keyed by purl (not packages_universe.id) so rows survive the weekly
 -- truncation of packages_universe. The latest window is also written
--- to packages_universe.downloads_last_30d for fast access by the ranking function.
+-- to packages_universe.downloads_last_30d column for fast access by the ranking function.
 --
 -- Writers should upsert: INSERT ... ON CONFLICT (purl, end_date) DO UPDATE SET count = EXCLUDED.count, start_date = EXCLUDED.start_date
 -- PK includes end_date because Postgres requires the partition key to be
 -- part of the primary key on range-partitioned tables.
+--
+-- Partitioned by month via pg_partman. pg_partman MUST be enabled in OCI
+-- config before this migration runs:
+--   OCI Console → Database → Configuration → Extensions → enable pg_partman
+--
+-- After enabling, run the setup below (once, outside Flyway or in a
+-- separate migration) to register pg_partman and create initial partitions:
+--
+--   CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;
+--
+--   SELECT partman.create_parent(
+--       p_parent_table => 'public.downloads_last_30d',
+--       p_control      => 'end_date',
+--       p_interval     => '1 month',
+--       p_premake      => 3   -- pre-creates 3 future monthly partitions
+--   );
+--
+--   -- pg_cron job to maintain partitions (also needs pg_cron enabled in OCI):
+--   SELECT cron.schedule('partman-maintain-30d', '0 2 * * *',
+--       $$CALL partman.run_maintenance_proc()$$);
+--
+-- Without this setup, inserts into downloads_last_30d will fail with
+-- "no partition found for row". The table structure below is correct;
+-- only the partition management setup is deferred.
+--
 -- ============================================================
 CREATE TABLE downloads_last_30d (
     id bigserial,


### PR DESCRIPTION
This pull request updates the schema for package download tracking and criticality ranking. The changes focus on improving how download statistics are stored and accessed, introducing new tables for daily and monthly download counts, and refactoring related columns and indexes. The most important changes are grouped below:

**Download tracking table changes:**

* Added a new column `downloads_last_30d` to the `packages_universe` table to cache the latest 30-day download snapshot, replacing the previous `downloads_30d` column. This value is written by the weekly ranking worker and used directly by the ranking function for efficiency.
* Removed the `downloads_last_month` column from the `packages` table and the `download_count` column from the `versions` table, as these are now tracked in dedicated download tables. [[1]](diffhunk://#diff-6f8476403c57dc51483b1a562224007022fa608d7361d71d511e0f1263a48393L57) [[2]](diffhunk://#diff-6f8476403c57dc51483b1a562224007022fa608d7361d71d511e0f1263a48393L129)

**New download history tables:**

* Introduced the `downloads_daily` table (partitioned by month) to store daily download counts per package, with a foreign key to `packages`.
* Added the `downloads_monthly` table to store monthly download counts keyed by `purl`, ensuring historical data persists across weekly truncations of `packages_universe`. Includes a unique constraint on `(purl, month)` and an index for efficient queries.

**Index and schema cleanup:**

* Removed the index on `downloads_last_month` in the `packages` table, as this column has been dropped.

**Criticality ranking function update:**

* Updated the ranking function and related comments to use the new `downloads_last_30d` column instead of the old `downloads_30d` column, ensuring the ranking logic aligns with the new schema. [[1]](diffhunk://#diff-6f8476403c57dc51483b1a562224007022fa608d7361d71d511e0f1263a48393L710-R746) [[2]](diffhunk://#diff-6f8476403c57dc51483b1a562224007022fa608d7361d71d511e0f1263a48393L720-R756)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Foundational schema for criticality ranking and partitioned time-series tables; wrong worker contracts or missing pg_partman partitions would break inserts and ranking inputs.
> 
> **Overview**
> This PR reshapes how download metrics are stored for **tier 2** (`packages`) vs **tier 3** (`packages_universe`) and wires criticality ranking to the new names.
> 
> **Universe (tier 3):** `downloads_30d` becomes **`downloads_last_30d`**, documented as the denormalized latest rolling 30-day total (written with upserts into a new history table). **`rank_packages_universe()`** now scores using `downloads_last_30d` instead of `downloads_30d`.
> 
> **Packages / versions:** **`downloads_last_month`** on `packages` and its partial index are removed—tier 2 windows are expected to come from **`downloads_daily`** (sum over days). Per-version **`download_count`** on `versions` is dropped.
> 
> **New / tightened download tables:** **`downloads_daily`** gains a **`REFERENCES packages (id)`** FK. A new range-partitioned **`downloads_last_30d`** table stores rolling windows by **`purl`** and **`end_date`** (survives weekly `packages_universe` truncation), with an index on `(purl, end_date DESC)` and pg_partman setup notes mirroring `downloads_daily`.
> 
> **Docs in migration:** A consolidated DOWNLOADS section explains the two-table split and upsert pattern for the 30-day timeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e07b22e21deb805f27a6fce3ecaeab1f9eb6d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->