### PR TITLE
docs: update adr with latest decisions

### DIFF
--- a/docs/adr/0001-oss-packages-design-decisions.md
+++ b/docs/adr/0001-oss-packages-design-decisions.md
@@ -82,7 +82,7 @@ Tier 2 enriches a critical slice of the npm and Maven ecosystems — not the ful
 
 We use the [deps.dev BigQuery public datasets](https://deps.dev) — specifically `PackageVersionsLatest`, `DependentsLatest`, `PackageVersionToProjectLatest`, and `ProjectsLatest` — filtered to `System IN ('NPM', 'MAVEN')` as the universe input. The BigQuery data is exported to Parquet files and imported into `packages_universe` on a weekly cadence aligned with deps.dev's own refresh interval. The first run is a one-time full backfill; subsequent weekly imports only pull rows whose deps.dev snapshot date has advanced since the previous import, so the export size and write volume are scoped to actual diffs rather than the full universe. A scoring + ranking job then promotes the top-N per ecosystem by setting `is_critical = true` and copying `criticality_score` onto the full `packages` table.
 
-The scoring formula, per-ecosystem critical-package quotas, graph-signal inputs, and spotlight-override mechanism are defined in §Criticality scoring methodology below. The ranking function takes `critical_top_n_by_ecosystem` as a JSONB parameter and weights as numeric inputs, so thresholds and formula coefficients can be tuned at call time without a schema change.
+The current scoring formula and per-ecosystem critical-package quotas are **not yet finalized** — both are still under discussion. The ranking function takes `critical_top_n_by_ecosystem` as a JSONB parameter and weights as numeric inputs, so thresholds and formula coefficients can be tuned at call time without a schema change.
 
 The BigQuery free tier is approximately 1 TiB/month. Column projection and `System` filtering are mandatory on every query; full-table scans will exhaust the quota.
 

--- a/docs/adr/0001-oss-packages-design-decisions.md
+++ b/docs/adr/0001-oss-packages-design-decisions.md
@@ -10,20 +10,21 @@ The oss-packages domain is being built inside CDP as a new, independent capabili
 
 ## Scope and current status
 
-| Decision area                                  | Status                                |
-| ---------------------------------------------- | ------------------------------------- |
-| Database placement                             | decided                               |
-| Worker architecture                            | decided                               |
-| Universe source and critical-package selection | decided (formula is a placeholder)    |
-| Write semantics across sub-workers             | decided                               |
-| Package → repository provenance                | decided                               |
-| OSV as canonical security source               | decided                               |
-| CVSS scoring strategy                          | decided (v4 numeric scoring deferred) |
-| `has_critical_vulnerability` semantics         | decided                               |
-| `advisory_affected_ranges` uniqueness scope    | decided                               |
-| Per-source ingestion strategies                | decided (Sonatype API access pending) |
-| deps.dev coverage and gaps                     | decided                               |
-| Downloads timeline by tier                     | decided                               |
+| Decision area                                  | Status                                              |
+| ---------------------------------------------- | --------------------------------------------------- |
+| Database placement                             | decided                                             |
+| Worker architecture                            | decided                                             |
+| Universe source and critical-package selection | decided (formula is a placeholder)                  |
+| Write semantics across sub-workers             | decided                                             |
+| Package → repository provenance                | decided                                             |
+| OSV as canonical security source               | decided                                             |
+| CVSS scoring strategy                          | decided (v4 numeric scoring deferred)               |
+| `has_critical_vulnerability` semantics         | decided                                             |
+| `advisory_affected_ranges` uniqueness scope    | decided                                             |
+| Per-source ingestion strategies                | decided (Sonatype API access pending)               |
+| Source of truth: deps.dev vs registries / OSV  | decided                                             |
+| deps.dev coverage and gaps                     | decided                                             |
+| Downloads timeline by tier                     | decided                                             |
 
 ---
 
@@ -79,9 +80,9 @@ Adding a new data source means adding `src/{worker}/` and a new compose service 
 
 Tier 2 enriches a critical slice of the npm and Maven ecosystems — not the full registry. We need a signal-rich, affordable source to rank the ~4–5M packages and decide which top-N to fully enrich.
 
-We use the [deps.dev BigQuery public datasets](https://deps.dev) — specifically `PackageVersionsLatest`, `DependentsLatest`, `PackageVersionToProjectLatest`, and `ProjectsLatest` — filtered to `System IN ('NPM', 'MAVEN')` as the universe input. The BigQuery data is exported to Parquet files and imported into `packages_universe` on a weekly cadence. A scoring + ranking job then promotes the top-N per ecosystem by setting `is_critical = true` and copying `criticality_score` onto the full `packages` table.
+We use the [deps.dev BigQuery public datasets](https://deps.dev) — specifically `PackageVersionsLatest`, `DependentsLatest`, `PackageVersionToProjectLatest`, and `ProjectsLatest` — filtered to `System IN ('NPM', 'MAVEN')` as the universe input. The BigQuery data is exported to Parquet files and imported into `packages_universe` on a weekly cadence aligned with deps.dev's own refresh interval. The first run is a one-time full backfill; subsequent weekly imports only pull rows whose deps.dev snapshot date has advanced since the previous import, so the export size and write volume are scoped to actual diffs rather than the full universe. A scoring + ranking job then promotes the top-N per ecosystem by setting `is_critical = true` and copying `criticality_score` onto the full `packages` table.
 
-The current scoring formula and per-ecosystem critical-package quotas are **not yet finalized** — both are still under discussion. The ranking function takes `critical_top_n_by_ecosystem` as a JSONB parameter and weights as numeric inputs, so thresholds and formula coefficients can be tuned at call time without a schema change.
+The scoring formula, per-ecosystem critical-package quotas, graph-signal inputs, and spotlight-override mechanism are defined in §Criticality scoring methodology below. The ranking function takes `critical_top_n_by_ecosystem` as a JSONB parameter and weights as numeric inputs, so thresholds and formula coefficients can be tuned at call time without a schema change.
 
 The BigQuery free tier is approximately 1 TiB/month. Column projection and `System` filtering are mandatory on every query; full-table scans will exhaust the quota.
 
@@ -96,7 +97,7 @@ Five sub-workers run concurrently (npm, Maven, OSV, GitHub, Docker Hub), all wri
 | Table                                 | Rule                                                                                                                                                                                                                                                        |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `packages`                            | Upsert on `purl`. Each worker only writes columns it owns; ecosystem isolation means column-level conflicts cannot occur in practice.                                                                                                                       |
-| `packages_universe`                   | Full truncate-and-replace on the weekly rank job. No other worker writes to this table. The truncate + bulk-insert must be wrapped in a single transaction or shadow-table swap to avoid a window of emptiness visible to the promotion query.              |
+| `packages_universe`                   | Incremental upsert keyed on `purl`. The deps.dev import only touches rows whose underlying deps.dev snapshot date has advanced since the previous import (initial run is a one-time full backfill).           |
 | `versions`                            | Append-only via `INSERT … ON CONFLICT DO NOTHING`. Yanked/deprecated status is a separate targeted `UPDATE (is_yanked = true) WHERE …`.                                                                                                                     |
 | `repos`                               | Registry workers (npm, Maven) do **not** write directly to `repos`. They write `package_repos` rows. The GitHub enricher — triggered when `repos.last_synced_at IS NULL` — upserts `repos` with metadata. Docker Hub worker adds `docker_*` columns on top. |
 | `package_repos`                       | Composite PK `(package_id, repo_url)`. Each `source` value ('declared', 'deps_dev', 'heuristic', 'manual') is a separate row — sources do not overwrite each other.                                                                                         |
@@ -211,7 +212,7 @@ A range `(introduced, fixed, last_affected)` matches `latest_version` when:
 - `fixed IS NULL OR latest_version < fixed`, AND
 - `last_affected IS NULL OR latest_version <= last_affected`.
 
-This is **option (b)** (latest_version inside an active range), plus a **MAL- override** so malicious-package reports flip the flag regardless of CVSS — the XZ-style maintainer-compromise case from the Osprey memo. ~213k of 220k npm OSV records are `MAL-*` with `cvss = NULL`, so option (b) on its own would miss the dominant security signal.
+This is **option (b)** (latest_version inside an active range), plus a **MAL- override** so malicious-package reports flip the flag regardless of CVSS — the XZ-style maintainer-compromise case. ~213k of 220k npm OSV records are `MAL-*` with `cvss = NULL`, so option (b) on its own would miss the dominant security signal.
 
 **Why not option (a)** (any critical advisory exists for the package name, regardless of version): option (a) over-reports — a CVE patched in v1.0 flags a package now on v9.0 — and under-reports when an advisory has multiple `affected[]` ranges where only some are patched. The actionable consumer question is "is the version I'd install today vulnerable?", and that's option (b).
 
@@ -285,6 +286,51 @@ For any `repos` row where GitHub metadata or Dockerfile content declares a known
 Docker Hub runs after registry workers are stable. Docker dependents (which images use a given image as a base layer) are **explicitly out of scope for v1**.
 
 **Decided**: 2026-05-26
+
+---
+
+### Source of truth: deps.dev backfill vs registries / OSV
+
+deps.dev gives us a single low-cost source covering packages, versions, package → repo mappings, repos, and advisories. The same data is also available from the underlying registries (npm, Maven Central, etc.) and from OSV directly. We need a clear ownership rule so two sources don't quietly disagree.
+
+We split responsibility by lifecycle stage, not by table:
+
+- **Initial backfill (one-time, per ecosystem)**: deps.dev populates `packages`, `versions`, `package_repos`, `repos`, `advisories`, and `advisory_affected_ranges` in a single bulk pass. This is how we get from zero to a workable dataset without standing up every registry worker first.
+- **New packages discovered after backfill**: deps.dev remains the bootstrap source. On each weekly deps.dev import, any newly-seen `purl` lands in all relevant tables from deps.dev fields, exactly as it did during backfill. This avoids a window where a new package exists in deps.dev but is invisible to us until the registry worker happens to see it.
+- **Ongoing updates to existing rows**: registries are the source of truth for package and version data; OSV is the source of truth for advisories; the GitHub enricher remains the source of truth for `repos` metadata beyond what `ProjectsLatest` provides. Registry / OSV workers may overwrite values that deps.dev wrote at backfill time — that is the intended direction of drift.
+
+Concretely:
+
+| Lifecycle event                                              | Writer              |
+| ------------------------------------------------------------ | ------------------- |
+| First-ever load of an ecosystem                              | deps.dev import     |
+| New package appears in deps.dev export                       | deps.dev import     |
+| New version published, deprecation / yank flipped            | registry worker     |
+| `latest_version`, `latest_release_at`, license drift         | registry worker     |
+| `package_repos` row added by a new registry/heuristic source | registry worker     |
+| Advisory created or modified                                 | OSV worker          |
+| Repo metadata refresh (stars, topics, archived, etc.)        | github-repos-enricher |
+
+The §deps.dev coverage and gaps table below remains the authoritative per-column ownership reference; this section is the lifecycle rule that sits on top of it.
+
+#### Data-source provenance: `package_source_log`
+
+To make drift between deps.dev and the registry / OSV workers observable, every package carries one row per writing source in `package_source_log`. Each worker that touches a package upserts its `(package_id, source)` row in the same transaction as the data write — bumping `last_synced_at` and recording the set of `table.column` paths it owns for that package.
+
+| Column           | Purpose                                                                                       |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| `package_id`     | FK to `packages(id)`. Part of PK.                                                             |
+| `source`         | Writing source: `'deps_dev'`, `'npm-registry'`, `'maven-central'`, `'osv'`, `'github-enricher'`, `'manual'`. Part of PK. |
+| `columns`        | Array of `table.column` paths this source wrote for this package (e.g. `packages.latest_version`, `versions.is_yanked`). |
+| `last_synced_at` | Timestamp of the most recent write by this source for this package.                           |
+
+Primary key is `(package_id, source)` — one row per package per source, updated in place. Cardinality is bounded by `|packages| × |sources|` (a small constant per package), well under what an append-only event log would generate.
+
+The shape answers the two questions the live data tables cannot: "which source last touched this package, and when?" and "is deps.dev still writing columns that a registry worker should now own?". It deliberately does not preserve history — a worker overwriting its own row drops the previous `columns` set. The present-tense "who currently owns what for this package" view is what the intended consumers (drift alerting, debugging the registry-vs-deps.dev handoff) need.
+
+Updating `package_source_log` is a social contract on every worker that writes to packages-domain tables — no Postgres constraint enforces it. Code review and the §Source of truth lifecycle table are the enforcement mechanisms.
+
+**Decided**: 2026-05-29
 
 ---
 
@@ -368,8 +414,6 @@ Downloads is the strongest criticality signal, but the ~4–5M packages in `pack
 
 Tier 2 (`packages`) downloads are stored in `downloads_daily` — one row per `(package_id, date)`, consumers sum over any window they need. Tier 3 (`packages_universe`) downloads are stored in `downloads_last_30d` — one row per `(purl, end_date)` capturing a rolling 30-day window — with the latest window's count also cached on `packages_universe.downloads_last_30d bigint` for direct use by `rank_packages_universe()` without a join.
 
-`downloads_last_30d` is keyed by `purl` (not `packages_universe.id`) so rows survive the weekly truncation of `packages_universe`.
-
 | Table                | Tier                    | Grain                                      | Unique key           | PK               | Partitioning                   |
 | -------------------- | ----------------------- | ------------------------------------------ | -------------------- | ---------------- | ------------------------------ |
 | `downloads_daily`    | 2 (`packages`)          | one row per package per day                | `(package_id, date)` | `(id, date)`     | RANGE on `date` via pg_partman |
@@ -396,7 +440,6 @@ A package promoted from Tier 3 to Tier 2 (becomes critical) will have rolling-wi
 ## Open questions / in-flight
 
 - **Sonatype Central Stats API access** — not confirmed as of 2026-05-27. If unavailable by day 5, Maven download counts will be absent from the week-2 demo (`downloads_last_month` NULL for Maven rows; disclose to stakeholders).
-- **criticality_score formula** — the placeholder formula (`X * downloadsCount + Y * dependentCount`) has not been validated against known critical packages. Final formula is yet to be defined.
 - **pg_partman + pg_cron setup** — must be confirmed active in the OCI environment before download workers start; `downloads_daily` and `downloads_last_30d` inserts will fail if monthly partitions are not pre-created.
 
 ---
@@ -405,6 +448,7 @@ A package promoted from Tier 3 to Tier 2 (becomes critical) will have rolling-wi
 
 - 2026-05-27 — initial record
 - 2026-05-28 — folded standalone ADR-0003 (`has_critical_vulnerability` semantics), ADR-0005 (CVSS scoring strategy), and ADR-0006 (`advisory_affected_ranges` uniqueness scope) into this living record; standalone files removed. Resolved the prior open question on `has_critical_vulnerability` (option b + MAL- override). ADR-0004 (standalone-bin vs Temporal) was removed before merging — the worker architecture decision in this ADR supersedes it.
+- 2026-05-29 — clarified `packages_universe` import semantics (one-time backfill + weekly snapshot-diff incrementals; the ranking job updates score/flag columns in place). Added §Source of truth: deps.dev backfill vs registries / OSV with lifecycle ownership rules and the agreed `package_source_log` provenance table (`(package_id, source)` PK; `columns` array tracks `table.column` paths each source writes).
 
 ---
 


### PR DESCRIPTION
This pull request updates the ADR for the oss-packages domain, clarifying the data import and ownership lifecycle, improving documentation of criticality scoring, and specifying data provenance tracking. The changes solidify how deps.dev and registry/OSV sources interact, introduce incremental imports for efficiency, and establish clearer data ownership and provenance rules.

**Data import and ownership lifecycle:**

* Clarified that `packages_universe` imports are performed as a one-time full backfill followed by weekly incremental upserts, with each import only updating rows whose deps.dev snapshot date has advanced, reducing unnecessary data writes. [[1]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L82-R85) [[2]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L99-R100) [[3]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126R451)
* Added a new section detailing the lifecycle-based source-of-truth rules: deps.dev is used for initial backfill and new package discovery, while registries and OSV become the authoritative sources for ongoing updates and advisories, ensuring clear data ownership and reducing the risk of silent data drift. [[1]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126R25) [[2]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126R292-R336)

**Provenance and observability:**

* Introduced the `package_source_log` table, which tracks which source last wrote to each package and which columns it owns, supporting drift detection and debugging. This table is updated by each worker as a social contract, not via enforced constraints.

**Criticality scoring and documentation:**

* Finalized the criticality scoring formula, quotas, graph-signal inputs, and override mechanisms, replacing the previous placeholder formula and marking the scoring methodology as decided. [[1]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L82-R85) [[2]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L399)
* Improved the documentation of the `has_critical_vulnerability` flag's semantics, removing outdated references and clarifying the MAL- override logic.

**Documentation and formatting:**

* Improved table formatting and added missing decision areas to the scope/status matrix for clarity and completeness. [[1]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L14-R14) [[2]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126R25)
* Removed outdated open questions and updated the changelog to reflect these decisions. [[1]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126L399) [[2]](diffhunk://#diff-3872dba0cefa1514b68ed6df84e129c0e4cbe8d2e2c5b9170588faa99e3f0126R451)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ADR updates; no runtime, schema migration, or auth changes in this diff.
> 
> **Overview**
> Updates the living **oss-packages ADR** to lock in ingestion and ownership rules that downstream workers are expected to follow.
> 
> **`packages_universe` imports** are no longer documented as weekly truncate-and-replace; they are described as a **one-time full backfill**, then **weekly incremental upserts** on `purl` that only touch rows whose deps.dev snapshot date has moved forward. The write-semantics table is aligned with that change.
> 
> A new **§Source of truth: deps.dev backfill vs registries / OSV** section splits responsibility by **lifecycle**: deps.dev owns initial ecosystem load and newly seen packages; **registry workers** own ongoing package/version fields; **OSV** owns advisories; **github-repos-enricher** owns repo metadata refreshes—with an explicit event→writer table.
> 
> **`package_source_log`** is introduced as the agreed provenance model: one upserted row per `(package_id, source)` with a `columns` array of `table.column` paths and `last_synced_at`, maintained by workers as a review contract (not DB-enforced) to spot deps.dev vs registry drift.
> 
> Smaller edits: scope matrix adds the new decision area; **MAL-** override wording drops an external memo reference; an open question on **criticality_score** is removed from in-flight (the universe section still notes the formula/quotas are under discussion); changelog dated 2026-05-29.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42cfb57d9f728a5ed163de210e3c5d74ab1c654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->