### PR TITLE
feat: add `audit_field_changes` table

### DIFF
--- a/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
+++ b/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
@@ -795,6 +795,27 @@ PARTITION BY RANGE (end_date);
 CREATE INDEX ON downloads_last_30d (purl, end_date DESC);
 
 -- ============================================================
+-- AUDIT — per-purl field-change log
+--
+-- One row per (worker, purl) per Temporal activity execution. changed_fields
+-- holds 'table.column' tokens for columns that actually changed value during
+-- that execution. Empty-change executions are not logged.
+-- ============================================================
+CREATE TABLE audit_field_changes (
+    id             bigserial PRIMARY KEY,
+    worker         text NOT NULL,
+    purl           text NOT NULL,
+    logged_at      timestamptz NOT NULL DEFAULT NOW(),
+    changed_fields text[] NOT NULL
+);
+
+CREATE INDEX ON audit_field_changes (purl, logged_at DESC);
+
+CREATE INDEX ON audit_field_changes (worker, logged_at DESC);
+
+CREATE INDEX ON audit_field_changes USING gin (changed_fields);
+
+-- ============================================================
 -- CRITICALITY RANKING FUNCTION
 -- ============================================================
 CREATE OR REPLACE FUNCTION rank_packages_universe(

--- a/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
+++ b/backend/src/osspckgs/migrations/V1779710880__initial_schema.sql
@@ -797,9 +797,10 @@ CREATE INDEX ON downloads_last_30d (purl, end_date DESC);
 -- ============================================================
 -- AUDIT — per-purl field-change log
 --
--- One row per (worker, purl) per Temporal activity execution. changed_fields
--- holds 'table.column' tokens for columns that actually changed value during
--- that execution. Empty-change executions are not logged.
+-- Append-only log of field-level changes. Each row records the set of
+-- 'table.column' tokens that were actually mutated for a given purl during one
+-- worker write pass. Rows with no real changes are not written (caller skips
+-- the insert when changed_fields is empty).
 -- ============================================================
 CREATE TABLE audit_field_changes (
     id             bigserial PRIMARY KEY,


### PR DESCRIPTION
## JIRA ticket
<!-- Link to the JIRA ticket, e.g. https://linuxfoundation.atlassian.net/browse/CDP-123 -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only additive table in an existing migration file; no runtime behavior or data migration in this PR.
> 
> **Overview**
> Adds an **append-only** `audit_field_changes` table to the initial Flyway schema (`V1779710880__initial_schema.sql`), placed after `downloads_last_30d` and before the criticality ranking function.
> 
> Each row records which worker touched a **purl**, when (`logged_at`), and which **`table.column`** tokens actually changed in that write pass (`changed_fields` as `text[]`). Comments state callers should **skip inserts** when there are no real changes.
> 
> Indexes support lookups by **purl over time**, by **worker over time**, and **GIN** search on `changed_fields`. No application/worker code in this PR references the table yet—schema only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 599a5a5848f4748bd59b49fbadff5e0f673c3d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->