### PR TITLE
fix: enricher worker

### DIFF
--- a/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
+++ b/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
@@ -66,7 +66,12 @@ async function fetchSecurityFileEnabled(
     return root || dotGithub
   } catch (err) {
     log.warn(
-      { url, errName: (err as Error).name, errMsg: (err as Error).message },
+      {
+        url,
+        errName: (err as Error).name,
+        errMsg: (err as Error).message,
+        errStack: (err as Error).stack,
+      },
       'Security file check failed — securityFileEnabled will be null',
     )
     return null

--- a/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
+++ b/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
@@ -65,7 +65,10 @@ async function fetchSecurityFileEnabled(
     ])
     return root || dotGithub
   } catch (err) {
-    log.warn({ url, err }, 'Security file check failed — securityFileEnabled will be null')
+    log.warn(
+      { url, errName: (err as Error).name, errMsg: (err as Error).message },
+      'Security file check failed — securityFileEnabled will be null',
+    )
     return null
   }
 }

--- a/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
@@ -16,6 +16,7 @@ const MAX_RETRIES = 3
 const DB_FETCH_SIZE = 2000
 const WRITE_FLUSH_SIZE = 500
 const WRITE_FLUSH_MS = 5000
+const MAX_FLUSH_FAILURES = 3
 
 // ─── Token selection ─────────────────────────────────────────────────────────
 
@@ -94,6 +95,7 @@ class WriteBuffer {
   private skipUrls: string[] = []
   private lastFlushAt = Date.now()
   private flushing = false
+  private flushFailures = 0
 
   constructor(private readonly qx: QueryExecutor) {}
 
@@ -118,6 +120,13 @@ class WriteBuffer {
     )
   }
 
+  private clearBatch(resultCount: number, snapshotCount: number, skipCount: number): void {
+    this.results.splice(0, resultCount)
+    this.snapshots.splice(0, snapshotCount)
+    this.skipUrls.splice(0, skipCount)
+    this.flushFailures = 0
+  }
+
   async flush(): Promise<number> {
     const batch = [...this.results]
     const snapshotBatch = [...this.snapshots]
@@ -125,19 +134,36 @@ class WriteBuffer {
     this.lastFlushAt = Date.now()
     this.flushing = true
     try {
-      await Promise.all([
-        bulkUpdateEnrichedRepos(this.qx, batch),
-        bulkUpsertRepoActivitySnapshot(this.qx, snapshotBatch),
-        markReposSkipped(this.qx, skips),
-      ])
-      // Clear only after all writes succeed — preserves items if the DB call throws
-      this.results.splice(0, batch.length)
-      this.snapshots.splice(0, snapshotBatch.length)
-      this.skipUrls.splice(0, skips.length)
+      // The snapshot upsert also updates repos rows — run in one transaction to avoid
+      // deadlocking with bulkUpdateEnrichedRepos on overlapping rows (40P01)
+      await this.qx.tx(async (tx) => {
+        await bulkUpdateEnrichedRepos(tx, batch)
+        await markReposSkipped(tx, skips)
+        await bulkUpsertRepoActivitySnapshot(tx, snapshotBatch)
+      })
+      this.clearBatch(batch.length, snapshotBatch.length, skips.length)
+      return batch.length
+    } catch (err) {
+      this.flushFailures++
+      // Dropping is safe: the rolled-back repos stay unsynced, so the next sweep retries them
+      const dropBatch = this.flushFailures >= MAX_FLUSH_FAILURES
+      log.error(
+        {
+          errCode: (err as { code?: string }).code,
+          errMsg: (err as Error).message,
+          flushFailures: this.flushFailures,
+          bufferedResults: this.results.length,
+          dropBatch,
+        },
+        dropBatch
+          ? 'Flush failed repeatedly — dropping batch, repos will be re-enriched next sweep'
+          : 'Flush failed — will retry on next cycle',
+      )
+      if (dropBatch) this.clearBatch(batch.length, snapshotBatch.length, skips.length)
+      return 0
     } finally {
       this.flushing = false
     }
-    return batch.length
   }
 }
 
@@ -202,7 +228,7 @@ async function runStreamingPool(
       })
       .catch((err) => {
         pendingFetch = null
-        log.warn({ err }, 'DB batch fetch failed, will retry')
+        log.warn({ errMsg: (err as Error).message }, 'DB batch fetch failed, will retry')
       })
   }
 
@@ -306,7 +332,15 @@ async function runStreamingPool(
             )
             queue.unshift(row)
           } else {
-            log.error({ url: row.url, err }, 'Unexpected error')
+            log.error(
+              {
+                url: row.url,
+                errName: (err as Error).name,
+                errMsg: (err as Error).message,
+                errStack: (err as Error).stack,
+              },
+              'Unexpected error while enriching repo',
+            )
           }
         }
 

--- a/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
@@ -128,10 +128,14 @@ class WriteBuffer {
   }
 
   async flush(): Promise<number> {
+    this.lastFlushAt = Date.now()
+    if (this.results.length === 0 && this.snapshots.length === 0 && this.skipUrls.length === 0) {
+      return 0
+    }
+
     const batch = [...this.results]
     const snapshotBatch = [...this.snapshots]
     const skips = [...this.skipUrls]
-    this.lastFlushAt = Date.now()
     this.flushing = true
     try {
       // The snapshot upsert also updates repos rows — run in one transaction to avoid
@@ -150,7 +154,9 @@ class WriteBuffer {
       log.error(
         {
           errCode: (err as { code?: string }).code,
+          errName: (err as Error).name,
           errMsg: (err as Error).message,
+          errStack: (err as Error).stack,
           flushFailures: this.flushFailures,
           bufferedResults: this.results.length,
           dropBatch,


### PR DESCRIPTION
This pull request improves error handling and logging in the enrichment worker, and adds resilience to database write failures. The main changes include enhanced logging for better debugging, transactional batching to prevent deadlocks, and a mechanism to drop batches after repeated flush failures to ensure the enrichment process remains robust.

**Error handling and logging improvements:**
* Expanded error logs to include error names, messages, and stack traces in several places, such as during security file checks, unexpected enrichment errors, and database fetch failures. This provides more context for debugging operational issues. [[1]](diffhunk://#diff-f3cffe9f41c3de7ec557f39e9cd3443733a20a0a1df42f926658f4bb5d7890baL68-R71) [[2]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7L205-R231) [[3]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7L309-R343)

**Database write and batching resilience:**
* Modified the `WriteBuffer.flush` method to perform all batch operations in a single transaction to avoid deadlocks, and to clear the batch only after a successful write.
* Introduced a retry and drop mechanism for flush failures: after three consecutive flush failures, the current batch is dropped to prevent the worker from getting stuck, with clear logging explaining the action. [[1]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R19) [[2]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R98) [[3]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R123-L140)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the enrichment worker’s DB write path and drops buffered work after repeated failures; dropped repos are intentionally left unsynced for the next sweep, but transient DB issues could briefly lose in-memory progress until re-enrichment.
> 
> **Overview**
> Hardens the GitHub repos **enrichment worker** so DB writes and failures are easier to debug and less likely to stall the loop.
> 
> **Write batching:** `WriteBuffer.flush` no longer runs `bulkUpdateEnrichedRepos`, `markReposSkipped`, and `bulkUpsertRepoActivitySnapshot` in parallel. Those three run **sequentially inside one transaction** to avoid PostgreSQL deadlocks (`40P01`) when snapshot upserts and repo updates touch the same rows. On success, buffers clear via a shared `clearBatch` helper; `lastFlushAt` is updated at flush start and empty flushes return early.
> 
> **Flush failures:** After **three consecutive** flush failures, the in-memory batch is **dropped** (with logging that repos will be picked up on the next sweep); otherwise the batch is retained for retry on the next flush cycle.
> 
> **Logging:** Security-file checks, unexpected enrichment errors, DB batch fetch failures, and flush errors now log structured fields (`errName`, `errMsg`, `errStack`, and `errCode` on flush) instead of raw error objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f72e9d3b00349666caeac9e6debbd22e4e89bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->