### PR TITLE
feat: improve enricher rate-limit handling for higher throughput [CM-1220]

### DIFF
--- a/services/apps/packages_worker/src/bin/github-repos-enricher.ts
+++ b/services/apps/packages_worker/src/bin/github-repos-enricher.ts
@@ -24,14 +24,23 @@ const main = async () => {
   const enricherConfig = getEnricherConfig()
   const appConfig = getGithubAppConfig()
 
-  const installationIds = await resolveInstallations(appConfig)
+  const discoveredIds = await resolveInstallations(appConfig)
 
-  if (installationIds.length === 0) {
+  if (discoveredIds.length === 0) {
     log.error('No GitHub App installations found — cannot build token pool')
     process.exit(1)
   }
 
-  await fetchRateLimitDiagnostics(appConfig.appId, appConfig.privateKeyPem, installationIds)
+  const installationIds = await fetchRateLimitDiagnostics(
+    appConfig.appId,
+    appConfig.privateKeyPem,
+    discoveredIds,
+  )
+
+  if (installationIds.length === 0) {
+    log.error('All installations failed the rate limit probe — cannot build token pool')
+    process.exit(1)
+  }
 
   log.info(
     {

--- a/services/apps/packages_worker/src/config.ts
+++ b/services/apps/packages_worker/src/config.ts
@@ -41,7 +41,7 @@ export function getEnricherConfig() {
   return {
     updateIntervalHours: requireEnvInt('ENRICHER_REPO_UPDATE_INTERVAL_HOURS'),
     idleSleepSec: requireEnvInt('ENRICHER_IDLE_SLEEP_SEC'),
-    concurrency: parseInt(process.env.ENRICHER_CONCURRENCY ?? '80', 10),
+    concurrency: parseInt(process.env.ENRICHER_CONCURRENCY ?? '150', 10),
     fetchTimeoutMs: parseInt(process.env.ENRICHER_FETCH_TIMEOUT_MS ?? '10000', 10),
   }
 }

--- a/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
+++ b/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
@@ -100,6 +100,8 @@ function buildDateWindows(): {
 
 interface RateLimit {
   cost: number
+  remaining: number
+  resetAt: string
 }
 
 interface IssueCount {
@@ -164,7 +166,7 @@ const SUMMARY_QUERY = `
     $searchIssuesOpened: String!, $searchIssuesClosed: String!,
     $searchIssuesOpened6m: String!, $searchIssuesOpenNow: String!
   ) {
-    rateLimit { cost }
+    rateLimit { cost remaining resetAt }
     repository(owner: $owner, name: $name) {
       defaultBranchRef {
         target {
@@ -188,7 +190,7 @@ const SUMMARY_QUERY = `
 
 const PR_PAGE_QUERY = `
   query($owner: String!, $name: String!, $cursor: String) {
-    rateLimit { cost }
+    rateLimit { cost remaining resetAt }
     repository(owner: $owner, name: $name) {
       pullRequests(first: ${PAGE_SIZE}, orderBy: { field: CREATED_AT, direction: DESC }, after: $cursor) {
         pageInfo { hasNextPage endCursor }
@@ -210,10 +212,16 @@ async function pagePrs(
   token: string,
   timeoutMs: number,
   windowStart: Date,
-): Promise<{ nodes: PrNode[]; rateLimitCost: number; httpRequestCount: number }> {
+): Promise<{
+  nodes: PrNode[]
+  rateLimitCost: number
+  httpRequestCount: number
+  rateLimit: RateLimit | null
+}> {
   const nodes: PrNode[] = []
   let rateLimitCost = 0
   let httpRequestCount = 0
+  let rateLimit: RateLimit | null = null
   let cursor: string | undefined
 
   for (;;) {
@@ -223,6 +231,7 @@ async function pagePrs(
     const data = await graphqlRequest<PrPageQueryResult>(PR_PAGE_QUERY, variables, token, timeoutMs)
     rateLimitCost += data.rateLimit.cost
     httpRequestCount++
+    rateLimit = data.rateLimit
 
     const connection = data.repository.pullRequests
     let reachedWindowBoundary = false
@@ -239,12 +248,12 @@ async function pagePrs(
     cursor = connection.pageInfo.endCursor
   }
 
-  return { nodes, rateLimitCost, httpRequestCount }
+  return { nodes, rateLimitCost, httpRequestCount, rateLimit }
 }
 
 const ISSUE_PAGE_QUERY = `
   query($owner: String!, $name: String!, $cursor: String) {
-    rateLimit { cost }
+    rateLimit { cost remaining resetAt }
     repository(owner: $owner, name: $name) {
       issues(first: ${PAGE_SIZE}, orderBy: { field: CREATED_AT, direction: DESC }, after: $cursor) {
         pageInfo { hasNextPage endCursor }
@@ -265,10 +274,16 @@ async function pageIssues(
   token: string,
   timeoutMs: number,
   windowStart: Date,
-): Promise<{ nodes: IssueNode[]; rateLimitCost: number; httpRequestCount: number }> {
+): Promise<{
+  nodes: IssueNode[]
+  rateLimitCost: number
+  httpRequestCount: number
+  rateLimit: RateLimit | null
+}> {
   const nodes: IssueNode[] = []
   let rateLimitCost = 0
   let httpRequestCount = 0
+  let rateLimit: RateLimit | null = null
   let cursor: string | undefined
 
   for (;;) {
@@ -283,6 +298,7 @@ async function pageIssues(
     )
     rateLimitCost += data.rateLimit.cost
     httpRequestCount++
+    rateLimit = data.rateLimit
 
     const connection = data.repository.issues
     let reachedWindowBoundary = false
@@ -299,7 +315,7 @@ async function pageIssues(
     cursor = connection.pageInfo.endCursor
   }
 
-  return { nodes, rateLimitCost, httpRequestCount }
+  return { nodes, rateLimitCost, httpRequestCount, rateLimit }
 }
 
 export async function fetchActivitySnapshot(
@@ -363,6 +379,11 @@ export async function fetchActivitySnapshot(
   const prMedians = computePrMedians(prResult.nodes)
   const issueMedians = computeIssueMedians(issueResult.nodes)
 
+  // Lowest remaining across all requests — remaining only decreases within a reset window
+  const lastRateLimit = [summaryData.rateLimit, prResult.rateLimit, issueResult.rateLimit]
+    .filter((rl): rl is RateLimit => rl !== null)
+    .reduce((min, rl) => (rl.remaining < min.remaining ? rl : min))
+
   return {
     repoId,
     snapshotAt: new Date().toISOString(),
@@ -385,5 +406,7 @@ export async function fetchActivitySnapshot(
     issueMedianTimeToFirstResponseHours: issueMedians.medianTimeToFirstResponseHours,
     httpRequestCount: totalHttpRequests,
     rateLimitCost: totalRateLimitCost,
+    rateLimitRemaining: lastRateLimit.remaining,
+    rateLimitResetAt: lastRateLimit.resetAt,
   }
 }

--- a/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
+++ b/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
@@ -52,6 +52,20 @@ async function fetchSecurityFileEnabled(
       })
       if (response.status === 200) return true
       if (response.status === 404) return false
+      if (response.status === 403) {
+        const body = await response.text()
+        if (body.toLowerCase().includes('rate limit')) {
+          // REST secondary limits send retry-after; primary limits send x-ratelimit-reset
+          const retryAfterSec = parseInt(response.headers.get('retry-after') ?? '0', 10)
+          const resetSec = parseInt(response.headers.get('x-ratelimit-reset') ?? '0', 10)
+          const resetMs = retryAfterSec
+            ? Date.now() + retryAfterSec * 1000
+            : resetSec
+              ? resetSec * 1000 + 5_000
+              : Date.now() + 65_000
+          throw new FetchError('RATE_LIMIT', `Contents API rate limited on ${path}`, resetMs)
+        }
+      }
       throw new Error(`Unexpected status ${response.status} for ${path}`)
     } finally {
       clearTimeout(timeoutId)
@@ -65,6 +79,8 @@ async function fetchSecurityFileEnabled(
     ])
     return root || dotGithub
   } catch (err) {
+    // Rate limits propagate so the caller can park the installation and requeue the repo
+    if (err instanceof FetchError && err.kind === 'RATE_LIMIT') throw err
     log.warn(
       {
         url,

--- a/services/apps/packages_worker/src/enricher/githubAppAuth.ts
+++ b/services/apps/packages_worker/src/enricher/githubAppAuth.ts
@@ -118,8 +118,9 @@ interface RateLimitEntry {
 
 /**
  * Fetches GraphQL rate limit info for every installation in parallel (one-time startup check).
- * GET /rate_limit does not consume quota. Returns the ids that passed the probe — installations
- * that fail (IP allowlists, suspended apps) would fail every enrichment request too.
+ * GET /rate_limit does not consume quota. Excludes installations that fail permanently
+ * (IP allowlists, suspended apps) — those would fail every enrichment request too.
+ * Transient probe failures stay in the pool; runtime parking handles them if truly broken.
  */
 export async function fetchRateLimitDiagnostics(
   appId: string,
@@ -128,13 +129,23 @@ export async function fetchRateLimitDiagnostics(
 ): Promise<number[]> {
   const results = await Promise.all(
     installationIds.map(
-      async (id): Promise<RateLimitEntry | { installationId: number; error: string }> => {
+      async (
+        id,
+      ): Promise<
+        RateLimitEntry | { installationId: number; error: string; permanent: boolean }
+      > => {
         try {
           const token = await getInstallationToken(appId, privateKeyPem, id)
           const resp = await fetch(`${GITHUB_API}/rate_limit`, {
             headers: { Authorization: `bearer ${token}`, Accept: 'application/vnd.github+json' },
           })
-          if (!resp.ok) return { installationId: id, error: `HTTP ${resp.status}` }
+          if (!resp.ok) {
+            return {
+              installationId: id,
+              error: `HTTP ${resp.status}`,
+              permanent: [401, 403, 404].includes(resp.status),
+            }
+          }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const data = (await resp.json()) as any
           const g = data.resources?.graphql
@@ -146,7 +157,8 @@ export async function fetchRateLimitDiagnostics(
             resetAt: new Date(g.reset * 1000).toISOString(),
           }
         } catch (err) {
-          return { installationId: id, error: (err as Error).message }
+          const permanent = err instanceof FetchError && err.kind === 'AUTH'
+          return { installationId: id, error: (err as Error).message, permanent }
         }
       },
     ),
@@ -155,10 +167,16 @@ export async function fetchRateLimitDiagnostics(
   let totalLimit = 0
   let totalRemaining = 0
   const healthyIds: number[] = []
-  const failed: Array<{ installationId: number; error: string }> = []
+  const excluded: Array<{ installationId: number; error: string }> = []
+  const transientFailures: Array<{ installationId: number; error: string }> = []
   for (const r of results) {
     if ('error' in r) {
-      failed.push(r)
+      if (r.permanent) {
+        excluded.push({ installationId: r.installationId, error: r.error })
+      } else {
+        transientFailures.push({ installationId: r.installationId, error: r.error })
+        healthyIds.push(r.installationId)
+      }
     } else {
       totalLimit += r.limit
       totalRemaining += r.remaining
@@ -169,7 +187,8 @@ export async function fetchRateLimitDiagnostics(
   log.info(
     {
       installations: installationIds.length,
-      failures: failed.length,
+      excluded: excluded.length,
+      transientFailures: transientFailures.length,
       totalLimit,
       totalRemaining,
       totalUsed: totalLimit - totalRemaining,
@@ -177,8 +196,11 @@ export async function fetchRateLimitDiagnostics(
     'GitHub App rate limit capacity',
   )
 
-  if (failed.length > 0) {
-    log.warn({ failed }, 'Excluding installations that failed the rate limit probe')
+  if (transientFailures.length > 0) {
+    log.warn({ transientFailures }, 'Probe failed transiently — keeping installations in the pool')
+  }
+  if (excluded.length > 0) {
+    log.warn({ excluded }, 'Excluding installations that permanently failed the probe')
   }
 
   return healthyIds

--- a/services/apps/packages_worker/src/enricher/githubAppAuth.ts
+++ b/services/apps/packages_worker/src/enricher/githubAppAuth.ts
@@ -2,6 +2,8 @@ import jwt from 'jsonwebtoken'
 
 import { getServiceChildLogger } from '@crowd/logging'
 
+import { FetchError } from './types'
+
 const log = getServiceChildLogger('github-app-auth')
 
 const GITHUB_API = 'https://api.github.com'
@@ -80,7 +82,22 @@ export async function getInstallationToken(
 
   if (!resp.ok) {
     const body = await resp.text()
-    throw new Error(
+    if (resp.status === 429 || (resp.status === 403 && body.toLowerCase().includes('rate limit'))) {
+      const retryAfterSec = parseInt(resp.headers.get('retry-after') ?? '0', 10)
+      const resetSec = parseInt(resp.headers.get('x-ratelimit-reset') ?? '0', 10)
+      const resetMs = retryAfterSec
+        ? Date.now() + retryAfterSec * 1000
+        : resetSec
+          ? resetSec * 1000 + 5_000
+          : Date.now() + 65_000
+      throw new FetchError(
+        'RATE_LIMIT',
+        `Rate limited minting token for installation ${installationId}`,
+        resetMs,
+      )
+    }
+    throw new FetchError(
+      'AUTH',
       `Failed to mint token for installation ${installationId} (${resp.status}): ${body}`,
     )
   }
@@ -100,14 +117,15 @@ interface RateLimitEntry {
 }
 
 /**
- * Fetches GraphQL rate limit info for every installation in parallel (one-time startup diagnostic).
- * GET /rate_limit does not consume quota.
+ * Fetches GraphQL rate limit info for every installation in parallel (one-time startup check).
+ * GET /rate_limit does not consume quota. Returns the ids that passed the probe — installations
+ * that fail (IP allowlists, suspended apps) would fail every enrichment request too.
  */
 export async function fetchRateLimitDiagnostics(
   appId: string,
   privateKeyPem: string,
   installationIds: number[],
-): Promise<void> {
+): Promise<number[]> {
   const results = await Promise.all(
     installationIds.map(
       async (id): Promise<RateLimitEntry | { installationId: number; error: string }> => {
@@ -136,26 +154,34 @@ export async function fetchRateLimitDiagnostics(
 
   let totalLimit = 0
   let totalRemaining = 0
-  let failures = 0
+  const healthyIds: number[] = []
+  const failed: Array<{ installationId: number; error: string }> = []
   for (const r of results) {
     if ('error' in r) {
-      failures++
+      failed.push(r)
     } else {
       totalLimit += r.limit
       totalRemaining += r.remaining
+      healthyIds.push(r.installationId)
     }
   }
 
   log.info(
     {
       installations: installationIds.length,
-      failures,
+      failures: failed.length,
       totalLimit,
       totalRemaining,
       totalUsed: totalLimit - totalRemaining,
     },
     'GitHub App rate limit capacity',
   )
+
+  if (failed.length > 0) {
+    log.warn({ failed }, 'Excluding installations that failed the rate limit probe')
+  }
+
+  return healthyIds
 }
 
 export interface GithubAppConfig {

--- a/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
@@ -17,36 +17,63 @@ const DB_FETCH_SIZE = 2000
 const WRITE_FLUSH_SIZE = 500
 const WRITE_FLUSH_MS = 5000
 const MAX_FLUSH_FAILURES = 3
+// Park an installation before GitHub starts rejecting — avoids a failed request + requeue
+const PROACTIVE_PARK_REMAINING = 50
+// Rate-limited snapshots retry once with another installation before being skipped
+const SNAPSHOT_RATE_LIMIT_RETRIES = 1
+// Installations whose token mint fails (e.g. org IP allowlist) sit out for an hour
+const MINT_FAILURE_PARK_MS = 60 * 60 * 1000
 
-// ─── Token selection ─────────────────────────────────────────────────────────
+// ─── Installation pool ────────────────────────────────────────────────────────
 
-function selectInstallation(
-  installationIds: number[],
-  parkedUntil: Map<number, number>,
-  roundRobinIdx: { value: number },
-): { installationId: number; waitMs: number } {
-  const now = Date.now()
-  const n = installationIds.length
+/** Round-robins over installations, skipping ones parked until their rate-limit reset. */
+class InstallationPool {
+  private readonly parkedUntil = new Map<number, number>()
+  private roundRobinIdx = 0
 
-  for (let i = 0; i < n; i++) {
-    const idx = (roundRobinIdx.value + i) % n
-    const id = installationIds[idx]
-    if ((parkedUntil.get(id) ?? 0) <= now) {
-      roundRobinIdx.value = (idx + 1) % n
-      return { installationId: id, waitMs: 0 }
+  constructor(private readonly ids: number[]) {}
+
+  select(): { installationId: number; waitMs: number } {
+    const now = Date.now()
+    const n = this.ids.length
+
+    for (let i = 0; i < n; i++) {
+      const idx = (this.roundRobinIdx + i) % n
+      const id = this.ids[idx]
+      if ((this.parkedUntil.get(id) ?? 0) <= now) {
+        this.roundRobinIdx = (idx + 1) % n
+        return { installationId: id, waitMs: 0 }
+      }
     }
+
+    let soonestReset = Infinity
+    let soonestId = this.ids[0]
+    for (const id of this.ids) {
+      const reset = this.parkedUntil.get(id) ?? 0
+      if (reset < soonestReset) {
+        soonestReset = reset
+        soonestId = id
+      }
+    }
+    return { installationId: soonestId, waitMs: Math.max(1_000, soonestReset - now) }
   }
 
-  let soonestReset = Infinity
-  let soonestId = installationIds[0]
-  for (const id of installationIds) {
-    const reset = parkedUntil.get(id) ?? 0
-    if (reset < soonestReset) {
-      soonestReset = reset
-      soonestId = id
-    }
+  park(installationId: number, untilMs: number): void {
+    this.parkedUntil.set(installationId, untilMs)
   }
-  return { installationId: soonestId, waitMs: Math.max(1_000, soonestReset - now) }
+
+  parkIfBudgetLow(
+    installationId: number,
+    remaining: number | null | undefined,
+    resetAt: string | null | undefined,
+  ): void {
+    if (remaining == null || resetAt == null || remaining >= PROACTIVE_PARK_REMAINING) return
+    this.park(installationId, new Date(resetAt).getTime() + 5_000)
+    log.info(
+      { installationId, remaining, resetAt },
+      'Budget low — proactively parking installation',
+    )
+  }
 }
 
 // ─── Fetch with retries ───────────────────────────────────────────────────────
@@ -175,11 +202,16 @@ class WriteBuffer {
 
 // ─── DB cursor stream ─────────────────────────────────────────────────────────
 
+interface RepoRow {
+  id: string
+  url: string
+}
+
 async function fetchDbBatch(
   qx: QueryExecutor,
   cursor: string | null,
   updateIntervalHours: number,
-): Promise<Array<{ id: string; url: string }>> {
+): Promise<RepoRow[]> {
   return qx.select(
     `
     SELECT id, url
@@ -195,6 +227,212 @@ async function fetchDbBatch(
   )
 }
 
+/** Streams repo rows from the DB by cursor, prefetching the next batch as the queue drains. */
+class RepoQueue {
+  private cursor: string | null = null
+  private dbDone = false
+  private rows: RepoRow[] = []
+  private pendingFetch: Promise<void> | null = null
+
+  constructor(
+    private readonly qx: QueryExecutor,
+    private readonly updateIntervalHours: number,
+  ) {}
+
+  private fill(): void {
+    if (this.pendingFetch || this.dbDone) return
+    this.pendingFetch = fetchDbBatch(this.qx, this.cursor, this.updateIntervalHours)
+      .then((rows) => {
+        this.pendingFetch = null
+        if (rows.length === 0) {
+          this.dbDone = true
+        } else {
+          this.rows.push(...rows)
+          this.cursor = rows[rows.length - 1].id
+        }
+      })
+      .catch((err) => {
+        this.pendingFetch = null
+        log.warn({ errMsg: (err as Error).message }, 'DB batch fetch failed, will retry')
+      })
+  }
+
+  async prime(): Promise<void> {
+    this.fill()
+    await (this.pendingFetch ?? Promise.resolve())
+  }
+
+  async next(): Promise<RepoRow | null> {
+    while (this.rows.length === 0) {
+      if (this.dbDone) return null
+      this.fill()
+      if (this.pendingFetch) await this.pendingFetch
+    }
+    if (this.rows.length < DB_FETCH_SIZE / 2 && !this.pendingFetch && !this.dbDone) this.fill()
+    return this.rows.shift() ?? null
+  }
+
+  requeue(row: RepoRow): void {
+    this.rows.unshift(row)
+  }
+
+  get depth(): number {
+    return this.rows.length
+  }
+}
+
+// ─── Per-repo pipeline ────────────────────────────────────────────────────────
+
+interface PoolMetrics {
+  totalFetched: number
+  totalHttpRequests: number
+  totalRateLimitCost: number
+  startTime: number
+}
+
+interface WorkerContext {
+  pool: InstallationPool
+  queue: RepoQueue
+  writeBuffer: WriteBuffer
+  appConfig: GithubAppConfig
+  config: ReturnType<typeof getEnricherConfig>
+  metrics: PoolMetrics
+}
+
+/** Fetches the activity snapshot, retrying once with another installation on rate limit. */
+async function fetchSnapshotWithRetry(
+  row: RepoRow,
+  owner: string,
+  name: string,
+  installationId: number,
+  token: string,
+  ctx: WorkerContext,
+): Promise<void> {
+  const { pool, writeBuffer, appConfig, config, metrics } = ctx
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const snapshot = await fetchActivitySnapshot(
+        row.id,
+        owner,
+        name,
+        token,
+        config.fetchTimeoutMs,
+      )
+      metrics.totalHttpRequests += snapshot.httpRequestCount
+      metrics.totalRateLimitCost += snapshot.rateLimitCost
+      writeBuffer.addSnapshot(snapshot)
+      pool.parkIfBudgetLow(installationId, snapshot.rateLimitRemaining, snapshot.rateLimitResetAt)
+      return
+    } catch (err) {
+      if (!(err instanceof FetchError) || err.kind !== 'RATE_LIMIT') {
+        log.warn(
+          {
+            url: row.url,
+            errKind: err instanceof FetchError ? err.kind : 'UNKNOWN',
+            errMsg: (err as Error).message,
+          },
+          'Snapshot fetch failed — skipping snapshot',
+        )
+        return
+      }
+
+      const resetAt = err.resetAt ?? Date.now() + 60_000
+      pool.park(installationId, resetAt)
+      const next = pool.select()
+      if (attempt >= SNAPSHOT_RATE_LIMIT_RETRIES || next.waitMs > 0) {
+        log.warn(
+          { installationId, resetAt: new Date(resetAt).toISOString() },
+          'Snapshot rate limited — parking installation, skipping snapshot',
+        )
+        return
+      }
+
+      log.warn(
+        { installationId, nextId: next.installationId },
+        'Snapshot rate limited — parking installation, retrying with another',
+      )
+      installationId = next.installationId
+      token = await getInstallationToken(appConfig.appId, appConfig.privateKeyPem, installationId)
+    }
+  }
+}
+
+/** Enriches one repo: light fetch + activity snapshot, with rate-limit parking/requeue. */
+async function processRepo(row: RepoRow, ctx: WorkerContext): Promise<void> {
+  const { pool, queue, writeBuffer, appConfig, config, metrics } = ctx
+
+  let owner: string
+  let name: string
+  try {
+    ;({ owner, name } = parseGithubUrl(row.url))
+  } catch {
+    log.warn({ url: row.url }, 'Skipping non-GitHub URL')
+    writeBuffer.addSkip(row.url)
+    return
+  }
+
+  const { installationId, waitMs } = pool.select()
+  if (waitMs > 0) {
+    log.warn(
+      { waitMs: Math.round(waitMs / 1000) },
+      `All installations parked, waiting ${Math.round(waitMs / 1000)}s`,
+    )
+    await new Promise((r) => setTimeout(r, waitMs))
+  }
+
+  try {
+    const token = await getInstallationToken(
+      appConfig.appId,
+      appConfig.privateKeyPem,
+      installationId,
+    )
+    metrics.totalHttpRequests++
+    const outcome = await fetchWithRetries(row.url, token, config.fetchTimeoutMs)
+
+    if (outcome.kind === 'success') {
+      metrics.totalFetched++
+      writeBuffer.add(outcome.data)
+      pool.parkIfBudgetLow(
+        installationId,
+        outcome.data.rateLimit?.remaining,
+        outcome.data.rateLimit?.resetAt,
+      )
+      await fetchSnapshotWithRetry(row, owner, name, installationId, token, ctx)
+    } else if (outcome.kind === 'permanent') {
+      writeBuffer.addSkip(row.url)
+    }
+  } catch (err) {
+    if (err instanceof FetchError && err.kind === 'RATE_LIMIT') {
+      const resetAt = err.resetAt ?? Date.now() + 60_000
+      pool.park(installationId, resetAt)
+      log.warn(
+        { installationId, resetAt: new Date(resetAt).toISOString() },
+        'Installation rate limited — parking, re-queuing url',
+      )
+      queue.requeue(row)
+    } else if (err instanceof FetchError && err.kind === 'AUTH') {
+      // Only token minting throws AUTH here — repo-level AUTH is handled in fetchWithRetries
+      pool.park(installationId, Date.now() + MINT_FAILURE_PARK_MS)
+      log.warn(
+        { installationId, errMsg: err.message },
+        'Token mint failed — parking installation for 1h, re-queuing url',
+      )
+      queue.requeue(row)
+    } else {
+      log.error(
+        {
+          url: row.url,
+          errName: (err as Error).name,
+          errMsg: (err as Error).message,
+          errStack: (err as Error).stack,
+        },
+        'Unexpected error while enriching repo',
+      )
+    }
+  }
+}
+
 // ─── Streaming pool ───────────────────────────────────────────────────────────
 
 async function runStreamingPool(
@@ -203,155 +441,30 @@ async function runStreamingPool(
   appConfig: GithubAppConfig,
   config: ReturnType<typeof getEnricherConfig>,
   isShuttingDown: () => boolean,
-  metrics: {
-    totalFetched: number
-    totalHttpRequests: number
-    totalRateLimitCost: number
-    startTime: number
-  },
+  metrics: PoolMetrics,
 ): Promise<'exhausted' | 'shutdown'> {
-  const parkedUntil = new Map<number, number>()
-  const roundRobinIdx = { value: 0 }
-  const writeBuffer = new WriteBuffer(qx)
-
-  let cursor: string | null = null
-  let dbDone = false
-  const queue: Array<{ id: string; url: string }> = []
-  let pendingFetch: Promise<void> | null = null
+  const ctx: WorkerContext = {
+    pool: new InstallationPool(installationIds),
+    queue: new RepoQueue(qx, config.updateIntervalHours),
+    writeBuffer: new WriteBuffer(qx),
+    appConfig,
+    config,
+    metrics,
+  }
   let logTimer = Date.now()
 
-  const fillQueue = (): void => {
-    if (pendingFetch || dbDone) return
-    pendingFetch = fetchDbBatch(qx, cursor, config.updateIntervalHours)
-      .then((rows) => {
-        pendingFetch = null
-        if (rows.length === 0) {
-          dbDone = true
-        } else {
-          queue.push(...rows)
-          cursor = rows[rows.length - 1].id
-        }
-      })
-      .catch((err) => {
-        pendingFetch = null
-        log.warn({ errMsg: (err as Error).message }, 'DB batch fetch failed, will retry')
-      })
-  }
-
-  const nextRow = async (): Promise<{ id: string; url: string } | null> => {
-    while (queue.length === 0) {
-      if (dbDone) return null
-      fillQueue()
-      if (pendingFetch) await pendingFetch
-    }
-    if (queue.length < DB_FETCH_SIZE / 2 && !pendingFetch && !dbDone) fillQueue()
-    return queue.shift() ?? null
-  }
-
-  // Prime the queue before workers start
-  fillQueue()
-  await (pendingFetch ?? Promise.resolve())
+  await ctx.queue.prime()
 
   await Promise.all(
     Array.from({ length: config.concurrency }, async () => {
       while (!isShuttingDown()) {
-        const row = await nextRow()
+        const row = await ctx.queue.next()
         if (!row) break
 
-        let parsedUrl: { owner: string; name: string }
-        try {
-          parsedUrl = parseGithubUrl(row.url)
-        } catch {
-          log.warn({ url: row.url }, 'Skipping non-GitHub URL')
-          writeBuffer.addSkip(row.url)
-          continue
-        }
-        const { owner, name } = parsedUrl
+        await processRepo(row, ctx)
 
-        const { installationId, waitMs } = selectInstallation(
-          installationIds,
-          parkedUntil,
-          roundRobinIdx,
-        )
-
-        if (waitMs > 0) {
-          log.warn(
-            { waitMs: Math.round(waitMs / 1000) },
-            `All installations parked, waiting ${Math.round(waitMs / 1000)}s`,
-          )
-          await new Promise((r) => setTimeout(r, waitMs))
-        }
-
-        try {
-          const token = await getInstallationToken(
-            appConfig.appId,
-            appConfig.privateKeyPem,
-            installationId,
-          )
-          metrics.totalHttpRequests++
-          const outcome = await fetchWithRetries(row.url, token, config.fetchTimeoutMs)
-
-          if (outcome.kind === 'success') {
-            metrics.totalFetched++
-            writeBuffer.add(outcome.data)
-
-            try {
-              const snapshot = await fetchActivitySnapshot(
-                row.id,
-                owner,
-                name,
-                token,
-                config.fetchTimeoutMs,
-              )
-              metrics.totalHttpRequests += snapshot.httpRequestCount
-              metrics.totalRateLimitCost += snapshot.rateLimitCost
-              writeBuffer.addSnapshot(snapshot)
-            } catch (snapshotErr) {
-              if (snapshotErr instanceof FetchError && snapshotErr.kind === 'RATE_LIMIT') {
-                const resetAt = snapshotErr.resetAt ?? Date.now() + 60_000
-                parkedUntil.set(installationId, resetAt)
-                log.warn(
-                  { installationId, resetAt: new Date(resetAt).toISOString() },
-                  'Snapshot rate limited — parking installation',
-                )
-              } else {
-                log.warn(
-                  {
-                    url: row.url,
-                    errKind: snapshotErr instanceof FetchError ? snapshotErr.kind : 'UNKNOWN',
-                    errMsg: (snapshotErr as Error).message,
-                  },
-                  'Snapshot fetch failed — skipping snapshot',
-                )
-              }
-            }
-          } else if (outcome.kind === 'permanent') {
-            writeBuffer.addSkip(row.url)
-          }
-        } catch (err) {
-          if (err instanceof FetchError && err.kind === 'RATE_LIMIT') {
-            const resetAt = err.resetAt ?? Date.now() + 60_000
-            parkedUntil.set(installationId, resetAt)
-            log.warn(
-              { installationId, resetAt: new Date(resetAt).toISOString() },
-              'Installation rate limited — parking, re-queuing url',
-            )
-            queue.unshift(row)
-          } else {
-            log.error(
-              {
-                url: row.url,
-                errName: (err as Error).name,
-                errMsg: (err as Error).message,
-                errStack: (err as Error).stack,
-              },
-              'Unexpected error while enriching repo',
-            )
-          }
-        }
-
-        if (writeBuffer.shouldFlush()) {
-          const flushed = await writeBuffer.flush()
+        if (ctx.writeBuffer.shouldFlush()) {
+          const flushed = await ctx.writeBuffer.flush()
           if (Date.now() - logTimer >= 10_000) {
             logTimer = Date.now()
             const elapsedHours = (Date.now() - metrics.startTime) / 3_600_000
@@ -369,7 +482,7 @@ async function runStreamingPool(
                     ? Math.round(metrics.totalHttpRequests / elapsedHours)
                     : metrics.totalHttpRequests,
                 flushed,
-                queueDepth: queue.length,
+                queueDepth: ctx.queue.depth,
               },
               'Throughput snapshot',
             )
@@ -379,7 +492,7 @@ async function runStreamingPool(
     }),
   )
 
-  await writeBuffer.flush()
+  await ctx.writeBuffer.flush()
   return isShuttingDown() ? 'shutdown' : 'exhausted'
 }
 

--- a/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/enricher/runEnrichmentLoop.ts
@@ -352,8 +352,28 @@ async function fetchSnapshotWithRetry(
         { installationId, nextId: next.installationId },
         'Snapshot rate limited — parking installation, retrying with another',
       )
+      try {
+        token = await getInstallationToken(
+          appConfig.appId,
+          appConfig.privateKeyPem,
+          next.installationId,
+        )
+      } catch (mintErr) {
+        if (mintErr instanceof FetchError) {
+          const until =
+            mintErr.kind === 'RATE_LIMIT'
+              ? (mintErr.resetAt ?? Date.now() + 60_000)
+              : Date.now() + MINT_FAILURE_PARK_MS
+          pool.park(next.installationId, until)
+          log.warn(
+            { installationId: next.installationId, errMsg: mintErr.message },
+            'Token mint failed during snapshot retry — skipping snapshot',
+          )
+          return
+        }
+        throw mintErr
+      }
       installationId = next.installationId
-      token = await getInstallationToken(appConfig.appId, appConfig.privateKeyPem, installationId)
     }
   }
 }

--- a/services/apps/packages_worker/src/enricher/types.ts
+++ b/services/apps/packages_worker/src/enricher/types.ts
@@ -46,6 +46,8 @@ export interface RepoActivitySnapshot {
   issueMedianTimeToFirstResponseHours: number | null
   httpRequestCount: number
   rateLimitCost: number
+  rateLimitRemaining: number
+  rateLimitResetAt: string
 }
 
 export type FetchErrorKind = 'RATE_LIMIT' | 'TRANSIENT' | 'NOT_FOUND' | 'AUTH' | 'MALFORMED'


### PR DESCRIPTION
This pull request introduces several improvements to how the GitHub enrichment worker handles rate limits, installation selection, and error handling. The main goals are to proactively avoid hitting GitHub API rate limits, make installation selection more robust, and propagate rate limit errors more cleanly throughout the codebase.

**Rate limit tracking and proactive management:**

- The enrichment worker now tracks the lowest remaining rate limit across all relevant requests for a repository snapshot and exposes this information in the snapshot result. This enables the system to proactively "park" installations (i.e., temporarily stop using them) before hitting hard rate limits, reducing failed requests and unnecessary retries. [[1]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R103-R104) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L167-R169) [[3]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L191-R193) [[4]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L213-R224) [[5]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R234) [[6]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L242-R256) [[7]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L268-R286) [[8]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R301) [[9]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L302-R318) [[10]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R382-R386) [[11]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R409-R410) [[12]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R20-R52) [[13]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R61-R78)

**Error propagation and handling:**

- Rate limit errors from both REST and GraphQL APIs are now detected and propagated as a custom `FetchError` type, allowing the caller to handle them appropriately (e.g., by parking an installation or retrying). This applies to both token minting and content fetching. [[1]](diffhunk://#diff-f3cffe9f41c3de7ec557f39e9cd3443733a20a0a1df42f926658f4bb5d7890baR55-R68) [[2]](diffhunk://#diff-f3cffe9f41c3de7ec557f39e9cd3443733a20a0a1df42f926658f4bb5d7890baR82-R83) [[3]](diffhunk://#diff-eeac32760d609f49de8b8dae0840ca7d2eac1e59606d5c919f151a732f1feaf1R5-R6) [[4]](diffhunk://#diff-eeac32760d609f49de8b8dae0840ca7d2eac1e59606d5c919f151a732f1feaf1L83-R100)

**Installation pool and selection improvements:**

- The installation selection logic has been refactored into an `InstallationPool` class, which round-robins over available installations and skips any that are currently "parked" due to rate limits or token mint failures. The pool can proactively park installations when their remaining budget is low, based on the tracked rate limit info. [[1]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R20-R52) [[2]](diffhunk://#diff-1bfbe22c8390d651a25bd23bfb08cb8a109434b9baebc07e702fc8db95e652b7R61-R78)

**Diagnostics and startup checks:**

- The rate limit diagnostics function now returns only installation IDs that passed the probe, logging and excluding any that failed (e.g., due to IP allowlists or suspension). This ensures the worker only uses healthy installations. [[1]](diffhunk://#diff-eeac32760d609f49de8b8dae0840ca7d2eac1e59606d5c919f151a732f1feaf1L103-R128) [[2]](diffhunk://#diff-eeac32760d609f49de8b8dae0840ca7d2eac1e59606d5c919f151a732f1feaf1L139-R184)

**Configuration and concurrency:**

- The default concurrency for the enricher has been increased from 80 to 150, allowing more parallelism when processing repositories.

These changes should make the enrichment process more resilient and efficient, especially under heavy load or when rate limits are tight.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises default parallelism and changes installation selection and error paths for external GitHub API calls; mis-tuned parking could slow enrichment but does not touch auth or customer data stores.
> 
> **Overview**
> Improves **GitHub repo enricher** throughput and resilience by treating rate limits as first-class signals across token minting, REST contents checks, GraphQL snapshots, and the worker loop.
> 
> **Startup** now builds the installation pool from `fetchRateLimitDiagnostics`’s return value (healthy IDs only), exiting if every probe fails; permanently broken installations (e.g. AUTH / 401–403) are dropped while transient probe failures stay in the pool.
> 
> **Runtime** introduces an `InstallationPool` (round-robin + parking until reset), a `RepoQueue` with requeue on limit/mint failure, and refactored `processRepo` / `fetchSnapshotWithRetry`. GraphQL queries expose `remaining` / `resetAt`; installations are **proactively parked** when budget drops below 50. `FetchError` with `RATE_LIMIT` / `AUTH` is thrown from token mint and SECURITY.md checks; rate-limited work is requeued or retried once on another installation for snapshots. Token mint **AUTH** failures park for 1 hour.
> 
> Default **`ENRICHER_CONCURRENCY`** rises from **80 → 150**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d692ca4e799ce3c6e1e4a5896f24cae7d59755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->