### PR TITLE
fix: derive activity counts from paged nodes instead of search [CM-1220]

### DIFF
--- a/services/apps/packages_worker/src/enricher/computeMedians.ts
+++ b/services/apps/packages_worker/src/enricher/computeMedians.ts
@@ -26,6 +26,7 @@ export interface ResponseNode {
 export interface PrNode {
   createdAt: string
   mergedAt: string | null
+  closedAt: string | null
   author: { login: string } | null
   comments: { nodes: ResponseNode[] }
   reviews: { nodes: ResponseNode[] }

--- a/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
+++ b/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
@@ -70,16 +70,11 @@ async function graphqlRequest<T>(
   return json.data as T
 }
 
-function toDateString(date: Date): string {
-  return date.toISOString().slice(0, 10)
-}
-
 function buildDateWindows(): {
   since12m: Date
+  since6m: Date
   since12mIso: string
   since6mIso: string
-  since12mDate: string
-  since6mDate: string
 } {
   const now = new Date()
 
@@ -91,10 +86,9 @@ function buildDateWindows(): {
 
   return {
     since12m,
+    since6m,
     since12mIso: since12m.toISOString(),
     since6mIso: since6m.toISOString(),
-    since12mDate: toDateString(since12m),
-    since6mDate: toDateString(since6m),
   }
 }
 
@@ -102,10 +96,6 @@ interface RateLimit {
   cost: number
   remaining: number
   resetAt: string
-}
-
-interface IssueCount {
-  issueCount: number
 }
 
 interface CommitHistory {
@@ -127,14 +117,8 @@ interface SummaryQueryResult {
         commitsPrior6m?: CommitHistory
       }
     }
+    openIssues: { totalCount: number }
   }
-  prsOpened: IssueCount
-  prsMerged: IssueCount
-  prsClosedUnmerged: IssueCount
-  issuesOpened: IssueCount
-  issuesClosed: IssueCount
-  issuesOpened6m: IssueCount
-  issuesOpenNow: IssueCount
 }
 
 interface PrPageQueryResult {
@@ -158,14 +142,7 @@ interface IssuePageQueryResult {
 }
 
 const SUMMARY_QUERY = `
-  query(
-    $owner: String!, $name: String!,
-    $since12m: GitTimestamp!, $since6m: GitTimestamp!,
-    $searchPrsOpened: String!, $searchPrsMerged: String!,
-    $searchPrsClosedUnmerged: String!,
-    $searchIssuesOpened: String!, $searchIssuesClosed: String!,
-    $searchIssuesOpened6m: String!, $searchIssuesOpenNow: String!
-  ) {
+  query($owner: String!, $name: String!, $since12m: GitTimestamp!, $since6m: GitTimestamp!) {
     rateLimit { cost remaining resetAt }
     repository(owner: $owner, name: $name) {
       defaultBranchRef {
@@ -177,14 +154,8 @@ const SUMMARY_QUERY = `
           }
         }
       }
+      openIssues: issues(states: OPEN) { totalCount }
     }
-    prsOpened:         search(query: $searchPrsOpened,         type: ISSUE) { issueCount }
-    prsMerged:         search(query: $searchPrsMerged,         type: ISSUE) { issueCount }
-    prsClosedUnmerged: search(query: $searchPrsClosedUnmerged, type: ISSUE) { issueCount }
-    issuesOpened:      search(query: $searchIssuesOpened,      type: ISSUE) { issueCount }
-    issuesClosed:      search(query: $searchIssuesClosed,      type: ISSUE) { issueCount }
-    issuesOpened6m:    search(query: $searchIssuesOpened6m,    type: ISSUE) { issueCount }
-    issuesOpenNow:     search(query: $searchIssuesOpenNow,     type: ISSUE) { issueCount }
   }
 `
 
@@ -197,6 +168,7 @@ const PR_PAGE_QUERY = `
         nodes {
           createdAt
           mergedAt
+          closedAt
           author { login }
           comments(first: ${RESPONSES_PER_NODE}) { nodes { createdAt author { login } } }
           reviews(first: ${RESPONSES_PER_NODE})  { nodes { createdAt author { login } } }
@@ -325,24 +297,11 @@ export async function fetchActivitySnapshot(
   token: string,
   timeoutMs: number,
 ): Promise<RepoActivitySnapshot> {
-  const { since12m, since12mIso, since6mIso, since12mDate, since6mDate } = buildDateWindows()
-  const repoFilter = `repo:${owner}/${name}`
+  const { since12m, since6m, since12mIso, since6mIso } = buildDateWindows()
 
   const summaryData = await graphqlRequest<SummaryQueryResult>(
     SUMMARY_QUERY,
-    {
-      owner,
-      name,
-      since12m: since12mIso,
-      since6m: since6mIso,
-      searchPrsOpened: `${repoFilter} is:pr created:>=${since12mDate}`,
-      searchPrsMerged: `${repoFilter} is:pr is:merged created:>=${since12mDate}`,
-      searchPrsClosedUnmerged: `${repoFilter} is:pr is:unmerged is:closed created:>=${since12mDate}`,
-      searchIssuesOpened: `${repoFilter} is:issue created:>=${since12mDate}`,
-      searchIssuesClosed: `${repoFilter} is:issue is:closed created:>=${since12mDate}`,
-      searchIssuesOpened6m: `${repoFilter} is:issue created:>=${since6mDate}`,
-      searchIssuesOpenNow: `${repoFilter} is:issue is:open`,
-    },
+    { owner, name, since12m: since12mIso, since6m: since6mIso },
     token,
     timeoutMs,
   )
@@ -378,6 +337,9 @@ export async function fetchActivitySnapshot(
 
   const prMedians = computePrMedians(prResult.nodes)
   const issueMedians = computeIssueMedians(issueResult.nodes)
+  const issuesOpenedLast6m = issueResult.nodes.filter(
+    (n) => new Date(n.createdAt) >= since6m,
+  ).length
 
   // Lowest remaining across all requests — remaining only decreases within a reset window
   const lastRateLimit = [summaryData.rateLimit, prResult.rateLimit, issueResult.rateLimit]
@@ -391,17 +353,16 @@ export async function fetchActivitySnapshot(
     commitsLast12m,
     commitsLast6m,
     commitsPrior6m,
-    prsOpenedLast12m: summaryData.prsOpened.issueCount,
-    prsMergedLast12m: summaryData.prsMerged.issueCount,
-    prsClosedUnmerged12m: summaryData.prsClosedUnmerged.issueCount,
+    prsOpenedLast12m: prResult.nodes.length,
+    prsMergedLast12m: prResult.nodes.filter((n) => n.mergedAt).length,
+    prsClosedUnmerged12m: prResult.nodes.filter((n) => n.closedAt && !n.mergedAt).length,
     prMedianTimeToMergeHours: prMedians.medianTimeToMergeHours,
     prMedianTimeToFirstResponseHours: prMedians.medianTimeToFirstResponseHours,
-    issuesOpenedLast12m: summaryData.issuesOpened.issueCount,
-    issuesClosedLast12m: summaryData.issuesClosed.issueCount,
-    issuesOpenedLast6m: summaryData.issuesOpened6m.issueCount,
-    issuesOpenedPrior6m:
-      summaryData.issuesOpened.issueCount - summaryData.issuesOpened6m.issueCount,
-    issuesOpenNow: summaryData.issuesOpenNow.issueCount,
+    issuesOpenedLast12m: issueResult.nodes.length,
+    issuesClosedLast12m: issueResult.nodes.filter((n) => n.closedAt).length,
+    issuesOpenedLast6m,
+    issuesOpenedPrior6m: issueResult.nodes.length - issuesOpenedLast6m,
+    issuesOpenNow: summaryData.repository.openIssues.totalCount,
     issueMedianTimeToCloseHours: issueMedians.medianTimeToCloseHours,
     issueMedianTimeToFirstResponseHours: issueMedians.medianTimeToFirstResponseHours,
     httpRequestCount: totalHttpRequests,


### PR DESCRIPTION
This pull request refactors how pull request (PR) and issue activity metrics are computed and retrieved in the `fetchActivitySnapshot.ts` worker. The main change is moving from GraphQL search-based aggregate queries to calculating metrics directly from the fetched PR and issue nodes, making the code more reliable and easier to maintain. It also introduces some small improvements and simplifications to the type definitions and query parameters.

Key changes include:

### Metrics Calculation Refactor

* Replaces GraphQL search queries for PR and issue counts with direct calculations on the fetched PR and issue nodes, improving accuracy and reducing complexity. For example, PRs opened, merged, and closed-unmerged in the last 12 months are now counted from the node data rather than relying on search queries. [[1]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L394-R365) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L328-R304) [[3]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L161-R145) [[4]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R157-L187) [[5]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R120-L137)

* Calculates issues opened in the last 6 months by filtering the fetched issue nodes by `createdAt`, instead of using a separate search query.

### GraphQL Query and Type Updates

* Removes unused search query variables and fields from the GraphQL summary query, simplifying the query structure. [[1]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L161-R145) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R157-L187)

* Adds `closedAt` to the PR node interface and GraphQL query, enabling accurate computation of closed-unmerged PRs. [[1]](diffhunk://#diff-c9fe34c2ab1b5c1acf92b29f834b2e0d0285d5a17c5972276a6466ebe2818371R29) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R171)

* Adds a direct query for the current number of open issues (`openIssues`) on the repository. [[1]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R120-L137) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R157-L187)

### Code and Type Simplifications

* Removes the `toDateString` helper and unused date string fields from the date window builder, as they are no longer needed for search queries. [[1]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998L73-L82) [[2]](diffhunk://#diff-adfbca60a0d8612d68a8310504fc4f46993c18473a2f48d29758eca85b143998R89-L97)

* Cleans up unused type definitions related to the old search-based approach.

These changes make the codebase more maintainable and ensure that activity metrics are calculated consistently from the same set of fetched data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Published enrichment metrics may shift if search totals previously disagreed with the paged 12m window or if paging stops early on very active repos.
> 
> **Overview**
> **Activity snapshot metrics** in `fetchActivitySnapshot` no longer use GitHub GraphQL **search** `issueCount` queries. PR and issue volume fields (opened/merged/closed in the 12m window, 6m issue splits) are **derived from the same paged PR/issue nodes** already fetched for median calculations.
> 
> The **summary query** is trimmed to commit history plus `repository.openIssues` for **issues open now**. PR paging now requests **`closedAt`** (and `PrNode` is updated) so **closed-unmerged** PRs can be counted as `closedAt && !mergedAt`. Date-window helpers drop search-only date strings and expose **`since6m`** for filtering 6-month issue opens on the node list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a718ac241a81b681d84da1e37c709c02e22acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->