### PR TITLE
fix: consider 401 errors as trasient

### DIFF
--- a/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
+++ b/services/apps/packages_worker/src/enricher/fetchActivitySnapshot.ts
@@ -46,7 +46,7 @@ async function graphqlRequest<T>(
   const resetSec = parseInt(response.headers.get('x-ratelimit-reset') ?? '0', 10)
   const resetMs = resetSec ? resetSec * 1000 + 5_000 : Date.now() + 65_000
 
-  if (response.status === 401) throw new FetchError('AUTH', '401 Unauthorized')
+  if (response.status === 401) throw new FetchError('TRANSIENT', '401 Unauthorized')
   if (response.status === 403) {
     const body = await response.text()
     if (body.toLowerCase().includes('rate limit'))

--- a/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
+++ b/services/apps/packages_worker/src/enricher/fetchLightRepo.ts
@@ -146,7 +146,8 @@ export async function fetchLightRepo(
   const resetSec = parseInt(response.headers.get('x-ratelimit-reset') ?? '0', 10)
   const resetMs = resetSec ? resetSec * 1000 + 5_000 : Date.now() + 65_000
 
-  if (response.status === 401) throw new FetchError('AUTH', `401 Unauthorized for ${url}`)
+  // 401 is requester/platform-side (bad token, GitHub auth incident) — never a repo signal
+  if (response.status === 401) throw new FetchError('TRANSIENT', `401 Unauthorized for ${url}`)
 
   if (response.status === 403) {
     const body = await response.text()


### PR DESCRIPTION
This pull request updates the error handling logic for HTTP 401 Unauthorized responses in two files to better categorize these errors as transient rather than authentication-specific. This change improves the way the system handles authentication failures, particularly by treating them as temporary issues that may resolve without user intervention.

Error handling improvements:

* Updated the `graphqlRequest` function in `fetchActivitySnapshot.ts` to throw a `FetchError` with type `'TRANSIENT'` instead of `'AUTH'` for 401 Unauthorized responses, aligning with the intended classification of these errors as potentially temporary.
* Updated the `fetchLightRepo` function in `fetchLightRepo.ts` to throw a `FetchError` with type `'TRANSIENT'` for 401 Unauthorized responses and added a clarifying comment explaining that 401 errors are typically due to requester or platform issues, not repository-specific problems.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enrichment failure classification so 401s no longer permanently skip repos; behavior is limited to two fetch paths but affects queue/retry outcomes.
> 
> **Overview**
> **HTTP 401 from GitHub is now treated as transient** in the packages worker enricher’s GraphQL helpers (`graphqlRequest` in `fetchActivitySnapshot.ts` and `fetchLightRepo`), instead of `AUTH`.
> 
> That matters because `fetchWithRetries` marks `AUTH` as **permanent** (`skip_enrichment`), while `TRANSIENT` errors are retried with backoff. A 401 (bad/expired token or GitHub-side auth glitch) should not permanently disqualify a repo.
> 
> **403** handling is unchanged: rate limits still map to `RATE_LIMIT`, and other 403s remain `AUTH`. `fetchLightRepo` adds a short comment that 401 reflects requester/platform issues, not repository access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a25dd3781fd22667d4fac33bd862f9c2594d611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->