### PR TITLE
fix: purls encoding (CM-1218)

### DIFF
--- a/backend/src/api/public/v1/packages/batchGetStewardship.ts
+++ b/backend/src/api/public/v1/packages/batchGetStewardship.ts
@@ -13,26 +13,33 @@ const MAX_PURLS = 100
 
 const bodySchema = z.object({
   purls: z
-    .array(z.string().trim().min(1))
+    .array(
+      z
+        .string()
+        .trim()
+        .min(1)
+        .refine((v) => v.startsWith('pkg:'), { message: 'each purl must start with pkg:' }),
+    )
     .min(1)
     .max(MAX_PURLS, `Maximum ${MAX_PURLS} purls per request`),
 })
 
 export async function batchGetStewardship(req: Request, res: Response): Promise<void> {
-  const { purls } = validateOrThrow(bodySchema, req.body)
+  const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
+  const normalizedPurls = rawPurls.map((p) => p.replace(/@/g, '%40'))
 
   const qx = await getPackagesQx()
-  const rows = await getPackagesByStewardshipPurls(qx, purls)
+  const rows = await getPackagesByStewardshipPurls(qx, normalizedPurls)
 
   const byPurl = new Map(rows.map((r) => [r.purl, r]))
 
   const packages: Record<string, StewardshipSummary | null> = {}
-  for (const purl of purls) {
-    const row = byPurl.get(purl)
+  for (let i = 0; i < rawPurls.length; i++) {
+    const row = byPurl.get(normalizedPurls[i])
     if (!row) {
-      packages[purl] = null
+      packages[rawPurls[i]] = null
     } else {
-      packages[purl] = {
+      packages[rawPurls[i]] = {
         name: row.name,
         ecosystem: row.ecosystem,
         lifecycle: null,

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -15,7 +15,8 @@ const querySchema = z.object({
     .string()
     .trim()
     .min(1)
-    .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' }),
+    .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' })
+    .transform((v) => v.replace(/@/g, '%40')),
 })
 
 export async function getPackage(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes a 404 bug on GET /v1/packages and POST /v1/packages:batch-stewardship for scoped npm packages (e.g. @babel/core). The packages DB stores purls with %40 as a literal string, but Express URL-decodes query parameters — causing @ to be passed to the query instead of %40, resulting in no match. This PR normalizes @ → %40 at the API boundary before any DB lookup.

## Changes

- getPackage: purl normalization (@ → %40) moved into Zod .transform() for cleaner handler code
- batchGetStewardship: added @ → %40 normalization + per-element pkg: prefix validation; response keys now use the client's original purls (not the
  normalized ones) to avoid lookup mismatches on the frontend

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized validation and string normalization on two read endpoints; no auth, writes, or schema changes.
> 
> **Overview**
> Fixes **404s for scoped npm purls** (e.g. `@babel/core`) on `GET /v1/packages` and `POST /v1/packages:batch-stewardship` by normalizing **`@` → `%40`** before DB lookups, matching how purls are stored after Express decodes query strings.
> 
> **`getPackage`** applies that normalization in the Zod schema via **`.transform()`** so handlers always query with encoded scope names.
> 
> **`batchGetStewardship`** adds per-item **`pkg:`** validation, maps purls to normalized form for `getPackagesByStewardshipPurls`, and builds the response **`packages` map keyed by the client’s original purls** (not the normalized strings) so callers can match results without key mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a612ef5c82b4faa88e6e97a5ea2bc587e2d2443b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->