### PR TITLE
fix: stweardship bug fixes (CM-1218)

### DIFF
--- a/backend/src/api/public/v1/packages/batchGetStewardship.ts
+++ b/backend/src/api/public/v1/packages/batchGetStewardship.ts
@@ -7,6 +7,7 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
+import { normalizePurl } from './purl'
 import type { StewardshipSummary } from './types'
 
 const MAX_PURLS = 100

--- a/backend/src/api/public/v1/packages/batchGetStewardship.ts
+++ b/backend/src/api/public/v1/packages/batchGetStewardship.ts
@@ -26,7 +26,9 @@ const bodySchema = z.object({
 
 export async function batchGetStewardship(req: Request, res: Response): Promise<void> {
   const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
-  const normalizedPurls = rawPurls.map((p) => p.replace(/@/g, '%40'))
+  // Normalize after parsing (not in the schema) so rawPurls keeps the client's
+  // original form — used as the response key so clients can look up their input.
+  const normalizedPurls = rawPurls.map(normalizePurl)
 
   const qx = await getPackagesQx()
   const rows = await getPackagesByStewardshipPurls(qx, normalizedPurls)

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -8,6 +8,7 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
+import { normalizePurl } from './purl'
 import type { StewardshipStatus } from './types'
 
 const querySchema = z.object({
@@ -16,7 +17,7 @@ const querySchema = z.object({
     .trim()
     .min(1)
     .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' })
-    .transform((v) => v.replace(/@/g, '%40')),
+    .transform(normalizePurl),
 })
 
 export async function getPackage(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/packages/listPackages.ts
+++ b/backend/src/api/public/v1/packages/listPackages.ts
@@ -33,7 +33,7 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     page,
     pageSize,
     ecosystem,
-    lifecycle,
+    lifecycle: _lifecycle,
     busFactor1Only,
     staleOnly,
     unstewardedOnly,

--- a/backend/src/api/public/v1/packages/listPackages.ts
+++ b/backend/src/api/public/v1/packages/listPackages.ts
@@ -21,7 +21,7 @@ const querySchema = z.object({
   pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
   ecosystem: z.string().trim().optional(),
   lifecycle: z.enum(lifecycleValues).optional(), // TODO: filter not yet implemented in DAL
-  busFactor1Only: booleanQueryParam, // TODO: filter not yet implemented in DAL
+  busFactor1Only: booleanQueryParam,
   staleOnly: booleanQueryParam,
   unstewardedOnly: booleanQueryParam,
   sortBy: z.enum(['name', 'health', 'impact', 'openVulns']).default('name'),
@@ -51,6 +51,7 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     ecosystem,
     staleOnly,
     unstewardedOnly,
+    busFactor1Only,
     sortBy: effectiveSortBy,
     sortDir,
   })
@@ -74,7 +75,7 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     total,
     filters: {
       ecosystem: ecosystem ?? null,
-      lifecycle: lifecycle ?? null,
+      lifecycle: null, // TODO: filter not yet implemented in DAL
       busFactor1Only,
       staleOnly,
       unstewardedOnly,

--- a/backend/src/api/public/v1/packages/purl.ts
+++ b/backend/src/api/public/v1/packages/purl.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalize a PURL for lookup against the packages table.
+ *
+ * The DB stores versionless PURLs with npm scope @ encoded as %40.
+ * Clients may send purls with versions (pkg:npm/lodash@4.17.21) and qualifiers.
+ *
+ * Transform order:
+ *   1. strip ?qualifiers and #subpath — not stored in DB
+ *   2. strip @version suffix — DB stores versionless PURLs
+ *   3. encode @ in namespace/scope (e.g. npm @babel → %40babel)
+ *
+ * The version regex matches @ followed by non-/ non-@ chars at end of string.
+ * This is always the version separator, not an npm scope (pkg:npm/@babel/core
+ * has @babel followed by /core, so it never matches the end-of-string pattern).
+ */
+export function normalizePurl(purl: string): string {
+  const withoutQualifiers = purl.replace(/[?#].*$/, '')
+  const withoutVersion = withoutQualifiers.replace(/@[^/@]+$/, '')
+  return withoutVersion.replace(/@/g, '%40')
+}

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -94,6 +94,11 @@ export async function listPackagesForApi(
     conditions.push(`(s.status = 'unassigned' OR s.id IS NULL)`)
   }
 
+  if (opts.busFactor1Only) {
+    // References pm_counts LATERAL join below — computed once, used in both WHERE and SELECT
+    conditions.push(`pm_counts.cnt = 1`)
+  }
+
   const where = `WHERE ${conditions.join(' AND ')}`
 
   // health is a v2 field — fall back to name sort
@@ -103,8 +108,8 @@ export async function listPackagesForApi(
   else sortExpr = 'LOWER(p.name)'
   const sortDir = opts.sortDir === 'desc' ? 'DESC' : 'ASC'
 
-  params.limit = opts.pageSize
-  params.offset = (opts.page - 1) * opts.pageSize
+  // Separate paginated params from filter-only params used by the fallback COUNT query
+  const queryParams = { ...params, limit: opts.pageSize, offset: (opts.page - 1) * opts.pageSize }
 
   const rows: PackageListRow[] = await qx.select(
     `
@@ -115,21 +120,42 @@ export async function listPackagesForApi(
       p.impact AS "criticalityScore",
       s.status AS "stewardshipStatus",
       COALESCE(ap_counts.cnt, 0) AS "openVulns",
-      (SELECT COUNT(*)::int FROM package_maintainers pm WHERE pm.package_id = p.id) AS "maintainerCount",
+      pm_counts.cnt AS "maintainerCount",
       COUNT(*) OVER() AS total
     FROM packages p
     LEFT JOIN stewardships s ON s.package_id = p.id
     LEFT JOIN LATERAL (
       SELECT COUNT(*)::int AS cnt FROM advisory_packages WHERE package_id = p.id
     ) ap_counts ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS cnt FROM package_maintainers pm WHERE pm.package_id = p.id
+    ) pm_counts ON true
     ${where}
     ORDER BY ${sortExpr} ${sortDir} NULLS LAST, p.purl ${sortDir}
     LIMIT $(limit) OFFSET $(offset)
     `,
-    params,
+    queryParams,
   )
 
-  const total = rows.length > 0 ? parseInt(rows[0].total, 10) : 0
+  let total: number
+  if (rows.length > 0) {
+    total = parseInt(rows[0].total, 10)
+  } else {
+    // Window function returns no rows when the page is beyond the result set.
+    // Fall back to a separate COUNT so the caller always gets the real total.
+    const countRow: { count: string } = await qx.selectOne(
+      `SELECT COUNT(*)::text AS count
+       FROM packages p
+       LEFT JOIN stewardships s ON s.package_id = p.id
+       LEFT JOIN LATERAL (
+         SELECT COUNT(*)::int AS cnt FROM package_maintainers pm WHERE pm.package_id = p.id
+       ) pm_counts ON true
+       ${where}`,
+      params,
+    )
+    total = parseInt(countRow.count, 10)
+  }
+
   return { rows, total }
 }
 

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -66,6 +66,7 @@ export interface ListPackagesOptions {
   ecosystem?: string
   staleOnly: boolean
   unstewardedOnly: boolean
+  busFactor1Only: boolean
   sortBy: 'name' | 'impact' | 'openVulns'
   sortDir: 'asc' | 'desc'
 }


### PR DESCRIPTION
## Summary

Fixes three issues reported against the packages API post-launch: versioned PURLs causing 404 on the detail endpoint, busFactor1Only filter silently doing nothing, and incorrect total=0 when paginating beyond the last page.

## Changes

- purl.ts (new) — shared normalizePurl() that strips @version, ?qualifiers, #subpath, then encodes npm scope @ → %40. The version regex (@[^/@]+$) correctly matches only the version separator, not scoped package namespaces like @babel/core.
- getPackage.ts / batchGetStewardship.ts — both now use normalizePurl() for DB lookup. pkg:npm/lodash@4.17.21 resolves to the same row as pkg:npm/lodash. Batch keeps manual normalization (not in schema) intentionally — rawPurls must be preserved as response keys so clients can look up their original input.
- listPackages.ts + DAL api.ts — busFactor1Only is now wired through to the DAL. Uses a LATERAL join on package_maintainers (same pattern as ap_counts) so maintainerCount is computed once and referenced in both the SELECT list and the WHERE pm_counts.cnt = 1 condition — no double subquery.
- DAL api.ts — pagination total fix — COUNT(*) OVER() returns no rows when the page offset is beyond the result set, causing total=0. Added a fallback COUNT(*) query for the empty-page case so clients always get the real matching-row count.
- DAL api.ts — param handling — replaced the filterParams = { ...params } snapshot-before-mutation pattern with an explicit queryParams = { ...params, limit, offset } object, making the separation between paginated and filter-only params clear.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public lookup and list-query behavior (PURL matching and filter/total semantics); logic is localized but affects all package detail, batch stewardship, and list clients.
> 
> **Overview**
> Fixes three post-launch packages API bugs: **PURL lookup**, **`busFactor1Only`**, and **list pagination totals**.
> 
> Adds shared **`normalizePurl()`** in `purl.ts` (strip qualifiers/subpath, strip trailing `@version`, encode scoped `@` → `%40`). **`getPackage`** and **`batchGetStewardship`** use it for DB lookups so versioned PURLs (e.g. `pkg:npm/lodash@4.17.21`) resolve like versionless rows; batch responses still key results by the client’s original PURL strings.
> 
> **`listPackages`** now passes **`busFactor1Only`** into the DAL. **`listPackagesForApi`** applies `pm_counts.cnt = 1` via a **`package_maintainers` LATERAL join** (shared for SELECT and WHERE). When a page is past the last results, **`total`** no longer reads as 0: it falls back to a separate **`COUNT(*)`** because `COUNT(*) OVER()` returns no rows on empty pages. **`lifecycle`** in the response `filters` is explicitly **`null`** until the DAL supports it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f113a5c28b24af21a27c03f9875b47c47d8c9da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->