### PR TITLE
fix: remove criticality_score

### DIFF
--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -102,7 +102,6 @@ async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Pr
     licensesRaw: null,
     latestVersion: null,
     ingestionSource: 'packages_universe',
-    criticalityScore: pkg.criticalityScore,
     dependentPackagesCount: pkg.dependentPackagesCount,
     dependentReposCount: pkg.dependentReposCount,
   })
@@ -142,7 +141,6 @@ async function processCriticalPackage(
         licensesRaw: null,
         latestVersion: pkg.latestVersion ?? null,
         ingestionSource: 'maven_not_on_central',
-        criticalityScore: pkg.criticalityScore,
         dependentPackagesCount: pkg.dependentPackagesCount,
         dependentReposCount: pkg.dependentReposCount,
       })
@@ -178,7 +176,6 @@ async function processCriticalPackage(
       licensesRaw: null,
       latestVersion: null,
       ingestionSource: 'maven_no_version',
-      criticalityScore: pkg.criticalityScore,
       dependentPackagesCount: pkg.dependentPackagesCount,
       dependentReposCount: pkg.dependentReposCount,
     })
@@ -189,7 +186,6 @@ async function processCriticalPackage(
   // Phase 2: skip full POM extraction when upstream version matches what we already have.
   if (!forceFullExtraction && version === pkg.latestVersion) {
     await touchPackageSyncedAt(qx, pkg.purl, {
-      criticalityScore: pkg.criticalityScore,
       dependentPackagesCount: pkg.dependentPackagesCount,
       dependentReposCount: pkg.dependentReposCount,
     })
@@ -217,7 +213,6 @@ async function processCriticalPackage(
       licensesRaw: null,
       latestVersion: version,
       ingestionSource: 'maven_error',
-      criticalityScore: pkg.criticalityScore,
       dependentPackagesCount: pkg.dependentPackagesCount,
       dependentReposCount: pkg.dependentReposCount,
     })
@@ -246,7 +241,6 @@ async function processCriticalPackage(
         versionsCount: metadata.versions.length > 0 ? metadata.versions.length : null,
         latestReleaseAt: metadata.lastUpdated,
         ingestionSource: 'maven-registry',
-        criticalityScore: pkg.criticalityScore,
         dependentPackagesCount: pkg.dependentPackagesCount,
         dependentReposCount: pkg.dependentReposCount,
       })

--- a/services/apps/packages_worker/src/maven/schedule.ts
+++ b/services/apps/packages_worker/src/maven/schedule.ts
@@ -34,11 +34,7 @@ export async function scheduleMavenCritical(): Promise<void> {
     await temporal.schedule.create(scheduleOptions)
   } catch (err) {
     if (err instanceof ScheduleAlreadyRunning) {
-      // Schedule exists → delete and recreate so cron/spec changes take effect on
-      // restart (schedule.create is a no-op when the id exists → it would keep the old cron).
-      await temporal.schedule.getHandle('maven-critical').delete()
-      await temporal.schedule.create(scheduleOptions)
-      svc.log.info('Schedule maven-critical recreated (cron synced).')
+      svc.log.info('Schedule maven-critical already exists, skipping creation.')
     } else {
       throw err
     }

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -21,12 +21,7 @@ export async function findPackageIdsByPurl(
  */
 export type MavenPackageToSync = Pick<
   IDbPackageUniverse,
-  | 'id'
-  | 'namespace'
-  | 'name'
-  | 'criticalityScore'
-  | 'dependentPackagesCount'
-  | 'dependentReposCount'
+  'id' | 'namespace' | 'name' | 'dependentPackagesCount' | 'dependentReposCount'
 > & {
   purl: string
   latestVersion: string | null
@@ -51,7 +46,7 @@ const MAVEN_WORKER_OUTCOMES = [
  * isCritical=true  → Tier 2: reads from `packages` (populated by the criticality
  *                    worker, which writes ingestion_source + last_synced_at).
  *                    A row is due when it hasn't been POM-enriched yet, or is
- *                    stale by refreshDays. Ordered by criticality_score.
+ *                    stale by refreshDays. Ordered by dependent_count.
  * isCritical=false → disabled non-critical path: reads from `packages_universe`.
  *                    Kept for reference only — the universe→packages copy is owned
  *                    by the criticality worker and this path is not scheduled.
@@ -70,7 +65,6 @@ export async function listMavenPackagesToSync(
         p.purl,
         p.namespace,
         p.name,
-        p.criticality_score        AS "criticalityScore",
         p.dependent_count          AS "dependentPackagesCount",
         p.dependent_repos_count    AS "dependentReposCount",
         p.latest_version           AS "latestVersion"
@@ -85,7 +79,7 @@ export async function listMavenPackagesToSync(
           OR p.last_synced_at < NOW() - ($(refreshDays) || ' days')::interval
         )
       ORDER BY
-        p.criticality_score DESC NULLS LAST,
+        p.dependent_count DESC NULLS LAST,
         p.id ASC
       LIMIT $(limit)
       `,
@@ -101,7 +95,6 @@ export async function listMavenPackagesToSync(
       pu.purl,
       pu.namespace,
       pu.name,
-      pu.criticality_score        AS "criticalityScore",
       pu.dependent_count          AS "dependentPackagesCount",
       pu.dependent_repos_count    AS "dependentReposCount",
       p.latest_version            AS "latestVersion"
@@ -136,7 +129,6 @@ export async function touchPackageSyncedAt(
   qx: QueryExecutor,
   purl: string,
   metrics: {
-    criticalityScore: number | null | undefined
     dependentPackagesCount: number | null | undefined
     dependentReposCount: number | null | undefined
   },
@@ -145,14 +137,12 @@ export async function touchPackageSyncedAt(
     `
     UPDATE packages SET
       last_synced_at           = NOW(),
-      criticality_score        = COALESCE($(criticalityScore),       criticality_score),
       dependent_count          = COALESCE($(dependentPackagesCount), dependent_count),
       dependent_repos_count    = COALESCE($(dependentReposCount),    dependent_repos_count)
     WHERE purl = $(purl)
     `,
     {
       purl,
-      criticalityScore: metrics.criticalityScore ?? null,
       dependentPackagesCount: metrics.dependentPackagesCount ?? null,
       dependentReposCount: metrics.dependentReposCount ?? null,
     },
@@ -196,13 +186,13 @@ export async function upsertPackage(
         purl, ecosystem, namespace, name,
         description, homepage, registry_url, declared_repository_url, repository_url,
         licenses, licenses_raw, latest_version, versions_count, latest_release_at,
-        criticality_score, dependent_count, dependent_repos_count,
+        dependent_count, dependent_repos_count,
         ingestion_source, last_synced_at, created_at
       ) VALUES (
         $(purl), $(ecosystem), $(namespace), $(name),
         $(description), $(homepage), $(registryUrl), $(declaredRepositoryUrl), $(repositoryUrl),
         $(licenses)::text[], $(licensesRaw), $(latestVersion), $(versionsCount), $(latestReleaseAt),
-        $(criticalityScore), $(dependentPackagesCount), $(dependentReposCount),
+        $(dependentPackagesCount), $(dependentReposCount),
         $(ingestionSource), NOW(), NOW()
       )
       ON CONFLICT (purl) DO UPDATE SET
@@ -216,7 +206,6 @@ export async function upsertPackage(
         latest_version           = COALESCE(EXCLUDED.latest_version,           packages.latest_version),
         versions_count           = COALESCE(EXCLUDED.versions_count,           packages.versions_count),
         latest_release_at        = COALESCE(EXCLUDED.latest_release_at,        packages.latest_release_at),
-        criticality_score        = COALESCE(EXCLUDED.criticality_score,        packages.criticality_score),
         dependent_count          = COALESCE(EXCLUDED.dependent_count,          packages.dependent_count),
         dependent_repos_count    = COALESCE(EXCLUDED.dependent_repos_count,    packages.dependent_repos_count),
         ingestion_source         = EXCLUDED.ingestion_source,
@@ -246,7 +235,6 @@ export async function upsertPackage(
       repositoryUrl: item.repositoryUrl ?? null,
       versionsCount: item.versionsCount ?? null,
       latestReleaseAt: item.latestReleaseAt ?? null,
-      criticalityScore: item.criticalityScore ?? null,
       dependentPackagesCount: item.dependentPackagesCount ?? null,
       dependentReposCount: item.dependentReposCount ?? null,
     },

--- a/services/libs/data-access-layer/src/osspckgs/types.ts
+++ b/services/libs/data-access-layer/src/osspckgs/types.ts
@@ -8,7 +8,6 @@ export interface IDbPackageUniverse {
   name: string
   rankInEcosystem: number | null
   isCritical: boolean
-  criticalityScore: number | null
   dependentPackagesCount: number | null
   dependentReposCount: number | null
   downloads30d: bigint | null
@@ -30,7 +29,6 @@ export type IDbPackageUpsert = {
   versionsCount?: number | null
   latestReleaseAt?: Date | null
   ingestionSource: string
-  criticalityScore?: number | null
   dependentPackagesCount?: number | null
   dependentReposCount?: number | null
   registryUrl?: string | null


### PR DESCRIPTION
## Summary

Removes criticality_score from the Maven worker code paths — the column does not exist in the production packages-db, causing an error on every activity execution. Ordering falls back to dependent_count. Also changes the Temporal schedule bootstrap to skip-if-exists instead of delete+recreate on restart.

## Changes

- runMavenEnrichmentLoop.ts — removed criticalityScore from all upsertPackage and touchPackageSyncedAt call sites (6 occurrences)
- packages.ts — removed criticality_score from listMavenPackagesToSync SELECT, changed ORDER BY to dependent_count DESC, removed from touchPackageSyncedAt UPDATE and upsertPackage INSERT/ON CONFLICT
- types.ts — removed criticalityScore from IDbPackageUniverse and IDbPackageUpsert
- schedule.ts — on ScheduleAlreadyRunning, skip instead of delete+recreate; schedule changes must now be applied manually via Temporal UI

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production bug fix with behavior change: sync priority shifts from criticality to dependent_count, and schedule spec no longer auto-syncs on deploy.
> 
> **Overview**
> Fixes Maven worker activity failures against production **packages-db**, which has no `criticality_score` column. All reads/writes of that field are removed from the Maven enrichment loop, DAL sync queries, `upsertPackage`, and `touchPackageSyncedAt`. **Critical Maven queue ordering** now uses `dependent_count DESC` instead of `criticality_score`.
> 
> **Temporal:** when `maven-critical` schedule already exists, startup **logs and skips** instead of delete-and-recreate, so cron/spec updates no longer apply automatically on worker restart (manual Temporal UI changes required).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d657a0a190bcd08327f3c1a7201b3dc73a0c889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->