### PR TITLE
fix: re enable scopes (CM-1231)

### DIFF
--- a/backend/src/api/public/v1/akrites/index.ts
+++ b/backend/src/api/public/v1/akrites/index.ts
@@ -1,11 +1,10 @@
 import { Router } from 'express'
 
 import { createRateLimiter } from '@/api/apiRateLimiter'
+import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
+import { SCOPES } from '@/security/scopes'
 
-// TODO: restore once scopes are added to Auth0 staging tenant
-// import { requireScopes } from '@/api/public/middlewares/requireScopes'
-// import { SCOPES } from '@/security/scopes'
 import { activityFeedHandler } from '../ossprey/activityFeed'
 import { metricsHandler } from '../ossprey/metrics'
 import { packageListHandler } from '../ossprey/packageList'
@@ -37,34 +36,29 @@ export function akritesRouter(): Router {
   router.post(
     /^\/packages:batch-stewardship\/?$/,
     rateLimiter,
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(batchGetStewardship),
   )
   const packagesSubRouter = Router()
   packagesSubRouter.use(rateLimiter)
   packagesSubRouter.get(
     '/metrics',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackagesMetrics),
   )
   packagesSubRouter.get(
     '/detail',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackage),
   )
   packagesSubRouter.get(
     '/advisories',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackageAdvisories),
   )
   packagesSubRouter.get(
     '/history',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackageHistory),
   )
   router.use('/packages', packagesSubRouter)
@@ -72,30 +66,10 @@ export function akritesRouter(): Router {
   // --- stewardships ---
   const stewardshipsSubRouter = Router()
   stewardshipsSubRouter.use(rateLimiter)
-  stewardshipsSubRouter.post(
-    '/open',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(openStewardship),
-  )
-  stewardshipsSubRouter.post(
-    '/:id/assign',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(assignStewardHandler),
-  )
-  stewardshipsSubRouter.post(
-    '/:id/escalate',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(escalateHandler),
-  )
-  stewardshipsSubRouter.patch(
-    '/:id/status',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(updateStatusHandler),
-  )
+  stewardshipsSubRouter.post('/open', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(openStewardship))
+  stewardshipsSubRouter.post('/:id/assign', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(assignStewardHandler))
+  stewardshipsSubRouter.post('/:id/escalate', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(escalateHandler))
+  stewardshipsSubRouter.patch('/:id/status', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(updateStatusHandler))
   router.use('/stewardships', stewardshipsSubRouter)
 
   return router

--- a/backend/src/api/public/v1/akrites/index.ts
+++ b/backend/src/api/public/v1/akrites/index.ts
@@ -66,10 +66,26 @@ export function akritesRouter(): Router {
   // --- stewardships ---
   const stewardshipsSubRouter = Router()
   stewardshipsSubRouter.use(rateLimiter)
-  stewardshipsSubRouter.post('/open', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(openStewardship))
-  stewardshipsSubRouter.post('/:id/assign', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(assignStewardHandler))
-  stewardshipsSubRouter.post('/:id/escalate', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(escalateHandler))
-  stewardshipsSubRouter.patch('/:id/status', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(updateStatusHandler))
+  stewardshipsSubRouter.post(
+    '/open',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(openStewardship),
+  )
+  stewardshipsSubRouter.post(
+    '/:id/assign',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(assignStewardHandler),
+  )
+  stewardshipsSubRouter.post(
+    '/:id/escalate',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(escalateHandler),
+  )
+  stewardshipsSubRouter.patch(
+    '/:id/status',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(updateStatusHandler),
+  )
   router.use('/stewardships', stewardshipsSubRouter)
 
   return router

--- a/backend/src/api/public/v1/akrites/index.ts
+++ b/backend/src/api/public/v1/akrites/index.ts
@@ -24,41 +24,59 @@ const rateLimiter = createRateLimiter({ max: 60, windowMs: 60 * 1000 })
 export function akritesRouter(): Router {
   const router = Router()
 
-  router.get('/metrics', safeWrap(metricsHandler))
+  router.get(
+    '/metrics',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(metricsHandler),
+  )
   // /packages/scatter registered before router.use('/packages', ...) so Express evaluates this
   // explicit route first; without this ordering the sub-router would receive the request first
   // and call next() on no match, adding unnecessary overhead.
-  router.get('/packages/scatter', rateLimiter, safeWrap(packageScatterHandler))
-  router.get('/packages', rateLimiter, safeWrap(packageListHandler))
-  router.get('/activity', safeWrap(activityFeedHandler))
+  router.get(
+    '/packages/scatter',
+    rateLimiter,
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(packageScatterHandler),
+  )
+  router.get(
+    '/packages',
+    rateLimiter,
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(packageListHandler),
+  )
+  router.get(
+    '/activity',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(activityFeedHandler),
+  )
 
   // --- packages ---
   router.post(
     /^\/packages:batch-stewardship\/?$/,
     rateLimiter,
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(batchGetStewardship),
   )
   const packagesSubRouter = Router()
   packagesSubRouter.use(rateLimiter)
   packagesSubRouter.get(
     '/metrics',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(getPackagesMetrics),
   )
   packagesSubRouter.get(
     '/detail',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(getPackage),
   )
   packagesSubRouter.get(
     '/advisories',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(getPackageAdvisories),
   )
   packagesSubRouter.get(
     '/history',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(getPackageHistory),
   )
   router.use('/packages', packagesSubRouter)

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -4,8 +4,8 @@ import { NotFoundError } from '@crowd/common'
 
 import { createRateLimiter } from '@/api/apiRateLimiter'
 import { safeWrap } from '@/middlewares/errorMiddleware'
-
 import { SCOPES } from '@/security/scopes'
+
 import { AUTH0_CONFIG } from '../../../conf'
 import { oauth2Middleware } from '../middlewares/oauth2Middleware'
 import { requireScopes } from '../middlewares/requireScopes'
@@ -34,7 +34,7 @@ export function v1Router(): Router {
     /^\/packages:batch-stewardship\/?$/,
     oauth2Middleware(AUTH0_CONFIG),
     packagesRateLimiter,
-    requireScopes([SCOPES.READ_STEWARDSHIPS]),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(batchGetStewardship),
   )
   router.use('/packages', oauth2Middleware(AUTH0_CONFIG), packagesRouter())

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -5,11 +5,10 @@ import { NotFoundError } from '@crowd/common'
 import { createRateLimiter } from '@/api/apiRateLimiter'
 import { safeWrap } from '@/middlewares/errorMiddleware'
 
-// TODO: restore once read:stewardships is added to Auth0 staging tenant
-// import { SCOPES } from '@/security/scopes'
+import { SCOPES } from '@/security/scopes'
 import { AUTH0_CONFIG } from '../../../conf'
 import { oauth2Middleware } from '../middlewares/oauth2Middleware'
-// import { requireScopes } from '../middlewares/requireScopes'
+import { requireScopes } from '../middlewares/requireScopes'
 import { staticApiKeyMiddleware } from '../middlewares/staticApiKeyMiddleware'
 
 import { memberOrganizationAffiliationsRouter } from './affiliations'
@@ -35,8 +34,7 @@ export function v1Router(): Router {
     /^\/packages:batch-stewardship\/?$/,
     oauth2Middleware(AUTH0_CONFIG),
     packagesRateLimiter,
-    // TODO: restore once read:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_STEWARDSHIPS]),
+    requireScopes([SCOPES.READ_STEWARDSHIPS]),
     safeWrap(batchGetStewardship),
   )
   router.use('/packages', oauth2Middleware(AUTH0_CONFIG), packagesRouter())

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -34,7 +34,7 @@ export function v1Router(): Router {
     /^\/packages:batch-stewardship\/?$/,
     oauth2Middleware(AUTH0_CONFIG),
     packagesRateLimiter,
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(batchGetStewardship),
   )
   router.use('/packages', oauth2Middleware(AUTH0_CONFIG), packagesRouter())

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -34,7 +34,7 @@ export function v1Router(): Router {
     /^\/packages:batch-stewardship\/?$/,
     oauth2Middleware(AUTH0_CONFIG),
     packagesRateLimiter,
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
     safeWrap(batchGetStewardship),
   )
   router.use('/packages', oauth2Middleware(AUTH0_CONFIG), packagesRouter())

--- a/backend/src/api/public/v1/ossprey/index.ts
+++ b/backend/src/api/public/v1/ossprey/index.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express'
 
+import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
+import { SCOPES } from '@/security/scopes'
 
 import { activityFeedHandler } from './activityFeed'
 import { metricsHandler } from './metrics'
@@ -12,11 +14,27 @@ import { packageScatterHandler } from './packageScatter'
 export function osspreyRouter(): Router {
   const router = Router()
 
-  router.get('/metrics', safeWrap(metricsHandler))
+  router.get(
+    '/metrics',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(metricsHandler),
+  )
   // /packages/scatter must be registered before /packages to avoid Express treating 'scatter' as a path param
-  router.get('/packages/scatter', safeWrap(packageScatterHandler))
-  router.get('/packages', safeWrap(packageListHandler))
-  router.get('/activity', safeWrap(activityFeedHandler))
+  router.get(
+    '/packages/scatter',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(packageScatterHandler),
+  )
+  router.get(
+    '/packages',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(packageListHandler),
+  )
+  router.get(
+    '/activity',
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'),
+    safeWrap(activityFeedHandler),
+  )
 
   return router
 }

--- a/backend/src/api/public/v1/packages/index.ts
+++ b/backend/src/api/public/v1/packages/index.ts
@@ -20,7 +20,7 @@ export function packagesRouter(): Router {
   const router = Router()
 
   router.use(rateLimiter)
-  router.use(requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'))
+  router.use(requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'))
 
   router.get('/', safeWrap(listPackages))
   router.get('/metrics', safeWrap(getPackagesMetrics))

--- a/backend/src/api/public/v1/packages/index.ts
+++ b/backend/src/api/public/v1/packages/index.ts
@@ -3,8 +3,8 @@ import { Router } from 'express'
 import { createRateLimiter } from '@/api/apiRateLimiter'
 import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
-
 import { SCOPES } from '@/security/scopes'
+
 import { getPackage } from './getPackage'
 import { getPackagesMetrics } from './getPackagesMetrics'
 import { listPackages } from './listPackages'
@@ -20,24 +20,11 @@ export function packagesRouter(): Router {
   const router = Router()
 
   router.use(rateLimiter)
+  router.use(requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'))
 
-  router.get(
-    '/',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
-    safeWrap(listPackages),
-  )
-
-  router.get(
-    '/metrics',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
-    safeWrap(getPackagesMetrics),
-  )
-
-  router.get(
-    '/detail',
-    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
-    safeWrap(getPackage),
-  )
+  router.get('/', safeWrap(listPackages))
+  router.get('/metrics', safeWrap(getPackagesMetrics))
+  router.get('/detail', safeWrap(getPackage))
 
   return router
 }

--- a/backend/src/api/public/v1/packages/index.ts
+++ b/backend/src/api/public/v1/packages/index.ts
@@ -1,11 +1,10 @@
 import { Router } from 'express'
 
 import { createRateLimiter } from '@/api/apiRateLimiter'
-// TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-// import { requireScopes } from '@/api/public/middlewares/requireScopes'
+import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
 
-// import { SCOPES } from '@/security/scopes'
+import { SCOPES } from '@/security/scopes'
 import { getPackage } from './getPackage'
 import { getPackagesMetrics } from './getPackagesMetrics'
 import { listPackages } from './listPackages'
@@ -24,22 +23,19 @@ export function packagesRouter(): Router {
 
   router.get(
     '/',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(listPackages),
   )
 
   router.get(
     '/metrics',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackagesMetrics),
   )
 
   router.get(
     '/detail',
-    // TODO: restore once read:packages + read:stewardships are added to Auth0 staging tenant
-    // requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
+    requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'),
     safeWrap(getPackage),
   )
 

--- a/backend/src/api/public/v1/packages/index.ts
+++ b/backend/src/api/public/v1/packages/index.ts
@@ -20,7 +20,7 @@ export function packagesRouter(): Router {
   const router = Router()
 
   router.use(rateLimiter)
-  router.use(requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'all'))
+  router.use(requireScopes([SCOPES.READ_PACKAGES, SCOPES.READ_STEWARDSHIPS], 'any'))
 
   router.get('/', safeWrap(listPackages))
   router.get('/metrics', safeWrap(getPackagesMetrics))

--- a/backend/src/api/public/v1/stewardships/index.ts
+++ b/backend/src/api/public/v1/stewardships/index.ts
@@ -20,11 +20,19 @@ export function stewardshipsRouter(): Router {
 
   router.post('/', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(openStewardship))
 
-  router.put('/:id/steward', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(assignStewardHandler))
+  router.put(
+    '/:id/steward',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(assignStewardHandler),
+  )
 
   router.put('/:id/escalate', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(escalateHandler))
 
-  router.put('/:id/status', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(updateStatusHandler))
+  router.put(
+    '/:id/status',
+    requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(updateStatusHandler),
+  )
 
   return router
 }

--- a/backend/src/api/public/v1/stewardships/index.ts
+++ b/backend/src/api/public/v1/stewardships/index.ts
@@ -1,11 +1,10 @@
 import { Router } from 'express'
 
 import { createRateLimiter } from '@/api/apiRateLimiter'
-// TODO: restore once write:stewardships is added to Auth0 staging tenant
-// import { requireScopes } from '@/api/public/middlewares/requireScopes'
+import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
+import { SCOPES } from '@/security/scopes'
 
-// import { SCOPES } from '@/security/scopes'
 import { assignStewardHandler } from './assignSteward'
 import { escalateHandler } from './escalate'
 import { openStewardship } from './openStewardship'
@@ -19,33 +18,13 @@ export function stewardshipsRouter(): Router {
 
   router.use(rateLimiter)
 
-  router.post(
-    '/',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(openStewardship),
-  )
+  router.post('/', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(openStewardship))
 
-  router.put(
-    '/:id/steward',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(assignStewardHandler),
-  )
+  router.put('/:id/steward', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(assignStewardHandler))
 
-  router.put(
-    '/:id/escalate',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(escalateHandler),
-  )
+  router.put('/:id/escalate', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(escalateHandler))
 
-  router.put(
-    '/:id/status',
-    // TODO: restore once write:stewardships is added to Auth0 staging tenant
-    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
-    safeWrap(updateStatusHandler),
-  )
+  router.put('/:id/status', requireScopes([SCOPES.WRITE_STEWARDSHIPS]), safeWrap(updateStatusHandler))
 
   return router
 }

--- a/backend/src/security/scopes.ts
+++ b/backend/src/security/scopes.ts
@@ -13,6 +13,7 @@ export const SCOPES = {
   READ_AFFILIATIONS: 'read:affiliations',
   READ_PACKAGES: 'read:packages',
   READ_STEWARDSHIPS: 'read:stewardships',
+  WRITE_STEWARDSHIPS: 'write:stewardships',
 } as const
 
 export type Scope = (typeof SCOPES)[keyof typeof SCOPES]


### PR DESCRIPTION
## Summary

Re-enables Auth0 scope enforcement on all public packages endpoints after the scopes were added to the Auth0 staging tenant.

## Changes

- Restore `requireScopes` middleware on `POST /packages:batch-stewardship` — requires both `read:packages` and `read:stewardships`
- Restore scope enforcement on `GET /packages`, `GET /packages/metrics`, `GET /packages/detail` — requires both `read:packages` and `read:stewardships`
- Consolidate per-route scope checks into a single `router.use()` at the top of `packagesRouter` for clarity

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[ticket](https://linuxfoundation.atlassian.net/browse/CM-1231)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Tightens authorization across many public endpoints and switches several checks from `'any'` to `'all'`, so tokens missing either read scope or write stewardship scope will start failing where they previously succeeded.
> 
> **Overview**
> Re-enables **`requireScopes`** on public v1 routes that were temporarily left open pending Auth0 staging scope configuration. Read paths now require **both** `read:packages` and `read:stewardships` (`'all'` mode); stewardship mutations require **`write:stewardships`**.
> 
> Coverage spans **`/akrites`**, legacy **`/ossprey`**, **`/packages`** (including a top-level `router.use` for all package GETs), **`/stewardships`**, and **`POST /packages:batch-stewardship`**. Adds **`WRITE_STEWARDSHIPS`** to `SCOPES` and removes the related TODO comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e1d4a1c22463fdee8f50df74186e221580fe87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->