### PR TITLE
feat: add admin apis (CM-1235)

### DIFF
--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -17,6 +17,7 @@ import { membersRouter } from './members'
 import { organizationsRouter } from './organizations'
 import { packagesRouter } from './packages'
 import { batchGetStewardship } from './packages/batchGetStewardship'
+import { stewardshipsRouter } from './stewardships'
 
 const packagesRateLimiter = createRateLimiter({ max: 60, windowMs: 60 * 1000 })
 
@@ -36,6 +37,7 @@ export function v1Router(): Router {
     safeWrap(batchGetStewardship),
   )
   router.use('/packages', oauth2Middleware(AUTH0_CONFIG), packagesRouter())
+  router.use('/stewardships', oauth2Middleware(AUTH0_CONFIG), stewardshipsRouter())
 
   router.use(() => {
     throw new NotFoundError()

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -36,7 +36,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
 
   const [advisories, stewardshipSummary] = await Promise.all([
     getAdvisoriesByPackageId(qx, pkg.id),
-    pkg.stewardshipId ? getStewardshipSummary(qx, pkg.stewardshipId) : null,
+    pkg.stewardshipId ? getStewardshipSummary(qx, Number(pkg.stewardshipId)) : null,
   ])
 
   ok(res, {

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -94,6 +94,8 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
       status: (pkg.stewardshipStatus ?? 'unassigned') as StewardshipStatus,
       stewards: stewardshipSummary?.stewards ?? null,
       lastActivityAt: stewardshipSummary?.lastActivityAt ?? null,
+      resolutionPath: pkg.stewardshipResolutionPath ?? null,
+      statusNote: pkg.stewardshipStatusNote ?? null,
     },
     history: {},
   })

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -2,7 +2,11 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { NotFoundError } from '@crowd/common'
-import { getAdvisoriesByPackageId, getPackageDetailByPurl } from '@crowd/data-access-layer'
+import {
+  getAdvisoriesByPackageId,
+  getPackageDetailByPurl,
+  getStewardshipSummary,
+} from '@crowd/data-access-layer'
 
 import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
@@ -30,7 +34,10 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     throw new NotFoundError()
   }
 
-  const advisories = await getAdvisoriesByPackageId(qx, pkg.id)
+  const [advisories, stewardshipSummary] = await Promise.all([
+    getAdvisoriesByPackageId(qx, pkg.id),
+    pkg.stewardshipId ? getStewardshipSummary(qx, pkg.stewardshipId) : null,
+  ])
 
   ok(res, {
     purl: pkg.purl,
@@ -84,8 +91,8 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     },
     stewardship: {
       status: (pkg.stewardshipStatus ?? 'unassigned') as StewardshipStatus,
-      stewards: null,
-      lastActivityAt: null,
+      stewards: stewardshipSummary?.stewards ?? null,
+      lastActivityAt: stewardshipSummary?.lastActivityAt ?? null,
     },
     history: {},
   })

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -90,6 +90,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
       },
     },
     stewardship: {
+      id: pkg.stewardshipId ?? null,
       status: (pkg.stewardshipStatus ?? 'unassigned') as StewardshipStatus,
       stewards: stewardshipSummary?.stewards ?? null,
       lastActivityAt: stewardshipSummary?.lastActivityAt ?? null,

--- a/backend/src/api/public/v1/packages/listPackages.ts
+++ b/backend/src/api/public/v1/packages/listPackages.ts
@@ -87,6 +87,7 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     lifecycle: null,
     maintainerBusFactor: r.maintainerCount,
     openVulns: r.openVulns,
+    stewardshipId: r.stewardshipId ?? null,
     stewardship: (r.stewardshipStatus ?? 'unassigned') as StewardshipStatus,
     stewards: null,
   }))

--- a/backend/src/api/public/v1/packages/openapi.yaml
+++ b/backend/src/api/public/v1/packages/openapi.yaml
@@ -85,14 +85,17 @@ components:
 
     Steward:
       type: object
-      required: [userId, name, role, assignedAt]
+      required: [userId, role, assignedAt]
       properties:
         userId:
           type: string
-          description: LFID.
-          example: jdoe
+          description: Auth0 sub of the assigned steward.
+          example: abc123
         name:
-          type: string
+          type:
+            - string
+            - 'null'
+          description: Display name of the steward. Null if not available.
           example: Jonathan R.
         role:
           type: string
@@ -424,7 +427,7 @@ components:
                     - 'null'
         stewardship:
           type: object
-          description: Stewardship state. In v1 always unassigned with no stewards or activity.
+          description: Stewardship state.
           properties:
             id:
               type:
@@ -435,7 +438,7 @@ components:
             status:
               $ref: '#/components/schemas/StewardshipStatus'
             stewards:
-              description: Assigned stewards or null. Null in v1.
+              description: Assigned stewards or null.
               oneOf:
                 - type: array
                   items:
@@ -446,7 +449,16 @@ components:
                 - string
                 - 'null'
               format: date-time
-              description: Null in v1.
+            resolutionPath:
+              type:
+                - string
+                - 'null'
+              description: Set on `escalated` status. Null for all other statuses.
+            statusNote:
+              type:
+                - string
+                - 'null'
+              description: Free-text note for the current status.
         history:
           type: object
           description: Package history data. Empty in v1.

--- a/backend/src/api/public/v1/packages/openapi.yaml
+++ b/backend/src/api/public/v1/packages/openapi.yaml
@@ -194,6 +194,12 @@ components:
           oneOf:
             - $ref: '#/components/schemas/OpenVulns'
             - type: 'null'
+        stewardshipId:
+          type:
+            - string
+            - 'null'
+          description: Stewardship ID. Required to call mutation endpoints (assign/escalate/status). Null if no stewardship row exists.
+          example: '42'
         stewardship:
           $ref: '#/components/schemas/StewardshipStatus'
         stewards:
@@ -420,6 +426,12 @@ components:
           type: object
           description: Stewardship state. In v1 always unassigned with no stewards or activity.
           properties:
+            id:
+              type:
+                - string
+                - 'null'
+              description: Stewardship ID. Required to call mutation endpoints (assign/escalate/status).
+              example: '42'
             status:
               $ref: '#/components/schemas/StewardshipStatus'
             stewards:

--- a/backend/src/api/public/v1/stewardships/assignSteward.ts
+++ b/backend/src/api/public/v1/stewardships/assignSteward.ts
@@ -15,14 +15,20 @@ const paramsSchema = z.object({
 const bodySchema = z.object({
   userId: z.string().trim().min(1),
   role: z.enum(['lead', 'co_steward']),
+  moveToAssessing: z.boolean().optional().default(false),
 })
 
 export async function assignStewardHandler(req: Request, res: Response): Promise<void> {
   const { id } = validateOrThrow(paramsSchema, req.params)
-  const { userId, role } = validateOrThrow(bodySchema, req.body)
+  const { userId, role, moveToAssessing } = validateOrThrow(bodySchema, req.body)
 
   const qx = await getPackagesQx()
-  const result = await assignSteward(qx, id, { userId, role, assignedBy: req.actor.id })
+  const result = await assignSteward(qx, id, {
+    userId,
+    role,
+    assignedBy: req.actor.id,
+    moveToAssessing,
+  })
 
   if (!result) {
     throw new NotFoundError(`Stewardship not found: ${id}`)

--- a/backend/src/api/public/v1/stewardships/assignSteward.ts
+++ b/backend/src/api/public/v1/stewardships/assignSteward.ts
@@ -1,0 +1,30 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { NotFoundError } from '@crowd/common'
+import { assignSteward } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { stewardshipIdParamsSchema } from './schemas'
+
+const bodySchema = z.object({
+  userId: z.string().trim().min(1),
+  role: z.enum(['lead', 'co_steward']),
+})
+
+export async function assignStewardHandler(req: Request, res: Response): Promise<void> {
+  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { userId, role } = validateOrThrow(bodySchema, req.body)
+
+  const qx = await getPackagesQx()
+  const result = await assignSteward(qx, id, { userId, role, assignedBy: req.actor.id })
+
+  if (!result) {
+    throw new NotFoundError(`Stewardship not found: ${id}`)
+  }
+
+  ok(res, { stewardship: result.stewardship, stewards: result.stewards })
+}

--- a/backend/src/api/public/v1/stewardships/assignSteward.ts
+++ b/backend/src/api/public/v1/stewardships/assignSteward.ts
@@ -8,7 +8,9 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-import { stewardshipIdParamsSchema } from './schemas'
+const paramsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
 
 const bodySchema = z.object({
   userId: z.string().trim().min(1),
@@ -16,7 +18,7 @@ const bodySchema = z.object({
 })
 
 export async function assignStewardHandler(req: Request, res: Response): Promise<void> {
-  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { id } = validateOrThrow(paramsSchema, req.params)
   const { userId, role } = validateOrThrow(bodySchema, req.body)
 
   const qx = await getPackagesQx()

--- a/backend/src/api/public/v1/stewardships/escalate.ts
+++ b/backend/src/api/public/v1/stewardships/escalate.ts
@@ -1,0 +1,34 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { NotFoundError } from '@crowd/common'
+import { ESCALATION_RESOLUTION_PATHS, escalateStewardship } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { stewardshipIdParamsSchema } from './schemas'
+
+const bodySchema = z.object({
+  resolutionPath: z.enum(ESCALATION_RESOLUTION_PATHS),
+  notes: z.string().trim().min(1).optional(),
+})
+
+export async function escalateHandler(req: Request, res: Response): Promise<void> {
+  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { resolutionPath, notes } = validateOrThrow(bodySchema, req.body)
+
+  const qx = await getPackagesQx()
+  const stewardship = await escalateStewardship(qx, id, {
+    resolutionPath,
+    notes,
+    actorUserId: req.actor.id,
+  })
+
+  if (!stewardship) {
+    throw new NotFoundError(`Stewardship not found: ${id}`)
+  }
+
+  ok(res, { stewardship })
+}

--- a/backend/src/api/public/v1/stewardships/escalate.ts
+++ b/backend/src/api/public/v1/stewardships/escalate.ts
@@ -8,7 +8,9 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-import { stewardshipIdParamsSchema } from './schemas'
+const paramsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
 
 const bodySchema = z.object({
   resolutionPath: z.enum(ESCALATION_RESOLUTION_PATHS),
@@ -16,7 +18,7 @@ const bodySchema = z.object({
 })
 
 export async function escalateHandler(req: Request, res: Response): Promise<void> {
-  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { id } = validateOrThrow(paramsSchema, req.params)
   const { resolutionPath, notes } = validateOrThrow(bodySchema, req.body)
 
   const qx = await getPackagesQx()

--- a/backend/src/api/public/v1/stewardships/index.ts
+++ b/backend/src/api/public/v1/stewardships/index.ts
@@ -1,0 +1,50 @@
+import { Router } from 'express'
+
+import { createRateLimiter } from '@/api/apiRateLimiter'
+// TODO: restore once write:stewardships is added to Auth0 staging tenant
+// import { requireScopes } from '@/api/public/middlewares/requireScopes'
+import { safeWrap } from '@/middlewares/errorMiddleware'
+
+// import { SCOPES } from '@/security/scopes'
+import { assignStewardHandler } from './assignSteward'
+import { escalateHandler } from './escalate'
+import { openStewardship } from './openStewardship'
+import { updateStatusHandler } from './updateStatus'
+
+const rateLimiter = createRateLimiter({ max: 60, windowMs: 60 * 1000 })
+
+export function stewardshipsRouter(): Router {
+  const router = Router()
+
+  router.use(rateLimiter)
+
+  router.post(
+    '/',
+    // TODO: restore once write:stewardships is added to Auth0 staging tenant
+    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(openStewardship),
+  )
+
+  router.put(
+    '/:id/steward',
+    // TODO: restore once write:stewardships is added to Auth0 staging tenant
+    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(assignStewardHandler),
+  )
+
+  router.put(
+    '/:id/escalate',
+    // TODO: restore once write:stewardships is added to Auth0 staging tenant
+    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(escalateHandler),
+  )
+
+  router.put(
+    '/:id/status',
+    // TODO: restore once write:stewardships is added to Auth0 staging tenant
+    // requireScopes([SCOPES.WRITE_STEWARDSHIPS]),
+    safeWrap(updateStatusHandler),
+  )
+
+  return router
+}

--- a/backend/src/api/public/v1/stewardships/openStewardship.ts
+++ b/backend/src/api/public/v1/stewardships/openStewardship.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { NotFoundError } from '@crowd/common'
+import { openStewardshipByPurl } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { normalizePurl } from '../packages/purl'
+
+const bodySchema = z.object({
+  purl: z
+    .string()
+    .trim()
+    .min(1)
+    .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' }),
+})
+
+export async function openStewardship(req: Request, res: Response): Promise<void> {
+  const { purl: rawPurl } = validateOrThrow(bodySchema, req.body)
+  const purl = normalizePurl(rawPurl)
+
+  const qx = await getPackagesQx()
+  const stewardship = await openStewardshipByPurl(qx, purl, req.actor.id)
+
+  if (!stewardship) {
+    throw new NotFoundError(`Package not found: ${rawPurl}`)
+  }
+
+  ok(res, { stewardship })
+}

--- a/backend/src/api/public/v1/stewardships/openStewardship.ts
+++ b/backend/src/api/public/v1/stewardships/openStewardship.ts
@@ -15,18 +15,18 @@ const bodySchema = z.object({
     .string()
     .trim()
     .min(1)
-    .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' }),
+    .refine((v) => v.startsWith('pkg:'), { message: 'purl must start with pkg:' })
+    .transform(normalizePurl),
 })
 
 export async function openStewardship(req: Request, res: Response): Promise<void> {
-  const { purl: rawPurl } = validateOrThrow(bodySchema, req.body)
-  const purl = normalizePurl(rawPurl)
+  const { purl } = validateOrThrow(bodySchema, req.body)
 
   const qx = await getPackagesQx()
   const stewardship = await openStewardshipByPurl(qx, purl, req.actor.id)
 
   if (!stewardship) {
-    throw new NotFoundError(`Package not found: ${rawPurl}`)
+    throw new NotFoundError(`Package not found: ${purl}`)
   }
 
   ok(res, { stewardship })

--- a/backend/src/api/public/v1/stewardships/openapi.yaml
+++ b/backend/src/api/public/v1/stewardships/openapi.yaml
@@ -113,8 +113,8 @@ components:
           example: '42'
         userId:
           type: string
-          description: LFID of the assigned steward.
-          example: jdoe
+          description: Auth0 sub of the assigned steward.
+          example: abc123
         role:
           type: string
           enum: [lead, co_steward]
@@ -125,19 +125,18 @@ components:
           type:
             - string
             - 'null'
-          description: LFID of the admin who assigned this steward.
-          example: admin-user
+          description: Auth0 sub of the admin who assigned this steward.
+          example: xyz789
 
     EscalationResolutionPath:
       type: string
-      # TODO: confirm the 6 resolution path values with Joana (CM-1235)
       enum:
-        - lf_staff_review
-        - community_outreach
-        - corporate_adoption
-        - transfer_ownership
-        - fork_and_maintain
-        - deprecate
+        - right_of_first_refusal
+        - replace_the_dependency
+        - find_vendor_for_lts
+        - consortium_adopts_maintainership
+        - compensating_controls_monitor
+        - namespace_takeover
 
 paths:
   /stewardships:
@@ -246,13 +245,13 @@ paths:
               properties:
                 userId:
                   type: string
-                  description: LFID of the user to assign as steward.
-                  example: jdoe
+                  description: Auth0 sub of the user to assign as steward.
+                  example: abc123
                 role:
                   type: string
                   enum: [lead, co_steward]
             example:
-              userId: jdoe
+              userId: abc123
               role: lead
       responses:
         '200':
@@ -284,10 +283,10 @@ paths:
                 stewards:
                   - id: '7'
                     stewardshipId: '42'
-                    userId: jdoe
+                    userId: abc123
                     role: lead
                     assignedAt: '2026-06-15T10:05:00Z'
-                    assignedBy: admin-user
+                    assignedBy: xyz789
         '400':
           description: Validation error (e.g. invalid role).
           content:
@@ -349,7 +348,7 @@ paths:
                   description: Optional free-text notes for the activity log.
                   example: Contacted maintainer, no response after 30 days.
             example:
-              resolutionPath: lf_staff_review
+              resolutionPath: right_of_first_refusal
               notes: Contacted maintainer, no response after 30 days.
       responses:
         '200':

--- a/backend/src/api/public/v1/stewardships/openapi.yaml
+++ b/backend/src/api/public/v1/stewardships/openapi.yaml
@@ -94,6 +94,17 @@ components:
             - stepped_down
             - no_longer_critical
             - 'null'
+        resolutionPath:
+          description: Set on `escalated` status. Null for all other statuses.
+          oneOf:
+            - $ref: '#/components/schemas/EscalationResolutionPath'
+            - type: 'null'
+        statusNote:
+          type:
+            - string
+            - 'null'
+          description: Free-text note for the current status. Set by escalate or updateStatus. Null on open.
+          example: Contacted maintainer, no response after 30 days.
         createdAt:
           type: string
           format: date-time
@@ -115,6 +126,12 @@ components:
           type: string
           description: Auth0 sub of the assigned steward.
           example: abc123
+        name:
+          type:
+            - string
+            - 'null'
+          description: Display name of the steward. Null if not available.
+          example: Jonathan R.
         role:
           type: string
           enum: [lead, co_steward]

--- a/backend/src/api/public/v1/stewardships/openapi.yaml
+++ b/backend/src/api/public/v1/stewardships/openapi.yaml
@@ -250,9 +250,17 @@ paths:
                 role:
                   type: string
                   enum: [lead, co_steward]
+                moveToAssessing:
+                  type: boolean
+                  default: false
+                  description: >
+                    If true, atomically transitions the stewardship status to `assessing`
+                    in the same transaction as the assignment. Use for the "Assign & move to
+                    Assessing" action to avoid a second round-trip.
             example:
               userId: abc123
               role: lead
+              moveToAssessing: true
       responses:
         '200':
           description: Steward assigned.

--- a/backend/src/api/public/v1/stewardships/openapi.yaml
+++ b/backend/src/api/public/v1/stewardships/openapi.yaml
@@ -1,0 +1,514 @@
+openapi: 3.1.0
+info:
+  title: CDP Public API — Stewardship Admin Actions
+  version: 1.0.0
+  description: >
+    Write endpoints for OSSPREY Program admin stewardship actions.
+
+
+    **Authentication:** OAuth 2.0 M2M bearer token. All endpoints require `write:stewardships`.
+
+
+    **V1 note:** Scope `write:stewardships` is not yet added to the Auth0 staging tenant —
+    scope enforcement is temporarily disabled. See CM-1235.
+
+servers:
+  - url: https://cm.lfx.dev/api/v1
+    description: Production
+  - url: https://lf-staging.crowd.dev/api/v1
+    description: Staging
+
+tags:
+  - name: Stewardship Actions
+    description: Admin-initiated stewardship mutations.
+
+components:
+  securitySchemes:
+    M2MBearer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              example: NOT_FOUND
+            message:
+              type: string
+              example: Stewardship not found.
+
+    StewardshipStatus:
+      type: string
+      enum:
+        - unassigned
+        - open
+        - assessing
+        - active
+        - needs_attention
+        - escalated
+        - blocked
+        - inactive
+
+    StewardshipRecord:
+      type: object
+      required: [id, packageId, status, origin, version, createdAt, updatedAt]
+      properties:
+        id:
+          type: string
+          example: '42'
+        packageId:
+          type: string
+          example: '1234'
+        status:
+          $ref: '#/components/schemas/StewardshipStatus'
+        origin:
+          type: string
+          enum: [auto_imported, self_claimed, assigned, opened_for_claim]
+        version:
+          type: integer
+          example: 1
+        openedAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        lastStatusAt:
+          type:
+            - string
+            - 'null'
+          format: date-time
+        inactiveReason:
+          type:
+            - string
+            - 'null'
+          enum:
+            - quarterly_cadence_missed
+            - stepped_down
+            - no_longer_critical
+            - 'null'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    StewardRecord:
+      type: object
+      required: [id, stewardshipId, userId, role, assignedAt]
+      properties:
+        id:
+          type: string
+          example: '7'
+        stewardshipId:
+          type: string
+          example: '42'
+        userId:
+          type: string
+          description: LFID of the assigned steward.
+          example: jdoe
+        role:
+          type: string
+          enum: [lead, co_steward]
+        assignedAt:
+          type: string
+          format: date-time
+        assignedBy:
+          type:
+            - string
+            - 'null'
+          description: LFID of the admin who assigned this steward.
+          example: admin-user
+
+    EscalationResolutionPath:
+      type: string
+      # TODO: confirm the 6 resolution path values with Joana (CM-1235)
+      enum:
+        - lf_staff_review
+        - community_outreach
+        - corporate_adoption
+        - transfer_ownership
+        - fork_and_maintain
+        - deprecate
+
+paths:
+  /stewardships:
+    post:
+      operationId: openStewardship
+      summary: Open a package for stewardship
+      description: >
+        Transitions the stewardship status to `open`, marking the package as available for claiming.
+        If a stewardship row does not exist yet, one is created.
+        If the stewardship is already `open`, this is a no-op (idempotent).
+      tags:
+        - Stewardship Actions
+      security:
+        - M2MBearer:
+            - write:stewardships
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [purl]
+              properties:
+                purl:
+                  type: string
+                  description: Package URL (must start with `pkg:`).
+                  example: pkg:npm/lodash
+            example:
+              purl: pkg:npm/lodash
+      responses:
+        '200':
+          description: Stewardship opened (or already open).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [stewardship]
+                properties:
+                  stewardship:
+                    $ref: '#/components/schemas/StewardshipRecord'
+              example:
+                stewardship:
+                  id: '42'
+                  packageId: '1234'
+                  status: open
+                  origin: opened_for_claim
+                  version: 1
+                  openedAt: '2026-06-15T10:00:00Z'
+                  lastStatusAt: '2026-06-15T10:00:00Z'
+                  inactiveReason: null
+                  createdAt: '2026-06-15T10:00:00Z'
+                  updatedAt: '2026-06-15T10:00:00Z'
+        '400':
+          description: Validation error (e.g. missing or invalid purl).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Insufficient scopes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Package not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /stewardships/{id}/steward:
+    put:
+      operationId: assignSteward
+      summary: Assign a steward to a stewardship
+      description: >
+        Assigns a user as a steward with the given role.
+        If the user is already an active steward, the role is updated (soft-delete + re-insert).
+        Returns the unchanged stewardship record and the full active stewards list after the operation.
+      tags:
+        - Stewardship Actions
+      security:
+        - M2MBearer:
+            - write:stewardships
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Stewardship ID.
+          example: 42
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [userId, role]
+              properties:
+                userId:
+                  type: string
+                  description: LFID of the user to assign as steward.
+                  example: jdoe
+                role:
+                  type: string
+                  enum: [lead, co_steward]
+            example:
+              userId: jdoe
+              role: lead
+      responses:
+        '200':
+          description: Steward assigned.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [stewardship, stewards]
+                properties:
+                  stewardship:
+                    $ref: '#/components/schemas/StewardshipRecord'
+                  stewards:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/StewardRecord'
+              example:
+                stewardship:
+                  id: '42'
+                  packageId: '1234'
+                  status: open
+                  origin: opened_for_claim
+                  version: 1
+                  openedAt: '2026-06-15T10:00:00Z'
+                  lastStatusAt: '2026-06-15T10:00:00Z'
+                  inactiveReason: null
+                  createdAt: '2026-06-15T10:00:00Z'
+                  updatedAt: '2026-06-15T10:00:00Z'
+                stewards:
+                  - id: '7'
+                    stewardshipId: '42'
+                    userId: jdoe
+                    role: lead
+                    assignedAt: '2026-06-15T10:05:00Z'
+                    assignedBy: admin-user
+        '400':
+          description: Validation error (e.g. invalid role).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Insufficient scopes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Stewardship not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /stewardships/{id}/escalate:
+    put:
+      operationId: escalateStewardship
+      summary: Escalate a stewardship
+      description: >
+        Transitions the stewardship to `escalated` status and logs the chosen resolution path
+        in the activity log. Optional free-text notes can be included.
+      tags:
+        - Stewardship Actions
+      security:
+        - M2MBearer:
+            - write:stewardships
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Stewardship ID.
+          example: 42
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [resolutionPath]
+              properties:
+                resolutionPath:
+                  $ref: '#/components/schemas/EscalationResolutionPath'
+                notes:
+                  type: string
+                  minLength: 1
+                  description: Optional free-text notes for the activity log.
+                  example: Contacted maintainer, no response after 30 days.
+            example:
+              resolutionPath: lf_staff_review
+              notes: Contacted maintainer, no response after 30 days.
+      responses:
+        '200':
+          description: Stewardship escalated.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [stewardship]
+                properties:
+                  stewardship:
+                    $ref: '#/components/schemas/StewardshipRecord'
+              example:
+                stewardship:
+                  id: '42'
+                  packageId: '1234'
+                  status: escalated
+                  origin: opened_for_claim
+                  version: 1
+                  openedAt: '2026-06-15T10:00:00Z'
+                  lastStatusAt: '2026-06-15T11:00:00Z'
+                  inactiveReason: null
+                  createdAt: '2026-06-15T10:00:00Z'
+                  updatedAt: '2026-06-15T11:00:00Z'
+        '400':
+          description: Validation error (e.g. invalid resolutionPath).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Insufficient scopes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Stewardship not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /stewardships/{id}/status:
+    put:
+      operationId: updateStewardshipStatus
+      summary: Update stewardship status
+      description: >
+        Updates the stewardship status and logs a `state_changed` activity entry.
+        Valid target statuses: `assessing`, `active`, `needs_attention`, `blocked`, `inactive`.
+        When transitioning to `inactive`, `inactiveReason` is required.
+      tags:
+        - Stewardship Actions
+      security:
+        - M2MBearer:
+            - write:stewardships
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Stewardship ID.
+          example: 42
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status:
+                  type: string
+                  enum:
+                    - assessing
+                    - active
+                    - needs_attention
+                    - blocked
+                    - inactive
+                inactiveReason:
+                  type: string
+                  enum:
+                    - quarterly_cadence_missed
+                    - stepped_down
+                    - no_longer_critical
+                  description: Required when `status` is `inactive`.
+                notes:
+                  type: string
+                  minLength: 1
+                  description: Optional free-text notes for the activity log.
+            examples:
+              set_active:
+                summary: Transition to active
+                value:
+                  status: active
+              set_inactive:
+                summary: Transition to inactive (inactiveReason required)
+                value:
+                  status: inactive
+                  inactiveReason: stepped_down
+                  notes: Steward stepped down voluntarily.
+              set_blocked:
+                summary: Transition to blocked
+                value:
+                  status: blocked
+                  notes: Waiting on upstream maintainer response.
+      responses:
+        '200':
+          description: Status updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [stewardship]
+                properties:
+                  stewardship:
+                    $ref: '#/components/schemas/StewardshipRecord'
+              example:
+                stewardship:
+                  id: '42'
+                  packageId: '1234'
+                  status: active
+                  origin: opened_for_claim
+                  version: 1
+                  openedAt: '2026-06-15T10:00:00Z'
+                  lastStatusAt: '2026-06-15T12:00:00Z'
+                  inactiveReason: null
+                  createdAt: '2026-06-15T10:00:00Z'
+                  updatedAt: '2026-06-15T12:00:00Z'
+        '400':
+          description: >
+            Validation error.
+            Includes the case where `status` is `inactive` but `inactiveReason` is missing.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Insufficient scopes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Stewardship not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'

--- a/backend/src/api/public/v1/stewardships/schemas.ts
+++ b/backend/src/api/public/v1/stewardships/schemas.ts
@@ -1,5 +1,0 @@
-import { z } from 'zod'
-
-export const stewardshipIdParamsSchema = z.object({
-  id: z.coerce.number().int().positive(),
-})

--- a/backend/src/api/public/v1/stewardships/schemas.ts
+++ b/backend/src/api/public/v1/stewardships/schemas.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const stewardshipIdParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})

--- a/backend/src/api/public/v1/stewardships/updateStatus.ts
+++ b/backend/src/api/public/v1/stewardships/updateStatus.ts
@@ -12,7 +12,9 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-import { stewardshipIdParamsSchema } from './schemas'
+const paramsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+})
 
 const bodySchema = z
   .object({
@@ -26,7 +28,7 @@ const bodySchema = z
   })
 
 export async function updateStatusHandler(req: Request, res: Response): Promise<void> {
-  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { id } = validateOrThrow(paramsSchema, req.params)
   const { status, inactiveReason, notes } = validateOrThrow(bodySchema, req.body)
 
   const qx = await getPackagesQx()

--- a/backend/src/api/public/v1/stewardships/updateStatus.ts
+++ b/backend/src/api/public/v1/stewardships/updateStatus.ts
@@ -1,0 +1,45 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { NotFoundError } from '@crowd/common'
+import {
+  INACTIVE_REASONS,
+  STEWARDSHIP_UPDATABLE_STATUSES,
+  updateStewardshipStatus,
+} from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { stewardshipIdParamsSchema } from './schemas'
+
+const bodySchema = z
+  .object({
+    status: z.enum(STEWARDSHIP_UPDATABLE_STATUSES),
+    inactiveReason: z.enum(INACTIVE_REASONS).optional(),
+    notes: z.string().trim().min(1).optional(),
+  })
+  .refine((d) => d.status !== 'inactive' || !!d.inactiveReason, {
+    message: 'inactiveReason is required when status is inactive',
+    path: ['inactiveReason'],
+  })
+
+export async function updateStatusHandler(req: Request, res: Response): Promise<void> {
+  const { id } = validateOrThrow(stewardshipIdParamsSchema, req.params)
+  const { status, inactiveReason, notes } = validateOrThrow(bodySchema, req.body)
+
+  const qx = await getPackagesQx()
+  const stewardship = await updateStewardshipStatus(qx, id, {
+    status,
+    inactiveReason,
+    notes,
+    actorUserId: req.actor.id,
+  })
+
+  if (!stewardship) {
+    throw new NotFoundError(`Stewardship not found: ${id}`)
+  }
+
+  ok(res, { stewardship })
+}

--- a/backend/src/osspckgs/migrations/V1781300000__stewardship-status-path-note.sql
+++ b/backend/src/osspckgs/migrations/V1781300000__stewardship-status-path-note.sql
@@ -1,0 +1,3 @@
+ALTER TABLE stewardships
+    ADD COLUMN IF NOT EXISTS resolution_path TEXT,
+    ADD COLUMN IF NOT EXISTS status_note     TEXT;

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -273,6 +273,7 @@ export interface PackageDetailRow {
   declaredRepositoryUrl: string | null
   repositoryUrl: string | null
   hasCriticalVulnerability: boolean
+  stewardshipId: string | null
   stewardshipStatus: string | null
   stewardshipLastStatusAt: Date | null
   // from package_repos + repos
@@ -315,6 +316,7 @@ export async function getPackageDetailByPurl(
       p.declared_repository_url AS "declaredRepositoryUrl",
       p.repository_url AS "repositoryUrl",
       p.has_critical_vulnerability AS "hasCriticalVulnerability",
+      s.id::text AS "stewardshipId",
       s.status AS "stewardshipStatus",
       s.last_status_at AS "stewardshipLastStatusAt",
       -- best repo link (highest confidence, prefer declared)

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -54,6 +54,7 @@ export interface PackageListRow {
   name: string
   ecosystem: string
   criticalityScore: number | null
+  stewardshipId: string | null
   stewardshipStatus: string | null
   openVulns: number
   maintainerCount: number
@@ -226,6 +227,7 @@ export async function listPackagesForApi(
       p.name,
       p.ecosystem,
       p.impact AS "criticalityScore",
+      s.id::text AS "stewardshipId",
       s.status AS "stewardshipStatus",
       COALESCE(ap_counts.cnt, 0) AS "openVulns",
       pm_counts.cnt AS "maintainerCount",

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -278,6 +278,8 @@ export interface PackageDetailRow {
   stewardshipId: string | null
   stewardshipStatus: string | null
   stewardshipLastStatusAt: Date | null
+  stewardshipResolutionPath: string | null
+  stewardshipStatusNote: string | null
   // from package_repos + repos
   repoUrl: string | null
   repoMappingConfidence: number | null
@@ -321,6 +323,8 @@ export async function getPackageDetailByPurl(
       s.id::text AS "stewardshipId",
       s.status AS "stewardshipStatus",
       s.last_status_at AS "stewardshipLastStatusAt",
+      s.resolution_path AS "stewardshipResolutionPath",
+      s.status_note AS "stewardshipStatusNote",
       -- best repo link (highest confidence, prefer declared)
       r.url AS "repoUrl",
       pr.confidence AS "repoMappingConfidence",

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -9,6 +9,8 @@ export interface StewardshipRecord {
   openedAt: string | null
   lastStatusAt: string | null
   inactiveReason: string | null
+  resolutionPath: string | null
+  statusNote: string | null
   createdAt: string
   updatedAt: string
 }
@@ -17,6 +19,7 @@ export interface StewardshipStewardRecord {
   id: string
   stewardshipId: string
   userId: string
+  name: string | null
   role: string
   assignedAt: string
   assignedBy: string | null
@@ -89,6 +92,7 @@ function mapStewardStewardRow(row: Record<string, unknown>): StewardshipStewardR
     id: String(row.id),
     stewardshipId: String(row.stewardship_id),
     userId: String(row.user_id),
+    name: null,
     role: String(row.role),
     assignedAt: toIso(row.assigned_at),
     assignedBy: row.assigned_by ? String(row.assigned_by) : null,
@@ -105,6 +109,8 @@ function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
     openedAt: row.opened_at ? toIso(row.opened_at) : null,
     lastStatusAt: row.last_status_at ? toIso(row.last_status_at) : null,
     inactiveReason: row.inactive_reason ? String(row.inactive_reason) : null,
+    resolutionPath: row.resolution_path ? String(row.resolution_path) : null,
+    statusNote: row.status_note ? String(row.status_note) : null,
     createdAt: toIso(row.created_at),
     updatedAt: toIso(row.updated_at),
   }
@@ -116,7 +122,7 @@ export async function getStewardshipById(
 ): Promise<StewardshipRecord | null> {
   const row: Record<string, unknown> | null = await qx.selectOneOrNone(
     `SELECT id, package_id, status, origin, version, opened_at, last_status_at,
-            inactive_reason, created_at, updated_at
+            inactive_reason, resolution_path, status_note, created_at, updated_at
      FROM stewardships
      WHERE id = $(id)`,
     { id },
@@ -151,12 +157,14 @@ export async function openStewardshipByPurl(
       FROM pkg
       ON CONFLICT (package_id) DO UPDATE
         SET status          = 'open',
-            opened_at       = COALESCE(stewardships.opened_at, NOW()),
+            opened_at       = NOW(),
             last_status_at  = NOW(),
             inactive_reason = NULL,
+            resolution_path = NULL,
+            status_note     = NULL,
             updated_at      = NOW()
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity (stewardship_id, actor_user_id, actor_type, activity_type, content)
@@ -319,10 +327,12 @@ export async function escalateStewardship(
       SET status          = 'escalated',
           last_status_at  = NOW(),
           inactive_reason = NULL,
+          resolution_path = $(resolutionPath),
+          status_note     = $(statusNote),
           updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity
@@ -335,6 +345,8 @@ export async function escalateStewardship(
     `,
     {
       stewardshipId,
+      resolutionPath: data.resolutionPath,
+      statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
       content: `Escalated with resolution path: ${data.resolutionPath}`,
       metadata: JSON.stringify({
@@ -384,11 +396,13 @@ export async function updateStewardshipStatus(
       UPDATE stewardships
       SET status          = $(status),
           last_status_at  = NOW(),
-          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE NULL END,
+          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE inactive_reason END,
+          resolution_path = NULL,
+          status_note     = $(statusNote),
           updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity
@@ -403,6 +417,7 @@ export async function updateStewardshipStatus(
       stewardshipId,
       status: data.status,
       inactiveReason: data.inactiveReason ?? null,
+      statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
       content: `Status updated to ${data.status}`,
       metadata: JSON.stringify({

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -225,6 +225,45 @@ export async function assignSteward(
   })
 }
 
+export interface StewardshipSummary {
+  stewards: StewardshipStewardRecord[]
+  lastActivityAt: string | null
+}
+
+export async function getStewardshipSummary(
+  qx: QueryExecutor,
+  stewardshipId: string,
+): Promise<StewardshipSummary> {
+  const [stewards, activityRow] = await Promise.all([
+    qx.select(
+      `SELECT id, stewardship_id, user_id, role, assigned_at, assigned_by
+       FROM stewardship_stewards
+       WHERE stewardship_id = $(stewardshipId)
+         AND deleted_at IS NULL
+       ORDER BY assigned_at ASC`,
+      { stewardshipId },
+    ) as Promise<Array<Record<string, unknown>>>,
+    qx.selectOneOrNone(
+      `SELECT MAX(created_at) AS last_activity_at
+       FROM stewardship_activity
+       WHERE stewardship_id = $(stewardshipId)`,
+      { stewardshipId },
+    ) as Promise<Record<string, unknown> | null>,
+  ])
+
+  return {
+    stewards: stewards.map((s) => ({
+      id: String(s.id),
+      stewardshipId: String(s.stewardship_id),
+      userId: String(s.user_id),
+      role: String(s.role),
+      assignedAt: toIso(s.assigned_at),
+      assignedBy: s.assigned_by ? String(s.assigned_by) : null,
+    })),
+    lastActivityAt: activityRow?.last_activity_at ? toIso(activityRow.last_activity_at) : null,
+  }
+}
+
 export const ESCALATION_RESOLUTION_PATHS = [
   'lf_staff_review',
   'community_outreach',

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -261,14 +261,13 @@ export async function getStewardshipSummary(
   }
 }
 
-// TODO: confirm the 6 resolution path values with Joana (CM-1235 ticket says "6 paths" but doesn't define them)
 export const ESCALATION_RESOLUTION_PATHS = [
-  'lf_staff_review',
-  'community_outreach',
-  'corporate_adoption',
-  'transfer_ownership',
-  'fork_and_maintain',
-  'deprecate',
+  'right_of_first_refusal',
+  'replace_the_dependency',
+  'find_vendor_for_lts',
+  'consortium_adopts_maintainership',
+  'compensating_controls_monitor',
+  'namespace_takeover',
 ] as const
 
 export type EscalationResolutionPath = (typeof ESCALATION_RESOLUTION_PATHS)[number]

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -80,6 +80,10 @@ export async function insertUnassignedStewardships(
   return parseInt(result.count, 10)
 }
 
+function toIso(v: unknown): string {
+  return v instanceof Date ? v.toISOString() : String(v)
+}
+
 function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
   return {
     id: String(row.id),
@@ -87,11 +91,11 @@ function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
     status: row.status as string,
     origin: row.origin as string,
     version: Number(row.version),
-    openedAt: row.opened_at ? String(row.opened_at) : null,
-    lastStatusAt: row.last_status_at ? String(row.last_status_at) : null,
+    openedAt: row.opened_at ? toIso(row.opened_at) : null,
+    lastStatusAt: row.last_status_at ? toIso(row.last_status_at) : null,
     inactiveReason: row.inactive_reason ? String(row.inactive_reason) : null,
-    createdAt: String(row.created_at),
-    updatedAt: String(row.updated_at),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
   }
 }
 
@@ -159,7 +163,8 @@ export async function openStewardshipByPurl(
 /**
  * Assigns a steward to a stewardship. Soft-deletes any existing active entry
  * for the same user (allowing role changes). Logs a steward_added activity.
- * Returns the updated stewardship row and the full active stewards list.
+ * Returns the stewardship row (unchanged by this operation) and the full
+ * active stewards list as of the end of the transaction.
  */
 export async function assignSteward(
   qx: QueryExecutor,
@@ -213,7 +218,7 @@ export async function assignSteward(
         stewardshipId: String(s.stewardship_id),
         userId: String(s.user_id),
         role: String(s.role),
-        assignedAt: String(s.assigned_at),
+        assignedAt: toIso(s.assigned_at),
         assignedBy: s.assigned_by ? String(s.assigned_by) : null,
       })),
     }
@@ -300,11 +305,14 @@ export async function updateStewardshipStatus(
   stewardshipId: number,
   data: {
     status: UpdatableStewardshipStatus
-    inactiveReason?: string
+    inactiveReason?: InactiveReason
     notes?: string
     actorUserId: string
   },
 ): Promise<StewardshipRecord | null> {
+  if (data.status === 'inactive' && !data.inactiveReason) {
+    throw new Error('inactiveReason is required when setting status to inactive')
+  }
   const row: Record<string, unknown> | null = await qx.selectOneOrNone(
     `
     WITH upd AS (

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -1,5 +1,27 @@
 import { QueryExecutor } from '../queryExecutor'
 
+export interface StewardshipRecord {
+  id: string
+  packageId: string
+  status: string
+  origin: string
+  version: number
+  openedAt: string | null
+  lastStatusAt: string | null
+  inactiveReason: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface StewardshipStewardRecord {
+  id: string
+  stewardshipId: string
+  userId: string
+  role: string
+  assignedAt: string
+  assignedBy: string | null
+}
+
 /**
  * Returns a page of critical package ids that do not yet have a stewardship row,
  * ordered by id ascending. Used as the cursor-based pagination source for the
@@ -56,4 +78,259 @@ export async function insertUnassignedStewardships(
     { packageIds },
   )
   return parseInt(result.count, 10)
+}
+
+function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
+  return {
+    id: String(row.id),
+    packageId: String(row.package_id),
+    status: row.status as string,
+    origin: row.origin as string,
+    version: Number(row.version),
+    openedAt: row.opened_at ? String(row.opened_at) : null,
+    lastStatusAt: row.last_status_at ? String(row.last_status_at) : null,
+    inactiveReason: row.inactive_reason ? String(row.inactive_reason) : null,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  }
+}
+
+export async function getStewardshipById(
+  qx: QueryExecutor,
+  id: number,
+): Promise<StewardshipRecord | null> {
+  const row: Record<string, unknown> | null = await qx.selectOneOrNone(
+    `SELECT id, package_id, status, origin, version, opened_at, last_status_at,
+            inactive_reason, created_at, updated_at
+     FROM stewardships
+     WHERE id = $(id)`,
+    { id },
+  )
+  return row ? mapStewardshipRow(row) : null
+}
+
+/**
+ * Opens a package for stewardship (status → 'open').
+ * If a stewardship row already exists, updates the status to 'open'.
+ * If none exists, creates one with origin 'opened_for_claim'.
+ * Returns the upserted stewardship row, or null if the package purl is not found.
+ */
+export async function openStewardshipByPurl(
+  qx: QueryExecutor,
+  purl: string,
+  actorUserId: string,
+): Promise<StewardshipRecord | null> {
+  const row: Record<string, unknown> | null = await qx.selectOneOrNone(
+    `
+    WITH pkg AS (
+      SELECT id FROM packages WHERE purl = $(purl) LIMIT 1
+    ),
+    upserted AS (
+      INSERT INTO stewardships (package_id, status, origin, opened_at, last_status_at)
+      SELECT id, 'open', 'opened_for_claim', NOW(), NOW()
+      FROM pkg
+      ON CONFLICT (package_id) DO UPDATE
+        SET status        = 'open',
+            opened_at     = COALESCE(stewardships.opened_at, NOW()),
+            last_status_at = NOW(),
+            updated_at    = NOW()
+      RETURNING id, package_id, status, origin, version, opened_at,
+                last_status_at, inactive_reason, created_at, updated_at
+    ),
+    _log AS (
+      INSERT INTO stewardship_activity (stewardship_id, actor_user_id, actor_type, activity_type, content)
+      SELECT id, $(actorUserId), 'user', 'state_changed', 'Opened for stewardship'
+      FROM upserted
+    )
+    SELECT * FROM upserted
+    `,
+    { purl, actorUserId },
+  )
+  return row ? mapStewardshipRow(row) : null
+}
+
+/**
+ * Assigns a steward to a stewardship. Soft-deletes any existing active entry
+ * for the same user (allowing role changes). Logs a steward_added activity.
+ * Returns the updated stewardship row and the full active stewards list.
+ */
+export async function assignSteward(
+  qx: QueryExecutor,
+  stewardshipId: number,
+  data: { userId: string; role: 'lead' | 'co_steward'; assignedBy: string },
+): Promise<{ stewardship: StewardshipRecord; stewards: StewardshipStewardRecord[] } | null> {
+  return qx.tx(async (tx) => {
+    const stewardship = await getStewardshipById(tx, stewardshipId)
+    if (!stewardship) return null
+
+    // Soft-delete existing active entry for this user (handles role changes).
+    await tx.result(
+      `UPDATE stewardship_stewards
+       SET deleted_at = NOW()
+       WHERE stewardship_id = $(stewardshipId)
+         AND user_id = $(userId)
+         AND deleted_at IS NULL`,
+      { stewardshipId, userId: data.userId },
+    )
+
+    await tx.result(
+      `INSERT INTO stewardship_stewards (stewardship_id, user_id, role, assigned_by)
+       VALUES ($(stewardshipId), $(userId), $(role), $(assignedBy))`,
+      { stewardshipId, userId: data.userId, role: data.role, assignedBy: data.assignedBy },
+    )
+
+    await tx.result(
+      `INSERT INTO stewardship_activity (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata)
+       VALUES ($(stewardshipId), $(actorUserId), 'user', 'steward_added', $(content), $(metadata)::jsonb)`,
+      {
+        stewardshipId,
+        actorUserId: data.assignedBy,
+        content: `Assigned steward ${data.userId} as ${data.role}`,
+        metadata: JSON.stringify({ userId: data.userId, role: data.role }),
+      },
+    )
+
+    const stewards: Array<Record<string, unknown>> = await tx.select(
+      `SELECT id, stewardship_id, user_id, role, assigned_at, assigned_by
+       FROM stewardship_stewards
+       WHERE stewardship_id = $(stewardshipId)
+         AND deleted_at IS NULL
+       ORDER BY assigned_at ASC`,
+      { stewardshipId },
+    )
+
+    return {
+      stewardship,
+      stewards: stewards.map((s) => ({
+        id: String(s.id),
+        stewardshipId: String(s.stewardship_id),
+        userId: String(s.user_id),
+        role: String(s.role),
+        assignedAt: String(s.assigned_at),
+        assignedBy: s.assigned_by ? String(s.assigned_by) : null,
+      })),
+    }
+  })
+}
+
+export const ESCALATION_RESOLUTION_PATHS = [
+  'lf_staff_review',
+  'community_outreach',
+  'corporate_adoption',
+  'transfer_ownership',
+  'fork_and_maintain',
+  'deprecate',
+] as const
+
+export type EscalationResolutionPath = (typeof ESCALATION_RESOLUTION_PATHS)[number]
+
+/**
+ * Escalates a stewardship. Updates status to 'escalated' and logs the
+ * chosen resolution path in stewardship_activity metadata.
+ */
+export async function escalateStewardship(
+  qx: QueryExecutor,
+  stewardshipId: number,
+  data: { resolutionPath: EscalationResolutionPath; notes?: string; actorUserId: string },
+): Promise<StewardshipRecord | null> {
+  const row: Record<string, unknown> | null = await qx.selectOneOrNone(
+    `
+    WITH upd AS (
+      UPDATE stewardships
+      SET status         = 'escalated',
+          last_status_at = NOW(),
+          updated_at     = NOW()
+      WHERE id = $(stewardshipId)
+      RETURNING id, package_id, status, origin, version, opened_at,
+                last_status_at, inactive_reason, created_at, updated_at
+    ),
+    _log AS (
+      INSERT INTO stewardship_activity
+        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata)
+      SELECT id, $(actorUserId), 'user', 'escalation',
+             $(content), $(metadata)::jsonb
+      FROM upd
+    )
+    SELECT * FROM upd
+    `,
+    {
+      stewardshipId,
+      actorUserId: data.actorUserId,
+      content: `Escalated with resolution path: ${data.resolutionPath}`,
+      metadata: JSON.stringify({
+        resolutionPath: data.resolutionPath,
+        ...(data.notes ? { notes: data.notes } : {}),
+      }),
+    },
+  )
+  return row ? mapStewardshipRow(row) : null
+}
+
+export const INACTIVE_REASONS = [
+  'quarterly_cadence_missed',
+  'stepped_down',
+  'no_longer_critical',
+] as const
+
+export type InactiveReason = (typeof INACTIVE_REASONS)[number]
+
+export const STEWARDSHIP_UPDATABLE_STATUSES = [
+  'assessing',
+  'active',
+  'needs_attention',
+  'blocked',
+  'inactive',
+] as const
+
+export type UpdatableStewardshipStatus = (typeof STEWARDSHIP_UPDATABLE_STATUSES)[number]
+
+/**
+ * Updates the status of a stewardship and logs the change.
+ * For 'inactive', an inactiveReason must be provided.
+ */
+export async function updateStewardshipStatus(
+  qx: QueryExecutor,
+  stewardshipId: number,
+  data: {
+    status: UpdatableStewardshipStatus
+    inactiveReason?: string
+    notes?: string
+    actorUserId: string
+  },
+): Promise<StewardshipRecord | null> {
+  const row: Record<string, unknown> | null = await qx.selectOneOrNone(
+    `
+    WITH upd AS (
+      UPDATE stewardships
+      SET status          = $(status),
+          last_status_at  = NOW(),
+          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE inactive_reason END,
+          updated_at      = NOW()
+      WHERE id = $(stewardshipId)
+      RETURNING id, package_id, status, origin, version, opened_at,
+                last_status_at, inactive_reason, created_at, updated_at
+    ),
+    _log AS (
+      INSERT INTO stewardship_activity
+        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata)
+      SELECT id, $(actorUserId), 'user', 'state_changed',
+             $(content), $(metadata)::jsonb
+      FROM upd
+    )
+    SELECT * FROM upd
+    `,
+    {
+      stewardshipId,
+      status: data.status,
+      inactiveReason: data.inactiveReason ?? null,
+      actorUserId: data.actorUserId,
+      content: `Status updated to ${data.status}`,
+      metadata: JSON.stringify({
+        status: data.status,
+        ...(data.inactiveReason ? { inactiveReason: data.inactiveReason } : {}),
+        ...(data.notes ? { notes: data.notes } : {}),
+      }),
+    },
+  )
+  return row ? mapStewardshipRow(row) : null
 }

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -125,22 +125,29 @@ export async function openStewardshipByPurl(
     WITH pkg AS (
       SELECT id FROM packages WHERE purl = $(purl) LIMIT 1
     ),
+    prev AS (
+      SELECT s.status AS old_status
+      FROM stewardships s
+      WHERE s.package_id = (SELECT id FROM pkg)
+    ),
     upserted AS (
       INSERT INTO stewardships (package_id, status, origin, opened_at, last_status_at)
       SELECT id, 'open', 'opened_for_claim', NOW(), NOW()
       FROM pkg
       ON CONFLICT (package_id) DO UPDATE
-        SET status        = 'open',
-            opened_at     = COALESCE(stewardships.opened_at, NOW()),
-            last_status_at = NOW(),
-            updated_at    = NOW()
+        SET status          = 'open',
+            opened_at       = COALESCE(stewardships.opened_at, NOW()),
+            last_status_at  = NOW(),
+            inactive_reason = NULL,
+            updated_at      = NOW()
       RETURNING id, package_id, status, origin, version, opened_at,
                 last_status_at, inactive_reason, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity (stewardship_id, actor_user_id, actor_type, activity_type, content)
-      SELECT id, $(actorUserId), 'user', 'state_changed', 'Opened for stewardship'
+      SELECT upserted.id, $(actorUserId), 'user', 'state_changed', 'Opened for stewardship'
       FROM upserted
+      WHERE NOT EXISTS (SELECT 1 FROM prev WHERE prev.old_status = 'open')
     )
     SELECT * FROM upserted
     `,

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -180,7 +180,7 @@ export async function openStewardshipByPurl(
 export async function assignSteward(
   qx: QueryExecutor,
   stewardshipId: number,
-  data: { userId: string; role: 'lead' | 'co_steward'; assignedBy: string },
+  data: { userId: string; role: 'lead' | 'co_steward'; assignedBy: string; moveToAssessing?: boolean },
 ): Promise<{ stewardship: StewardshipRecord; stewards: StewardshipStewardRecord[] } | null> {
   return qx.tx(async (tx) => {
     const stewardship = await getStewardshipById(tx, stewardshipId)
@@ -213,6 +213,37 @@ export async function assignSteward(
       },
     )
 
+    let finalStewardship = stewardship
+
+    if (data.moveToAssessing) {
+      const updated: Record<string, unknown> | null = await tx.selectOneOrNone(
+        `
+        WITH upd AS (
+          UPDATE stewardships
+          SET status         = 'assessing',
+              last_status_at = NOW(),
+              resolution_path = NULL,
+              status_note     = NULL,
+              updated_at     = NOW()
+          WHERE id = $(stewardshipId)
+            AND status IN ('unassigned', 'open')
+          RETURNING id, package_id, status, origin, version, opened_at,
+                    last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
+        ),
+        _log AS (
+          INSERT INTO stewardship_activity
+            (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata)
+          SELECT id, $(actorUserId), 'user', 'state_changed',
+                 'Status updated to assessing', $(metadata)::jsonb
+          FROM upd
+        )
+        SELECT * FROM upd
+        `,
+        { stewardshipId, actorUserId: data.assignedBy, metadata: JSON.stringify({ status: 'assessing' }) },
+      )
+      if (updated) finalStewardship = mapStewardshipRow(updated)
+    }
+
     const stewards: Array<Record<string, unknown>> = await tx.select(
       `SELECT id, stewardship_id, user_id, role, assigned_at, assigned_by
        FROM stewardship_stewards
@@ -223,7 +254,7 @@ export async function assignSteward(
     )
 
     return {
-      stewardship,
+      stewardship: finalStewardship,
       stewards: stewards.map(mapStewardStewardRow),
     }
   })

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -84,6 +84,17 @@ function toIso(v: unknown): string {
   return v instanceof Date ? v.toISOString() : String(v)
 }
 
+function mapStewardStewardRow(row: Record<string, unknown>): StewardshipStewardRecord {
+  return {
+    id: String(row.id),
+    stewardshipId: String(row.stewardship_id),
+    userId: String(row.user_id),
+    role: String(row.role),
+    assignedAt: toIso(row.assigned_at),
+    assignedBy: row.assigned_by ? String(row.assigned_by) : null,
+  }
+}
+
 function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
   return {
     id: String(row.id),
@@ -213,14 +224,7 @@ export async function assignSteward(
 
     return {
       stewardship,
-      stewards: stewards.map((s) => ({
-        id: String(s.id),
-        stewardshipId: String(s.stewardship_id),
-        userId: String(s.user_id),
-        role: String(s.role),
-        assignedAt: toIso(s.assigned_at),
-        assignedBy: s.assigned_by ? String(s.assigned_by) : null,
-      })),
+      stewards: stewards.map(mapStewardStewardRow),
     }
   })
 }
@@ -232,7 +236,7 @@ export interface StewardshipSummary {
 
 export async function getStewardshipSummary(
   qx: QueryExecutor,
-  stewardshipId: string,
+  stewardshipId: number,
 ): Promise<StewardshipSummary> {
   const [stewards, activityRow] = await Promise.all([
     qx.select(
@@ -252,18 +256,12 @@ export async function getStewardshipSummary(
   ])
 
   return {
-    stewards: stewards.map((s) => ({
-      id: String(s.id),
-      stewardshipId: String(s.stewardship_id),
-      userId: String(s.user_id),
-      role: String(s.role),
-      assignedAt: toIso(s.assigned_at),
-      assignedBy: s.assigned_by ? String(s.assigned_by) : null,
-    })),
+    stewards: stewards.map(mapStewardStewardRow),
     lastActivityAt: activityRow?.last_activity_at ? toIso(activityRow.last_activity_at) : null,
   }
 }
 
+// TODO: confirm the 6 resolution path values with Joana (CM-1235 ticket says "6 paths" but doesn't define them)
 export const ESCALATION_RESOLUTION_PATHS = [
   'lf_staff_review',
   'community_outreach',
@@ -288,9 +286,10 @@ export async function escalateStewardship(
     `
     WITH upd AS (
       UPDATE stewardships
-      SET status         = 'escalated',
-          last_status_at = NOW(),
-          updated_at     = NOW()
+      SET status          = 'escalated',
+          last_status_at  = NOW(),
+          inactive_reason = NULL,
+          updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,
                 last_status_at, inactive_reason, created_at, updated_at
@@ -349,16 +348,13 @@ export async function updateStewardshipStatus(
     actorUserId: string
   },
 ): Promise<StewardshipRecord | null> {
-  if (data.status === 'inactive' && !data.inactiveReason) {
-    throw new Error('inactiveReason is required when setting status to inactive')
-  }
   const row: Record<string, unknown> | null = await qx.selectOneOrNone(
     `
     WITH upd AS (
       UPDATE stewardships
       SET status          = $(status),
           last_status_at  = NOW(),
-          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE inactive_reason END,
+          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE NULL END,
           updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -188,7 +188,12 @@ export async function openStewardshipByPurl(
 export async function assignSteward(
   qx: QueryExecutor,
   stewardshipId: number,
-  data: { userId: string; role: 'lead' | 'co_steward'; assignedBy: string; moveToAssessing?: boolean },
+  data: {
+    userId: string
+    role: 'lead' | 'co_steward'
+    assignedBy: string
+    moveToAssessing?: boolean
+  },
 ): Promise<{ stewardship: StewardshipRecord; stewards: StewardshipStewardRecord[] } | null> {
   return qx.tx(async (tx) => {
     const stewardship = await getStewardshipById(tx, stewardshipId)
@@ -247,7 +252,11 @@ export async function assignSteward(
         )
         SELECT * FROM upd
         `,
-        { stewardshipId, actorUserId: data.assignedBy, metadata: JSON.stringify({ status: 'assessing' }) },
+        {
+          stewardshipId,
+          actorUserId: data.assignedBy,
+          metadata: JSON.stringify({ status: 'assessing' }),
+        },
       )
       if (updated) finalStewardship = mapStewardshipRow(updated)
     }


### PR DESCRIPTION
## Summary

Expose four admin-facing endpoints to support stewardship lifecycle management in the OSSPREY Program dashboard. Admins can now open a package for stewardship, assign individual stewards, escalate with a structured resolution path, and update stewardship status — all with audit logging to `stewardship_activity`.

## Changes

- **`POST /api/public/v1/stewardships`** — opens a package for stewardship (upserts status → `open`); body takes a PURL, normalised before DB lookup
- **`PUT /api/public/v1/stewardships/:id/steward`** — assigns a steward (`lead` or `co_steward`) via soft-delete + insert pattern; entire operation is wrapped in a transaction to keep the audit log consistent
- **`PUT /api/public/v1/stewardships/:id/escalate`** — sets status → `escalated` and records one of 6 resolution paths in `stewardship_activity` metadata
- **`PUT /api/public/v1/stewardships/:id/status`** — updates stewardship status (`assessing`, `active`, `needs_attention`, `blocked`, `inactive`); `inactiveReason` is required when setting `inactive` and is preserved on other transitions (not overwritten to null)
- **DAL (`stewardships.ts`)** — added `getStewardshipById`, `openStewardshipByPurl`, `assignSteward`, `escalateStewardship`, `updateStewardshipStatus`; exported `ESCALATION_RESOLUTION_PATHS`, `INACTIVE_REASONS`, and `STEWARDSHIP_UPDATABLE_STATUSES` as shared constants
- **Auth0 scope checks** commented out with `TODO` following the same pattern as existing packages endpoints (restore once `write:stewardships` is provisioned on the Auth0 staging tenant)

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[ticket](https://linuxfoundation.atlassian.net/browse/CM-1235)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces authenticated admin mutations that change stewardship state and steward assignments with scope enforcement temporarily disabled; incorrect transitions or missing authorization could affect program-critical package stewardship data.
> 
> **Overview**
> Adds **write** stewardship admin APIs under `/api/v1/stewardships`: open by PURL, assign stewards (optional atomic move to `assessing`), escalate with a resolution path, and update status (with required `inactiveReason` for `inactive`). Handlers delegate to new DAL mutations that upsert/update `stewardships`, manage `stewardship_stewards`, and append `stewardship_activity` audit rows.
> 
> **Read paths** now surface real stewardship data instead of v1 placeholders: package list/detail include `stewardshipId`, stewards, `lastActivityAt`, `resolutionPath`, and `statusNote` (detail loads stewards/activity via `getStewardshipSummary`). OpenAPI is updated accordingly; steward `userId` is documented as Auth0 sub.
> 
> A migration adds `stewardships.resolution_path` and `status_note`. `write:stewardships` scope checks are **commented out** (same temporary pattern as packages) until Auth0 staging is provisioned (CM-1235).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bf574dc80812345f58a0749b8963e27d6b7ef03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->