### PR TITLE
fix: privateer binary version compatibility with pvtr-github-repo-scanner v0.23.2 (IN-1170)

### DIFF
--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -2,7 +2,7 @@ FROM alpine:3.21 AS core
 RUN apk add --no-cache wget tar unzip
 
 WORKDIR /app
-ARG VERSION=0.7.0
+ARG VERSION=0.21.2
 ARG PLATFORM=Linux_x86_64
 
 RUN wget https://github.com/privateerproj/privateer/releases/download/v${VERSION}/privateer_${PLATFORM}.tar.gz

--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -36,6 +36,7 @@ RUN mkdir -p /.privateer/bin
 WORKDIR /.privateer/bin
 COPY --from=core /app/pvtr ./privateer
 COPY --from=plugin /plugin/github-repo /root/.privateer/bin/github-repo
+RUN echo '{"plugins":[{"name":"github-repo","version":"v0.23.2","binaryPath":"github-repo"}]}' > /root/.privateer/bin/plugins.json
 COPY ./services/apps/security_best_practices_worker/example-config.yml /.privateer/example-config.yml
 
 WORKDIR /usr/crowd/app

--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -34,7 +34,7 @@ FROM node:20-bookworm-slim as runner
 
 RUN mkdir -p /.privateer/bin
 WORKDIR /.privateer/bin
-COPY --from=core /app/privateer .
+COPY --from=core /app/pvtr ./privateer
 COPY --from=plugin /plugin/github-repo /root/.privateer/bin/github-repo
 COPY ./services/apps/security_best_practices_worker/example-config.yml /.privateer/example-config.yml
 

--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -1,3 +1,5 @@
+ARG PVTR_VERSION=v0.23.2
+
 FROM alpine:3.21 AS core
 RUN apk add --no-cache wget tar unzip
 
@@ -12,7 +14,7 @@ FROM golang:1.26.3-alpine3.23 AS plugin
 RUN apk add --no-cache make git
 WORKDIR /plugin
 ARG PVTR_COMMIT=c7bd9538d64f7eaab94a05c9b5fd05458a387b1c
-ARG PVTR_VERSION=v0.23.2
+ARG PVTR_VERSION
 # To run the latest version of the plugin, we need to use the latest commit of the pvtr-github-repo-scanner repository.
 # Currently using v0.23.2: https://github.com/ossf/pvtr-github-repo-scanner/commit/c7bd9538d64f7eaab94a05c9b5fd05458a387b1c
 RUN git clone https://github.com/ossf/pvtr-github-repo-scanner.git && cd pvtr-github-repo-scanner && git checkout ${PVTR_COMMIT}
@@ -36,7 +38,7 @@ FROM node:20-bookworm-slim as runner
 RUN mkdir -p /.privateer/bin
 WORKDIR /.privateer/bin
 COPY --from=core /app/pvtr ./privateer
-ARG PVTR_VERSION=v0.23.2
+ARG PVTR_VERSION
 COPY --from=plugin /plugin/github-repo /root/.privateer/bin/github-repo
 RUN echo "{\"plugins\":[{\"name\":\"github-repo\",\"version\":\"${PVTR_VERSION}\",\"binaryPath\":\"github-repo\"}]}" > /root/.privateer/bin/plugins.json
 COPY ./services/apps/security_best_practices_worker/example-config.yml /.privateer/example-config.yml

--- a/scripts/services/docker/Dockerfile.security_best_practices_worker
+++ b/scripts/services/docker/Dockerfile.security_best_practices_worker
@@ -12,6 +12,7 @@ FROM golang:1.26.3-alpine3.23 AS plugin
 RUN apk add --no-cache make git
 WORKDIR /plugin
 ARG PVTR_COMMIT=c7bd9538d64f7eaab94a05c9b5fd05458a387b1c
+ARG PVTR_VERSION=v0.23.2
 # To run the latest version of the plugin, we need to use the latest commit of the pvtr-github-repo-scanner repository.
 # Currently using v0.23.2: https://github.com/ossf/pvtr-github-repo-scanner/commit/c7bd9538d64f7eaab94a05c9b5fd05458a387b1c
 RUN git clone https://github.com/ossf/pvtr-github-repo-scanner.git && cd pvtr-github-repo-scanner && git checkout ${PVTR_COMMIT}
@@ -35,8 +36,9 @@ FROM node:20-bookworm-slim as runner
 RUN mkdir -p /.privateer/bin
 WORKDIR /.privateer/bin
 COPY --from=core /app/pvtr ./privateer
+ARG PVTR_VERSION=v0.23.2
 COPY --from=plugin /plugin/github-repo /root/.privateer/bin/github-repo
-RUN echo '{"plugins":[{"name":"github-repo","version":"v0.23.2","binaryPath":"github-repo"}]}' > /root/.privateer/bin/plugins.json
+RUN echo "{\"plugins\":[{\"name\":\"github-repo\",\"version\":\"${PVTR_VERSION}\",\"binaryPath\":\"github-repo\"}]}" > /root/.privateer/bin/plugins.json
 COPY ./services/apps/security_best_practices_worker/example-config.yml /.privateer/example-config.yml
 
 WORKDIR /usr/crowd/app

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -132,6 +132,9 @@ export async function saveOSPSBaselineInsightsToDB(
 
     const controlEvaluation = await findSuiteControlEvaluation(qx, repo.repoUrl, controlId, suite.id)
     for (const assessment of evaluation['assessment-logs']) {
+      const runDuration = assessment.end
+        ? `${new Date(assessment.end).getTime() - new Date(assessment.start).getTime()}ms`
+        : ''
       await addControlEvaluationAssessment(qx, {
         applicability: assessment.applicability,
         description: assessment.description,
@@ -141,7 +144,7 @@ export async function saveOSPSBaselineInsightsToDB(
         insightsProjectSlug: repo.insightsProjectSlug,
         requirementId: assessment.requirement['entry-id'],
         result: assessment.result,
-        runDuration: '',
+        runDuration,
         steps: assessment.steps,
         stepsExecuted: assessment['steps-executed'] || 0,
         securityInsightsEvaluationId: controlEvaluation.id,

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -150,9 +150,7 @@ export async function saveOSPSBaselineInsightsToDB(
       )
     }
     for (const assessment of evaluation['assessment-logs']) {
-      const runDuration = assessment.end
-        ? `${new Date(assessment.end).getTime() - new Date(assessment.start).getTime()}ms`
-        : ''
+      const runDuration = computeRunDuration(assessment.start, assessment.end)
       await addControlEvaluationAssessment(qx, {
         applicability: assessment.applicability,
         description: assessment.description,
@@ -191,6 +189,14 @@ export async function saveOSPSBaselineInsightsToRedis(
 ): Promise<void> {
   const redisCache = new RedisCache(`osps-baseline-insights`, svc.redis, svc.log)
   await redisCache.set(key, JSON.stringify(insights), 60 * 60 * 24) // 1 day
+}
+
+function computeRunDuration(start: string | undefined, end: string | undefined): string {
+  if (!start || !end) return ''
+  const startMs = new Date(start).getTime()
+  const endMs = new Date(end).getTime()
+  if (isNaN(startMs) || isNaN(endMs) || endMs < startMs) return ''
+  return `${endMs - startMs}ms`
 }
 
 async function cleanupFiles(repoName: string): Promise<void> {
@@ -247,11 +253,13 @@ async function runBinary(
         resolve({ stdout, stderr })
       } else {
         const truncated = (s: string) => (s.length > 500 ? s.slice(0, 500) + '…' : s)
+        const truncStdout = truncated(stdout)
+        const truncStderr = truncated(stderr)
         const err = Object.assign(
           new Error(
-            `Binary exited with code ${code}\nStderr:\n${truncated(stderr)}\nStdout:\n${truncated(stdout)}`,
+            `Binary exited with code ${code}\nStderr:\n${truncStderr}\nStdout:\n${truncStdout}`,
           ),
-          { stdout, stderr },
+          { stdout: truncStdout, stderr: truncStderr },
         )
         reject(err)
       }

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -97,7 +97,9 @@ export async function saveOSPSBaselineInsightsToDB(
   const redisCache = new RedisCache(`osps-baseline-insights`, svc.redis, svc.log)
   const result = await redisCache.get(key)
   const parsedResult: ISecurityInsightsPrivateerResult = JSON.parse(result)
-  const evaluationSuite = parsedResult.evaluation_suites.find((s) => s.catalog_id === CATALOG_ID)
+  const evaluationSuite = parsedResult['evaluation-suites'].find(
+    (s) => s['catalog-id'] === CATALOG_ID,
+  )
 
   const qx = pgpQx(svc.postgres.writer.connection())
 
@@ -105,35 +107,31 @@ export async function saveOSPSBaselineInsightsToDB(
     repo: repo.repoUrl,
     insightsProjectId: repo.insightsProjectId,
     insightsProjectSlug: repo.insightsProjectSlug,
-    catalogId: evaluationSuite.catalog_id,
+    catalogId: evaluationSuite['catalog-id'],
     name: evaluationSuite.name,
     result: evaluationSuite.result,
-    corruptedState: evaluationSuite.corrupted_state,
+    corruptedState: evaluationSuite['corrupted-state'],
   })
 
-  const suite = await findEvaluationSuite(qx, repo.repoUrl, evaluationSuite.catalog_id)
+  const suite = await findEvaluationSuite(qx, repo.repoUrl, evaluationSuite['catalog-id'])
 
-  for (const evaluation of evaluationSuite.control_evaluations) {
+  for (const evaluation of evaluationSuite['control-evaluations'].evaluations) {
+    const controlId = evaluation.control['entry-id']
     await addSuiteControlEvaluation(qx, {
-      controlId: evaluation['control-id'],
+      controlId,
       name: evaluation.name,
-      corruptedState: evaluation['corrupted-state'],
+      corruptedState: false,
       message: evaluation.message,
       repo: repo.repoUrl,
       insightsProjectId: repo.insightsProjectId,
       insightsProjectSlug: repo.insightsProjectSlug,
-      remediationGuide: evaluation['remediation-guide'] || '',
+      remediationGuide: '',
       result: evaluation.result,
       securityInsightsEvaluationSuiteId: suite.id,
     })
 
-    const controlEvaluation = await findSuiteControlEvaluation(
-      qx,
-      repo.repoUrl,
-      evaluation['control-id'],
-      suite.id,
-    )
-    for (const assessment of evaluation.assessments) {
+    const controlEvaluation = await findSuiteControlEvaluation(qx, repo.repoUrl, controlId, suite.id)
+    for (const assessment of evaluation['assessment-logs']) {
       await addControlEvaluationAssessment(qx, {
         applicability: assessment.applicability,
         description: assessment.description,
@@ -141,17 +139,17 @@ export async function saveOSPSBaselineInsightsToDB(
         repo: repo.repoUrl,
         insightsProjectId: repo.insightsProjectId,
         insightsProjectSlug: repo.insightsProjectSlug,
-        requirementId: assessment['requirement-id'],
+        requirementId: assessment.requirement['entry-id'],
         result: assessment.result,
-        runDuration: assessment['run-duration'] || '',
+        runDuration: '',
         steps: assessment.steps,
         stepsExecuted: assessment['steps-executed'] || 0,
         securityInsightsEvaluationId: controlEvaluation.id,
         recommendation: assessment.recommendation,
         start: assessment.start,
         end: assessment.end,
-        value: assessment.value,
-        changes: assessment.changes,
+        value: null,
+        changes: null,
       })
     }
   }

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -226,11 +226,13 @@ async function runBinary(
         resolve({ stdout, stderr })
       } else {
         const truncated = (s: string) => (s.length > 500 ? s.slice(0, 500) + '…' : s)
-        reject(
+        const err = Object.assign(
           new Error(
-            `Binary exited with code ${code}\nStderr:\n${truncated(stderr)}Stdout:\n${truncated(stdout)}`,
+            `Binary exited with code ${code}\nStderr:\n${truncated(stderr)}\nStdout:\n${truncated(stdout)}`,
           ),
+          { stdout, stderr },
         )
+        reject(err)
       }
     })
   })

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -221,11 +221,18 @@ async function runBinary(
     })
 
     proc.on('close', (code) => {
-      if (code === 0) {
-        svc.log.info(`Binary completed successfully`)
+      // exit code 0 = all tests passed, 1 = some tests failed — both mean the
+      // evaluation ran to completion and wrote its output file
+      if (code === 0 || code === 1) {
+        svc.log.info(`Binary completed with exit code ${code}`)
         resolve({ stdout, stderr })
       } else {
-        reject(new Error(`Binary exited with code ${code}\nStderr:\n${stderr}Stdout:\n${stdout}`))
+        const truncated = (s: string) => (s.length > 500 ? s.slice(0, 500) + '…' : s)
+        reject(
+          new Error(
+            `Binary exited with code ${code}\nStderr:\n${truncated(stderr)}Stdout:\n${truncated(stdout)}`,
+          ),
+        )
       }
     })
   })

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -96,10 +96,18 @@ export async function saveOSPSBaselineInsightsToDB(
   const CATALOG_ID = 'osps-baseline-2026-02'
   const redisCache = new RedisCache(`osps-baseline-insights`, svc.redis, svc.log)
   const result = await redisCache.get(key)
+  if (!result) {
+    throw new Error(`No cached privateer result found for key: ${key}`)
+  }
   const parsedResult: ISecurityInsightsPrivateerResult = JSON.parse(result)
-  const evaluationSuite = parsedResult['evaluation-suites'].find(
+  const evaluationSuite = parsedResult['evaluation-suites']?.find(
     (s) => s['catalog-id'] === CATALOG_ID,
   )
+  if (!evaluationSuite) {
+    throw new Error(
+      `No evaluation suite found for catalog '${CATALOG_ID}' in privateer output for repo ${repo.repoUrl}`,
+    )
+  }
 
   const qx = pgpQx(svc.postgres.writer.connection())
 
@@ -114,6 +122,11 @@ export async function saveOSPSBaselineInsightsToDB(
   })
 
   const suite = await findEvaluationSuite(qx, repo.repoUrl, evaluationSuite['catalog-id'])
+  if (!suite) {
+    throw new Error(
+      `Evaluation suite not found after insert for repo ${repo.repoUrl}, catalog ${evaluationSuite['catalog-id']}`,
+    )
+  }
 
   for (const evaluation of evaluationSuite['control-evaluations'].evaluations) {
     const controlId = evaluation.control['entry-id']
@@ -131,6 +144,11 @@ export async function saveOSPSBaselineInsightsToDB(
     })
 
     const controlEvaluation = await findSuiteControlEvaluation(qx, repo.repoUrl, controlId, suite.id)
+    if (!controlEvaluation) {
+      throw new Error(
+        `Control evaluation not found after insert for repo ${repo.repoUrl}, controlId ${controlId}, suiteId ${suite.id}`,
+      )
+    }
     for (const assessment of evaluation['assessment-logs']) {
       const runDuration = assessment.end
         ? `${new Date(assessment.end).getTime() - new Date(assessment.start).getTime()}ms`

--- a/services/apps/security_best_practices_worker/src/activities/index.ts
+++ b/services/apps/security_best_practices_worker/src/activities/index.ts
@@ -143,7 +143,12 @@ export async function saveOSPSBaselineInsightsToDB(
       securityInsightsEvaluationSuiteId: suite.id,
     })
 
-    const controlEvaluation = await findSuiteControlEvaluation(qx, repo.repoUrl, controlId, suite.id)
+    const controlEvaluation = await findSuiteControlEvaluation(
+      qx,
+      repo.repoUrl,
+      controlId,
+      suite.id,
+    )
     if (!controlEvaluation) {
       throw new Error(
         `Control evaluation not found after insert for repo ${repo.repoUrl}, controlId ${controlId}, suiteId ${suite.id}`,

--- a/services/apps/security_best_practices_worker/src/types.ts
+++ b/services/apps/security_best_practices_worker/src/types.ts
@@ -1,28 +1,30 @@
 export interface ISecurityInsightsPrivateerResult {
-  evaluation_suites: ISecurityInsightsPrivateerEvaluationSuite[]
+  'evaluation-suites': ISecurityInsightsPrivateerEvaluationSuite[]
 }
 
 export interface ISecurityInsightsPrivateerEvaluationSuite {
   name: string
-  catalog_id: string
-  start_time: string
-  end_time: string
+  'catalog-id': string
+  'start-time': string
+  'end-time': string
   result: string
-  corrupted_state: boolean
-  control_evaluations: ISecurityInsightsPrivateerResultControlEvaluations[]
+  'corrupted-state': boolean
+  'control-evaluations': {
+    result: string
+    evaluations: ISecurityInsightsPrivateerResultControlEvaluations[]
+  }
 }
 
 export interface ISecurityInsightsPrivateerResultControlEvaluations {
   name: string
-  'control-id': string
+  control: { 'reference-id': string; 'entry-id': string }
   result: string
   message: string
-  'corrupted-state': boolean
-  assessments: ISecurityInsightsPrivateerResultAssessment[]
+  'assessment-logs': ISecurityInsightsPrivateerResultAssessment[]
 }
 
 export interface ISecurityInsightsPrivateerResultAssessment {
-  'requirement-id': string
+  requirement: { 'reference-id': string; 'entry-id': string }
   applicability: string[]
   description: string
   result: string
@@ -31,8 +33,6 @@ export interface ISecurityInsightsPrivateerResultAssessment {
   'steps-executed': number
   start: string
   end?: string
-  value?: unknown
-  changes?: Record<string, unknown>
   recommendation?: string
 }
 

--- a/services/apps/security_best_practices_worker/src/types.ts
+++ b/services/apps/security_best_practices_worker/src/types.ts
@@ -25,6 +25,7 @@ export interface ISecurityInsightsPrivateerResultControlEvaluations {
 
 export interface ISecurityInsightsPrivateerResultAssessment {
   requirement: { 'reference-id': string; 'entry-id': string }
+  plan?: { 'reference-id': string; 'entry-id': string }
   applicability: string[]
   description: string
   result: string
@@ -34,6 +35,7 @@ export interface ISecurityInsightsPrivateerResultAssessment {
   start: string
   end?: string
   recommendation?: string
+  'confidence-level'?: string
 }
 
 export interface IUpsertOSPSBaselineSecurityInsightsParams {


### PR DESCRIPTION
## Summary

Restores the `upsertOSPSBaselineSecurityInsights` workflow after the plugin upgrade in #4126. That PR bumped `pvtr-github-repo-scanner` to v0.23.2 (requires `privateer-sdk v1.24.0`) but left the rest of the stack on the v1.4.0 contract, causing the workflow to fail at every layer.

## What changed

**Dockerfile (`scripts/services/docker/Dockerfile.security_best_practices_worker`)**
- Bumps the privateer binary release from `0.7.0` → `0.21.2` to match the plugin's SDK
- Copies the renamed `pvtr` binary as `privateer`
- Writes `/root/.privateer/bin/plugins.json` so the SDK's new manifest-based plugin discovery finds the `github-repo` plugin

**Runtime (`services/apps/security_best_practices_worker/src/activities/index.ts`)**
- `runBinary` treats exit code `1` (failed assessments — run completed) as success, since the result file is still written. Codes ≥2 still reject and attach truncated stdout/stderr as structured fields on the error
- `saveOSPSBaselineInsightsToDB` updated for the new YAML shape (see below)
- `runDuration` derived from `start`/`end` timestamps (the SDK no longer emits it as a discrete field)

**Types (`services/apps/security_best_practices_worker/src/types.ts`)**
- Mapped to the v1.24.0 YAML schema: kebab-case top-level keys (`evaluation-suites`, `catalog-id`, `start-time`, `end-time`, `corrupted-state`), `control-evaluations` is now a nested `EvaluationLog` object with an `evaluations` array, `assessment-logs` replaces `assessments`, and control/requirement IDs are now nested `EntryMapping` objects with `reference-id`/`entry-id`. Verified field-for-field against [`gemaraproj/go-gemara` v0.4.0](https://github.com/gemaraproj/go-gemara/blob/v0.4.0/generated_types.go)
- Adds the new optional `plan` and `confidence-level` fields shipped by the SDK so they survive the YAML → Redis hop (DB persistence deferred — see follow-ups)

## Schema changes shipped by upstream

Five fields the old SDK emitted are no longer present in the v1.24.0 output. Tracked upstream:

| Old field | Status in v1.24.0 |
|---|---|
| `corrupted-state` per control | Removed; only at suite level now (lost in the ossf/gemara → go-gemara type-system migration) |
| `remediation-guide` per control | **Migrated** to `assessment-logs[].recommendation` ([ossf/gemara#109](https://github.com/ossf/gemara/commit/db23ed72c2be10b21406a520a2b9b0690c4761bd)) — already captured per-assessment |
| `run-duration` per assessment | **Replaced** by `start` + `end` timestamps ([ossf/gemara#112](https://github.com/ossf/gemara/commit/da6487ddde262522f4cf598a957dd2fddb9eeeba)) — derived locally in this PR |
| `value` per assessment | Removed, no replacement |
| `changes` per assessment | Removed, no replacement |

The DB columns for the removed-without-replacement fields (`corruptedState` per-control, `value`, `changes`) will be populated with their default (`false` / `''` / `null`) for new rows. `ON CONFLICT DO UPDATE` is left as plain `EXCLUDED.*`, so re-evaluations overwrite normally.

**Verified no display impact**: the Tinybird pipe that feeds the Insights security widget (`security_deduplicated_merged_copy_pipe.pipe`) does not project any of the 5 fields, and the frontend `SecurityData` / `SecurityAssessmentData` types in `lfx-insights` only consume `controlId`, `result`, `message`, `category`, `assessments[].{requirementId, description, result, message, recommendation}`. All of these are still populated.

## Follow-ups (not in this PR)

- Persist `confidence-level` and `plan` to new columns on `securityInsightsEvaluationAssessments` — net-new SDK data we currently drop after parsing
- Drop the now-unsourced columns (`corruptedState` per-control, `remediationGuide`, `runDuration`, `value`, `changes`) and clean up the Tinybird datasource schemas — they're unused downstream

## Test plan

- [ ] Build the security_best_practices_worker image with the updated Dockerfile
- [ ] Deploy to a non-prod environment and trigger `upsertOSPSBaselineSecurityInsights` against a test repo
- [ ] Verify the workflow completes without the gob/plugin-installed/Temporal-size-limit errors
- [ ] Check the `securityInsightsEvaluations` and `securityInsightsEvaluationAssessments` rows: `recommendation`, `start`, `end`, `runDuration` populated; missing fields default as documented
- [ ] Confirm the OSPS Baseline widget in Insights still renders for a freshly-evaluated project

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the security insights ingestion path and DB writes for evaluation data; schema mapping errors could mis-persist or fail workflows, but changes are scoped to the worker and align with an intentional upstream format upgrade.
> 
> **Overview**
> Restores **`upsertOSPSBaselineSecurityInsights`** after the plugin bump left the worker on an incompatible privateer/SDK contract.
> 
> The **Docker image** now ships **privateer `0.21.2`** (was `0.7.0`), copies the renamed **`pvtr`** binary as `privateer`, and writes **`plugins.json`** so the SDK discovers the **`github-repo`** plugin at runtime.
> 
> **Runtime behavior** treats privateer exit code **`1`** (failed assessments but finished run) like success so the YAML result is still read; higher exit codes still fail with truncated stdout/stderr. **`saveOSPSBaselineInsightsToDB`** maps the new **kebab-case** schema (`evaluation-suites`, nested `control-evaluations.evaluations`, `assessment-logs`, nested control/requirement `entry-id`s), adds guards when Redis/suite rows are missing, derives **`runDuration`** from `start`/`end`, and stores defaults where upstream dropped fields (per-control `corruptedState`, `remediationGuide`, `value`, `changes`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88e821f74670c9bfb77d7585d86c3b61905b47b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->