### PR TITLE
fix: add resolution path

### DIFF
--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -93,6 +93,8 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
       status: (pkg.stewardshipStatus ?? 'unassigned') as StewardshipStatus,
       stewards: stewardshipSummary?.stewards ?? null,
       lastActivityAt: stewardshipSummary?.lastActivityAt ?? null,
+      resolutionPath: pkg.stewardshipResolutionPath ?? null,
+      statusNote: pkg.stewardshipStatusNote ?? null,
     },
     history: {},
   })

--- a/backend/src/api/public/v1/packages/openapi.yaml
+++ b/backend/src/api/public/v1/packages/openapi.yaml
@@ -85,14 +85,17 @@ components:
 
     Steward:
       type: object
-      required: [userId, name, role, assignedAt]
+      required: [userId, role, assignedAt]
       properties:
         userId:
           type: string
-          description: LFID.
-          example: jdoe
+          description: Auth0 sub of the assigned steward.
+          example: abc123
         name:
-          type: string
+          type:
+            - string
+            - 'null'
+          description: Display name of the steward. Null if not available.
           example: Jonathan R.
         role:
           type: string
@@ -418,12 +421,12 @@ components:
                     - 'null'
         stewardship:
           type: object
-          description: Stewardship state. In v1 always unassigned with no stewards or activity.
+          description: Stewardship state.
           properties:
             status:
               $ref: '#/components/schemas/StewardshipStatus'
             stewards:
-              description: Assigned stewards or null. Null in v1.
+              description: Assigned stewards or null.
               oneOf:
                 - type: array
                   items:
@@ -434,7 +437,16 @@ components:
                 - string
                 - 'null'
               format: date-time
-              description: Null in v1.
+            resolutionPath:
+              type:
+                - string
+                - 'null'
+              description: Set on `escalated` status. Null for all other statuses.
+            statusNote:
+              type:
+                - string
+                - 'null'
+              description: Free-text note for the current status.
         history:
           type: object
           description: Package history data. Empty in v1.

--- a/backend/src/api/public/v1/stewardships/openapi.yaml
+++ b/backend/src/api/public/v1/stewardships/openapi.yaml
@@ -94,6 +94,17 @@ components:
             - stepped_down
             - no_longer_critical
             - 'null'
+        resolutionPath:
+          description: Set on `escalated` status. Null for all other statuses.
+          oneOf:
+            - $ref: '#/components/schemas/EscalationResolutionPath'
+            - type: 'null'
+        statusNote:
+          type:
+            - string
+            - 'null'
+          description: Free-text note for the current status. Set by escalate or updateStatus. Null on open.
+          example: Contacted maintainer, no response after 30 days.
         createdAt:
           type: string
           format: date-time
@@ -115,6 +126,12 @@ components:
           type: string
           description: Auth0 sub of the assigned steward.
           example: abc123
+        name:
+          type:
+            - string
+            - 'null'
+          description: Display name of the steward. Null if not available.
+          example: Jonathan R.
         role:
           type: string
           enum: [lead, co_steward]

--- a/backend/src/osspckgs/migrations/V1781300000__stewardship-status-path-note.sql
+++ b/backend/src/osspckgs/migrations/V1781300000__stewardship-status-path-note.sql
@@ -1,0 +1,3 @@
+ALTER TABLE stewardships
+    ADD COLUMN IF NOT EXISTS resolution_path TEXT,
+    ADD COLUMN IF NOT EXISTS status_note     TEXT;

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -276,6 +276,8 @@ export interface PackageDetailRow {
   stewardshipId: string | null
   stewardshipStatus: string | null
   stewardshipLastStatusAt: Date | null
+  stewardshipResolutionPath: string | null
+  stewardshipStatusNote: string | null
   // from package_repos + repos
   repoUrl: string | null
   repoMappingConfidence: number | null
@@ -319,6 +321,8 @@ export async function getPackageDetailByPurl(
       s.id::text AS "stewardshipId",
       s.status AS "stewardshipStatus",
       s.last_status_at AS "stewardshipLastStatusAt",
+      s.resolution_path AS "stewardshipResolutionPath",
+      s.status_note AS "stewardshipStatusNote",
       -- best repo link (highest confidence, prefer declared)
       r.url AS "repoUrl",
       pr.confidence AS "repoMappingConfidence",

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -9,6 +9,8 @@ export interface StewardshipRecord {
   openedAt: string | null
   lastStatusAt: string | null
   inactiveReason: string | null
+  resolutionPath: string | null
+  statusNote: string | null
   createdAt: string
   updatedAt: string
 }
@@ -17,6 +19,7 @@ export interface StewardshipStewardRecord {
   id: string
   stewardshipId: string
   userId: string
+  name: string | null
   role: string
   assignedAt: string
   assignedBy: string | null
@@ -89,6 +92,7 @@ function mapStewardStewardRow(row: Record<string, unknown>): StewardshipStewardR
     id: String(row.id),
     stewardshipId: String(row.stewardship_id),
     userId: String(row.user_id),
+    name: null,
     role: String(row.role),
     assignedAt: toIso(row.assigned_at),
     assignedBy: row.assigned_by ? String(row.assigned_by) : null,
@@ -105,6 +109,8 @@ function mapStewardshipRow(row: Record<string, unknown>): StewardshipRecord {
     openedAt: row.opened_at ? toIso(row.opened_at) : null,
     lastStatusAt: row.last_status_at ? toIso(row.last_status_at) : null,
     inactiveReason: row.inactive_reason ? String(row.inactive_reason) : null,
+    resolutionPath: row.resolution_path ? String(row.resolution_path) : null,
+    statusNote: row.status_note ? String(row.status_note) : null,
     createdAt: toIso(row.created_at),
     updatedAt: toIso(row.updated_at),
   }
@@ -116,7 +122,7 @@ export async function getStewardshipById(
 ): Promise<StewardshipRecord | null> {
   const row: Record<string, unknown> | null = await qx.selectOneOrNone(
     `SELECT id, package_id, status, origin, version, opened_at, last_status_at,
-            inactive_reason, created_at, updated_at
+            inactive_reason, resolution_path, status_note, created_at, updated_at
      FROM stewardships
      WHERE id = $(id)`,
     { id },
@@ -151,12 +157,14 @@ export async function openStewardshipByPurl(
       FROM pkg
       ON CONFLICT (package_id) DO UPDATE
         SET status          = 'open',
-            opened_at       = COALESCE(stewardships.opened_at, NOW()),
+            opened_at       = NOW(),
             last_status_at  = NOW(),
             inactive_reason = NULL,
+            resolution_path = NULL,
+            status_note     = NULL,
             updated_at      = NOW()
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity (stewardship_id, actor_user_id, actor_type, activity_type, content)
@@ -288,10 +296,12 @@ export async function escalateStewardship(
       SET status          = 'escalated',
           last_status_at  = NOW(),
           inactive_reason = NULL,
+          resolution_path = $(resolutionPath),
+          status_note     = $(statusNote),
           updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity
@@ -304,6 +314,8 @@ export async function escalateStewardship(
     `,
     {
       stewardshipId,
+      resolutionPath: data.resolutionPath,
+      statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
       content: `Escalated with resolution path: ${data.resolutionPath}`,
       metadata: JSON.stringify({
@@ -353,11 +365,13 @@ export async function updateStewardshipStatus(
       UPDATE stewardships
       SET status          = $(status),
           last_status_at  = NOW(),
-          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE NULL END,
+          inactive_reason = CASE WHEN $(status) = 'inactive' THEN $(inactiveReason) ELSE inactive_reason END,
+          resolution_path = NULL,
+          status_note     = $(statusNote),
           updated_at      = NOW()
       WHERE id = $(stewardshipId)
       RETURNING id, package_id, status, origin, version, opened_at,
-                last_status_at, inactive_reason, created_at, updated_at
+                last_status_at, inactive_reason, resolution_path, status_note, created_at, updated_at
     ),
     _log AS (
       INSERT INTO stewardship_activity
@@ -372,6 +386,7 @@ export async function updateStewardshipStatus(
       stewardshipId,
       status: data.status,
       inactiveReason: data.inactiveReason ?? null,
+      statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
       content: `Status updated to ${data.status}`,
       metadata: JSON.stringify({


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
<!-- Example: Adds batch processing for member enrichment to reduce API calls -->

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
-

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
<!-- Link to the JIRA ticket, e.g. https://linuxfoundation.atlassian.net/browse/CDP-123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration and stewardship state-transition semantics changed (re-open resets opened_at; inactive_reason preserved when leaving inactive). API contract updates are additive but affect clients reading stewardship data.
> 
> **Overview**
> Adds **`resolution_path`** and **`status_note`** on `stewardships` (migration + DAL) so escalation resolution paths and free-text notes are stored on the row, not only in activity metadata. **Escalate** sets both; **update status** writes `status_note` and clears `resolution_path`; **open for stewardship** clears both and now always resets **`opened_at`** to the current time on re-open.
> 
> **GET package detail** returns `stewardship.resolutionPath` and `stewardship.statusNote` from the package detail query. Public OpenAPI is updated for those fields, drops “always unassigned in v1” stewardship copy, and aligns **Steward** / **StewardRecord** with optional nullable **name** and Auth0 **userId** docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23eb372a489878483ba31a53d0c28e81e3d5e515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->