### PR TITLE
feat: add per-status package counts to list endpoint (CM-1245)

### DIFF
--- a/backend/.prettierignore
+++ b/backend/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 admin
 venv-*
 .serverless
+.claude

--- a/backend/src/api/public/v1/packages/listPackages.ts
+++ b/backend/src/api/public/v1/packages/listPackages.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 import { z } from 'zod'
 
-import { listPackagesForApi } from '@crowd/data-access-layer'
+import { getPackageStatusCounts, listPackagesForApi } from '@crowd/data-access-layer'
 
 import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
@@ -61,22 +61,13 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     sortDir,
   } = validateOrThrow(querySchema, req.query)
 
+  const filterOpts = { ecosystem, lifecycle, name, healthBand, vulnSeverity, staleOnly, unstewardedOnly, busFactor1Only }
+
   const qx = await getPackagesQx()
-  const { rows, total } = await listPackagesForApi(qx, {
-    page,
-    pageSize,
-    ecosystem,
-    lifecycle,
-    name,
-    status,
-    healthBand,
-    vulnSeverity,
-    staleOnly,
-    unstewardedOnly,
-    busFactor1Only,
-    sortBy,
-    sortDir,
-  })
+  const [{ rows, total }, statusCounts] = await Promise.all([
+    listPackagesForApi(qx, { page, pageSize, status, sortBy, sortDir, ...filterOpts }),
+    getPackageStatusCounts(qx, filterOpts),
+  ])
 
   const packages = rows.map((r) => ({
     purl: r.purl,
@@ -96,6 +87,7 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     page,
     pageSize,
     total,
+    statusCounts,
     filters: {
       ecosystem: ecosystem ?? null,
       lifecycle: lifecycle ?? null,

--- a/backend/src/api/public/v1/packages/listPackages.ts
+++ b/backend/src/api/public/v1/packages/listPackages.ts
@@ -61,7 +61,16 @@ export async function listPackages(req: Request, res: Response): Promise<void> {
     sortDir,
   } = validateOrThrow(querySchema, req.query)
 
-  const filterOpts = { ecosystem, lifecycle, name, healthBand, vulnSeverity, staleOnly, unstewardedOnly, busFactor1Only }
+  const filterOpts = {
+    ecosystem,
+    lifecycle,
+    name,
+    healthBand,
+    vulnSeverity,
+    staleOnly,
+    unstewardedOnly,
+    busFactor1Only,
+  }
 
   const qx = await getPackagesQx()
   const [{ rows, total }, statusCounts] = await Promise.all([

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -104,7 +104,10 @@ export interface PackageStatusCounts {
   inactive: number
 }
 
-export type StatusCountsOptions = Omit<ListPackagesOptions, 'status' | 'page' | 'pageSize' | 'sortBy' | 'sortDir'>
+export type StatusCountsOptions = Omit<
+  ListPackagesOptions,
+  'status' | 'page' | 'pageSize' | 'sortBy' | 'sortDir'
+>
 
 const ALL_STEWARDSHIP_STATUSES = [
   'unassigned',
@@ -220,7 +223,17 @@ export async function getPackageStatusCounts(
     all += row.count
   }
 
-  const result: PackageStatusCounts = { all, unassigned: 0, open: 0, assessing: 0, active: 0, needs_attention: 0, escalated: 0, blocked: 0, inactive: 0 }
+  const result: PackageStatusCounts = {
+    all,
+    unassigned: 0,
+    open: 0,
+    assessing: 0,
+    active: 0,
+    needs_attention: 0,
+    escalated: 0,
+    blocked: 0,
+    inactive: 0,
+  }
   for (const status of ALL_STEWARDSHIP_STATUSES) {
     result[status] = countsMap[status] ?? 0
   }

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -92,6 +92,141 @@ const SEVERITY_RANK_EXPR = `MAX(CASE a.severity
     WHEN 'LOW'      THEN 1
     ELSE 0 END)::int`
 
+export interface PackageStatusCounts {
+  all: number
+  unassigned: number
+  open: number
+  assessing: number
+  active: number
+  needs_attention: number
+  escalated: number
+  blocked: number
+  inactive: number
+}
+
+export type StatusCountsOptions = Omit<ListPackagesOptions, 'status' | 'page' | 'pageSize' | 'sortBy' | 'sortDir'>
+
+const ALL_STEWARDSHIP_STATUSES = [
+  'unassigned',
+  'open',
+  'assessing',
+  'active',
+  'needs_attention',
+  'escalated',
+  'blocked',
+  'inactive',
+] as const
+
+/**
+ * Returns per-status counts for the same filter set used by listPackagesForApi, but without
+ * the status filter so the tab bar always shows all status breakdowns for the active filters.
+ */
+export async function getPackageStatusCounts(
+  qx: QueryExecutor,
+  opts: StatusCountsOptions,
+): Promise<PackageStatusCounts> {
+  const conditions: string[] = ['p.is_critical = true']
+  const params: Record<string, unknown> = {}
+
+  if (opts.ecosystem) {
+    conditions.push('p.ecosystem = $(ecosystem)')
+    params.ecosystem = opts.ecosystem
+  }
+
+  if (opts.name) {
+    conditions.push('p.name ILIKE $(name)')
+    params.name = `%${opts.name}%`
+  }
+
+  if (opts.lifecycle) {
+    conditions.push('p.status IS NOT NULL')
+  }
+
+  if (opts.healthBand) {
+    if (opts.healthBand === 'healthy') {
+      conditions.push('r_sc.scorecard_score >= 7.0')
+    } else if (opts.healthBand === 'fair') {
+      conditions.push('r_sc.scorecard_score >= 5.0 AND r_sc.scorecard_score < 7.0')
+    } else if (opts.healthBand === 'concerning') {
+      conditions.push('r_sc.scorecard_score >= 3.0 AND r_sc.scorecard_score < 5.0')
+    } else {
+      conditions.push('(r_sc.scorecard_score IS NULL OR r_sc.scorecard_score < 3.0)')
+    }
+  }
+
+  if (opts.vulnSeverity) {
+    if (opts.vulnSeverity === 'any') {
+      conditions.push('ap_counts.cnt > 0')
+    } else if (opts.vulnSeverity === 'high') {
+      conditions.push('ap_severity.max_rank >= 3')
+    } else {
+      conditions.push('ap_severity.max_rank >= 4')
+    }
+  }
+
+  if (opts.staleOnly) {
+    conditions.push(
+      `(p.latest_release_at IS NULL OR p.latest_release_at < NOW() - INTERVAL '${STALE_MONTHS} months')`,
+    )
+  }
+
+  if (opts.unstewardedOnly) {
+    conditions.push(`(s.status = 'unassigned' OR s.id IS NULL)`)
+  }
+
+  if (opts.busFactor1Only) {
+    conditions.push(`pm_counts.cnt = 1`)
+  }
+
+  const where = `WHERE ${conditions.join(' AND ')}`
+
+  const rows: { status: string; count: number }[] = await qx.select(
+    `
+    SELECT
+      COALESCE(s.status, 'unassigned') AS status,
+      COUNT(*)::int AS count
+    FROM packages p
+    LEFT JOIN stewardships s ON s.package_id = p.id
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS cnt FROM advisory_packages WHERE package_id = p.id
+    ) ap_counts ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS cnt FROM package_maintainers pm WHERE pm.package_id = p.id
+    ) pm_counts ON true
+    LEFT JOIN LATERAL (
+      SELECT ${SEVERITY_RANK_EXPR} AS max_rank
+      FROM advisory_packages ap
+      JOIN advisories a ON a.id = ap.advisory_id
+      WHERE ap.package_id = p.id
+    ) ap_severity ON true
+    LEFT JOIN LATERAL (
+      SELECT r.scorecard_score
+      FROM package_repos pr
+      JOIN repos r ON r.id = pr.repo_id
+      WHERE pr.package_id = p.id
+      ORDER BY pr.confidence DESC
+      LIMIT 1
+    ) r_sc ON true
+    ${where}
+    GROUP BY COALESCE(s.status, 'unassigned')
+    `,
+    params,
+  )
+
+  const countsMap: Record<string, number> = {}
+  let all = 0
+  for (const row of rows) {
+    countsMap[row.status] = row.count
+    all += row.count
+  }
+
+  const result: PackageStatusCounts = { all, unassigned: 0, open: 0, assessing: 0, active: 0, needs_attention: 0, escalated: 0, blocked: 0, inactive: 0 }
+  for (const status of ALL_STEWARDSHIP_STATUSES) {
+    result[status] = countsMap[status] ?? 0
+  }
+  return result
+}
+
 export async function listPackagesForApi(
   qx: QueryExecutor,
   opts: ListPackagesOptions,


### PR DESCRIPTION
## Summary

- Adds `getPackageStatusCounts` to the DAL (`osspckgs/api.ts`) — returns a count breakdown by all stewardship statuses for the currently active filters (excluding the status filter itself)
- The `listPackages` API endpoint now fires both queries in parallel via `Promise.all` and returns `statusCounts` alongside the existing paginated rows
- Enables the frontend tab bar to always show counts for every status tab while respecting ecosystem, lifecycle, health band, vuln severity, stale, unstewareded, and bus-factor filters

## Test plan

- [ ] Call `GET /api/v1/packages` with no filters — verify `statusCounts` is present in the response with `all` equalling the sum of individual status counts
- [ ] Apply an ecosystem or name filter — verify `statusCounts` reflects only matching packages and `all` matches `total`
- [ ] Apply a `status` filter — verify `statusCounts` still shows counts across all statuses (not filtered by the selected status)
- [ ] Apply stale-only / bus-factor-1 / unstewareded filters — verify counts update accordingly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a second heavy aggregate query on every list request; counts must stay in sync with list filter logic as those evolve.
> 
> **Overview**
> **`GET /api/v1/packages`** now returns **`statusCounts`** — stewardship tab totals (`all` plus each status) that respect the same non-status filters as the list (ecosystem, name, lifecycle, health band, vuln severity, stale/unstewarded/bus-factor flags) but **ignore** the `status` query param so every tab can show counts while one status is selected.
> 
> The handler loads paginated rows and counts in **parallel** (`Promise.all`) after splitting shared filter options from pagination/sort/status. The DAL adds **`getPackageStatusCounts`** with a grouped SQL query aligned to **`listPackagesForApi`**’s filter joins (stewardships, advisories, maintainers, scorecard).
> 
> Also adds **`.claude`** to **`backend/.prettierignore`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7fa68c5756a7c184f8cef9fb49b76c6b0204f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->