### PR TITLE
fix: guard against empty relevantPayloads before querying activityRelations

### DIFF
--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -646,6 +646,13 @@ export default class ActivityService extends LoggerBase {
       `[ACTIVITY] We still have ${relevantPayloads.length} activities left to process after finding segments!`,
     )
 
+    // relevantPayloads can be drained to zero by the erasure/segment loop above (e.g. all
+    // members flagged for erasure). Calling queryActivityRelations with an empty array would
+    // produce invalid SQL: `timestamp in ()` and a bare `()` group.
+    if (relevantPayloads.length === 0) {
+      return resultMap
+    }
+
     const orConditions = relevantPayloads.map((r) => {
       return {
         and: [


### PR DESCRIPTION
This pull request introduces a small but important safeguard in the `ActivityService` to prevent invalid SQL queries when there are no relevant payloads left to process. The change ensures that if all activities have been filtered out (for example, due to erasure flags), the method exits early and avoids constructing a faulty query.

- **Bug fix / Data integrity:**
  * Added a check to return early if `relevantPayloads` is empty, preventing invalid SQL queries such as `timestamp in ()` when all activities have been filtered out. (`services/apps/data_sink_worker/src/service/activity.service.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guard on an edge path; no change to normal activity upsert behavior when payloads remain.
> 
> **Overview**
> Adds a **second early return** in `processActivities` after erasure handling and segment lookup, when `relevantPayloads` has been drained to zero (e.g. every activity skipped for user-requested erasure or missing `segmentId`).
> 
> Without this guard, the next step still calls `queryActivityRelations` with empty `timestamp in (...)` / `or` filters, producing **invalid SQL** and failing the batch. The method now returns the existing `resultMap` (already marked for skipped items) instead of querying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6807889536090b4a29f5f09b844bb2269fc2ffa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->