### PR TITLE
fix: skip bot members from stint inference and lfid enrichment (CM-1260)

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -502,6 +502,10 @@ export default class MemberService extends LoggerBase {
             }
           }
 
+          const isBotMember = this.botDetectionService.isFlaggedAsBot(
+            attributes as Record<string, unknown>,
+          )
+
           const emailIdentities = data.identities.filter(
             (i) => i.type === MemberIdentityType.EMAIL && i.verified,
           )
@@ -514,6 +518,7 @@ export default class MemberService extends LoggerBase {
                   orgPromiseCache,
                   effectiveMemberId,
                   activityTimestamp,
+                  isBotMember,
                 ),
               this.log,
               'memberService -> create -> assignOrganizationByEmailDomain',
@@ -693,7 +698,11 @@ export default class MemberService extends LoggerBase {
             }
           }
 
-          if (this.botDetectionService.isFlaggedAsBot(toUpdate.attributes)) {
+          const isBotMember = this.botDetectionService.isFlaggedAsBot(
+            original.attributes as Record<string, unknown>,
+          )
+
+          if (isBotMember) {
             this.log.debug({ memberId: id }, 'Skipping organization creation for bot member')
             return effectiveMemberId !== id ? effectiveMemberId : undefined
           }
@@ -752,6 +761,7 @@ export default class MemberService extends LoggerBase {
                   orgPromiseCache,
                   effectiveMemberId,
                   activityTimestamp,
+                  isBotMember,
                 ),
               this.log,
               'memberService -> update -> assignOrganizationByEmailDomain',
@@ -807,6 +817,7 @@ export default class MemberService extends LoggerBase {
     orgPromiseCache?: Map<string, Promise<string | undefined>>,
     memberId?: string,
     activityTimestamp?: string,
+    isBotMember = false,
   ): Promise<IOrganizationIdSource[]> {
     const orgService = new OrganizationService(this.store, this.log)
     const organizations: IOrganizationIdSource[] = []
@@ -866,7 +877,8 @@ export default class MemberService extends LoggerBase {
           id: orgId,
           source: orgSource,
         })
-        if (memberId && activityTimestamp) {
+
+        if (memberId && activityTimestamp && !isBotMember) {
           await this.bufferMemberOrganizationActivityDates(memberId, orgId, activityTimestamp)
         }
       }

--- a/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
@@ -198,6 +198,8 @@ export async function fetchMembersForLFIDEnrichment(db: DbStore, limit: number, 
           (mi.type = 'email' and mi.verified)
           )
         AND members."deletedAt" IS NULL
+        AND coalesce((members.attributes -> 'isBot' ->> 'default')::boolean, false) = false
+        AND coalesce((members.attributes -> 'isOrganization' ->> 'default')::boolean, false) = false
         ${idFilter}
       GROUP BY members.id
       ORDER BY members.id desc


### PR DESCRIPTION
## Summary

Bot members were incorrectly enqueued for email-domain stint inference, which created `memberOrganizations` and triggered affiliation refreshes they should not have. LFID enrichment also did not exclude bot members, unlike the main enrichment pipeline.

## Changes

- Use existing db state to correctly detect bot members during updates
- Skip bot members in stint inference processing
- Exclude bot and organization members from LFID enrichment, consistent with fetchMembersForEnrichment