### PR TITLE
fix: downloads count for ai report (IN-1182)

### DIFF
--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -100,30 +100,34 @@ NODE ai_package_metrics
 SQL >
     SELECT
         insightsProjectId,
-        argMax(downloadsCount, date) AS downloads,
-        toInt64(argMax(downloadsCount, date)) - toInt64(
-            argMaxIf(downloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
-        ) AS downloads30d,
-        argMax(dockerDownloadsCount, date) AS dockerPulls,
-        toInt64(argMax(dockerDownloadsCount, date)) - toInt64(
-            argMaxIf(dockerDownloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
-        ) AS dockerPulls30d,
-        max(dependentReposCount) AS dependentRepos,
-        max(dependentPackagesCount) AS dependentPackages
+        sum(downloads) AS downloads,
+        sum(downloads30d) AS downloads30d,
+        sum(dockerPulls) AS dockerPulls,
+        sum(dockerPulls30d) AS dockerPulls30d,
+        max(dependentRepos) AS dependentRepos,
+        max(dependentPackages) AS dependentPackages
     FROM
         (
             SELECT
                 insightsProjectId,
-                date,
-                sum(downloadsCount) AS downloadsCount,
-                sum(dockerDownloadsCount) AS dockerDownloadsCount,
-                max(dependentReposCount) AS dependentReposCount,
-                max(dependentPackagesCount) AS dependentPackagesCount
+                argMax(downloadsCount, date) AS downloads,
+                toInt64(argMax(downloadsCount, date)) - toInt64(
+                    argMaxIf(downloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
+                ) AS downloads30d,
+                argMax(dockerDownloadsCount, date) AS dockerPulls,
+                toInt64(argMax(dockerDownloadsCount, date)) - toInt64(
+                    argMaxIf(dockerDownloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
+                ) AS dockerPulls30d,
+                max(dependentReposCount) AS dependentRepos,
+                max(dependentPackagesCount) AS dependentPackages
             FROM
                 (
                     SELECT
                         insightsProjectId,
                         date,
+                        ecosystem,
+                        repo,
+                        name,
                         argMax(downloadsCount, updatedAt) AS downloadsCount,
                         argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
                         argMax(dependentReposCount, updatedAt) AS dependentReposCount,
@@ -132,7 +136,7 @@ SQL >
                     WHERE insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos)
                     GROUP BY insightsProjectId, date, ecosystem, repo, name
                 )
-            GROUP BY insightsProjectId, date
+            GROUP BY insightsProjectId, ecosystem, repo, name
         )
     GROUP BY insightsProjectId
 

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -129,8 +129,11 @@ SQL >
                         argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
                     FROM packageDownloads
                     WHERE
-                        insightsProjectId
-                        IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
+                        insightsProjectId IN (
+                            SELECT DISTINCT insightsProjectId
+                            FROM ai_repos
+                            WHERE insightsProjectId != ''
+                        )
                     GROUP BY insightsProjectId, date, ecosystem, repo, name
                 )
             GROUP BY insightsProjectId, date

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -100,27 +100,29 @@ SQL >
     SELECT
         insightsProjectId,
         max(downloadsCount) AS downloads,
-        toInt64(max(downloadsCount)) - toInt64(
-            maxIf(downloadsCount, date <= toDate(now() - INTERVAL 30 DAY))
-        ) AS downloads30d,
+        toInt64(max(downloadsCount))
+        - toInt64(maxIf(downloadsCount, date <= toDate(now() - INTERVAL 30 DAY))) AS downloads30d,
         max(dockerDownloadsCount) AS dockerPulls,
         toInt64(max(dockerDownloadsCount)) - toInt64(
             maxIf(dockerDownloadsCount, date <= toDate(now() - INTERVAL 30 DAY))
         ) AS dockerPulls30d,
         max(dependentReposCount) AS dependentRepos,
         max(dependentPackagesCount) AS dependentPackages
-    FROM (
-        SELECT
-            insightsProjectId,
-            date,
-            argMax(downloadsCount, updatedAt) AS downloadsCount,
-            argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
-            argMax(dependentReposCount, updatedAt) AS dependentReposCount,
-            argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
-        FROM packageDownloads
-        WHERE insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
-        GROUP BY insightsProjectId, date, ecosystem, repo, name
-    )
+    FROM
+        (
+            SELECT
+                insightsProjectId,
+                date,
+                argMax(downloadsCount, updatedAt) AS downloadsCount,
+                argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
+                argMax(dependentReposCount, updatedAt) AS dependentReposCount,
+                argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
+            FROM packageDownloads
+            WHERE
+                insightsProjectId
+                IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
+            GROUP BY insightsProjectId, date, ecosystem, repo, name
+        )
     GROUP BY insightsProjectId
 
 NODE pr_metrics

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -13,6 +13,7 @@ SQL >
         AND isNull (cr.deletedAt)
         AND isNull (r.deletedAt)
         AND r.enabled = true
+        AND r.insightsProjectId != ''
 
 NODE ai_projects
 SQL >
@@ -129,11 +130,7 @@ SQL >
                         argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
                     FROM packageDownloads
                     WHERE
-                        insightsProjectId IN (
-                            SELECT DISTINCT insightsProjectId
-                            FROM ai_repos
-                            WHERE insightsProjectId != ''
-                        )
+                        insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos)
                     GROUP BY insightsProjectId, date, ecosystem, repo, name
                 )
             GROUP BY insightsProjectId, date

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -99,12 +99,13 @@ NODE ai_package_metrics
 SQL >
     SELECT
         insightsProjectId,
-        max(downloadsCount) AS downloads,
-        toInt64(max(downloadsCount))
-        - toInt64(maxIf(downloadsCount, date <= toDate(now() - INTERVAL 30 DAY))) AS downloads30d,
-        max(dockerDownloadsCount) AS dockerPulls,
-        toInt64(max(dockerDownloadsCount)) - toInt64(
-            maxIf(dockerDownloadsCount, date <= toDate(now() - INTERVAL 30 DAY))
+        argMax(downloadsCount, date) AS downloads,
+        toInt64(argMax(downloadsCount, date)) - toInt64(
+            argMaxIf(downloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
+        ) AS downloads30d,
+        argMax(dockerDownloadsCount, date) AS dockerPulls,
+        toInt64(argMax(dockerDownloadsCount, date)) - toInt64(
+            argMaxIf(dockerDownloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
         ) AS dockerPulls30d,
         max(dependentReposCount) AS dependentRepos,
         max(dependentPackagesCount) AS dependentPackages
@@ -113,15 +114,26 @@ SQL >
             SELECT
                 insightsProjectId,
                 date,
-                argMax(downloadsCount, updatedAt) AS downloadsCount,
-                argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
-                argMax(dependentReposCount, updatedAt) AS dependentReposCount,
-                argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
-            FROM packageDownloads
-            WHERE
-                insightsProjectId
-                IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
-            GROUP BY insightsProjectId, date, ecosystem, repo, name
+                sum(downloadsCount) AS downloadsCount,
+                sum(dockerDownloadsCount) AS dockerDownloadsCount,
+                max(dependentReposCount) AS dependentReposCount,
+                max(dependentPackagesCount) AS dependentPackagesCount
+            FROM
+                (
+                    SELECT
+                        insightsProjectId,
+                        date,
+                        argMax(downloadsCount, updatedAt) AS downloadsCount,
+                        argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
+                        argMax(dependentReposCount, updatedAt) AS dependentReposCount,
+                        argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
+                    FROM packageDownloads
+                    WHERE
+                        insightsProjectId
+                        IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
+                    GROUP BY insightsProjectId, date, ecosystem, repo, name
+                )
+            GROUP BY insightsProjectId, date
         )
     GROUP BY insightsProjectId
 

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -99,18 +99,28 @@ NODE ai_package_metrics
 SQL >
     SELECT
         insightsProjectId,
-        argMax(downloadsCount, date) AS downloads,
-        toInt64(argMax(downloadsCount, date)) - toInt64(
-            argMaxIf(downloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
+        max(downloadsCount) AS downloads,
+        toInt64(max(downloadsCount)) - toInt64(
+            maxIf(downloadsCount, date <= toDate(now() - INTERVAL 30 DAY))
         ) AS downloads30d,
-        argMax(dockerDownloadsCount, date) AS dockerPulls,
-        toInt64(argMax(dockerDownloadsCount, date)) - toInt64(
-            argMaxIf(dockerDownloadsCount, date, date <= toDate(now() - INTERVAL 30 DAY))
+        max(dockerDownloadsCount) AS dockerPulls,
+        toInt64(max(dockerDownloadsCount)) - toInt64(
+            maxIf(dockerDownloadsCount, date <= toDate(now() - INTERVAL 30 DAY))
         ) AS dockerPulls30d,
         max(dependentReposCount) AS dependentRepos,
         max(dependentPackagesCount) AS dependentPackages
-    FROM packageDownloads FINAL
-    WHERE insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos)
+    FROM (
+        SELECT
+            insightsProjectId,
+            date,
+            argMax(downloadsCount, updatedAt) AS downloadsCount,
+            argMax(dockerDownloadsCount, updatedAt) AS dockerDownloadsCount,
+            argMax(dependentReposCount, updatedAt) AS dependentReposCount,
+            argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
+        FROM packageDownloads
+        WHERE insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos WHERE insightsProjectId != '')
+        GROUP BY insightsProjectId, date, ecosystem, repo, name
+    )
     GROUP BY insightsProjectId
 
 NODE pr_metrics

--- a/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
+++ b/services/libs/tinybird/pipes/agentic_ai_projects_list_copy.pipe
@@ -129,8 +129,7 @@ SQL >
                         argMax(dependentReposCount, updatedAt) AS dependentReposCount,
                         argMax(dependentPackagesCount, updatedAt) AS dependentPackagesCount
                     FROM packageDownloads
-                    WHERE
-                        insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos)
+                    WHERE insightsProjectId IN (SELECT DISTINCT insightsProjectId FROM ai_repos)
                     GROUP BY insightsProjectId, date, ecosystem, repo, name
                 )
             GROUP BY insightsProjectId, date


### PR DESCRIPTION
Fixes incorrect download and Docker pull metrics on the Agentic AI projects list by rewriting the `ai_package_metrics` node in `agentic_ai_projects_list_copy.pipe`.

**What changed:**

* **`ai_repos`** now excludes repositories with an empty `insightsProjectId`, so all downstream nodes (activity, contributor, PR, issue metrics) automatically skip those repos.
* **`ai_package_metrics`** is restructured as a three-level pipeline:
  1. **Inner deduplication** — `argMax(..., updatedAt)` per `(insightsProjectId, date, ecosystem, repo, name)` to collapse duplicate/versioned rows in `packageDownloads`.
  2. **Per-package rollup** — groups by `(insightsProjectId, ecosystem, repo, name)` and applies `argMax(..., date)` / `argMaxIf(..., date, ...)` independently per package, so each package contributes its own latest cumulative value and its own 30-day delta regardless of when it was last updated.
  3. **Project rollup** — `sum` across packages per `insightsProjectId` for downloads and Docker pulls; `max` for dependent repo/package counts.

The previous single-pass query either picked one package's value per project (original) or summed per calendar date and silently dropped packages whose last row predated the project's latest date (intermediate version).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes analytics aggregation for a production report datasource; logic is more correct but totals and 30d deltas may shift materially for multi-package projects.
> 
> **Overview**
> Fixes inflated or incomplete **download**, **Docker pull**, and related package metrics on the Agentic AI projects list by changing the daily copy pipe that feeds `agentic_ai_projects_list_ds`.
> 
> **`ai_repos`** now requires a non-empty `insightsProjectId`, so repos without a linked insights project are dropped from every downstream metric node.
> 
> **`ai_package_metrics`** is rebuilt as a three-stage rollup over `packageDownloads`: dedupe rows per package/day with `argMax(..., updatedAt)`, compute each package’s latest totals and 30-day deltas, then **`sum`** downloads/Docker metrics (and **`max`** for dependent counts) per `insightsProjectId`. That replaces a single-pass `argMax`/`FINAL` query that could reflect only one package or miss packages whose last snapshot was older than the project’s latest date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa1083b353b29bbcd25da7214e45390b5448743c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->