### PR TITLE
fix: translate keys

### DIFF
--- a/backend/src/api/public/v1/ossprey/packageList.ts
+++ b/backend/src/api/public/v1/ossprey/packageList.ts
@@ -5,6 +5,7 @@ import {
   computeHealthBand,
   getPackageStatusCounts,
   listPackagesForApi,
+  translateActivityContent,
 } from '@crowd/data-access-layer'
 
 import { getPackagesQx } from '@/db/packagesDb'
@@ -79,7 +80,7 @@ export async function packageListHandler(req: Request, res: Response): Promise<v
       lastActivity: r.lastActivityAt
         ? {
             type: r.lastActivityType,
-            content: r.lastActivityContent,
+            content: translateActivityContent(r.lastActivityContent ?? null, r.lastActivityType, r.lastActivityMetadata),
             at: r.lastActivityAt.toISOString(),
           }
         : null,

--- a/backend/src/api/public/v1/ossprey/packageList.ts
+++ b/backend/src/api/public/v1/ossprey/packageList.ts
@@ -80,7 +80,11 @@ export async function packageListHandler(req: Request, res: Response): Promise<v
       lastActivity: r.lastActivityAt
         ? {
             type: r.lastActivityType,
-            content: translateActivityContent(r.lastActivityContent ?? null, r.lastActivityType, r.lastActivityMetadata),
+            content: translateActivityContent(
+              r.lastActivityContent ?? null,
+              r.lastActivityType,
+              r.lastActivityMetadata,
+            ),
             at: r.lastActivityAt.toISOString(),
           }
         : null,

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -126,6 +126,7 @@ export interface PackageListRow {
   latestReleaseAt: Date | null
   lastActivityType?: string | null
   lastActivityContent?: string | null
+  lastActivityMetadata?: Record<string, unknown> | null
   lastActivityAt?: Date | null
   stewards?: StewardEntry[]
   total: string
@@ -470,7 +471,7 @@ export async function listPackagesForApi(
     opts.includeLastActivity === true
       ? `
     LEFT JOIN LATERAL (
-      SELECT sa.activity_type, sa.content, sa.created_at
+      SELECT sa.activity_type, sa.content, sa.metadata, sa.created_at
       FROM stewardship_activity sa
       WHERE sa.stewardship_id = s.id
       ORDER BY sa.created_at DESC
@@ -502,7 +503,7 @@ export async function listPackagesForApi(
       pm_counts.cnt AS "maintainerCount",
       r_sc.scorecard_score AS "scorecardScore",
       p.latest_release_at AS "latestReleaseAt",
-      ${opts.includeLastActivity === true ? `last_act.activity_type AS "lastActivityType", last_act.content AS "lastActivityContent", last_act.created_at AS "lastActivityAt",` : ''}
+      ${opts.includeLastActivity === true ? `last_act.activity_type AS "lastActivityType", last_act.content AS "lastActivityContent", last_act.metadata AS "lastActivityMetadata", last_act.created_at AS "lastActivityAt",` : ''}
       ${opts.includeStewards === true ? "COALESCE(ss_agg.stewards, '[]'::json) AS stewards," : ''}
       COUNT(*) OVER() AS total
     FROM packages p

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -383,7 +383,7 @@ export async function listStewardshipActivity(
       actorUserId: row.actorUserId,
       actorType: row.actorType,
       activityType: row.activityType,
-      content: row.content,
+      content: translateActivityContent(row.content),
       metadata: row.metadata as Record<string, unknown> | null,
       stewardshipStatus: row.stewardshipStatus,
       createdAt: toIso(row.createdAt),
@@ -424,7 +424,7 @@ export async function listPackageHistory(
     actorUserId: r.actorUserId ? String(r.actorUserId) : null,
     actorType: String(r.actorType),
     activityType: String(r.activityType),
-    content: r.content ? String(r.content) : null,
+    content: translateActivityContent(r.content ? String(r.content) : null),
     metadata: r.metadata as Record<string, unknown> | null,
     createdAt: toIso(r.createdAt),
   }))
@@ -448,6 +448,14 @@ export const ESCALATION_RESOLUTION_PATH_LABELS: Record<EscalationResolutionPath,
   consortium_adopts_maintainership: 'Consortium Adopts Maintainership',
   compensating_controls_monitor: 'Compensating Controls / Monitor',
   namespace_takeover: 'Namespace Takeover',
+}
+
+function translateActivityContent(content: string | null): string | null {
+  if (!content) return content
+  return content.replace(/^(Escalated with resolution path: )(\S+)$/, (_, prefix, key) => {
+    const label = ESCALATION_RESOLUTION_PATH_LABELS[key as EscalationResolutionPath]
+    return label ? `${prefix}${label}` : content
+  })
 }
 
 /**
@@ -487,7 +495,7 @@ export async function escalateStewardship(
       resolutionPath: data.resolutionPath,
       statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
-      content: `Escalated with resolution path: ${ESCALATION_RESOLUTION_PATH_LABELS[data.resolutionPath]}`,
+      content: `Escalated with resolution path: ${data.resolutionPath}`,
       metadata: JSON.stringify({
         resolutionPath: data.resolutionPath,
         ...(data.notes ? { notes: data.notes } : {}),

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -383,7 +383,7 @@ export async function listStewardshipActivity(
       actorUserId: row.actorUserId,
       actorType: row.actorType,
       activityType: row.activityType,
-      content: translateActivityContent(row.content),
+      content: translateActivityContent(row.content, row.activityType, row.metadata as Record<string, unknown> | null),
       metadata: row.metadata as Record<string, unknown> | null,
       stewardshipStatus: row.stewardshipStatus,
       createdAt: toIso(row.createdAt),
@@ -424,7 +424,7 @@ export async function listPackageHistory(
     actorUserId: r.actorUserId ? String(r.actorUserId) : null,
     actorType: String(r.actorType),
     activityType: String(r.activityType),
-    content: translateActivityContent(r.content ? String(r.content) : null),
+    content: translateActivityContent(r.content ? String(r.content) : null, String(r.activityType), r.metadata as Record<string, unknown> | null),
     metadata: r.metadata as Record<string, unknown> | null,
     createdAt: toIso(r.createdAt),
   }))
@@ -450,8 +450,16 @@ export const ESCALATION_RESOLUTION_PATH_LABELS: Record<EscalationResolutionPath,
   namespace_takeover: 'Namespace Takeover',
 }
 
-function translateActivityContent(content: string | null): string | null {
+export function translateActivityContent(
+  content: string | null,
+  activityType?: string | null,
+  metadata?: Record<string, unknown> | null,
+): string | null {
   if (!content) return content
+  if (activityType === 'escalation' && metadata?.resolutionPath) {
+    const label = ESCALATION_RESOLUTION_PATH_LABELS[metadata.resolutionPath as EscalationResolutionPath]
+    if (label) return `Escalated with resolution path: ${label}`
+  }
   return content.replace(/^(Escalated with resolution path: )(\S+)$/, (_, prefix, key) => {
     const label = ESCALATION_RESOLUTION_PATH_LABELS[key as EscalationResolutionPath]
     return label ? `${prefix}${label}` : content

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -441,6 +441,15 @@ export const ESCALATION_RESOLUTION_PATHS = [
 
 export type EscalationResolutionPath = (typeof ESCALATION_RESOLUTION_PATHS)[number]
 
+export const ESCALATION_RESOLUTION_PATH_LABELS: Record<EscalationResolutionPath, string> = {
+  right_of_first_refusal: 'Right of First Refusal',
+  replace_the_dependency: 'Replace the Dependency',
+  find_vendor_for_lts: 'Find Vendor for LTS',
+  consortium_adopts_maintainership: 'Consortium Adopts Maintainership',
+  compensating_controls_monitor: 'Compensating Controls / Monitor',
+  namespace_takeover: 'Namespace Takeover',
+}
+
 /**
  * Escalates a stewardship. Updates status to 'escalated' and logs the
  * chosen resolution path in stewardship_activity metadata.
@@ -478,7 +487,7 @@ export async function escalateStewardship(
       resolutionPath: data.resolutionPath,
       statusNote: data.notes ?? null,
       actorUserId: data.actorUserId,
-      content: `Escalated with resolution path: ${data.resolutionPath}`,
+      content: `Escalated with resolution path: ${ESCALATION_RESOLUTION_PATH_LABELS[data.resolutionPath]}`,
       metadata: JSON.stringify({
         resolutionPath: data.resolutionPath,
         ...(data.notes ? { notes: data.notes } : {}),

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -383,7 +383,11 @@ export async function listStewardshipActivity(
       actorUserId: row.actorUserId,
       actorType: row.actorType,
       activityType: row.activityType,
-      content: translateActivityContent(row.content, row.activityType, row.metadata as Record<string, unknown> | null),
+      content: translateActivityContent(
+        row.content,
+        row.activityType,
+        row.metadata as Record<string, unknown> | null,
+      ),
       metadata: row.metadata as Record<string, unknown> | null,
       stewardshipStatus: row.stewardshipStatus,
       createdAt: toIso(row.createdAt),
@@ -424,7 +428,11 @@ export async function listPackageHistory(
     actorUserId: r.actorUserId ? String(r.actorUserId) : null,
     actorType: String(r.actorType),
     activityType: String(r.activityType),
-    content: translateActivityContent(r.content ? String(r.content) : null, String(r.activityType), r.metadata as Record<string, unknown> | null),
+    content: translateActivityContent(
+      r.content ? String(r.content) : null,
+      String(r.activityType),
+      r.metadata as Record<string, unknown> | null,
+    ),
     metadata: r.metadata as Record<string, unknown> | null,
     createdAt: toIso(r.createdAt),
   }))
@@ -457,7 +465,8 @@ export function translateActivityContent(
 ): string | null {
   if (!content) return content
   if (activityType === 'escalation' && metadata?.resolutionPath) {
-    const label = ESCALATION_RESOLUTION_PATH_LABELS[metadata.resolutionPath as EscalationResolutionPath]
+    const label =
+      ESCALATION_RESOLUTION_PATH_LABELS[metadata.resolutionPath as EscalationResolutionPath]
     if (label) return `Escalated with resolution path: ${label}`
   }
   return content.replace(/^(Escalated with resolution path: )(\S+)$/, (_, prefix, key) => {


### PR DESCRIPTION
## Summary
The stewardship escalation activity log was storing the raw enum value as the resolution path (e.g. `namespace_takeover`), making it unreadable for end users. This PR adds a human-readable label map and uses it when writing the activity log content.

## Changes
- Added `ESCALATION_RESOLUTION_PATH_LABELS` — a `Record<EscalationResolutionPath, string>` map that covers all 6 resolution paths; TypeScript enforces exhaustiveness at compile time
- Updated `escalateStewardship()` to use the label in the `content` field of the activity log entry (e.g. `"Escalated with resolution path: Namespace Takeover"` instead of `"...namespace_takeover"`); the raw enum value is still preserved in `metadata.resolutionPath`

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only mapping on read paths; raw enum values remain in the database and metadata unchanged.
> 
> **Overview**
> Escalation activity messages no longer surface raw resolution-path enum keys (e.g. `namespace_takeover`) in API responses.
> 
> A shared **`ESCALATION_RESOLUTION_PATH_LABELS`** map and **`translateActivityContent`** turn stored content and/or `metadata.resolutionPath` into readable labels (with a regex fallback for legacy rows that only have the key in `content`). **`listPackagesForApi`** now selects **`lastActivityMetadata`** so the public package list can translate **`lastActivity.content`** the same way as the stewardship activity feed and package history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de639e88501bcd6d9227fb447b812eef046f32b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->