### PR TITLE
fix: wrong unassigned count

### DIFF
--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -78,7 +78,7 @@ export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetri
         COUNT(*) FILTER (WHERE s.status IN ('assessing','active','needs_attention'))::text AS covered,
         COUNT(*) FILTER (WHERE s.status = 'needs_attention')::text                        AS "needsAttention",
         COUNT(*) FILTER (WHERE s.status = 'escalated')::text                              AS escalated,
-        COUNT(*) FILTER (WHERE s.status = 'unassigned' OR s.id IS NULL)::text             AS "unassignedCritical"
+        COUNT(*) FILTER (WHERE s.status NOT IN ('assessing','active','needs_attention','escalated') OR s.id IS NULL)::text AS "unassignedCritical"
       FROM packages p
       LEFT JOIN stewardships s ON s.package_id = p.id
       WHERE p.is_critical = true

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -78,7 +78,7 @@ export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetri
         COUNT(*) FILTER (WHERE s.status IN ('assessing','active','needs_attention'))::text AS covered,
         COUNT(*) FILTER (WHERE s.status = 'needs_attention')::text                        AS "needsAttention",
         COUNT(*) FILTER (WHERE s.status = 'escalated')::text                              AS escalated,
-        COUNT(*) FILTER (WHERE s.status NOT IN ('assessing','active','needs_attention','escalated') OR s.id IS NULL)::text AS "unassignedCritical"
+        COUNT(*) FILTER (WHERE s.id IS NULL OR s.status IS NULL OR s.status IN ('unassigned','open','blocked','inactive'))::text AS "unassignedCritical"
       FROM packages p
       LEFT JOIN stewardships s ON s.package_id = p.id
       WHERE p.is_critical = true


### PR DESCRIPTION
## Summary
Wrong unassigned count fix

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SQL filter change in a read-only metrics query; no auth or write paths affected.
> 
> **Overview**
> Fixes **`unassignedCritical`** in **`getOsspreyMetrics`** so dashboard metrics match how “unstewarded” critical packages are defined elsewhere.
> 
> The SQL `COUNT(*) FILTER` for unassigned critical packages now includes critical packages with **no stewardship row**, **NULL stewardship status**, or status **`unassigned`**, **`open`**, **`blocked`**, or **`inactive`**. Previously only missing stewardship or explicit **`unassigned`** counted, so **`open`**, **`blocked`**, **`inactive`**, and NULL-status rows were excluded from the metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8b51b1e33cf2323dab684b10e2420677c71aeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->