### PR TITLE
fix: adding total count

### DIFF
--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -51,6 +51,7 @@ export async function getPackagesByStewardshipPurls(
 
 // TODO[deprecate]: rename to AkritesMetrics once /v1/ossprey is removed
 export interface OsspreyMetrics {
+  totalPackages: number
   criticalPackages: number
   coveragePercent: number
   coverageTrend: number | null
@@ -64,6 +65,7 @@ export interface OsspreyMetrics {
 export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetrics> {
   const [counts, stewardRow]: [
     {
+      totalPackages: string
       criticalPackages: string
       covered: string
       needsAttention: string
@@ -74,6 +76,7 @@ export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetri
   ] = await Promise.all([
     qx.selectOne(`
       SELECT
+        (SELECT COUNT(*)::text FROM packages)                                               AS "totalPackages",
         COUNT(*)::text                                                                     AS "criticalPackages",
         COUNT(*) FILTER (WHERE s.status IN ('assessing','active','needs_attention'))::text AS covered,
         COUNT(*) FILTER (WHERE s.status = 'needs_attention')::text                        AS "needsAttention",
@@ -96,6 +99,7 @@ export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetri
   const covered = parseInt(counts.covered, 10)
 
   return {
+    totalPackages: parseInt(counts.totalPackages, 10),
     criticalPackages: total,
     coveragePercent: total > 0 ? Math.round((covered / total) * 1000) / 10 : 0,
     coverageTrend: null, // TODO: requires snapshot mechanism or stewardship_activity timestamp analysis

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -76,7 +76,7 @@ export async function getOsspreyMetrics(qx: QueryExecutor): Promise<OsspreyMetri
   ] = await Promise.all([
     qx.selectOne(`
       SELECT
-        (SELECT COUNT(*)::text FROM packages)                                               AS "totalPackages",
+        (SELECT reltuples::bigint::text FROM pg_class WHERE relname = 'packages')            AS "totalPackages",
         COUNT(*)::text                                                                     AS "criticalPackages",
         COUNT(*) FILTER (WHERE s.status IN ('assessing','active','needs_attention'))::text AS covered,
         COUNT(*) FILTER (WHERE s.status = 'needs_attention')::text                        AS "needsAttention",


### PR DESCRIPTION
## Summary

Adds totalPackages to the OSSPREY metrics endpoint response, which was missing from the getOsspreyMetrics query.

## Changes
- Added totalPackages field to OsspreyMetrics interface

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only metrics query change with no auth or mutation paths; the main caveat is possible semantic mismatch between OpenAPI and the `reltuples` estimate.
> 
> **Overview**
> **Fixes a gap in the OSSPREY KPI metrics** where the API contract expected `totalPackages` but `getOsspreyMetrics` never populated it.
> 
> The `OsspreyMetrics` type and the metrics SQL now include `totalPackages`, sourced via `pg_class.reltuples` on the `packages` table (a planner estimate, not an exact `COUNT(*)`). The function maps that value into the response alongside the existing critical-package stewardship aggregates.
> 
> **Note for reviewers:** OpenAPI describes `totalPackages` as critical packages (`is_critical = true`), while this implementation uses an estimate of **all** rows in `packages`—worth confirming product intent if clients rely on that field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b556c77d94c292e7ed5678338f3ab357317d7e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->