### PR TITLE
feat: add status filter as array (CM-1236)

### DIFF
--- a/backend/src/api/public/v1/ossprey/packageScatter.ts
+++ b/backend/src/api/public/v1/ossprey/packageScatter.ts
@@ -9,8 +9,21 @@ import { validateOrThrow } from '@/utils/validation'
 
 import { STEWARDSHIP_STATUS_VALUES } from '../packages/types'
 
+const statusEnum = z.enum(STEWARDSHIP_STATUS_VALUES)
+
+function normalizeToArray(v: unknown): unknown[] | undefined {
+  if (v === undefined) return undefined
+  if (Array.isArray(v)) return v
+  if (typeof v === 'string' && v.includes(','))
+    return v
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  return [v]
+}
+
 const scatterQuerySchema = z.object({
-  status: z.enum(STEWARDSHIP_STATUS_VALUES).optional(),
+  status: z.preprocess(normalizeToArray, z.array(statusEnum).min(1)).optional(),
 })
 
 export async function packageScatterHandler(req: Request, res: Response): Promise<void> {

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -667,17 +667,16 @@ export interface ScatterPoint {
 
 export async function listPackagesForScatter(
   qx: QueryExecutor,
-  options: { status?: string } = {},
+  options: { status?: string[] } = {},
 ): Promise<ScatterPoint[]> {
   const { status } = options
 
   // 'unassigned' covers packages with no stewardship row (s.id IS NULL) in addition
-  // to rows explicitly marked unassigned. All other statuses filter via s.status directly.
+  // to rows explicitly marked unassigned. All other statuses filter via s.status = ANY(...).
   // The query always uses LEFT JOIN — the filter is applied in the WHERE clause, not the join.
-  const statusFilter = status
-    ? status === 'unassigned'
-      ? `AND (s.status = 'unassigned' OR s.id IS NULL)`
-      : `AND s.status = $(status)`
+  const includesUnassigned = status?.includes('unassigned') ?? false
+  const statusFilter = status?.length
+    ? `AND (s.status = ANY($(status)::text[])${includesUnassigned ? ' OR s.id IS NULL' : ''})`
     : ''
 
   const rows: Array<{


### PR DESCRIPTION
## Summary
filter status by array

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only scatter query filtering in a public API; single-value queries still work via normalization.
> 
> **Overview**
> The **package scatter** endpoint now accepts **multiple stewardship statuses** in one request instead of a single `status` value.
> 
> Query parsing adds `normalizeToArray`, so clients can pass repeated params, a comma-separated string, or a lone value; validation requires a non-empty array of known status enums when `status` is present. **`listPackagesForScatter`** builds a `s.status = ANY(...)` filter and still treats **`unassigned`** as including packages with no stewardship row (`s.id IS NULL`) when that value is in the list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d80d97cf6449d72b88422eb5fe7d51e4213579. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->