### PR TITLE
feat: add ecosystem filter (CM-1236)

### DIFF
--- a/backend/src/api/public/v1/ossprey/packageScatter.ts
+++ b/backend/src/api/public/v1/ossprey/packageScatter.ts
@@ -24,7 +24,7 @@ function normalizeToArray(v: unknown): unknown[] | undefined {
 
 const scatterQuerySchema = z.object({
   status: z.preprocess(normalizeToArray, z.array(statusEnum).min(1)).optional(),
-  ecosystem: z.string().optional(),
+  ecosystem: z.string().min(1).optional(),
 })
 
 export async function packageScatterHandler(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/ossprey/packageScatter.ts
+++ b/backend/src/api/public/v1/ossprey/packageScatter.ts
@@ -24,11 +24,12 @@ function normalizeToArray(v: unknown): unknown[] | undefined {
 
 const scatterQuerySchema = z.object({
   status: z.preprocess(normalizeToArray, z.array(statusEnum).min(1)).optional(),
+  ecosystem: z.string().optional(),
 })
 
 export async function packageScatterHandler(req: Request, res: Response): Promise<void> {
-  const { status } = validateOrThrow(scatterQuerySchema, req.query)
+  const { status, ecosystem } = validateOrThrow(scatterQuerySchema, req.query)
   const qx = await getPackagesQx()
-  const points = await listPackagesForScatter(qx, { status })
+  const points = await listPackagesForScatter(qx, { status, ecosystem })
   ok(res, { points, total: points.length })
 }

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -667,9 +667,9 @@ export interface ScatterPoint {
 
 export async function listPackagesForScatter(
   qx: QueryExecutor,
-  options: { status?: string[] } = {},
+  options: { status?: string[]; ecosystem?: string } = {},
 ): Promise<ScatterPoint[]> {
-  const { status } = options
+  const { status, ecosystem } = options
 
   // 'unassigned' covers packages with no stewardship row (s.id IS NULL) in addition
   // to rows explicitly marked unassigned. All other statuses filter via s.status = ANY(...).
@@ -678,6 +678,7 @@ export async function listPackagesForScatter(
   const statusFilter = status?.length
     ? `AND (s.status = ANY($(status)::text[])${includesUnassigned ? ' OR s.id IS NULL' : ''})`
     : ''
+  const ecosystemFilter = ecosystem ? `AND p.ecosystem = $(ecosystem)` : ''
 
   const rows: Array<{
     purl: string
@@ -714,10 +715,11 @@ export async function listPackagesForScatter(
     ) r_sc ON true
     WHERE p.is_critical = true
     ${statusFilter}
+    ${ecosystemFilter}
     ORDER BY p.impact DESC NULLS LAST, p.purl ASC
     LIMIT 2000
     `,
-    { status },
+    { status, ecosystem },
   )
 
   return rows.map((r) => ({


### PR DESCRIPTION
## Summary
Add filter by ecosystem in the risk-matrix api

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1236](https://linuxfoundation.atlassian.net/browse/CM-1236)

[CM-1236]: https://linuxfoundation.atlassian.net/browse/CM-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive API and SQL filter aligned with existing package-list ecosystem filtering; no auth or data-model changes.
> 
> **Overview**
> Adds an optional **`ecosystem`** query parameter to the **packages scatter** endpoint (risk matrix), so clients can narrow scatter points by package ecosystem alongside the existing **`status`** filter.
> 
> The handler validates `ecosystem` as a non-empty string when present and passes it into **`listPackagesForScatter`**, which applies `p.ecosystem = $(ecosystem)` on critical packages when the value is set. Behavior is unchanged when the parameter is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48da1ad88dbf7933c811380c715e85578e2b20d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->