### PR TITLE
feat: support cargo in osv worker [CM-1269]

### DIFF
--- a/backend/.env.dist.local
+++ b/backend/.env.dist.local
@@ -195,7 +195,7 @@ OSSPCKGS_GCP_CREDENTIALS_B64=e30=
 # maven/all.zip 404s). The allowlist check and DB storage normalize to lowercase
 # internally per ADR-0001 §OSV "Ecosystem normalization", so downstream stays lowercase.
 OSV_BULK_BASE_URL=https://osv-vulnerabilities.storage.googleapis.com
-OSV_ECOSYSTEMS=npm,Maven
+OSV_ECOSYSTEMS=npm,Maven,cargo
 OSV_TMP_DIR=/tmp/osv
 OSV_BATCH_SIZE=500
 OSV_DERIVE_BATCH_SIZE=1000

--- a/services/apps/packages_worker/src/osv/__tests__/versionCompare.test.ts
+++ b/services/apps/packages_worker/src/osv/__tests__/versionCompare.test.ts
@@ -6,7 +6,7 @@ import { compareVersion } from '../versionCompare'
 // the contract is -1/0/1, but we only care about the sign.
 const sign = (n: number | null) => (n === null ? null : Math.sign(n))
 
-describe('compareVersion — npm (semver)', () => {
+describe('compareVersion — npm/cargo (semver)', () => {
   it.each([
     ['1.2.3', '1.2.4', -1],
     ['1.2.4', '1.2.3', 1],
@@ -20,11 +20,21 @@ describe('compareVersion — npm (semver)', () => {
     expect(sign(compareVersion('npm', a, b))).toBe(expected)
   })
 
-  it('returns null for unparseable npm versions', () => {
-    expect(compareVersion('npm', 'not-a-version-at-all', '1.0.0')).toBeNull()
+  it.each([
+    ['0.1.0', '0.2.0', -1],
+    ['1.0.0', '1.0.0', 0],
+    ['2.0.0', '1.9.9', 1],
+    ['0.3.0-alpha.1', '0.3.0', -1],
+  ])('compareVersion("cargo", %s, %s) sign = %s', (a, b, expected) => {
+    expect(sign(compareVersion('cargo', a, b))).toBe(expected)
   })
 
-  it('returns null for short / lossy npm versions instead of coercing', () => {
+  it('returns null for unparseable semver versions', () => {
+    expect(compareVersion('npm', 'not-a-version-at-all', '1.0.0')).toBeNull()
+    expect(compareVersion('cargo', 'not-a-version-at-all', '1.0.0')).toBeNull()
+  })
+
+  it('returns null for short / lossy versions instead of coercing', () => {
     // Under-flag over mis-flag: semver.coerce would map "1.2" → "1.2.0" and
     // "1.2-junk-3" → "1.2.3", which can flip has_critical_vulnerability on
     // a malformed introduced/fixed boundary. We prefer null (no match).
@@ -76,7 +86,6 @@ describe('compareVersion — maven (ComparableVersion-style)', () => {
 describe('compareVersion — unsupported ecosystems', () => {
   it('returns null for ecosystems we have no comparator for', () => {
     expect(compareVersion('PyPI', '1.0.0', '2.0.0')).toBeNull()
-    expect(compareVersion('crates.io', '0.1', '0.2')).toBeNull()
   })
 
   it('rejects titlecase "Maven" — production storage is always lowercase', () => {

--- a/services/apps/packages_worker/src/osv/fetchEcosystemZip.ts
+++ b/services/apps/packages_worker/src/osv/fetchEcosystemZip.ts
@@ -70,7 +70,8 @@ export async function* fetchEcosystemZip(
   await mkdir(ecoDir, { recursive: true })
   const zipPath = path.join(ecoDir, 'all.zip')
 
-  const url = `${baseUrl.replace(/\/$/, '')}/${ecosystem}/all.zip`
+  const bucketEcosystem = ecosystem === 'cargo' ? 'crates.io' : ecosystem
+  const url = `${baseUrl.replace(/\/$/, '')}/${bucketEcosystem}/all.zip`
 
   try {
     await downloadZip(url, zipPath)

--- a/services/apps/packages_worker/src/osv/parseOsvRecord.ts
+++ b/services/apps/packages_worker/src/osv/parseOsvRecord.ts
@@ -111,7 +111,8 @@ export function parseOsvRecord(
   for (const affected of record.affected ?? []) {
     const pkg = affected.package
     if (!pkg) continue
-    const ecosystem = pkg.ecosystem.toLowerCase()
+    const rawEcosystem = pkg.ecosystem.toLowerCase()
+    const ecosystem = rawEcosystem === 'crates.io' ? 'cargo' : rawEcosystem
     if (!allowedEcosystems.has(ecosystem)) continue
 
     const ranges = flattenRanges(affected)

--- a/services/apps/packages_worker/src/osv/schedule.ts
+++ b/services/apps/packages_worker/src/osv/schedule.ts
@@ -11,7 +11,7 @@ const SCHEDULE_ID = 'osv-advisories-sync'
 // validate the env input against this list and refuse to register the
 // schedule on a mismatch — better a loud startup error than a silent miss.
 // Add new entries here when v1 expands beyond npm + Maven.
-const VALID_ECOSYSTEMS = ['npm', 'Maven'] as const
+const VALID_ECOSYSTEMS = ['npm', 'Maven', 'cargo'] as const
 
 function getEcosystems(): string[] {
   const raw = process.env.OSV_ECOSYSTEMS

--- a/services/apps/packages_worker/src/osv/versionCompare.ts
+++ b/services/apps/packages_worker/src/osv/versionCompare.ts
@@ -14,7 +14,7 @@ function parseLoose(v: string): semver.SemVer | null {
   return semver.parse(v, { loose: true })
 }
 
-function compareNpm(a: string, b: string): number | null {
+function compareSemver(a: string, b: string): number | null {
   const pa = parseLoose(a)
   const pb = parseLoose(b)
   if (!pa || !pb) return null
@@ -127,10 +127,10 @@ function compareMaven(a: string, b: string): number | null {
 }
 
 // Ecosystem names are stored lowercase in packages-db per ADR-0001 §OSV
-// "Ecosystem normalization" — 'npm' and 'maven'. Callers (deriveCriticalFlag)
+// "Ecosystem normalization" — 'npm', 'maven', 'cargo'. Callers (deriveCriticalFlag)
 // pull the value straight from the DB so the literals here must match.
 export function compareVersion(ecosystem: string, a: string, b: string): number | null {
-  if (ecosystem === 'npm') return compareNpm(a, b)
+  if (ecosystem === 'npm' || ecosystem === 'cargo') return compareSemver(a, b)
   if (ecosystem === 'maven') return compareMaven(a, b)
   return null
 }


### PR DESCRIPTION
This pull request improves the handling of the "cargo" ecosystem (Rust) in the OSV advisories sync process, ensuring consistency between naming conventions and expanding support for this ecosystem. The changes address both the fetching and parsing of advisories, as well as the configuration of valid ecosystems.

Ecosystem naming consistency and support:

* Updated the zip file fetching logic in `fetchEcosystemZip.ts` to use "crates.io" as the bucket name when the ecosystem is "cargo", ensuring the correct URL is constructed for Rust advisories.
* Modified the parsing logic in `parseOsvRecord.ts` to map "crates.io" back to "cargo" for internal consistency, so advisories from Rust are handled uniformly.

Configuration improvements:

* Added "cargo" to the list of valid ecosystems in `schedule.ts`, allowing the advisories sync process to support Rust packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches vulnerability range matching and new bulk ingest surface; semver reuse for cargo is reasonable but mis-parsed versions still follow the under-flag-over-mis-flag policy.
> 
> **Overview**
> Extends the OSV advisories worker to ingest **Rust (cargo)** alongside npm and Maven, with naming aligned to OSV’s bucket vs internal storage.
> 
> **Ingestion:** `cargo` is a valid `OSV_ECOSYSTEMS` value (local dist env and schedule allowlist). Bulk zips are fetched from the **`crates.io`** path segment while tmp dirs still use `cargo`. Parsed records map OSV’s **`crates.io`** ecosystem label to stored **`cargo`**.
> 
> **Matching:** `compareVersion` treats **`cargo`** like npm via shared loose semver parsing, so critical-range derivation works for Rust crate versions. Tests cover cargo ordering and drop the old “unsupported crates.io” expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2307535cfbdc26a8dc36859694f947c281cc5500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->