### PR TITLE
feat: adding me apis (CM-1272)

### DIFF
--- a/backend/src/api/public/v1/akrites/index.ts
+++ b/backend/src/api/public/v1/akrites/index.ts
@@ -16,6 +16,8 @@ import { getPackageHistory } from '../packages/getPackageHistory'
 import { getPackagesMetrics } from '../packages/getPackagesMetrics'
 import { assignStewardHandler } from '../stewardships/assignSteward'
 import { escalateHandler } from '../stewardships/escalate'
+import { getMyActivityHandler } from '../stewardships/getMyActivity'
+import { getMyPackagesHandler } from '../stewardships/getMyPackages'
 import { openStewardship } from '../stewardships/openStewardship'
 import { updateStatusHandler } from '../stewardships/updateStatus'
 
@@ -84,6 +86,16 @@ export function akritesRouter(): Router {
   // --- stewardships ---
   const stewardshipsSubRouter = Router()
   stewardshipsSubRouter.use(rateLimiter)
+  stewardshipsSubRouter.get(
+    '/me/packages',
+    requireScopes([SCOPES.READ_STEWARDSHIPS]),
+    safeWrap(getMyPackagesHandler),
+  )
+  stewardshipsSubRouter.get(
+    '/me/activity',
+    requireScopes([SCOPES.READ_STEWARDSHIPS]),
+    safeWrap(getMyActivityHandler),
+  )
   stewardshipsSubRouter.post(
     '/open',
     requireScopes([SCOPES.WRITE_STEWARDSHIPS]),

--- a/backend/src/api/public/v1/akrites/openapi.yaml
+++ b/backend/src/api/public/v1/akrites/openapi.yaml
@@ -1127,6 +1127,299 @@ paths:
 
   # ── Stewardships ───────────────────────────────────────────────────────────
 
+  /akrites/stewardships/me/packages:
+    get:
+      operationId: getMyPackages
+      summary: List packages stewarded by the authenticated user
+      description: >
+        Returns a paginated list of packages where the authenticated user
+        (`req.actor.id`) is an active steward (`lead` or `co_steward`).
+        Includes package metadata, health, open vulnerabilities, last activity,
+        and the user's role and stewardship status.
+        The `meta.statusCounts` object always reflects counts across **all**
+        of the user's stewardships, regardless of the active `status` filter,
+        so the tab bar can render all buckets at once.
+      tags:
+        - Stewardships
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+        - name: status
+          in: query
+          description: Filter by stewardship status.
+          schema:
+            type: string
+            enum: [assessing, active, needs_attention, escalated, blocked]
+        - name: search
+          in: query
+          description: Case-insensitive substring match on package name or PURL.
+          schema:
+            type: string
+        - name: ecosystem
+          in: query
+          schema:
+            type: string
+            enum: [npm, maven, pypi, go, cargo]
+        - name: healthBand
+          in: query
+          schema:
+            type: string
+            enum: [healthy, fair, concerning, critical]
+        - name: vulnSeverity
+          in: query
+          description: Filter to packages with at least one vulnerability of this severity or worse.
+          schema:
+            type: string
+            enum: [high, critical]
+        - name: sortBy
+          in: query
+          schema:
+            type: string
+            enum: [risk, health, vulns, name, last_activity]
+            default: risk
+        - name: sortDir
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+      responses:
+        '200':
+          description: Paginated list of the user's stewarded packages.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - purl
+                        - name
+                        - ecosystem
+                        - openVulns
+                        - stewardshipId
+                        - stewardshipStatus
+                        - myRole
+                      properties:
+                        purl:
+                          type: string
+                          example: pkg:npm/minimist
+                        name:
+                          type: string
+                          example: minimist
+                        ecosystem:
+                          type: string
+                          example: npm
+                        lifecycle:
+                          type: string
+                          nullable: true
+                          example: abandoned
+                        healthScore:
+                          type: integer
+                          minimum: 0
+                          maximum: 100
+                          nullable: true
+                          description: Scorecard score scaled to 0–100.
+                        healthBand:
+                          type: string
+                          enum: [healthy, fair, concerning, critical]
+                        openVulns:
+                          type: integer
+                          example: 2
+                        vulnSeverity:
+                          type: string
+                          enum: [critical, high, medium, low]
+                          nullable: true
+                          description: Worst open vulnerability severity.
+                        lastActivityDescription:
+                          type: string
+                          nullable: true
+                          example: Escalated for intervention
+                        lastActivityAt:
+                          type: string
+                          format: date-time
+                          nullable: true
+                        stewardshipId:
+                          type: string
+                          example: '42'
+                        stewardshipStatus:
+                          type: string
+                          enum: [assessing, active, needs_attention, escalated, blocked]
+                        myRole:
+                          type: string
+                          enum: [lead, co_steward]
+                  meta:
+                    type: object
+                    required: [total, page, pageSize, statusCounts]
+                    properties:
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+                      statusCounts:
+                        type: object
+                        required: [assessing, active, needs_attention, escalated, blocked]
+                        properties:
+                          assessing:
+                            type: integer
+                          active:
+                            type: integer
+                          needs_attention:
+                            type: integer
+                          escalated:
+                            type: integer
+                          blocked:
+                            type: integer
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /akrites/stewardships/me/activity:
+    get:
+      operationId: getMyActivity
+      summary: Latest activity feed for the authenticated user's stewardships
+      description: >
+        Returns the most recent stewardship activity events scoped to packages
+        where the authenticated user is an active steward. Results are
+        **deduplicated by stewardship** — only the single most recent event per
+        package is returned — and sorted newest-first.
+        Designed to power the "Latest activity" strip on the My Stewardships
+        page. Default `pageSize` is 3 (one card per attention-needed status);
+        increase for a "load more" experience.
+      tags:
+        - Stewardships
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 3
+        - name: status
+          in: query
+          description: >
+            Comma-separated list of stewardship statuses to filter.
+            Example: `needs_attention,blocked,escalated,assessing`
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Deduplicated activity feed for the user's stewardships.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - stewardshipId
+                        - packageName
+                        - purl
+                        - packageEcosystem
+                        - stewardshipStatus
+                        - activityType
+                        - createdAt
+                      properties:
+                        stewardshipId:
+                          type: string
+                          example: '42'
+                        packageName:
+                          type: string
+                          example: jackson-databind
+                        purl:
+                          type: string
+                          example: pkg:maven/com.fasterxml.jackson.core/jackson-databind
+                        packageEcosystem:
+                          type: string
+                          example: maven
+                        stewardshipStatus:
+                          type: string
+                          enum:
+                            [
+                              assessing,
+                              active,
+                              needs_attention,
+                              escalated,
+                              blocked,
+                              unassigned,
+                              open,
+                              inactive,
+                            ]
+                        activityType:
+                          type: string
+                          example: advisory_detected
+                        description:
+                          type: string
+                          nullable: true
+                          example: New security advisory detected
+                        createdAt:
+                          type: string
+                          format: date-time
+                        suggestedAction:
+                          type: string
+                          nullable: true
+                          description: Label for the primary CTA button on the activity card.
+                          example: Review & respond
+                  meta:
+                    type: object
+                    required: [total, page, pageSize]
+                    properties:
+                      total:
+                        type: integer
+                      page:
+                        type: integer
+                      pageSize:
+                        type: integer
+        '400':
+          description: Validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /akrites/stewardships/open:
     post:
       operationId: openStewardship

--- a/backend/src/api/public/v1/stewardships/getMyActivity.ts
+++ b/backend/src/api/public/v1/stewardships/getMyActivity.ts
@@ -1,0 +1,75 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import { listMyActivity } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+const VALID_STATUSES = [
+  'assessing',
+  'active',
+  'needs_attention',
+  'escalated',
+  'blocked',
+  'unassigned',
+  'open',
+  'inactive',
+] as const
+
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(3),
+  status: z
+    .string()
+    .optional()
+    .transform((v) => {
+      if (!v) return undefined
+      const parts = v
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      return parts.length > 0 ? parts : undefined
+    })
+    .pipe(z.array(z.enum(VALID_STATUSES)).optional()),
+})
+
+const SUGGESTED_ACTIONS: Record<string, string> = {
+  needs_attention: 'Review & respond',
+  blocked: 'Resolve blocker',
+  escalated: 'Add escalation context',
+  assessing: 'Continue assessment',
+  active: 'View stewardship',
+}
+
+export async function getMyActivityHandler(req: Request, res: Response): Promise<void> {
+  const params = validateOrThrow(querySchema, req.query)
+
+  const qx = await getPackagesQx()
+  const { rows, total } = await listMyActivity(qx, {
+    userId: req.actor.id,
+    page: params.page,
+    pageSize: params.pageSize,
+    status: params.status,
+  })
+
+  ok(res, {
+    data: rows.map((r) => ({
+      stewardshipId: r.stewardshipId,
+      packageName: r.packageName,
+      purl: r.packagePurl,
+      packageEcosystem: r.packageEcosystem,
+      stewardshipStatus: r.stewardshipStatus,
+      activityType: r.activityType,
+      description: r.content,
+      createdAt: r.createdAt,
+      suggestedAction: SUGGESTED_ACTIONS[r.stewardshipStatus] ?? null,
+    })),
+    meta: {
+      total,
+      page: params.page,
+      pageSize: params.pageSize,
+    },
+  })
+}

--- a/backend/src/api/public/v1/stewardships/getMyPackages.ts
+++ b/backend/src/api/public/v1/stewardships/getMyPackages.ts
@@ -1,0 +1,62 @@
+import type { Request, Response } from 'express'
+import { z } from 'zod'
+
+import {
+  computeHealthBand,
+  listMyPackages,
+  translateActivityContent,
+} from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+const querySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(25),
+  status: z.enum(['assessing', 'active', 'needs_attention', 'escalated', 'blocked']).optional(),
+  search: z.string().trim().optional(),
+  ecosystem: z.string().trim().optional(),
+  healthBand: z.enum(['healthy', 'fair', 'concerning', 'critical']).optional(),
+  vulnSeverity: z.enum(['high', 'critical']).optional(),
+  sortBy: z.enum(['risk', 'health', 'vulns', 'name', 'last_activity']).default('risk'),
+  sortDir: z.enum(['asc', 'desc']).default('desc'),
+})
+
+export async function getMyPackagesHandler(req: Request, res: Response): Promise<void> {
+  const params = validateOrThrow(querySchema, req.query)
+
+  const qx = await getPackagesQx()
+  const { rows, total, statusCounts } = await listMyPackages(qx, {
+    userId: req.actor.id,
+    ...params,
+  })
+
+  ok(res, {
+    data: rows.map((r) => ({
+      purl: r.purl,
+      name: r.name,
+      ecosystem: r.ecosystem,
+      lifecycle: r.lifecycle,
+      healthScore: r.scorecardScore != null ? Math.round(r.scorecardScore * 10) : null,
+      healthBand: computeHealthBand(r.scorecardScore),
+      openVulns: r.openVulns,
+      vulnSeverity: r.maxVulnSeverity,
+      lastActivityDescription: translateActivityContent(
+        r.lastActivityContent,
+        r.lastActivityType,
+        r.lastActivityMetadata,
+      ),
+      lastActivityAt: r.lastActivityAt ? r.lastActivityAt.toISOString() : null,
+      stewardshipId: r.stewardshipId,
+      stewardshipStatus: r.stewardshipStatus,
+      myRole: r.myRole,
+    })),
+    meta: {
+      total,
+      page: params.page,
+      pageSize: params.pageSize,
+      statusCounts,
+    },
+  })
+}

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -170,7 +170,7 @@ const STALE_MONTHS = 18
 
 // Severity stored as uppercase in advisories table.
 // Ranks: CRITICAL=4, HIGH=3, MEDIUM=2, LOW=1
-const SEVERITY_RANK_EXPR = `MAX(CASE a.severity
+export const SEVERITY_RANK_EXPR = `MAX(CASE a.severity
     WHEN 'CRITICAL' THEN 4
     WHEN 'HIGH'     THEN 3
     WHEN 'MEDIUM'   THEN 2

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -510,6 +510,10 @@ export async function listMyPackages(
   if (opts.status) {
     conditions.push('s.status = $(status)')
     params.status = opts.status
+  } else {
+    conditions.push(
+      "s.status IN ('assessing', 'active', 'needs_attention', 'escalated', 'blocked')",
+    )
   }
 
   if (opts.search) {

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -1,5 +1,7 @@
 import { QueryExecutor } from '../queryExecutor'
 
+import { SEVERITY_RANK_EXPR } from './api'
+
 export interface StewardshipRecord {
   id: string
   packageId: string
@@ -453,6 +455,364 @@ export async function listPackageHistory(
     metadata: r.metadata as Record<string, unknown> | null,
     createdAt: toIso(r.createdAt),
   }))
+}
+
+export interface MyPackageRow {
+  purl: string
+  name: string
+  ecosystem: string
+  lifecycle: string | null
+  scorecardScore: number | null
+  openVulns: number
+  maxVulnSeverity: 'critical' | 'high' | 'medium' | 'low' | null
+  lastActivityContent: string | null
+  lastActivityType: string | null
+  lastActivityMetadata: Record<string, unknown> | null
+  lastActivityAt: Date | null
+  stewardshipId: string
+  stewardshipStatus: string
+  myRole: string
+  total: string
+}
+
+export interface MyPackageStatusCounts {
+  assessing: number
+  active: number
+  needs_attention: number
+  escalated: number
+  blocked: number
+}
+
+export interface ListMyPackagesOptions {
+  userId: string
+  page: number
+  pageSize: number
+  status?: 'assessing' | 'active' | 'needs_attention' | 'escalated' | 'blocked'
+  search?: string
+  ecosystem?: string
+  healthBand?: 'healthy' | 'fair' | 'concerning' | 'critical'
+  vulnSeverity?: 'high' | 'critical'
+  sortBy: 'risk' | 'health' | 'vulns' | 'name' | 'last_activity'
+  sortDir: 'asc' | 'desc'
+}
+
+export async function listMyPackages(
+  qx: QueryExecutor,
+  opts: ListMyPackagesOptions,
+): Promise<{
+  rows: Omit<MyPackageRow, 'total'>[]
+  total: number
+  statusCounts: MyPackageStatusCounts
+}> {
+  const conditions: string[] = ['ss.user_id = $(userId)', 'ss.deleted_at IS NULL']
+  const params: Record<string, unknown> = { userId: opts.userId }
+
+  if (opts.status) {
+    conditions.push('s.status = $(status)')
+    params.status = opts.status
+  }
+
+  if (opts.search) {
+    conditions.push('(p.name ILIKE $(search) OR p.purl ILIKE $(search))')
+    params.search = `%${opts.search}%`
+  }
+
+  if (opts.ecosystem) {
+    conditions.push('p.ecosystem = $(ecosystem)')
+    params.ecosystem = opts.ecosystem
+  }
+
+  if (opts.healthBand) {
+    if (opts.healthBand === 'healthy') {
+      conditions.push('r_sc.scorecard_score >= 7.0')
+    } else if (opts.healthBand === 'fair') {
+      conditions.push('r_sc.scorecard_score >= 5.0 AND r_sc.scorecard_score < 7.0')
+    } else if (opts.healthBand === 'concerning') {
+      conditions.push('r_sc.scorecard_score >= 3.0 AND r_sc.scorecard_score < 5.0')
+    } else {
+      conditions.push('(r_sc.scorecard_score IS NULL OR r_sc.scorecard_score < 3.0)')
+    }
+  }
+
+  if (opts.vulnSeverity) {
+    if (opts.vulnSeverity === 'high') {
+      conditions.push('ap_severity.max_rank >= 3')
+    } else {
+      conditions.push('ap_severity.max_rank >= 4')
+    }
+  }
+
+  const where = `WHERE ${conditions.join(' AND ')}`
+
+  let sortExpr: string
+  if (opts.sortBy === 'health') {
+    sortExpr = 'r_sc.scorecard_score'
+  } else if (opts.sortBy === 'vulns') {
+    sortExpr = 'ap_counts.cnt'
+  } else if (opts.sortBy === 'name') {
+    sortExpr = 'LOWER(p.name)'
+  } else if (opts.sortBy === 'last_activity') {
+    sortExpr = 'last_act.created_at'
+  } else {
+    // risk: composite of impact + health deficit + vuln severity + vuln count
+    sortExpr = `(
+      COALESCE(p.impact, 0) * 100
+      + (100.0 - COALESCE(r_sc.scorecard_score, 0) * 10) * 0.8
+      + COALESCE(ap_severity.max_rank, 0) * 15
+      + COALESCE(ap_counts.cnt, 0) * 4
+    )`
+  }
+  const sortDir = opts.sortDir === 'asc' ? 'ASC' : 'DESC'
+
+  const queryParams = { ...params, limit: opts.pageSize, offset: (opts.page - 1) * opts.pageSize }
+
+  // filterLaterals affect WHERE clauses — included in both main query and fallback COUNT.
+  // displayLaterals are SELECT-only — excluded from COUNT to avoid unnecessary subqueries.
+  const filterLaterals = `
+    LEFT JOIN LATERAL (
+      SELECT r.scorecard_score
+      FROM package_repos pr
+      JOIN repos r ON r.id = pr.repo_id
+      WHERE pr.package_id = p.id
+      ORDER BY pr.confidence DESC
+      LIMIT 1
+    ) r_sc ON true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS cnt FROM advisory_packages WHERE package_id = p.id
+    ) ap_counts ON true
+    LEFT JOIN LATERAL (
+      SELECT ${SEVERITY_RANK_EXPR} AS max_rank
+      FROM advisory_packages ap
+      JOIN advisories a ON a.id = ap.advisory_id
+      WHERE ap.package_id = p.id
+    ) ap_severity ON true`
+
+  const displayLaterals = `
+    LEFT JOIN LATERAL (
+      SELECT sa.content, sa.activity_type, sa.metadata, sa.created_at
+      FROM stewardship_activity sa
+      WHERE sa.stewardship_id = s.id
+      ORDER BY sa.created_at DESC
+      LIMIT 1
+    ) last_act ON true`
+
+  const [rows, statusRows] = await Promise.all([
+    qx.select(
+      `
+      SELECT
+        p.purl,
+        p.name,
+        p.ecosystem,
+        p.status                       AS lifecycle,
+        r_sc.scorecard_score           AS "scorecardScore",
+        COALESCE(ap_counts.cnt, 0)     AS "openVulns",
+        CASE ap_severity.max_rank
+          WHEN 4 THEN 'critical'
+          WHEN 3 THEN 'high'
+          WHEN 2 THEN 'medium'
+          WHEN 1 THEN 'low'
+          ELSE NULL
+        END                            AS "maxVulnSeverity",
+        last_act.content               AS "lastActivityContent",
+        last_act.activity_type         AS "lastActivityType",
+        last_act.metadata              AS "lastActivityMetadata",
+        last_act.created_at            AS "lastActivityAt",
+        s.id::text                     AS "stewardshipId",
+        s.status                       AS "stewardshipStatus",
+        ss.role                        AS "myRole",
+        COUNT(*) OVER()::text          AS total
+      FROM stewardship_stewards ss
+      JOIN stewardships s ON s.id = ss.stewardship_id
+      JOIN packages p ON p.id = s.package_id
+      ${filterLaterals}
+      ${displayLaterals}
+      ${where}
+      ORDER BY ${sortExpr} ${sortDir} NULLS LAST, p.purl ASC
+      LIMIT $(limit) OFFSET $(offset)
+      `,
+      queryParams,
+    ) as Promise<MyPackageRow[]>,
+    qx.select(
+      `
+      SELECT s.status, COUNT(*)::int AS count
+      FROM stewardship_stewards ss
+      JOIN stewardships s ON s.id = ss.stewardship_id
+      WHERE ss.user_id = $(userId) AND ss.deleted_at IS NULL
+        AND s.status IN ('assessing', 'active', 'needs_attention', 'escalated', 'blocked')
+      GROUP BY s.status
+      `,
+      { userId: opts.userId },
+    ) as Promise<{ status: string; count: number }[]>,
+  ])
+
+  let total: number
+  if (rows.length > 0) {
+    total = parseInt(rows[0].total, 10)
+  } else {
+    const countRow: { count: string } = await qx.selectOne(
+      `
+      SELECT COUNT(*)::text AS count
+      FROM stewardship_stewards ss
+      JOIN stewardships s ON s.id = ss.stewardship_id
+      JOIN packages p ON p.id = s.package_id
+      ${filterLaterals}
+      ${where}
+      `,
+      params,
+    )
+    total = parseInt(countRow.count, 10)
+  }
+
+  const countsMap: Record<string, number> = {}
+  for (const r of statusRows) {
+    countsMap[r.status] = r.count
+  }
+  const statusCounts: MyPackageStatusCounts = {
+    assessing: countsMap.assessing ?? 0,
+    active: countsMap.active ?? 0,
+    needs_attention: countsMap.needs_attention ?? 0,
+    escalated: countsMap.escalated ?? 0,
+    blocked: countsMap.blocked ?? 0,
+  }
+
+  return {
+    rows: rows.map((row) => ({
+      purl: row.purl,
+      name: row.name,
+      ecosystem: row.ecosystem,
+      lifecycle: row.lifecycle ?? null,
+      scorecardScore: row.scorecardScore != null ? Number(row.scorecardScore) : null,
+      openVulns: Number(row.openVulns),
+      maxVulnSeverity: row.maxVulnSeverity ?? null,
+      lastActivityContent: row.lastActivityContent ?? null,
+      lastActivityType: row.lastActivityType ?? null,
+      lastActivityMetadata: row.lastActivityMetadata ?? null,
+      lastActivityAt: row.lastActivityAt ?? null,
+      stewardshipId: row.stewardshipId,
+      stewardshipStatus: row.stewardshipStatus,
+      myRole: row.myRole,
+    })),
+    total,
+    statusCounts,
+  }
+}
+
+export interface ListMyActivityOptions {
+  userId: string
+  page: number
+  pageSize: number
+  status?: string[]
+}
+
+export async function listMyActivity(
+  qx: QueryExecutor,
+  opts: ListMyActivityOptions,
+): Promise<{ rows: Omit<ActivityFeedRow, 'total'>[]; total: number }> {
+  const params: Record<string, unknown> = {
+    userId: opts.userId,
+    limit: opts.pageSize,
+    offset: (opts.page - 1) * opts.pageSize,
+  }
+
+  const statusFilter =
+    opts.status && opts.status.length > 0 ? 'AND s.status = ANY($(statusFilter))' : ''
+  if (opts.status && opts.status.length > 0) {
+    params.statusFilter = opts.status
+  }
+
+  // DISTINCT ON keeps the most recent event per stewardship; the outer query
+  // re-sorts newest-first after deduplication and applies pagination.
+  const rows: ActivityFeedRow[] = await qx.select(
+    `
+    SELECT
+      sub.id,
+      sub."stewardshipId",
+      sub."packagePurl",
+      sub."packageName",
+      sub."packageEcosystem",
+      sub."actorUserId",
+      sub."actorType",
+      sub."activityType",
+      sub.content,
+      sub.metadata,
+      sub."stewardshipStatus",
+      sub."createdAt",
+      COUNT(*) OVER()::text AS total
+    FROM (
+      SELECT DISTINCT ON (sa.stewardship_id)
+        sa.id::text                        AS id,
+        sa.stewardship_id::text            AS "stewardshipId",
+        p.purl                             AS "packagePurl",
+        p.name                             AS "packageName",
+        p.ecosystem                        AS "packageEcosystem",
+        sa.actor_user_id                   AS "actorUserId",
+        sa.actor_type                      AS "actorType",
+        sa.activity_type                   AS "activityType",
+        sa.content                         AS content,
+        sa.metadata                        AS metadata,
+        s.status                           AS "stewardshipStatus",
+        sa.created_at                      AS "createdAt"
+      FROM stewardship_activity sa
+      JOIN stewardships s ON s.id = sa.stewardship_id
+      JOIN packages p ON p.id = s.package_id
+      WHERE s.id IN (
+        SELECT stewardship_id FROM stewardship_stewards
+        WHERE user_id = $(userId) AND deleted_at IS NULL
+      )
+      ${statusFilter}
+      ORDER BY sa.stewardship_id, sa.created_at DESC, sa.id DESC
+    ) sub
+    ORDER BY sub."createdAt" DESC, sub.id::bigint DESC
+    LIMIT $(limit) OFFSET $(offset)
+    `,
+    params,
+  )
+
+  let total: number
+  if (rows.length > 0) {
+    total = parseInt(rows[0].total, 10)
+  } else {
+    const countParams: Record<string, unknown> = { userId: opts.userId }
+    if (opts.status && opts.status.length > 0) {
+      countParams.statusFilter = opts.status
+    }
+    const countRow: { count: string } = await qx.selectOne(
+      `
+      SELECT COUNT(DISTINCT sa.stewardship_id)::text AS count
+      FROM stewardship_activity sa
+      JOIN stewardships s ON s.id = sa.stewardship_id
+      WHERE s.id IN (
+        SELECT stewardship_id FROM stewardship_stewards
+        WHERE user_id = $(userId) AND deleted_at IS NULL
+      )
+      ${statusFilter}
+      `,
+      countParams,
+    )
+    total = parseInt(countRow.count, 10)
+  }
+
+  return {
+    rows: rows.map((row) => ({
+      id: row.id,
+      stewardshipId: row.stewardshipId,
+      packagePurl: row.packagePurl,
+      packageName: row.packageName,
+      packageEcosystem: row.packageEcosystem,
+      actorUserId: row.actorUserId,
+      actorType: row.actorType,
+      activityType: row.activityType,
+      content: translateActivityContent(
+        row.content,
+        row.activityType,
+        row.metadata as Record<string, unknown> | null,
+      ),
+      metadata: row.metadata as Record<string, unknown> | null,
+      stewardshipStatus: row.stewardshipStatus,
+      createdAt: toIso(row.createdAt),
+    })),
+    total,
+  }
 }
 
 export const ESCALATION_RESOLUTION_PATHS = [


### PR DESCRIPTION
## Summary

Adds two user-scoped read endpoints to the Akrites API to power the My Stewardships page in LFX One. The existing endpoints (GET /v1/akrites/packages, /v1/akrites/activity) are global — they return data across all stewards. This PR adds the same data scoped to req.actor.id, which is required for the personal dashboard view.

## Changes

- GET /v1/akrites/stewardships/me/packages — Returns the authenticated user's stewarded packages with full table metadata: stewardship ID and status, role (lead/co_steward), package health score + band, open vuln count + worst severity, last activity summary + timestamp. Supports filtering by status, search (name or PURL), ecosystem, health band, and vuln severity; sortable by risk (composite score), health, vulns, name, or last activity. meta.statusCounts always reflects all 5 statuses regardless of the active filter, so the tab bar renders without a second request.
- GET /v1/akrites/stewardships/me/activity — Returns the most recent activity event per stewarded package (deduplicated via DISTINCT ON stewardship_id), filtered to the requesting user's stewardships. Powers the "Latest activity" cards. Default pageSize=3; accepts a comma-separated status filter (e.g. needs_attention,blocked,escalated). Each item includes a suggestedAction label for the primary CTA button.
- DAL (stewardships.ts) — listMyPackages and listMyActivity added. Filter and display laterals are kept separate so the fallback COUNT query skips the last_act lateral (SELECT-only, not needed for counting). SEVERITY_RANK_EXPR extracted to a shared export in api.ts to avoid duplication.
- OpenAPI — Both endpoints fully documented in openapi.yaml under the Stewardships tag, including query params, response schemas, and statusCounts shape.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1272](https://linuxfoundation.atlassian.net/browse/CM-1272)


[CM-1272]: https://linuxfoundation.atlassian.net/browse/CM-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read APIs with complex SQL (laterals, DISTINCT ON, user scoping) on stewardship and vulnerability data; scope is limited to the caller's stewardships but query performance and correctness matter for production dashboards.
> 
> **Overview**
> Adds **user-scoped** Akrites stewardship reads so the My Stewardships dashboard can show only packages where `req.actor.id` is an active steward, instead of relying on global `/akrites/packages` and `/akrites/activity`.
> 
> **`GET /v1/akrites/stewardships/me/packages`** returns a paginated table with health, vulns, role, status, and last activity. It supports filters (status, search, ecosystem, health band, vuln severity) and sorting (default composite **risk**). **`meta.statusCounts`** is always computed across all five in-scope statuses, independent of the active status filter, so status tabs do not need a second request.
> 
> **`GET /v1/akrites/stewardships/me/activity`** returns the latest activity **per stewardship** (`DISTINCT ON`), newest-first, with optional comma-separated status filter and API-layer **`suggestedAction`** labels for CTAs (default `pageSize=3`).
> 
> The DAL adds **`listMyPackages`** and **`listMyActivity`** with lateral joins split into filter vs display paths so empty-page COUNT queries skip display-only work. **`SEVERITY_RANK_EXPR`** is exported from `api.ts` for reuse. OpenAPI documents both routes under Stewardships with `READ_STEWARDSHIPS` scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73d2dfcc8332590ff498d94d553b52166d65ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->