### PR TITLE
fix: return empty activity channels when no subprojects are found

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -296,6 +296,10 @@ class SegmentRepository extends RepositoryBase<
   }
 
   async fetchTenantActivityChannels(segmentIds: string[]) {
+    if (segmentIds.length === 0) {
+      return {}
+    }
+
     const transaction = this.transaction
 
     const records = await this.options.database.sequelize.query(

--- a/backend/src/services/activityService.ts
+++ b/backend/src/services/activityService.ts
@@ -108,6 +108,10 @@ export default class ActivityService extends LoggerBase {
 
     const subprojectIds = await getSegmentSubprojectIds(qx, currentSegments)
 
+    if (subprojectIds.length === 0) {
+      return {}
+    }
+
     return SegmentService.getTenantActivityChannels(subprojectIds, this.options)
   }
 


### PR DESCRIPTION
## Summary

Fixes a 500 on `GET /activity/channel` after moving segment expansion out of middleware. When the current project scope expands to zero active subprojects, the handler now returns an empty channel map instead of running SQL with `segmentId IN ()`.

## Changes

- **`activityService.findActivityChannels`** — return `{}` when `getSegmentSubprojectIds` yields no IDs (same pattern as `activity/query` for empty expansion).
- **`segmentRepository.fetchTenantActivityChannels`** — early return `{}` when `segmentIds` is empty, so no caller can generate invalid `IN ()` SQL.

## Context

With the middleware refactor, `/activity/channel` expands segments at the call site instead of relying on pre-expanded `currentSegments` or the old all-tenant-subprojects fallback. Expansion can legitimately be empty (e.g. project group with no active subprojects, or segment context not ready). Activities already handled this; channels did not.