### PR TITLE
fix: cargo dump failure due to schema changes [CM-1282]

### DIFF
--- a/services/apps/packages_worker/src/cargo/loadDump.ts
+++ b/services/apps/packages_worker/src/cargo/loadDump.ts
@@ -40,20 +40,20 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
 }
 
 async function readCsvHeader(csvPath: string): Promise<string[]> {
-  const rl = createInterface({ input: createReadStream(csvPath), crlfDelay: Infinity })
+  const source = createReadStream(csvPath)
+  const rl = createInterface({ input: source, crlfDelay: Infinity })
   try {
-    for await (const line of rl) return line.split(',').map((c) => c.trim())
+    for await (const line of rl) {
+      return line.split(',').map((c) => c.trim())
+    }
   } finally {
     rl.close()
+    source.destroy()
   }
   throw new Error(`CSV has no header line: ${csvPath}`)
 }
 
-async function buildStagingTable(
-  qx: QueryExecutor,
-  table: string,
-  csvPath: string,
-): Promise<void> {
+async function buildStagingTable(qx: QueryExecutor, table: string, csvPath: string): Promise<void> {
   const cols = await readCsvHeader(csvPath)
   const missing = (REQUIRED_COLUMNS[table] ?? []).filter((c) => !cols.includes(c))
   if (missing.length) {
@@ -63,7 +63,7 @@ async function buildStagingTable(
     )
   }
   const types = COLUMN_TYPES[table] ?? {}
-  const ddl = cols.map((c) => `"${c}" ${types[c] ?? 'text'}`).join(', ')
+  const ddl = cols.map((c) => `"${c.replace(/"/g, '""')}" ${types[c] ?? 'text'}`).join(', ')
   await qx.result(
     `DROP TABLE IF EXISTS ${STAGING_SCHEMA}.${table} CASCADE; CREATE TABLE ${STAGING_SCHEMA}.${table} (${ddl})`,
   )

--- a/services/apps/packages_worker/src/cargo/loadDump.ts
+++ b/services/apps/packages_worker/src/cargo/loadDump.ts
@@ -1,5 +1,6 @@
 import { createReadStream } from 'node:fs'
 import * as path from 'node:path'
+import { createInterface } from 'node:readline'
 import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { CopyStreamQuery, from as copyFrom } from 'pg-copy-streams'
@@ -14,55 +15,59 @@ const log = getServiceChildLogger('cargo-load')
 
 export const STAGING_SCHEMA = 'cargo_sync'
 
-// Column order matches each CSV header exactly so COPY FROM STDIN CSV HEADER maps by position.
-const STAGING_DDL = `
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.crates CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.crates (
-    created_at text, description text, documentation text, homepage text,
-    id integer, max_features text, max_upload_size text, name text,
-    readme text, repository text, trustpub_only text, updated_at text
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.versions CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.versions (
-    bin_names text, categories text, checksum text, crate_id integer,
-    crate_size text, created_at text, description text, documentation text,
-    downloads text, edition text, features text, has_lib text, homepage text,
-    id integer, keywords text, license text, links text, num text,
-    num_no_build text, published_by text, repository text, rust_version text,
-    updated_at text, yanked text
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.default_versions CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.default_versions (
-    crate_id integer, num_versions integer, version_id integer
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.version_downloads CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.version_downloads (
-    date date, downloads integer, version_id integer
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.dependencies CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.dependencies (
-    crate_id integer, default_features text, explicit_name text, features text,
-    id integer, kind integer, optional text, req text, target text,
-    version_id integer
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.keywords CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.keywords (
-    crates_cnt integer, created_at text, id integer, keyword text
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.crates_keywords CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.crates_keywords (
-    crate_id integer, keyword_id integer
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.crate_owners CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.crate_owners (
-    crate_id integer, created_at text, created_by text, owner_id integer,
-    owner_kind integer
-  );
-  DROP TABLE IF EXISTS ${STAGING_SCHEMA}.oauth_github CASCADE;
-  CREATE TABLE ${STAGING_SCHEMA}.oauth_github (
-    account_id text, avatar text, login text, user_id integer
-  );
-`
+const COLUMN_TYPES: Record<string, Record<string, string>> = {
+  crates: { id: 'integer' },
+  versions: { crate_id: 'integer', id: 'integer' },
+  default_versions: { crate_id: 'integer', num_versions: 'integer', version_id: 'integer' },
+  version_downloads: { date: 'date', downloads: 'integer', version_id: 'integer' },
+  dependencies: { crate_id: 'integer', id: 'integer', kind: 'integer', version_id: 'integer' },
+  keywords: { crates_cnt: 'integer', id: 'integer' },
+  crates_keywords: { crate_id: 'integer', keyword_id: 'integer' },
+  crate_owners: { crate_id: 'integer', owner_id: 'integer', owner_kind: 'integer' },
+  oauth_github: { user_id: 'integer' },
+}
+
+const REQUIRED_COLUMNS: Record<string, string[]> = {
+  crates: ['id', 'name', 'description', 'homepage', 'repository'],
+  versions: ['id', 'crate_id', 'created_at', 'num', 'license', 'yanked'],
+  default_versions: ['crate_id', 'version_id'],
+  version_downloads: ['date', 'downloads', 'version_id'],
+  dependencies: ['crate_id', 'version_id', 'kind'],
+  keywords: ['id', 'keyword'],
+  crates_keywords: ['crate_id', 'keyword_id'],
+  crate_owners: ['crate_id', 'owner_id', 'owner_kind'],
+  oauth_github: ['user_id', 'login'],
+}
+
+async function readCsvHeader(csvPath: string): Promise<string[]> {
+  const rl = createInterface({ input: createReadStream(csvPath), crlfDelay: Infinity })
+  try {
+    for await (const line of rl) return line.split(',').map((c) => c.trim())
+  } finally {
+    rl.close()
+  }
+  throw new Error(`CSV has no header line: ${csvPath}`)
+}
+
+async function buildStagingTable(
+  qx: QueryExecutor,
+  table: string,
+  csvPath: string,
+): Promise<void> {
+  const cols = await readCsvHeader(csvPath)
+  const missing = (REQUIRED_COLUMNS[table] ?? []).filter((c) => !cols.includes(c))
+  if (missing.length) {
+    throw new Error(
+      `cargo dump ${table}.csv is missing required column(s) [${missing.join(', ')}] — ` +
+        `crates.io schema changed; header was [${cols.join(', ')}]`,
+    )
+  }
+  const types = COLUMN_TYPES[table] ?? {}
+  const ddl = cols.map((c) => `"${c}" ${types[c] ?? 'text'}`).join(', ')
+  await qx.result(
+    `DROP TABLE IF EXISTS ${STAGING_SCHEMA}.${table} CASCADE; CREATE TABLE ${STAGING_SCHEMA}.${table} (${ddl})`,
+  )
+}
 
 // crates.csv needs NUL stripping — readme blobs contain 0x00 bytes that COPY rejects.
 const CSV_FILES: Array<{ table: string; file: string; stripNul?: boolean }> = [
@@ -265,14 +270,13 @@ export async function loadDump(
   const dataDir = path.join(dumpDir, 'data')
 
   log.info('Creating staging schema...')
-  await qx.result(
-    `CREATE SCHEMA IF NOT EXISTS ${STAGING_SCHEMA};
-     ${STAGING_DDL}`,
-  )
+  await qx.result(`CREATE SCHEMA IF NOT EXISTS ${STAGING_SCHEMA}`)
 
   const counts: Record<string, number> = {}
   for (const { table, file, stripNul: doStripNul } of CSV_FILES) {
-    counts[table] = await copyCsv(db, table, path.join(dataDir, file), doStripNul ?? false)
+    const csvPath = path.join(dataDir, file)
+    await buildStagingTable(qx, table, csvPath)
+    counts[table] = await copyCsv(db, table, csvPath, doStripNul ?? false)
     log.info({ table, rows: counts[table] }, 'Loaded staging table')
   }
 


### PR DESCRIPTION
This pull request refactors how staging tables are created and validated when loading cargo dump CSVs. Instead of relying on a static DDL string, the code now dynamically constructs the SQL table definitions based on the CSV headers and enforces that required columns are present. This makes the process more robust to schema changes in the input data.

Key changes:

**Dynamic Table Creation and Validation**
* Replaces the static `STAGING_DDL` with logic that reads CSV headers and dynamically builds the `CREATE TABLE` statements for each staging table. This ensures the table schema matches the actual CSV columns and types, and adapts automatically to changes in the dump format.
* Introduces validation to check for required columns in each CSV file before table creation. If any required columns are missing, an error is thrown with details, preventing silent data issues.

**Supporting Utilities**
* Adds a `readCsvHeader` utility to efficiently read the header row from a CSV file.
* Adds `COLUMN_TYPES` and `REQUIRED_COLUMNS` definitions to specify expected types and required fields for each table, used in dynamic DDL generation and validation.

**Integration with Load Process**
* Updates the `loadDump` function to call the new dynamic table creation logic (`buildStagingTable`) for each CSV, instead of executing a static DDL block.

These changes make the CSV import process more maintainable and resilient to upstream schema changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the packages worker cargo ingest path; failures are clearer but header parsing is naive (comma-split) and downstream SQL still assumes specific column names exist in staging.
> 
> **Overview**
> Fixes cargo dump loads breaking when crates.io adds or reorders CSV columns by **replacing the fixed `STAGING_DDL`** with **per-file staging tables built from each file’s header row**.
> 
> `loadDump` now only ensures the `cargo_sync` schema exists, then for each dump CSV calls **`buildStagingTable`** (read header → validate **`REQUIRED_COLUMNS`** → `DROP`/`CREATE` with **`COLUMN_TYPES`** where defined, else `text`) before **`COPY`**. Missing required columns fail fast with a message that points at a crates.io schema change.
> 
> New columns in upstream dumps are accepted as extra `text` fields without code changes, while core ingest columns stay explicitly required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb185ec93e208a893644df69a7a98f7b932525c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->