### PR TITLE
fix: prevent member identity existence check from timing out

### DIFF
--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -5,10 +5,10 @@ import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
 import { Error404, Error409 } from '@crowd/common'
 import { createMemberIdentity, findIdentitiesForMembers, optionsQx } from '@crowd/data-access-layer'
 import {
-  checkMemberIdentityExistence,
   deleteMemberIdentity,
   fetchMemberIdentities,
   findMemberIdentityById,
+  findMemberIdentityConflict,
   touchMemberUpdatedAt,
   updateMemberIdentity,
 } from '@crowd/data-access-layer/src/members'
@@ -58,20 +58,19 @@ export default class MemberIdentityService extends LoggerBase {
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
           // Check if identity already exists
-          const existingIdentities = await checkMemberIdentityExistence(
-            qx,
-            data.value,
-            data.platform,
-            data.type,
-          )
+          const conflict = await findMemberIdentityConflict(qx, {
+            value: data.value,
+            platform: data.platform,
+            type: data.type,
+          })
 
-          if (existingIdentities.length > 0) {
+          if (conflict) {
             throw new Error409(
               this.options.language,
               'errors.alreadyExists',
               // @ts-ignore
               JSON.stringify({
-                memberId: existingIdentities[0].memberId,
+                memberId: conflict.memberId,
               }),
             )
           }
@@ -132,20 +131,19 @@ export default class MemberIdentityService extends LoggerBase {
 
           // Check if any of the identities already exist
           for (const identity of data) {
-            const existingIdentities = await checkMemberIdentityExistence(
-              qx,
-              identity.value,
-              identity.platform,
-              identity.type,
-            )
+            const conflict = await findMemberIdentityConflict(qx, {
+              value: identity.value,
+              platform: identity.platform,
+              type: identity.type,
+            })
 
-            if (existingIdentities.length > 0) {
+            if (conflict) {
               throw new Error409(
                 this.options.language,
                 'errors.alreadyExists',
                 // @ts-ignore
                 JSON.stringify({
-                  memberId: existingIdentities[0].memberId,
+                  memberId: conflict.memberId,
                 }),
               )
             }
@@ -215,8 +213,13 @@ export default class MemberIdentityService extends LoggerBase {
           const platform = data.platform ?? currentIdentity.platform
           const type = data.type ?? currentIdentity.type
 
-          const existingIdentities = await checkMemberIdentityExistence(qx, value, platform, type)
-          const conflict = existingIdentities.find((identity) => identity.memberId !== memberId)
+          const conflict = await findMemberIdentityConflict(qx, {
+            value,
+            platform,
+            type,
+            excludeMemberId: memberId,
+          })
+
           if (conflict) {
             throw new Error409(
               this.options.language,

--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -2,7 +2,7 @@
 import lodash from 'lodash'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { Error409 } from '@crowd/common'
+import { Error404, Error409 } from '@crowd/common'
 import { createMemberIdentity, findIdentitiesForMembers, optionsQx } from '@crowd/data-access-layer'
 import {
   checkMemberIdentityExistence,
@@ -62,7 +62,9 @@ export default class MemberIdentityService extends LoggerBase {
             qx,
             data.value,
             data.platform,
+            data.type,
           )
+        
           if (existingIdentities.length > 0) {
             throw new Error409(
               this.options.language,
@@ -134,6 +136,7 @@ export default class MemberIdentityService extends LoggerBase {
               qx,
               identity.value,
               identity.platform,
+              identity.type,
             )
 
             if (existingIdentities.length > 0) {
@@ -203,20 +206,29 @@ export default class MemberIdentityService extends LoggerBase {
 
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
-          // Check if identity already exists
+          const currentIdentity = memberIdentities.find((identity) => identity.id === id)
+          if (!currentIdentity) {
+            throw new Error404(this.options.language, 'errors.notFound.message')
+          }
+
+          const value = data.value ?? currentIdentity.value
+          const platform = data.platform ?? currentIdentity.platform
+          const type = data.type ?? currentIdentity.type
+
           const existingIdentities = await checkMemberIdentityExistence(
             qx,
-            data.value,
-            data.platform,
+            value,
+            platform,
+            type,
           )
-          const filteredExistingIdentities = existingIdentities.filter((i) => i.id !== id)
-          if (filteredExistingIdentities.length > 0) {
+          const conflict = existingIdentities.find((identity) => identity.memberId !== memberId)
+          if (conflict) {
             throw new Error409(
               this.options.language,
               'errors.alreadyExists',
               // @ts-ignore
               JSON.stringify({
-                memberId: filteredExistingIdentities[0].memberId,
+                memberId: conflict.memberId,
               }),
             )
           }

--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -64,7 +64,7 @@ export default class MemberIdentityService extends LoggerBase {
             data.platform,
             data.type,
           )
-        
+
           if (existingIdentities.length > 0) {
             throw new Error409(
               this.options.language,
@@ -215,12 +215,7 @@ export default class MemberIdentityService extends LoggerBase {
           const platform = data.platform ?? currentIdentity.platform
           const type = data.type ?? currentIdentity.type
 
-          const existingIdentities = await checkMemberIdentityExistence(
-            qx,
-            value,
-            platform,
-            type,
-          )
+          const existingIdentities = await checkMemberIdentityExistence(qx, value, platform, type)
           const conflict = existingIdentities.find((identity) => identity.memberId !== memberId)
           if (conflict) {
             throw new Error409(

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -53,16 +53,16 @@ export async function checkMemberIdentityExistence(
   qx: QueryExecutor,
   value: string,
   platform: string,
-  type?: MemberIdentityType,
+  type: MemberIdentityType,
 ): Promise<IMemberIdentity[]> {
-  return await qx.select(
+  return qx.select(
     `
-        SELECT id, "memberId", verified
-        FROM "memberIdentities"
-        WHERE "value" = $(value)
-          AND "platform" = $(platform)
-          ${type ? 'AND "type" = $(type)' : ''}
-          AND "deletedAt" is null;
+      SELECT id, "memberId"
+      FROM "memberIdentities"
+      WHERE platform = $(platform)
+        AND type = $(type)
+        AND lower(value) = lower($(value))
+        AND "deletedAt" IS NULL;
     `,
     {
       value,

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -49,26 +49,29 @@ export async function fetchManyMemberIdentities(
   )
 }
 
-export async function checkMemberIdentityExistence(
+interface FindMemberIdentityConflictParams {
+  value: IMemberIdentity['value']
+  platform: IMemberIdentity['platform']
+  type: IMemberIdentity['type']
+  excludeMemberId?: string
+}
+
+export async function findMemberIdentityConflict(
   qx: QueryExecutor,
-  value: string,
-  platform: string,
-  type: MemberIdentityType,
-): Promise<IMemberIdentity[]> {
-  return qx.select(
+  params: FindMemberIdentityConflictParams,
+): Promise<{ id: string; memberId: string } | null> {
+  return qx.selectOneOrNone(
     `
       SELECT id, "memberId"
       FROM "memberIdentities"
       WHERE platform = $(platform)
         AND type = $(type)
         AND lower(value) = lower($(value))
-        AND "deletedAt" IS NULL;
+        AND "deletedAt" IS NULL
+        ${params.excludeMemberId ? 'AND "memberId" <> $(excludeMemberId)' : ''}
+      LIMIT 1;
     `,
-    {
-      value,
-      platform,
-      type,
-    },
+    params,
   )
 }
 


### PR DESCRIPTION
## Summary

Fixes 500 query timeouts on `PUT /member/:memberId/identity` caused by `checkMemberIdentityExistence` performing a full table scan on ~25M rows. The check now uses an indexed query aligned with DB unique constraints and returns 409 quickly when an identity already exists on another profile.

## Changes

- Rewrite `checkMemberIdentityExistence` to require `type` and query by `platform`, `type`, and `lower(value)`
- Pass `type` from `create`, `createMultiple`, and `update` in `memberIdentityService`
- On update, return 404 when the identity id is not found, resolve the effective identity key from the patch and current row, and only 409 when a different member owns the identity