### PR TITLE
feat: add advisories pagination (CM-1283)

### DIFF
--- a/backend/src/api/public/v1/akrites/openapi.yaml
+++ b/backend/src/api/public/v1/akrites/openapi.yaml
@@ -399,18 +399,22 @@ components:
 
     Advisory:
       type: object
-      required: [osvId, severity, resolution]
+      required: [osvId, severity, resolution, isCritical]
       properties:
         osvId:
           type: string
           example: GHSA-xxxx-xxxx-xxxx
         severity:
           type: string
-          enum: [critical, high, medium, low]
+          enum: [critical, high, moderate, low]
           nullable: true
         resolution:
           type: string
+          enum: [open, patched]
           nullable: true
+        isCritical:
+          type: boolean
+          description: True when CVSS score >= 7.0.
 
     PackageHistoryEvent:
       type: object
@@ -1000,6 +1004,30 @@ paths:
             minimum: 1
             maximum: 100
             default: 20
+        - name: severity
+          in: query
+          required: false
+          description: Filter by severity. Accepts comma-separated values or multiple params.
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [critical, high, moderate, low]
+        - name: resolution
+          in: query
+          required: false
+          description: Filter by resolution status. Accepts comma-separated values or multiple params.
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [open, patched]
+        - name: critical
+          in: query
+          required: false
+          description: Filter by criticality flag (CVSS >= 7.0).
+          schema:
+            type: boolean
       responses:
         '200':
           description: Paginated advisory list.

--- a/backend/src/api/public/v1/akrites/openapi.yaml
+++ b/backend/src/api/public/v1/akrites/openapi.yaml
@@ -970,8 +970,9 @@ paths:
       operationId: getAkritesPackageAdvisories
       summary: Get advisories for a package
       description: >
-        Returns all open security advisories for a single package identified by
-        PURL. Intended for lazy-loading the Security tab in the package detail drawer.
+        Returns a paginated list of security advisories for a single package
+        identified by PURL. Intended for lazy-loading the Security tab in the
+        package detail drawer.
       tags:
         - Packages
       parameters:
@@ -982,21 +983,42 @@ paths:
           schema:
             type: string
             example: pkg:npm/%40angular/core@17.0.0
+        - name: page
+          in: query
+          required: false
+          description: Page number (1-based).
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          required: false
+          description: Number of advisories per page (max 100).
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
-          description: Advisory list.
+          description: Paginated advisory list.
           content:
             application/json:
               schema:
                 type: object
-                required: [advisories, total]
+                required: [page, pageSize, total, advisories]
                 properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
                   advisories:
                     type: array
                     items:
                       $ref: '#/components/schemas/Advisory'
-                  total:
-                    type: integer
         '400':
           description: Validation error (malformed purl).
           content:

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -74,6 +74,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         osvId: a.osvId,
         severity: a.severity,
         resolution: a.resolution,
+        isCritical: a.isCritical,
       })),
       cvd: {
         isPvrEnabled: null,

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -32,7 +32,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     throw new NotFoundError()
   }
 
-  const [advisories, stewardshipSummary] = await Promise.all([
+  const [{ rows: advisories }, stewardshipSummary] = await Promise.all([
     getAdvisoriesByPackageId(qx, pkg.id),
     pkg.stewardshipId ? getStewardshipSummary(qx, Number(pkg.stewardshipId)) : null,
   ])

--- a/backend/src/api/public/v1/packages/getPackageAdvisories.ts
+++ b/backend/src/api/public/v1/packages/getPackageAdvisories.ts
@@ -8,18 +8,33 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-import { purlQuerySchema } from './purl'
+import { extractPurlVersion, purlQuerySchema } from './purl'
 
 const DEFAULT_PAGE_SIZE = 20
 const MAX_PAGE_SIZE = 100
 
+const SEVERITY_VALUES = ['critical', 'high', 'moderate', 'low'] as const
+
 const querySchema = purlQuerySchema.extend({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+  severity: z
+    .preprocess(
+      (v) => {
+        if (!v) return undefined
+        const vals = Array.isArray(v) ? v : [v]
+        return vals.flatMap((s: unknown) => String(s).split(','))
+      },
+      z.array(z.enum(SEVERITY_VALUES)).optional(),
+    )
+    .optional(),
 })
 
 export async function getPackageAdvisories(req: Request, res: Response): Promise<void> {
-  const { purl, page, pageSize } = validateOrThrow(querySchema, req.query)
+  const rawPurl = typeof req.query.purl === 'string' ? req.query.purl : ''
+  const version = extractPurlVersion(rawPurl)
+
+  const { purl, page, pageSize, severity } = validateOrThrow(querySchema, req.query)
 
   const qx = await getPackagesQx()
   const pkg = await getPackageDetailByPurl(qx, purl)
@@ -28,7 +43,12 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
     throw new NotFoundError()
   }
 
-  const { rows, total } = await getAdvisoriesByPackageId(qx, pkg.id, { page, pageSize })
+  const { rows, total } = await getAdvisoriesByPackageId(qx, pkg.id, {
+    page,
+    pageSize,
+    version: version ?? undefined,
+    severities: severity,
+  })
 
   ok(res, {
     page,

--- a/backend/src/api/public/v1/packages/getPackageAdvisories.ts
+++ b/backend/src/api/public/v1/packages/getPackageAdvisories.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express'
+import { z } from 'zod'
 
 import { NotFoundError } from '@crowd/common'
 import { getAdvisoriesByPackageId, getPackageDetailByPurl } from '@crowd/data-access-layer'
@@ -9,8 +10,16 @@ import { validateOrThrow } from '@/utils/validation'
 
 import { purlQuerySchema } from './purl'
 
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
+const querySchema = purlQuerySchema.extend({
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+})
+
 export async function getPackageAdvisories(req: Request, res: Response): Promise<void> {
-  const { purl } = validateOrThrow(purlQuerySchema, req.query)
+  const { purl, page, pageSize } = validateOrThrow(querySchema, req.query)
 
   const qx = await getPackagesQx()
   const pkg = await getPackageDetailByPurl(qx, purl)
@@ -19,14 +28,16 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
     throw new NotFoundError()
   }
 
-  const advisories = await getAdvisoriesByPackageId(qx, pkg.id)
+  const { rows, total } = await getAdvisoriesByPackageId(qx, pkg.id, { page, pageSize })
 
   ok(res, {
-    advisories: advisories.map((a) => ({
+    page,
+    pageSize,
+    total,
+    advisories: rows.map((a) => ({
       osvId: a.osvId,
       severity: a.severity,
       resolution: a.resolution,
     })),
-    total: advisories.length,
   })
 }

--- a/backend/src/api/public/v1/packages/getPackageAdvisories.ts
+++ b/backend/src/api/public/v1/packages/getPackageAdvisories.ts
@@ -14,19 +14,28 @@ const DEFAULT_PAGE_SIZE = 20
 const MAX_PAGE_SIZE = 100
 
 const SEVERITY_VALUES = ['critical', 'high', 'moderate', 'low'] as const
+const RESOLUTION_VALUES = ['open', 'patched'] as const
+
+function toStringArray(v: unknown): unknown {
+  if (!v) return undefined
+  const vals = Array.isArray(v) ? v : [v]
+  return vals
+    .flatMap((s: unknown) => String(s).split(','))
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
 
 const querySchema = purlQuerySchema.extend({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-  severity: z
-    .preprocess(
-      (v) => {
-        if (!v) return undefined
-        const vals = Array.isArray(v) ? v : [v]
-        return vals.flatMap((s: unknown) => String(s).split(','))
-      },
-      z.array(z.enum(SEVERITY_VALUES)).optional(),
-    )
+  severity: z.preprocess(toStringArray, z.array(z.enum(SEVERITY_VALUES)).optional()).optional(),
+  resolution: z.preprocess(toStringArray, z.array(z.enum(RESOLUTION_VALUES)).optional()).optional(),
+  critical: z
+    .preprocess((v) => {
+      if (v === 'true') return true
+      if (v === 'false') return false
+      return v
+    }, z.boolean().optional())
     .optional(),
 })
 
@@ -34,7 +43,10 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
   const rawPurl = typeof req.query.purl === 'string' ? req.query.purl : ''
   const version = extractPurlVersion(rawPurl)
 
-  const { purl, page, pageSize, severity } = validateOrThrow(querySchema, req.query)
+  const { purl, page, pageSize, severity, resolution, critical } = validateOrThrow(
+    querySchema,
+    req.query,
+  )
 
   const qx = await getPackagesQx()
   const pkg = await getPackageDetailByPurl(qx, purl)
@@ -48,6 +60,8 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
     pageSize,
     version: version ?? undefined,
     severities: severity,
+    resolutions: resolution,
+    critical,
   })
 
   ok(res, {
@@ -58,6 +72,7 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
       osvId: a.osvId,
       severity: a.severity,
       resolution: a.resolution,
+      isCritical: a.isCritical,
     })),
   })
 }

--- a/backend/src/api/public/v1/packages/getPackageAdvisories.ts
+++ b/backend/src/api/public/v1/packages/getPackageAdvisories.ts
@@ -8,7 +8,7 @@ import { getPackagesQx } from '@/db/packagesDb'
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-import { extractPurlVersion, purlQuerySchema } from './purl'
+import { purlQuerySchema } from './purl'
 
 const DEFAULT_PAGE_SIZE = 20
 const MAX_PAGE_SIZE = 100
@@ -28,8 +28,8 @@ function toStringArray(v: unknown): unknown {
 const querySchema = purlQuerySchema.extend({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-  severity: z.preprocess(toStringArray, z.array(z.enum(SEVERITY_VALUES)).optional()).optional(),
-  resolution: z.preprocess(toStringArray, z.array(z.enum(RESOLUTION_VALUES)).optional()).optional(),
+  severity: z.preprocess(toStringArray, z.array(z.enum(SEVERITY_VALUES)).optional()),
+  resolution: z.preprocess(toStringArray, z.array(z.enum(RESOLUTION_VALUES)).optional()),
   critical: z
     .preprocess((v) => {
       if (v === 'true') return true
@@ -40,9 +40,6 @@ const querySchema = purlQuerySchema.extend({
 })
 
 export async function getPackageAdvisories(req: Request, res: Response): Promise<void> {
-  const rawPurl = typeof req.query.purl === 'string' ? req.query.purl : ''
-  const version = extractPurlVersion(rawPurl)
-
   const { purl, page, pageSize, severity, resolution, critical } = validateOrThrow(
     querySchema,
     req.query,
@@ -58,7 +55,6 @@ export async function getPackageAdvisories(req: Request, res: Response): Promise
   const { rows, total } = await getAdvisoriesByPackageId(qx, pkg.id, {
     page,
     pageSize,
-    version: version ?? undefined,
     severities: severity,
     resolutions: resolution,
     critical,

--- a/backend/src/api/public/v1/packages/purl.ts
+++ b/backend/src/api/public/v1/packages/purl.ts
@@ -30,12 +30,6 @@ export function normalizePurl(purl: string): string {
   return withoutVersion.replace(/@/g, '%40')
 }
 
-export function extractPurlVersion(purl: string): string | null {
-  const withoutQualifiers = stripQualifiers(purl)
-  const match = withoutQualifiers.match(/@([^/@]+)$/)
-  return match ? match[1] : null
-}
-
 export const purlFieldSchema = z
   .string()
   .trim()

--- a/backend/src/api/public/v1/packages/purl.ts
+++ b/backend/src/api/public/v1/packages/purl.ts
@@ -21,6 +21,12 @@ export function normalizePurl(purl: string): string {
   return withoutVersion.replace(/@/g, '%40')
 }
 
+export function extractPurlVersion(purl: string): string | null {
+  const withoutQualifiers = purl.replace(/[?#].*$/, '')
+  const match = withoutQualifiers.match(/@([^/@]+)$/)
+  return match ? match[1] : null
+}
+
 export const purlFieldSchema = z
   .string()
   .trim()

--- a/backend/src/api/public/v1/packages/purl.ts
+++ b/backend/src/api/public/v1/packages/purl.ts
@@ -15,14 +15,23 @@
  */
 import { z } from 'zod'
 
+function stripQualifiers(purl: string): string {
+  const q = purl.indexOf('?')
+  const h = purl.indexOf('#')
+  if (q === -1 && h === -1) return purl
+  if (q === -1) return purl.slice(0, h)
+  if (h === -1) return purl.slice(0, q)
+  return purl.slice(0, Math.min(q, h))
+}
+
 export function normalizePurl(purl: string): string {
-  const withoutQualifiers = purl.replace(/[?#].*$/, '')
+  const withoutQualifiers = stripQualifiers(purl)
   const withoutVersion = withoutQualifiers.replace(/@[^/@]+$/, '')
   return withoutVersion.replace(/@/g, '%40')
 }
 
 export function extractPurlVersion(purl: string): string | null {
-  const withoutQualifiers = purl.replace(/[?#].*$/, '')
+  const withoutQualifiers = stripQualifiers(purl)
   const match = withoutQualifiers.match(/@([^/@]+)$/)
   return match ? match[1] : null
 }

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -624,6 +624,7 @@ export interface AdvisoryRow {
   osvId: string
   severity: string
   resolution: 'open' | 'patched' | null
+  isCritical: boolean
 }
 
 export async function getPackageDetailByPurl(
@@ -783,13 +784,21 @@ export async function listPackagesForScatter(
 export async function getAdvisoriesByPackageId(
   qx: QueryExecutor,
   packageId: string,
-  opts?: { page: number; pageSize: number; version?: string; severities?: string[] },
+  opts?: {
+    page: number
+    pageSize: number
+    version?: string
+    severities?: string[]
+    resolutions?: ('open' | 'patched')[]
+    critical?: boolean
+  },
 ): Promise<{ rows: AdvisoryRow[]; total: number }> {
   const cte = `
     WITH advisory_data AS (
       SELECT
         a.osv_id AS "osvId",
         LOWER(a.severity) AS severity,
+        a.is_critical AS "isCritical",
         CASE
           WHEN COALESCE($(version), p.latest_version) IS NULL THEN NULL
           WHEN COUNT(ar.id) = 0 THEN NULL
@@ -811,25 +820,36 @@ export async function getAdvisoriesByPackageId(
       LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
       JOIN packages p ON p.id = ap.package_id
       WHERE ap.package_id = $(packageId)::bigint
-      GROUP BY a.osv_id, a.severity, p.latest_version
+      GROUP BY a.osv_id, a.severity, a.is_critical, p.latest_version
     )
   `
 
-  const severityClause = opts?.severities?.length
-    ? `WHERE severity = ANY($(severities)::text[])`
-    : ''
+  const conditions: string[] = []
+  if (opts?.severities?.length) {
+    conditions.push('severity = ANY($(severities)::text[])')
+  }
+  if (opts?.resolutions?.length) {
+    conditions.push('resolution = ANY($(resolutions)::text[])')
+  }
+  if (opts?.critical !== undefined) {
+    conditions.push('"isCritical" = $(critical)')
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : ''
   const paginationClause = opts ? `LIMIT $(limit) OFFSET $(offset)` : ''
   const params = {
     packageId,
     version: opts?.version ?? null,
     severities: opts?.severities ?? null,
+    resolutions: opts?.resolutions ?? null,
+    critical: opts?.critical ?? null,
     limit: opts?.pageSize,
     offset: opts ? (opts.page - 1) * opts.pageSize : 0,
   }
 
   const rows = (await qx.select(
     `${cte} SELECT * FROM advisory_data
-     ${severityClause}
+     ${whereClause}
      ORDER BY
        CASE severity WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'low' THEN 4 ELSE 5 END,
        CASE resolution WHEN 'open' THEN 1 WHEN 'patched' THEN 2 ELSE 3 END,
@@ -843,7 +863,7 @@ export async function getAdvisoriesByPackageId(
   }
 
   const countResult = (await qx.selectOne(
-    `${cte} SELECT COUNT(*) AS total FROM advisory_data ${severityClause}`,
+    `${cte} SELECT COUNT(*) AS total FROM advisory_data ${whereClause}`,
     params,
   )) as { total: string }
 

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -783,7 +783,7 @@ export async function listPackagesForScatter(
 export async function getAdvisoriesByPackageId(
   qx: QueryExecutor,
   packageId: string,
-  opts?: { page: number; pageSize: number },
+  opts?: { page: number; pageSize: number; version?: string; severities?: string[] },
 ): Promise<{ rows: AdvisoryRow[]; total: number }> {
   const cte = `
     WITH advisory_data AS (
@@ -791,16 +791,16 @@ export async function getAdvisoriesByPackageId(
         a.osv_id AS "osvId",
         LOWER(a.severity) AS severity,
         CASE
-          WHEN p.latest_version IS NULL THEN NULL
+          WHEN COALESCE($(version), p.latest_version) IS NULL THEN NULL
           WHEN COUNT(ar.id) = 0 THEN NULL
           -- TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
           -- Replace with a proper semver comparison function when one is available in the DB.
           WHEN BOOL_AND(
             CASE
               WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
-              WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
+              WHEN ar.fixed_version IS NOT NULL AND COALESCE($(version), p.latest_version) >= ar.fixed_version THEN TRUE
               WHEN ar.fixed_version IS NOT NULL THEN FALSE
-              WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
+              WHEN ar.last_affected IS NOT NULL AND COALESCE($(version), p.latest_version) > ar.last_affected THEN TRUE
               ELSE FALSE
             END
           ) THEN 'patched'
@@ -815,25 +815,37 @@ export async function getAdvisoriesByPackageId(
     )
   `
 
+  const severityClause = opts?.severities?.length
+    ? `WHERE severity = ANY($(severities)::text[])`
+    : ''
   const paginationClause = opts ? `LIMIT $(limit) OFFSET $(offset)` : ''
+  const params = {
+    packageId,
+    version: opts?.version ?? null,
+    severities: opts?.severities ?? null,
+    limit: opts?.pageSize,
+    offset: opts ? (opts.page - 1) * opts.pageSize : 0,
+  }
 
   const rows = (await qx.select(
     `${cte} SELECT * FROM advisory_data
+     ${severityClause}
      ORDER BY
        CASE severity WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'low' THEN 4 ELSE 5 END,
        CASE resolution WHEN 'open' THEN 1 WHEN 'patched' THEN 2 ELSE 3 END,
        "osvId"
      ${paginationClause}`,
-    { packageId, limit: opts?.pageSize, offset: opts ? (opts.page - 1) * opts.pageSize : 0 },
+    params,
   )) as AdvisoryRow[]
 
   if (!opts) {
     return { rows, total: rows.length }
   }
 
-  const countResult = (await qx.selectOne(`${cte} SELECT COUNT(*) AS total FROM advisory_data`, {
-    packageId,
-  })) as { total: string }
+  const countResult = (await qx.selectOne(
+    `${cte} SELECT COUNT(*) AS total FROM advisory_data ${severityClause}`,
+    params,
+  )) as { total: string }
 
   return { rows, total: Number(countResult.total) }
 }

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -787,7 +787,6 @@ export async function getAdvisoriesByPackageId(
   opts?: {
     page: number
     pageSize: number
-    version?: string
     severities?: string[]
     resolutions?: ('open' | 'patched')[]
     critical?: boolean
@@ -800,16 +799,16 @@ export async function getAdvisoriesByPackageId(
         LOWER(a.severity) AS severity,
         a.is_critical AS "isCritical",
         CASE
-          WHEN COALESCE($(version), p.latest_version) IS NULL THEN NULL
+          WHEN p.latest_version IS NULL THEN NULL
           WHEN COUNT(ar.id) = 0 THEN NULL
           -- TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
           -- Replace with a proper semver comparison function when one is available in the DB.
           WHEN BOOL_AND(
             CASE
               WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
-              WHEN ar.fixed_version IS NOT NULL AND COALESCE($(version), p.latest_version) >= ar.fixed_version THEN TRUE
+              WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
               WHEN ar.fixed_version IS NOT NULL THEN FALSE
-              WHEN ar.last_affected IS NOT NULL AND COALESCE($(version), p.latest_version) > ar.last_affected THEN TRUE
+              WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
               ELSE FALSE
             END
           ) THEN 'patched'
@@ -839,7 +838,6 @@ export async function getAdvisoriesByPackageId(
   const paginationClause = opts ? `LIMIT $(limit) OFFSET $(offset)` : ''
   const params = {
     packageId,
-    version: opts?.version ?? null,
     severities: opts?.severities ?? null,
     resolutions: opts?.resolutions ?? null,
     critical: opts?.critical ?? null,

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -818,7 +818,12 @@ export async function getAdvisoriesByPackageId(
   const paginationClause = opts ? `LIMIT $(limit) OFFSET $(offset)` : ''
 
   const rows = (await qx.select(
-    `${cte} SELECT * FROM advisory_data ORDER BY "osvId" ${paginationClause}`,
+    `${cte} SELECT * FROM advisory_data
+     ORDER BY
+       CASE severity WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'low' THEN 4 ELSE 5 END,
+       CASE resolution WHEN 'open' THEN 1 WHEN 'patched' THEN 2 ELSE 3 END,
+       "osvId"
+     ${paginationClause}`,
     { packageId, limit: opts?.pageSize, offset: opts ? (opts.page - 1) * opts.pageSize : 0 },
   )) as AdvisoryRow[]
 

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -783,35 +783,52 @@ export async function listPackagesForScatter(
 export async function getAdvisoriesByPackageId(
   qx: QueryExecutor,
   packageId: string,
-): Promise<AdvisoryRow[]> {
-  return qx.select(
-    `
-    SELECT
-      a.osv_id AS "osvId",
-      LOWER(a.severity) AS severity,
-      CASE
-        WHEN p.latest_version IS NULL THEN NULL
-        WHEN COUNT(ar.id) = 0 THEN NULL
-        -- TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
-        -- Replace with a proper semver comparison function when one is available in the DB.
-        WHEN BOOL_AND(
-          CASE
-            WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
-            WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
-            WHEN ar.fixed_version IS NOT NULL THEN FALSE
-            WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
-            ELSE FALSE
-          END
-        ) THEN 'patched'
-        ELSE 'open'
-      END AS resolution
-    FROM advisory_packages ap
-    JOIN advisories a ON a.id = ap.advisory_id
-    LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
-    JOIN packages p ON p.id = ap.package_id
-    WHERE ap.package_id = $(packageId)::bigint
-    GROUP BY a.osv_id, a.severity, p.latest_version
-    `,
-    { packageId },
-  )
+  opts?: { page: number; pageSize: number },
+): Promise<{ rows: AdvisoryRow[]; total: number }> {
+  const cte = `
+    WITH advisory_data AS (
+      SELECT
+        a.osv_id AS "osvId",
+        LOWER(a.severity) AS severity,
+        CASE
+          WHEN p.latest_version IS NULL THEN NULL
+          WHEN COUNT(ar.id) = 0 THEN NULL
+          -- TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
+          -- Replace with a proper semver comparison function when one is available in the DB.
+          WHEN BOOL_AND(
+            CASE
+              WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
+              WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
+              WHEN ar.fixed_version IS NOT NULL THEN FALSE
+              WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
+              ELSE FALSE
+            END
+          ) THEN 'patched'
+          ELSE 'open'
+        END AS resolution
+      FROM advisory_packages ap
+      JOIN advisories a ON a.id = ap.advisory_id
+      LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
+      JOIN packages p ON p.id = ap.package_id
+      WHERE ap.package_id = $(packageId)::bigint
+      GROUP BY a.osv_id, a.severity, p.latest_version
+    )
+  `
+
+  const paginationClause = opts ? `LIMIT $(limit) OFFSET $(offset)` : ''
+
+  const rows = (await qx.select(
+    `${cte} SELECT * FROM advisory_data ORDER BY "osvId" ${paginationClause}`,
+    { packageId, limit: opts?.pageSize, offset: opts ? (opts.page - 1) * opts.pageSize : 0 },
+  )) as AdvisoryRow[]
+
+  if (!opts) {
+    return { rows, total: rows.length }
+  }
+
+  const countResult = (await qx.selectOne(`${cte} SELECT COUNT(*) AS total FROM advisory_data`, {
+    packageId,
+  })) as { total: string }
+
+  return { rows, total: Number(countResult.total) }
 }


### PR DESCRIPTION
## Summary

Adds page and pageSize query parameters to GET /api/v1/akrites/packages/advisories. Previously the endpoint returned all advisories for a package in a single response (up to 700+ for some packages), with no way to page through results.

## Changes

- getPackageAdvisories.ts — accepts page (default 1) and pageSize (default 20, max 100) query params via Zod schema; response now includes page, pageSize, total alongside advisories
- api.ts (DAL) — getAdvisoriesByPackageId now accepts optional opts: { page, pageSize }:
    - when provided: runs paginated SELECT + COUNT(*) in parallel, returns { rows, total }
    - when omitted (used by getPackage.ts detail view): returns all rows, derives total from rows.length — skips the extra COUNT query
- openapi.yaml — documents page and pageSize parameters and updated response schema

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1283](https://linuxfoundation.atlassian.net/browse/CM-1283)


[CM-1283]: https://linuxfoundation.atlassian.net/browse/CM-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API contract changes: advisories are paginated by default (breaking for clients that expected the full list), and Advisory adds required `isCritical` plus severity enum `moderate` instead of `medium`.
> 
> **Overview**
> Adds **pagination and filtering** to `GET /akrites/packages/advisories` so the Security tab can load advisories in chunks instead of returning hundreds in one response. The handler now accepts `page` (default 1) and `pageSize` (default 20, max 100), plus optional `severity`, `resolution`, and `critical` filters (comma-separated or repeated query params). Responses include `page`, `pageSize`, and `total` alongside `advisories`.
> 
> **`getAdvisoriesByPackageId`** in the DAL was refactored around a CTE that computes resolution and **`isCritical`** from `advisories.is_critical`, applies filters, orders by severity/resolution/osvId, and runs a separate `COUNT` when pagination opts are passed. When opts are omitted (package detail), it still returns all rows and skips the count query.
> 
> **Advisory** objects now require **`isCritical`** (CVSS ≥ 7.0) on both the advisories endpoint and package detail `security.advisories`. OpenAPI updates severity to **`moderate`** (was `medium`), documents **`resolution`** as `open` | `patched`, and describes the new query params.
> 
> **`normalizePurl`** replaces the qualifier-stripping regex with an explicit `stripQualifiers` helper (same normalization behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43f9058b80826523619a2fa01df29911230146e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->