### PR TITLE
feat: add enriched fields (CM-1285)

### DIFF
--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -40,8 +40,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
   const scorecardScore = pkg.scorecardScore != null ? Number(pkg.scorecardScore) : null
   const mappingConfidence =
     pkg.repoMappingConfidence != null ? Number(pkg.repoMappingConfidence) : null
-  const healthScoreTotal =
-    pkg.healthScore ?? (scorecardScore !== null ? Math.round(scorecardScore * 10) : null)
+  const healthBandScore = pkg.healthScore !== null ? pkg.healthScore / 10 : scorecardScore
 
   ok(res, {
     purl: pkg.purl,
@@ -49,15 +48,15 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     ecosystem: pkg.ecosystem,
     latestVersion: pkg.latestVersion ?? null,
     general: {
-      healthScore: healthScoreTotal,
+      healthScore: pkg.healthScore,
       healthScoreDetails: {
-        total: healthScoreTotal,
+        total: pkg.healthScore,
         label: pkg.healthLabel,
         maintainerHealth: pkg.maintainerHealthScore,
         securitySupplyChain: pkg.securitySupplyChainScore,
         developmentActivity: pkg.developmentActivityScore,
       },
-      healthBand: computeHealthBand(scorecardScore),
+      healthBand: computeHealthBand(healthBandScore),
       impact: {
         impactScore:
           pkg.criticalityScore != null ? Math.round(Number(pkg.criticalityScore) * 100) : null,
@@ -67,7 +66,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         transitiveReach: pkg.transitiveReach,
       },
       riskSignals: {
-        lifecycle: pkg.lifecycleLabel ?? null,
+        lifecycle: pkg.lifecycleLabel,
         maintainerBusFactor: pkg.maintainerCount,
         lastRelease: pkg.latestReleaseAt ? pkg.latestReleaseAt.toISOString() : null,
         hasSecurityFile: pkg.hasSecurityFile,
@@ -76,7 +75,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         openSSFScorecard: scorecardScore,
       },
     },
-    signalCoverageHealth: pkg.signalCoverageHealth ?? null,
+    signalCoverageHealth: pkg.signalCoverageHealth,
     assessment: null,
     security: {
       securityContacts: null,

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -40,6 +40,8 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
   const scorecardScore = pkg.scorecardScore != null ? Number(pkg.scorecardScore) : null
   const mappingConfidence =
     pkg.repoMappingConfidence != null ? Number(pkg.repoMappingConfidence) : null
+  const healthScoreTotal =
+    pkg.healthScore ?? (scorecardScore !== null ? Math.round(scorecardScore * 10) : null)
 
   ok(res, {
     purl: pkg.purl,
@@ -47,7 +49,14 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     ecosystem: pkg.ecosystem,
     latestVersion: pkg.latestVersion ?? null,
     general: {
-      healthScore: scorecardScore !== null ? Math.round(scorecardScore * 10) : null,
+      healthScore: healthScoreTotal,
+      healthScoreDetails: {
+        total: healthScoreTotal,
+        label: pkg.healthLabel,
+        maintainerHealth: pkg.maintainerHealthScore,
+        securitySupplyChain: pkg.securitySupplyChainScore,
+        developmentActivity: pkg.developmentActivityScore,
+      },
       healthBand: computeHealthBand(scorecardScore),
       impact: {
         impactScore:
@@ -58,7 +67,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         transitiveReach: pkg.transitiveReach,
       },
       riskSignals: {
-        lifecycle: null,
+        lifecycle: pkg.lifecycleLabel ?? null,
         maintainerBusFactor: pkg.maintainerCount,
         lastRelease: pkg.latestReleaseAt ? pkg.latestReleaseAt.toISOString() : null,
         hasSecurityFile: pkg.hasSecurityFile,
@@ -67,6 +76,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         openSSFScorecard: scorecardScore,
       },
     },
+    signalCoverageHealth: pkg.signalCoverageHealth ?? null,
     assessment: null,
     security: {
       securityContacts: null,

--- a/backend/src/api/public/v1/packages/openapi.yaml
+++ b/backend/src/api/public/v1/packages/openapi.yaml
@@ -291,6 +291,11 @@ components:
                     - integer
                     - 'null'
                   example: 18
+                label:
+                  type:
+                    - string
+                    - 'null'
+                  example: Good
             impact:
               type:
                 - object
@@ -466,6 +471,12 @@ components:
         history:
           type: object
           description: Package history data. Empty in v1.
+        signalCoverageHealth:
+          type:
+            - object
+            - 'null'
+          description: Signal coverage health data enriched by Tinybird. Null until enriched.
+          additionalProperties: true
 
     # ── Metrics ──────────────────────────────────────────────────────────────────
 

--- a/backend/src/api/public/v1/packages/openapi.yaml
+++ b/backend/src/api/public/v1/packages/openapi.yaml
@@ -268,9 +268,26 @@ components:
           properties:
             healthScore:
               type:
+                - integer
+                - 'null'
+              description: Composite health score (0–100). Tinybird-enriched when available, null otherwise.
+              example: 18
+            healthScoreDetails:
+              type:
                 - object
                 - 'null'
+              description: Breakdown of the composite health score. Null until Tinybird enrichment runs.
               properties:
+                total:
+                  type:
+                    - integer
+                    - 'null'
+                  example: 18
+                label:
+                  type:
+                    - string
+                    - 'null'
+                  example: Good
                 maintainerHealth:
                   type:
                     - integer
@@ -286,16 +303,13 @@ components:
                     - integer
                     - 'null'
                   example: 6
-                total:
-                  type:
-                    - integer
-                    - 'null'
-                  example: 18
-                label:
-                  type:
-                    - string
-                    - 'null'
-                  example: Good
+            healthBand:
+              type:
+                - string
+                - 'null'
+              enum: [healthy, fair, concerning, critical, null]
+              description: Derived from Tinybird health score when available, OpenSSF Scorecard otherwise.
+              example: concerning
             impact:
               type:
                 - object
@@ -683,11 +697,14 @@ paths:
                 name: lodash
                 ecosystem: npm
                 general:
-                  healthScore:
+                  healthScore: 18
+                  healthScoreDetails:
+                    total: 18
+                    label: critical
                     maintainerHealth: 4
                     securitySupplyChain: 8
                     developmentActivity: 6
-                    total: 18
+                  healthBand: critical
                   impact:
                     impactScore: 71
                     downloadsLastMonth: 52142891

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -618,6 +618,14 @@ export interface PackageDetailRow {
   downloadsLast30d: string | null
   maintainerCount: number
   transitiveReach: number | null
+  // Tinybird-enriched health fields
+  healthScore: number | null
+  healthLabel: string | null
+  maintainerHealthScore: number | null
+  securitySupplyChainScore: number | null
+  developmentActivityScore: number | null
+  lifecycleLabel: string | null
+  signalCoverageHealth: Record<string, unknown> | null
 }
 
 export interface AdvisoryRow {
@@ -672,6 +680,13 @@ export async function getPackageDetailByPurl(
         LIMIT 1
       ) AS "downloadsLast30d",
       (SELECT COUNT(*)::int FROM package_maintainers pm WHERE pm.package_id = p.id) AS "maintainerCount",
+      p.health_score AS "healthScore",
+      p.health_label AS "healthLabel",
+      p.maintainer_health_score AS "maintainerHealthScore",
+      p.security_supply_chain_score AS "securitySupplyChainScore",
+      p.development_activity_score AS "developmentActivityScore",
+      p.lifecycle_label AS "lifecycleLabel",
+      p.signal_coverage_health AS "signalCoverageHealth",
       -- TODO: precompute and store in packages.transitive_reach_prank; full window scan is too slow at npm scale (~24s for npm)
       -- (
       --   SELECT r.prank


### PR DESCRIPTION
## Summary

Exposes Tinybird-enriched package health fields in the self-serve package detail API (`GET /packages/detail`, `/akrites/packages/detail`). These columns were added to the `packages` table in PR #4243 and are now returned in the response instead of being omitted or null.

## Changes

- **`data-access-layer` — `getPackageDetailByPurl`**: adds 7 new columns to the SQL SELECT (`health_score`, `health_label`, `maintainer_health_score`, `security_supply_chain_score`, `development_activity_score`, `lifecycle_label`, `signal_coverage_health`) and extends `PackageDetailRow` with the corresponding typed fields.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1285](https://linuxfoundation.atlassian.net/browse/CM-1285)

[CM-1285]: https://linuxfoundation.atlassian.net/browse/CM-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public package-detail response semantics change for `healthScore` and new fields; clients that assumed Scorecard-derived health may see different values when Tinybird data exists.
> 
> **Overview**
> **Package detail** (`GET /packages/detail`) now returns **Tinybird-enriched** health data from `packages` instead of deriving health mostly from OpenSSF Scorecard.
> 
> `getPackageDetailByPurl` selects seven new columns (`health_score`, breakdown scores, `lifecycle_label`, `signal_coverage_health`) and maps them on `PackageDetailRow`. The handler returns **`healthScore`** and **`healthScoreDetails`** (total, label, maintainer/security/development subscores) from those fields, sets **`riskSignals.lifecycle`** from `lifecycleLabel`, and adds top-level **`signalCoverageHealth`**. **`healthBand`** still uses `computeHealthBand`, but the input is Tinybird `healthScore / 10` when present, otherwise Scorecard as before.
> 
> OpenAPI **`PackageDetail`** is updated to document the new fields and examples (replacing the old “scorecard × 10 only” health shape).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fa261c41be2f6a9d009da67b0d5aa0b6f08ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->