### PR TITLE
fix: add helper snake to camle case (CM-1285)

### DIFF
--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -15,6 +15,13 @@ import { validateOrThrow } from '@/utils/validation'
 import { purlQuerySchema } from './purl'
 import type { StewardshipStatus } from './types'
 
+function snakeToCamelKeys(obj: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (obj === null) return null
+  return Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k.replace(/_([a-z])/g, (_, c) => c.toUpperCase()), v]),
+  )
+}
+
 function repoMappingLabel(confidence: number | null): 'High' | 'Medium' | 'Low' | null {
   if (confidence === null) return null
   if (confidence >= 0.8) return 'High'
@@ -75,7 +82,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         openSSFScorecard: scorecardScore,
       },
     },
-    signalCoverageHealth: pkg.signalCoverageHealth,
+    signalCoverageHealth: snakeToCamelKeys(pkg.signalCoverageHealth),
     assessment: null,
     security: {
       securityContacts: null,


### PR DESCRIPTION
## Summary

Fixes the `signalCoverageHealth` object returned by the package detail API: keys were coming through in `snake_case` (as stored in the DB by Tinybird) and are now converted to `camelCase` to be consistent with the rest of the API response.

## Changes

- **`getPackage.ts`**: adds a `snakeToCamelKeys` helper that converts top-level object keys from `snake_case` to `camelCase`, and applies it to `signalCoverageHealth` before returning the response.
  - e.g. `bus_factor` → `busFactor`, `supply_chain_integrity` → `supplyChainIntegrity`
  - The helper is a pass-through for `null` (not-yet-enriched packages).


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1285](https://linuxfoundation.atlassian.net/browse/CM-1285)

[CM-1285]: https://linuxfoundation.atlassian.net/browse/CM-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field response shaping in a read endpoint; no auth, persistence, or behavioral logic changes beyond key naming.
> 
> **Overview**
> Fixes **`signalCoverageHealth`** on the package detail API so top-level keys match the rest of the response (**camelCase**) instead of the **snake_case** shape from Tinybird/DB storage.
> 
> Adds a **`snakeToCamelKeys`** helper in `getPackage.ts` (pass-through for `null`) and wraps **`pkg.signalCoverageHealth`** before it is returned—e.g. `bus_factor` → `busFactor`, `supply_chain_integrity` → `supplyChainIntegrity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ee6f3ec59d8282a62712f74c9fc2782c3bcd12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->