### PR TITLE
feat: move to continue as new pattern (CM-1277)

### DIFF
--- a/services/apps/packages_worker/src/activities.ts
+++ b/services/apps/packages_worker/src/activities.ts
@@ -12,7 +12,7 @@ export {
 } from './npm/activities'
 export * from './deps-dev/activities'
 export { osvSyncEcosystem, osvDeriveCriticalFlag } from './osv/activities'
-export { processMavenCriticalBatch, processMavenNonCriticalBatch } from './maven/activities'
+export { processMavenCriticalBatch } from './maven/activities'
 export { criticalityComputePageRank, rankPackages } from './criticality/activities'
 export {
   cargoDownloadAndLoad,

--- a/services/apps/packages_worker/src/bin/maven-worker.ts
+++ b/services/apps/packages_worker/src/bin/maven-worker.ts
@@ -1,8 +1,8 @@
-import { scheduleMavenCritical } from '../maven/schedule'
+import { scheduleMavenIngestion } from '../maven/schedule'
 import { svc } from '../service'
 
 setImmediate(async () => {
   await svc.init()
-  await scheduleMavenCritical()
+  await scheduleMavenIngestion()
   await svc.start()
 })

--- a/services/apps/packages_worker/src/maven/activities.ts
+++ b/services/apps/packages_worker/src/maven/activities.ts
@@ -19,20 +19,3 @@ export async function processMavenCriticalBatch(): Promise<BatchResult> {
   log.info({ ...result }, 'Maven critical batch complete')
   return result
 }
-
-export async function processMavenNonCriticalBatch(): Promise<BatchResult> {
-  const config = getMavenConfig()
-  const qx = await getPackagesDb()
-  // Non-critical is DB-only (no POM fetch); the flag is unused on this path.
-  const result = await processBatch(qx, config, false, false)
-  log.info(
-    {
-      processed: result.processed,
-      skipped: result.skipped,
-      unchanged: result.unchanged,
-      error: result.error,
-    },
-    'Maven non-critical batch complete',
-  )
-  return result
-}

--- a/services/apps/packages_worker/src/maven/schedule.ts
+++ b/services/apps/packages_worker/src/maven/schedule.ts
@@ -1,78 +1,49 @@
 import { ScheduleAlreadyRunning, ScheduleOverlapPolicy } from '@temporalio/client'
 
 import { svc } from '../service'
-import { mavenCriticalWorkflow } from '../workflows'
+import { ingestMavenPackages } from '../workflows'
 
-export async function scheduleMavenCritical(): Promise<void> {
+const LEGACY_SCHEDULE_ID = 'maven-critical'
+
+export async function scheduleMavenIngestion(): Promise<void> {
   const { temporal } = svc
   if (!temporal) throw new Error('Temporal client not initialized')
 
-  const scheduleOptions: Parameters<typeof temporal.schedule.create>[0] = {
-    scheduleId: 'maven-critical',
-    spec: {
-      cronExpressions: ['*/1 * * * *'],
-    },
-    policies: {
-      overlap: ScheduleOverlapPolicy.SKIP,
-      catchupWindow: '1 hour',
-    },
-    action: {
-      type: 'startWorkflow',
-      workflowType: mavenCriticalWorkflow,
-      taskQueue: 'packages-worker',
-      workflowExecutionTimeout: '15 minutes',
-      retry: {
-        initialInterval: '30 seconds',
-        backoffCoefficient: 2,
-        maximumAttempts: 3,
-      },
-      args: [],
-    },
+  try {
+    await temporal.schedule.getHandle(LEGACY_SCHEDULE_ID).delete()
+    svc.log.info({ scheduleId: LEGACY_SCHEDULE_ID }, 'Deleted legacy schedule.')
+  } catch {
+    // Not found — nothing to clean up.
   }
 
   try {
-    await temporal.schedule.create(scheduleOptions)
+    await temporal.schedule.create({
+      scheduleId: 'maven-ingestion',
+      spec: {
+        cronExpressions: ['0 0 * * *'],
+      },
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: '1 hour',
+      },
+      action: {
+        type: 'startWorkflow',
+        workflowType: ingestMavenPackages,
+        taskQueue: 'packages-worker',
+        workflowRunTimeout: '24 hours',
+        retry: {
+          initialInterval: '30 seconds',
+          backoffCoefficient: 2,
+          maximumAttempts: 3,
+        },
+        args: [],
+      },
+    })
   } catch (err) {
     if (err instanceof ScheduleAlreadyRunning) {
-      svc.log.info('Schedule maven-critical already exists, skipping creation.')
+      svc.log.info('Schedule maven-ingestion already exists, skipping creation.')
     } else {
       throw err
     }
   }
 }
-
-// export async function scheduleMavenNonCritical(): Promise<void> {
-//   const { temporal } = svc
-//   if (!temporal) throw new Error('Temporal client not initialized')
-
-//   try {
-//     await temporal.schedule.create({
-//       scheduleId: 'maven-non-critical',
-//       spec: {
-//         cronExpressions: ['*/10 * * * *'],
-//       },
-//       policies: {
-//         overlap: ScheduleOverlapPolicy.SKIP,
-//         catchupWindow: '1 hour',
-//       },
-//       action: {
-//         type: 'startWorkflow',
-//         workflowType: mavenNonCriticalWorkflow,
-//         taskQueue: 'packages-worker',
-//         workflowExecutionTimeout: '5 minutes',
-//         retry: {
-//           initialInterval: '30 seconds',
-//           backoffCoefficient: 2,
-//           maximumAttempts: 3,
-//         },
-//         args: [],
-//       },
-//     })
-//   } catch (err) {
-//     if (err instanceof ScheduleAlreadyRunning) {
-//       svc.log.info('Schedule maven-non-critical already registered.')
-//     } else {
-//       throw err
-//     }
-// }
-// }

--- a/services/apps/packages_worker/src/maven/schedule.ts
+++ b/services/apps/packages_worker/src/maven/schedule.ts
@@ -12,8 +12,11 @@ export async function scheduleMavenIngestion(): Promise<void> {
   try {
     await temporal.schedule.getHandle(LEGACY_SCHEDULE_ID).delete()
     svc.log.info({ scheduleId: LEGACY_SCHEDULE_ID }, 'Deleted legacy schedule.')
-  } catch {
-    // Not found — nothing to clean up.
+  } catch (err) {
+    svc.log.warn(
+      { err, scheduleId: LEGACY_SCHEDULE_ID },
+      'Failed to delete legacy schedule (may not exist).',
+    )
   }
 
   try {

--- a/services/apps/packages_worker/src/maven/schedule.ts
+++ b/services/apps/packages_worker/src/maven/schedule.ts
@@ -23,7 +23,7 @@ export async function scheduleMavenIngestion(): Promise<void> {
     await temporal.schedule.create({
       scheduleId: 'maven-ingestion',
       spec: {
-        cronExpressions: ['0 0 * * *'],
+        cronExpressions: ['0 9 * * *'],
       },
       policies: {
         overlap: ScheduleOverlapPolicy.SKIP,

--- a/services/apps/packages_worker/src/maven/schedule.ts
+++ b/services/apps/packages_worker/src/maven/schedule.ts
@@ -32,6 +32,7 @@ export async function scheduleMavenIngestion(): Promise<void> {
       action: {
         type: 'startWorkflow',
         workflowType: ingestMavenPackages,
+        workflowId: 'maven-daily-enrichment',
         taskQueue: 'packages-worker',
         workflowRunTimeout: '24 hours',
         retry: {

--- a/services/apps/packages_worker/src/maven/workflows.ts
+++ b/services/apps/packages_worker/src/maven/workflows.ts
@@ -11,15 +11,10 @@ const acts = proxyActivities<typeof activities>({
   },
 })
 
-const BATCHES_PER_RUN = 5
-
 export async function ingestMavenPackages(): Promise<void> {
-  for (let i = 0; i < BATCHES_PER_RUN; i++) {
-    const result = await acts.processMavenCriticalBatch()
-    if (result.processed + result.skipped + result.error + result.unchanged === 0) {
-      return
-    }
+  const result = await acts.processMavenCriticalBatch()
+  if (result.processed + result.skipped + result.error + result.unchanged === 0) {
+    return
   }
-
   await continueAsNew<typeof ingestMavenPackages>()
 }

--- a/services/apps/packages_worker/src/maven/workflows.ts
+++ b/services/apps/packages_worker/src/maven/workflows.ts
@@ -14,7 +14,7 @@ const acts = proxyActivities<typeof activities>({
 export async function ingestMavenPackages(): Promise<void> {
   const result = await acts.processMavenCriticalBatch()
   if (result.processed + result.skipped + result.unchanged === 0) {
-    log.info({ ...result }, 'Maven ingestion complete — no more work, exiting.')
+    log.info('Maven ingestion complete — no more work, exiting.', { ...result })
     return
   }
   await continueAsNew<typeof ingestMavenPackages>()

--- a/services/apps/packages_worker/src/maven/workflows.ts
+++ b/services/apps/packages_worker/src/maven/workflows.ts
@@ -1,19 +1,25 @@
-import { proxyActivities } from '@temporalio/workflow'
+import { continueAsNew, proxyActivities } from '@temporalio/workflow'
 
 import type * as activities from './activities'
 
-const { processMavenCriticalBatch } = proxyActivities<typeof activities>({
+const acts = proxyActivities<typeof activities>({
   startToCloseTimeout: '15 minutes',
+  retry: {
+    initialInterval: '30 seconds',
+    backoffCoefficient: 2,
+    maximumAttempts: 5,
+  },
 })
 
-const { processMavenNonCriticalBatch } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '5 minutes',
-})
+const BATCHES_PER_RUN = 5
 
-export async function mavenCriticalWorkflow(): Promise<void> {
-  await processMavenCriticalBatch()
-}
+export async function ingestMavenPackages(): Promise<void> {
+  for (let i = 0; i < BATCHES_PER_RUN; i++) {
+    const result = await acts.processMavenCriticalBatch()
+    if (result.processed + result.skipped + result.error + result.unchanged === 0) {
+      return
+    }
+  }
 
-export async function mavenNonCriticalWorkflow(): Promise<void> {
-  await processMavenNonCriticalBatch()
+  await continueAsNew<typeof ingestMavenPackages>()
 }

--- a/services/apps/packages_worker/src/maven/workflows.ts
+++ b/services/apps/packages_worker/src/maven/workflows.ts
@@ -13,7 +13,7 @@ const acts = proxyActivities<typeof activities>({
 
 export async function ingestMavenPackages(): Promise<void> {
   const result = await acts.processMavenCriticalBatch()
-  if (result.processed + result.skipped + result.error + result.unchanged === 0) {
+  if (result.processed + result.skipped + result.unchanged === 0) {
     return
   }
   await continueAsNew<typeof ingestMavenPackages>()

--- a/services/apps/packages_worker/src/maven/workflows.ts
+++ b/services/apps/packages_worker/src/maven/workflows.ts
@@ -1,4 +1,4 @@
-import { continueAsNew, proxyActivities } from '@temporalio/workflow'
+import { continueAsNew, log, proxyActivities } from '@temporalio/workflow'
 
 import type * as activities from './activities'
 
@@ -14,6 +14,7 @@ const acts = proxyActivities<typeof activities>({
 export async function ingestMavenPackages(): Promise<void> {
   const result = await acts.processMavenCriticalBatch()
   if (result.processed + result.skipped + result.unchanged === 0) {
+    log.info({ ...result }, 'Maven ingestion complete — no more work, exiting.')
     return
   }
   await continueAsNew<typeof ingestMavenPackages>()

--- a/services/apps/packages_worker/src/workflows/index.ts
+++ b/services/apps/packages_worker/src/workflows/index.ts
@@ -15,7 +15,7 @@ export {
   ingestDependentCounts,
 } from '../deps-dev/workflows'
 export { osvSync } from '../osv/workflows'
-export { mavenCriticalWorkflow, mavenNonCriticalWorkflow } from '../maven/workflows'
+export { ingestMavenPackages } from '../maven/workflows'
 export { ingestScorecard } from '../scorecard/workflows'
 export { rankPackagesWorkflow } from '../criticality/workflow'
 export { cargoSyncWorkflow } from '../cargo/workflows'


### PR DESCRIPTION
## Summary

Replaces the per-minute Maven schedule (launching a new Temporal workflow every minute) with a single long-running `ingestMavenPackages` workflow that uses `continueAsNew` — the same pattern already in use by the npm, go, and other workers. The workflow processes one batch of 2000 packages per cycle, calls `continueAsNew` as long as there is work, and exits cleanly when the queue is drained. A daily Temporal schedule restarts it the next day.

## Changes

- `maven/workflows.ts` — replaces `mavenCriticalWorkflow` / `mavenNonCriticalWorkflow` (single-shot, no retry) with `ingestMavenPackages`: processes one batch per cycle, calls `continueAsNew` if work remains, returns when the queue is empty
- `maven/schedule.ts` — schedule ID `maven-critical` (every minute, 15 min timeout) → `maven-ingestion` (daily at midnight, `workflowRunTimeout: 24h`); startup now deletes the legacy `maven-critical` schedule to prevent ghost runs after deploy
- `maven/activities.ts` — removes dead `processMavenNonCriticalBatch` (no callers since non-critical schedule was never activated)
- `activities.ts` — removes `processMavenNonCriticalBatch` from the activities index export
- `bin/maven-worker.ts`, `workflows/index.ts` — updated to reference the new names



## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1277](https://linuxfoundation.atlassian.net/browse/CM-1277)

[CM-1277]: https://linuxfoundation.atlassian.net/browse/CM-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Maven ingestion cadence and Temporal workflow lifecycle (24h runs vs 1-minute launches), which can affect how quickly the universe is polled until the first daily run completes; deploy-time legacy schedule deletion is intentional but environment-specific if schedules were customized.
> 
> **Overview**
> Maven package enrichment moves from **minute-by-minute one-shot workflows** to a **single long-running `ingestMavenPackages` workflow** that processes one batch per cycle, **`continueAsNew`s** while work remains, and **exits when the queue is empty**—aligned with npm/go workers.
> 
> **Scheduling:** Temporal schedule **`maven-critical` (every minute, 15m execution timeout)** is replaced by **`maven-ingestion` (daily `0 9 * * *`, fixed workflow id `maven-daily-enrichment`, 24h run timeout)**. Worker startup **deletes the legacy `maven-critical` schedule** to avoid duplicate runs after deploy.
> 
> **Cleanup:** **`processMavenNonCriticalBatch`** and **`mavenNonCriticalWorkflow`** are removed (non-critical path was never scheduled). Activity proxy gains **retry (max 5)** on the critical batch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837668d7cbb6c33f2f691e9a14fcdfe1b3f2e36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->