### PR TITLE
feat: update sorting (CM-1293)

### DIFF
--- a/backend/src/api/public/v1/ossprey/packageList.ts
+++ b/backend/src/api/public/v1/ossprey/packageList.ts
@@ -20,33 +20,38 @@ const LIFECYCLE_SET = new Set<string>(LIFECYCLE_VALUES)
 
 const boolParam = z.preprocess((v) => v === 'true', z.boolean()).default(false)
 
-const querySchema = z.object({
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(25),
-  ecosystem: z.string().trim().optional(),
-  lifecycle: z.enum(LIFECYCLE_VALUES).optional(),
-  name: z.string().trim().optional(),
-  purl: purlFilterSchema,
-  status: z
-    .enum([
-      'unassigned',
-      'open',
-      'assessing',
-      'active',
-      'needs_attention',
-      'escalated',
-      'blocked',
-      'inactive',
-    ])
-    .optional(),
-  healthBand: z.enum(HEALTH_BAND_VALUES).optional(),
-  vulnSeverity: z.enum(['any', 'high', 'critical', 'none']).optional(),
-  staleOnly: boolParam,
-  unstewardedOnly: boolParam,
-  busFactor1Only: boolParam,
-  sortBy: z.enum(['name', 'risk', 'impact', 'openVulns', 'health']).default('risk'),
-  sortDir: z.enum(['asc', 'desc']).default('desc'),
-})
+const querySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(25),
+    ecosystem: z.string().trim().optional(),
+    lifecycle: z.enum(LIFECYCLE_VALUES).optional(),
+    name: z.string().trim().optional(),
+    purl: purlFilterSchema,
+    status: z
+      .enum([
+        'unassigned',
+        'open',
+        'assessing',
+        'active',
+        'needs_attention',
+        'escalated',
+        'blocked',
+        'inactive',
+      ])
+      .optional(),
+    healthBand: z.enum(HEALTH_BAND_VALUES).optional(),
+    vulnSeverity: z.enum(['any', 'high', 'critical', 'none']).optional(),
+    staleOnly: boolParam,
+    unstewardedOnly: boolParam,
+    busFactor1Only: boolParam,
+    sortBy: z.enum(['name', 'risk', 'impact', 'openVulns', 'health']).default('risk'),
+    sortDir: z.enum(['asc', 'desc']).optional(),
+  })
+  .transform((data) => ({
+    ...data,
+    sortDir: data.sortDir ?? (data.sortBy === 'name' || data.sortBy === 'health' ? 'asc' : 'desc'),
+  }))
 
 export async function packageListHandler(req: Request, res: Response): Promise<void> {
   const params = validateOrThrow(querySchema, req.query)

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -436,7 +436,7 @@ export async function listPackagesForApi(
   } else if (opts.sortBy === 'openVulns') {
     sortExpr = '"openVulns"'
   } else if (opts.sortBy === 'health') {
-    sortExpr = 'r_sc.scorecard_score'
+    sortExpr = 'COALESCE(p.health_score, r_sc.scorecard_score * 10)'
   } else if (opts.sortBy === 'risk') {
     // Composite risk score: impact + health deficit + vuln exposure + bus factor + staleness
     sortExpr = `(
@@ -451,6 +451,7 @@ export async function listPackagesForApi(
     sortExpr = 'LOWER(p.name)'
   }
   const sortDir = opts.sortDir === 'desc' ? 'DESC' : 'ASC'
+  const nullsDir = sortDir === 'ASC' ? 'NULLS FIRST' : 'NULLS LAST'
 
   // Separate paginated params from filter-only params used by the fallback COUNT query
   const queryParams: Record<string, unknown> = {
@@ -568,7 +569,7 @@ export async function listPackagesForApi(
     FROM packages p
     ${laterals}
     ${where}
-    ORDER BY ${[exactSort, `${sortExpr} ${sortDir} NULLS LAST`, `p.purl ${sortDir}`].filter(Boolean).join(', ')}
+    ORDER BY ${[exactSort, `${sortExpr} ${sortDir} ${nullsDir}`, `p.purl ${sortDir}`].filter(Boolean).join(', ')}
     LIMIT $(limit) OFFSET $(offset)
     `,
     queryParams,


### PR DESCRIPTION
## Summary

Fixes sorting and health score consistency in the Akrites packages list API (`GET /akrites/packages`) to match the contract expected by the LFX Akrites admin dashboard.

## Changes

- **`sortDir` default per `sortBy`**: the akrites handler was defaulting `sortDir` to `desc` globally. Now when `sortDir` is omitted, it defaults to `asc` for `name` and `health` (matching the frontend's hard-coded directions) and `desc` for all other sort keys (`risk`, `impact`, `openVulns`).
- **Health sort expression**: sorting by `health` was using the raw `r_sc.scorecard_score` (0–10 scale), inconsistent with the `health.score` field returned in the response (which uses `p.health_score` first, falling back to `scorecard_score * 10`). Now the sort uses the same `COALESCE(p.health_score, r_sc.scorecard_score * 10)` expression.
- **NULL handling for ascending sorts**: added a `nullsDir` variable that applies `NULLS FIRST` for `ASC` sorts and `NULLS LAST` for `DESC` sorts. This ensures packages with missing health/impact data surface at the top when ordering worst-first, rather than being silently hidden at the end.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1293](https://linuxfoundation.atlassian.net/browse/CM-1293)


[CM-1293]: https://linuxfoundation.atlassian.net/browse/CM-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Query-parameter and ORDER BY behavior only for the packages list endpoint; no auth or data mutation.
> 
> **Overview**
> Aligns **Akrites/Ossprey package list** query sorting with what the admin UI expects when `sortDir` is omitted or when ordering by health.
> 
> **`sortDir` defaults** are no longer always `desc`. After validation, missing `sortDir` becomes **`asc` for `name` and `health`**, and **`desc` for `risk`, `impact`, and `openVulns`**.
> 
> **Health column sorting** now uses the same composite score as the API response (`COALESCE(p.health_score, r_sc.scorecard_score * 10)`), instead of raw scorecard on a 0–10 scale.
> 
> **NULL placement** in `ORDER BY` follows sort direction: **`NULLS FIRST` for ascending**, **`NULLS LAST` for descending**, so missing health/impact data is not always pushed to the end on ascending sorts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de8c27e666e4bdd762ea15112b65609d67b51de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->