### PR TITLE
fix: fetch gitlab groups concurrently and improve logs

### DIFF
--- a/backend/src/serverless/integrations/usecases/gitlab/getProjects.ts
+++ b/backend/src/serverless/integrations/usecases/gitlab/getProjects.ts
@@ -23,37 +23,47 @@ export async function fetchAllGitlabGroups(accessToken: string) {
   }))
 }
 
-export async function fetchGitlabGroupProjects(accessToken: string, groups: any[]) {
-  const groupProjects = {}
+async function fetchProjectsForGroup(accessToken: string, group: any) {
+  const projects = []
+  let page = 1
+  let hasMorePages = true
 
-  for (const group of groups) {
-    const projects = []
-    let page = 1
-    let hasMorePages = true
-
-    while (hasMorePages) {
-      const response = await axios.get(`https://gitlab.com/api/v4/groups/${group.id}/projects`, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params: { page, per_page: 100, archived: false },
-      })
-      projects.push(...response.data)
-      hasMorePages = response.headers['x-next-page'] !== ''
-      page++
-    }
-
-    groupProjects[group.id] = projects.map((project) => ({
-      groupId: group.id,
-      groupName: group.name,
-      groupPath: group.path,
-      id: project.id,
-      name: project.name,
-      path_with_namespace: project.path_with_namespace,
-      enabled: false,
-      forkedFrom: project?.forked_from_project?.web_url || null,
-    }))
+  while (hasMorePages) {
+    const response = await axios.get(`https://gitlab.com/api/v4/groups/${group.id}/projects`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      params: { page, per_page: 100, archived: false },
+    })
+    projects.push(...response.data)
+    hasMorePages = response.headers['x-next-page'] !== ''
+    page++
   }
 
-  return groupProjects as Record<number, any[]>
+  return projects.map((project) => ({
+    groupId: group.id,
+    groupName: group.name,
+    groupPath: group.path,
+    id: project.id,
+    name: project.name,
+    path_with_namespace: project.path_with_namespace,
+    enabled: false,
+    forkedFrom: project?.forked_from_project?.web_url || null,
+  }))
+}
+
+export async function fetchGitlabGroupProjects(accessToken: string, groups: any[]) {
+  const groupProjects: Record<number, any[]> = {}
+
+  for (let i = 0; i < groups.length; i += CONCURRENCY) {
+    const batch = groups.slice(i, i + CONCURRENCY)
+    const results = await Promise.all(
+      batch.map((group) => fetchProjectsForGroup(accessToken, group)),
+    )
+    batch.forEach((group, idx) => {
+      groupProjects[group.id] = results[idx]
+    })
+  }
+
+  return groupProjects
 }
 
 export async function fetchGitlabUserProjects(accessToken: string, userId: number) {

--- a/backend/src/serverless/integrations/usecases/gitlab/getProjects.ts
+++ b/backend/src/serverless/integrations/usecases/gitlab/getProjects.ts
@@ -51,6 +51,7 @@ async function fetchProjectsForGroup(accessToken: string, group: any) {
 }
 
 export async function fetchGitlabGroupProjects(accessToken: string, groups: any[]) {
+  const CONCURRENCY = 10
   const groupProjects: Record<number, any[]> = {}
 
   for (let i = 0; i < groups.length; i += CONCURRENCY) {

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -2776,14 +2776,13 @@ export default class IntegrationService {
     } catch (err) {
       this.options.log.error(
         {
-          err,
           errMessage: err?.message,
           errName: err?.name,
           errStack: err?.stack,
           gitlabStatus: err?.response?.status,
           gitlabError: err?.response?.data,
           gitlabUrl: err?.config?.url,
-          isAxiosError: !!err?.isAxiosError,
+          gitlabMethod: err?.config?.method,
         },
         'gitlabConnect failed',
       )

--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -2774,6 +2774,19 @@ export default class IntegrationService {
 
       await SequelizeRepository.commitTransaction(transaction)
     } catch (err) {
+      this.options.log.error(
+        {
+          err,
+          errMessage: err?.message,
+          errName: err?.name,
+          errStack: err?.stack,
+          gitlabStatus: err?.response?.status,
+          gitlabError: err?.response?.data,
+          gitlabUrl: err?.config?.url,
+          isAxiosError: !!err?.isAxiosError,
+        },
+        'gitlabConnect failed',
+      )
       await SequelizeRepository.rollbackTransaction(transaction)
       throw err
     }


### PR DESCRIPTION
This pull request refactors the way GitLab group projects are fetched to improve performance and error logging. The main updates include batching API calls for better concurrency and adding more detailed error logging for GitLab integration failures.

### Performance improvements for fetching GitLab group projects
* Refactored the logic to fetch projects for each group into a new helper function `fetchProjectsForGroup`, enabling better code organization.
* Updated `fetchGitlabGroupProjects` to fetch projects in batches of 10 groups concurrently, significantly speeding up the process when handling many groups.
* Changed the structure so that results are collected and mapped back to the correct group in the final result.

### Enhanced error logging for GitLab integration
* Added detailed error logging in the `IntegrationService` to capture GitLab-specific error information (status, error message, URL, and method) when a connection fails. This will help with debugging integration issues.