### PR TITLE
fix: cache regression

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -50,7 +50,7 @@ import {
   includeMemberToSegments,
 } from '@crowd/data-access-layer/src/members/segments'
 import { IDbMemberData } from '@crowd/data-access-layer/src/members/types'
-import { optionsQx } from '@crowd/data-access-layer/src/queryExecutor'
+import { optionsBgQx, optionsQx } from '@crowd/data-access-layer/src/queryExecutor'
 import {
   fetchManySegments,
   getSegmentMergeSuggestionCounts,
@@ -1259,7 +1259,7 @@ class MemberRepository {
     let memberResponse = null
 
     const qx = optionsQx(options)
-    const bgQx = optionsQx({ ...options, transaction: null })
+    const bgQx = optionsBgQx(options)
 
     memberResponse = await queryMembersAdvanced(qx, bgQx, options.redis, {
       filter: { id: { eq: id } },

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -21,7 +21,7 @@ import {
   insertMemberSegmentAggregates,
   queryMembersAdvanced,
 } from '@crowd/data-access-layer/src/members'
-import { QueryExecutor, optionsQx } from '@crowd/data-access-layer/src/queryExecutor'
+import { QueryExecutor, optionsBgQx, optionsQx } from '@crowd/data-access-layer/src/queryExecutor'
 import {
   decrementMemberMergeSuggestionCounts,
   fetchManySegments,
@@ -944,7 +944,7 @@ export default class MemberService extends LoggerBase {
 
   async findAllAutocomplete(data) {
     const qx = optionsQx(this.options)
-    const bgQx = optionsQx({ ...this.options, transaction: null })
+    const bgQx = optionsBgQx(this.options)
 
     return queryMembersAdvanced(qx, bgQx, this.options.redis, {
       filter: data.filter,
@@ -970,7 +970,7 @@ export default class MemberService extends LoggerBase {
     }
 
     const qx = optionsQx(this.options)
-    const bgQx = optionsQx({ ...this.options, transaction: null })
+    const bgQx = optionsBgQx(this.options)
 
     return queryMembersAdvanced(qx, bgQx, this.options.redis, {
       ...data,

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -195,8 +195,11 @@ export async function queryMembersAdvanced(
   // Initialize cache
   const cache = new MemberQueryCache(redis)
 
-  // Build cache key — countOnly is excluded so count and full-result caches share the same key.
-  // Normalize empty search to null so "" and null produce the same key (buildSearchCTE treats them identically).
+  // Normalize search once: trim whitespace, lowercase (buildSearchCTE lowercases anyway),
+  // convert empty string to null so "" and null hash identically.
+  const normalizedSearch = search?.trim().toLowerCase() || null
+
+  // Full result key — includes pagination and projection so page 1 and page 2 are separate entries.
   const cacheKey = cache.buildCacheKey({
     fields,
     filter,
@@ -205,18 +208,26 @@ export async function queryMembersAdvanced(
     limit,
     offset,
     orderBy,
-    search: search?.trim() || null,
+    search: normalizedSearch,
+    segmentId,
+  })
+
+  // Count key — excludes pagination/projection and include flags since the count query
+  // only depends on filter, search, and segmentId (buildCountQuery hardcodes includeMemberOrgs=false).
+  const countCacheKey = cache.buildCountCacheKey({
+    filter,
+    search: normalizedSearch,
     segmentId,
   })
 
   // Try to get from cache first
   const cachedResult = countOnly ? null : await cache.get(cacheKey)
-  const cachedCount = countOnly ? await cache.getCount(cacheKey) : null
+  const cachedCount = countOnly ? await cache.getCount(countCacheKey) : null
 
   if (cachedResult) {
     refreshCacheInBackground(bgQx, redis, cacheKey, {
       filter,
-      search,
+      search: normalizedSearch,
       limit,
       offset,
       orderBy,
@@ -233,16 +244,16 @@ export async function queryMembersAdvanced(
   }
 
   if (countOnly && cachedCount !== null) {
-    refreshCountCacheInBackground(bgQx, redis, cacheKey, {
+    refreshCountCacheInBackground(bgQx, redis, countCacheKey, {
       filter,
-      search,
+      search: normalizedSearch,
       segmentId,
       include,
       includeAllAttributes,
       attributeSettings,
     })
 
-    log.debug(`Members advanced count query cache hit: ${cacheKey}`)
+    log.debug(`Members advanced count query cache hit: ${countCacheKey}`)
     return {
       rows: [],
       count: cachedCount,
@@ -253,7 +264,7 @@ export async function queryMembersAdvanced(
 
   return await executeQuery(qx, redis, cacheKey, {
     filter,
-    search,
+    search: normalizedSearch,
     limit,
     offset,
     orderBy,
@@ -299,6 +310,11 @@ export async function executeQuery(
   }: IQueryMembersAdvancedParams,
 ): Promise<PageData<IDbMemberData>> {
   const cache = new MemberQueryCache(redis)
+  const countCacheKey = cache.buildCountCacheKey({
+    filter,
+    search: search ?? null,
+    segmentId,
+  })
   const withAggregates = !!segmentId
   const searchConfig = buildSearchCTE(search)
 
@@ -352,8 +368,7 @@ export async function executeQuery(
     const result = await qx.selectOne(countQuery, params)
     const count = parseInt(result.count, 10)
 
-    // Cache the count
-    await cache.setCount(cacheKey, count, 21600) // 6 hours TTL
+    await cache.setCount(countCacheKey, count, 21600)
 
     return {
       rows: [],
@@ -540,8 +555,8 @@ export async function executeQuery(
   const result = { rows, count, limit, offset }
 
   await Promise.all([
-    cache.set(cacheKey, result, 21600), // 6 hours TTL
-    cache.setCount(cacheKey, count, 21600), // also warm count cache so countOnly=true hits next time
+    cache.set(cacheKey, result, 21600),
+    cache.setCount(countCacheKey, count, 21600),
   ])
 
   return result

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -225,6 +225,10 @@ export async function queryMembersAdvanced(
   const cachedCount = countOnly ? await cache.getCount(countCacheKey) : null
 
   if (cachedResult) {
+    log.info(
+      { cacheKey, segmentId, search: normalizedSearch, limit, offset, orderBy },
+      'Members advanced query cache hit — returning cached result, scheduling background refresh',
+    )
     refreshCacheInBackground(bgQx, redis, cacheKey, {
       filter,
       search: normalizedSearch,
@@ -238,12 +242,14 @@ export async function queryMembersAdvanced(
       includeAllAttributes,
       attributeSettings,
     })
-
-    log.info(`Members advanced query cache hit: ${cacheKey}`)
     return cachedResult
   }
 
   if (countOnly && cachedCount !== null) {
+    log.info(
+      { countCacheKey, segmentId, search: normalizedSearch },
+      'Members advanced count cache hit — returning cached count, scheduling background refresh',
+    )
     refreshCountCacheInBackground(bgQx, redis, countCacheKey, {
       filter,
       search: normalizedSearch,
@@ -252,8 +258,6 @@ export async function queryMembersAdvanced(
       includeAllAttributes,
       attributeSettings,
     })
-
-    log.debug(`Members advanced count query cache hit: ${countCacheKey}`)
     return {
       rows: [],
       count: cachedCount,
@@ -262,19 +266,65 @@ export async function queryMembersAdvanced(
     }
   }
 
-  return await executeQuery(qx, redis, cacheKey, {
-    filter,
-    search: normalizedSearch,
-    limit,
-    offset,
-    orderBy,
-    segmentId,
-    countOnly,
-    fields,
-    include,
-    includeAllAttributes,
-    attributeSettings,
-  })
+  log.info(
+    {
+      cacheKey,
+      countCacheKey,
+      segmentId,
+      search: normalizedSearch,
+      limit,
+      offset,
+      orderBy,
+      countOnly,
+    },
+    'Members advanced query cache miss — executing query synchronously',
+  )
+
+  try {
+    return await executeQuery(qx, redis, cacheKey, {
+      filter,
+      search: normalizedSearch,
+      limit,
+      offset,
+      orderBy,
+      segmentId,
+      countOnly,
+      fields,
+      include,
+      includeAllAttributes,
+      attributeSettings,
+    })
+  } catch (error) {
+    log.warn(
+      { cacheKey, countCacheKey, segmentId, search: normalizedSearch, countOnly, err: error },
+      'Members advanced query failed on cache miss — scheduling background refresh for next retry',
+    )
+    if (countOnly) {
+      refreshCountCacheInBackground(bgQx, redis, countCacheKey, {
+        filter,
+        search: normalizedSearch,
+        segmentId,
+        include,
+        includeAllAttributes,
+        attributeSettings,
+      })
+    } else {
+      refreshCacheInBackground(bgQx, redis, cacheKey, {
+        filter,
+        search: normalizedSearch,
+        limit,
+        offset,
+        orderBy,
+        segmentId,
+        countOnly: false,
+        fields,
+        include,
+        includeAllAttributes,
+        attributeSettings,
+      })
+    }
+    throw error
+  }
 }
 
 export async function executeQuery(
@@ -567,29 +617,36 @@ async function refreshCacheInBackground(
   redis: RedisClient,
   cacheKey: string,
   params: IQueryMembersAdvancedParams,
+  countOnly = false,
 ): Promise<void> {
+  const label = countOnly ? 'count cache' : 'query cache'
+  const cache = new MemberQueryCache(redis)
+  const acquired = await cache.tryAcquireRefreshLock(cacheKey)
+  if (!acquired) {
+    log.debug(
+      { cacheKey },
+      `Members advanced ${label} refresh already in progress — skipping duplicate`,
+    )
+    return
+  }
   try {
-    log.info(`Refreshing members advanced query cache in background: ${cacheKey}`)
-    await executeQuery(qx, redis, cacheKey, params)
-    log.info(`Members advanced query cache refreshed in background: ${cacheKey}`)
+    log.info({ cacheKey }, `Members advanced ${label} background refresh started`)
+    await executeQuery(qx, redis, cacheKey, countOnly ? { ...params, countOnly: true } : params)
+    log.info({ cacheKey }, `Members advanced ${label} background refresh completed`)
   } catch (error) {
-    log.warn('Background cache refresh failed:', error)
+    log.warn({ cacheKey, err: error }, `Members advanced ${label} background refresh failed`)
+  } finally {
+    await cache.releaseRefreshLock(cacheKey)
   }
 }
 
-async function refreshCountCacheInBackground(
+function refreshCountCacheInBackground(
   qx: QueryExecutor,
   redis: RedisClient,
   cacheKey: string,
   params: IQueryMembersAdvancedParams,
 ): Promise<void> {
-  try {
-    log.info(`Refreshing members advanced count cache in background: ${cacheKey}`)
-    await executeQuery(qx, redis, cacheKey, { ...params, countOnly: true })
-    log.info(`Members advanced count cache refreshed in background: ${cacheKey}`)
-  } catch (error) {
-    log.warn('Background count cache refresh failed:', error)
-  }
+  return refreshCacheInBackground(qx, redis, cacheKey, params, true)
 }
 
 export async function queryMembers<T extends MemberField>(

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -569,7 +569,9 @@ async function refreshCacheInBackground(
   params: IQueryMembersAdvancedParams,
 ): Promise<void> {
   try {
+    log.info(`Refreshing members advanced query cache in background: ${cacheKey}`)
     await executeQuery(qx, redis, cacheKey, params)
+    log.info(`Members advanced query cache refreshed in background: ${cacheKey}`)
   } catch (error) {
     log.warn('Background cache refresh failed:', error)
   }
@@ -584,6 +586,7 @@ async function refreshCountCacheInBackground(
   try {
     log.info(`Refreshing members advanced count cache in background: ${cacheKey}`)
     await executeQuery(qx, redis, cacheKey, { ...params, countOnly: true })
+    log.info(`Members advanced count cache refreshed in background: ${cacheKey}`)
   } catch (error) {
     log.warn('Background count cache refresh failed:', error)
   }

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -456,16 +456,24 @@ export async function executeQuery(
     offset,
   })
 
+  // Skip the count sub-query if the count is already cached — saves a full table scan
+  // on every page navigation after the first (page 2, 3, ... all share the same countCacheKey).
+  const cachedCount = await cache.getCount(countCacheKey)
   const [rows, countResult] = await Promise.all([
     qx.select(mainQuery, params),
-    qx.selectOne(countQuery, params),
+    cachedCount === null ? qx.selectOne(countQuery, params) : Promise.resolve(null),
   ])
 
-  const count = parseInt(countResult.count, 10)
+  const count = cachedCount !== null ? cachedCount : parseInt(countResult?.count ?? '0', 10)
   const memberIds = rows.map((org) => org.id)
 
   if (memberIds.length === 0) {
-    return { rows: [], count, limit, offset }
+    const emptyResult = { rows: [], count, limit, offset }
+    await Promise.all([
+      cache.set(cacheKey, emptyResult, 21600),
+      cachedCount === null ? cache.setCount(countCacheKey, count, 21600) : Promise.resolve(),
+    ])
+    return emptyResult
   }
 
   const [memberOrganizations, identities, memberSegments, maintainerRoles] = await Promise.all([

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -205,7 +205,7 @@ export async function queryMembersAdvanced(
     limit,
     offset,
     orderBy,
-    search: search || null,
+    search: search?.trim() || null,
     segmentId,
   })
 

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -195,9 +195,9 @@ export async function queryMembersAdvanced(
   // Initialize cache
   const cache = new MemberQueryCache(redis)
 
-  // Build cache key
+  // Build cache key — countOnly is excluded so count and full-result caches share the same key.
+  // Normalize empty search to null so "" and null produce the same key (buildSearchCTE treats them identically).
   const cacheKey = cache.buildCacheKey({
-    countOnly,
     fields,
     filter,
     include,
@@ -205,13 +205,13 @@ export async function queryMembersAdvanced(
     limit,
     offset,
     orderBy,
-    search,
+    search: search || null,
     segmentId,
   })
 
   // Try to get from cache first
   const cachedResult = countOnly ? null : await cache.get(cacheKey)
-  const cachedCount = countOnly ? null : await cache.getCount(cacheKey)
+  const cachedCount = countOnly ? await cache.getCount(cacheKey) : null
 
   if (cachedResult) {
     refreshCacheInBackground(bgQx, redis, cacheKey, {
@@ -343,7 +343,9 @@ export async function executeQuery(
     withAggregates,
     searchConfig,
     filterString,
-    includeMemberOrgs: include.memberOrganizations,
+    // Count never needs org data in SELECT — filterHasMo inside buildCountQuery already
+    // handles the case where the filter itself references mo.* columns.
+    includeMemberOrgs: false,
   })
 
   if (countOnly) {
@@ -537,7 +539,10 @@ export async function executeQuery(
 
   const result = { rows, count, limit, offset }
 
-  await cache.set(cacheKey, result, 21600) // 6 hours TTL
+  await Promise.all([
+    cache.set(cacheKey, result, 21600), // 6 hours TTL
+    cache.setCount(cacheKey, count, 21600), // also warm count cache so countOnly=true hits next time
+  ])
 
   return result
 }

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -248,16 +248,12 @@ export async function queryMembersAdvanced(
   if (countOnly && cachedCount !== null) {
     log.info(
       { countCacheKey, segmentId, search: normalizedSearch },
-      'Members advanced count cache hit — returning cached count, scheduling background refresh',
+      'Members advanced count cache hit — returning cached count',
     )
-    refreshCountCacheInBackground(bgQx, redis, countCacheKey, {
-      filter,
-      search: normalizedSearch,
-      segmentId,
-      include,
-      includeAllAttributes,
-      attributeSettings,
-    })
+    // No background refresh for count hits: the count is a single integer with a 6h TTL,
+    // refreshing it on every hit would fire a COUNT(*) query per request, defeating the cache.
+    // The count is kept fresh by: (1) full-result refreshes that also write countCacheKey,
+    // (2) natural TTL expiry, (3) explicit cache invalidation on member updates.
     return {
       rows: [],
       count: cachedCount,

--- a/services/libs/data-access-layer/src/members/queryBuilder.ts
+++ b/services/libs/data-access-layer/src/members/queryBuilder.ts
@@ -464,9 +464,13 @@ export const buildCountQuery = ({
     searchConfig.join,
   ].filter(Boolean)
 
+  // When withAggregates is true the join is on memberSegmentsAgg_pkey (unique on memberId+segmentId),
+  // so there are no duplicate m.id values — COUNT(*) is equivalent to COUNT(DISTINCT m.id) but cheaper.
+  const countExpr = withAggregates ? 'COUNT(*)' : 'COUNT(DISTINCT m.id)'
+
   return `
     ${ctes.length > 0 ? `WITH ${ctes.join(',\n')}` : ''}
-    SELECT COUNT(DISTINCT m.id) AS count
+    SELECT ${countExpr} AS count
     FROM members m
     ${joins.join('\n')}
     WHERE (${filterString})

--- a/services/libs/data-access-layer/src/members/queryBuilder.ts
+++ b/services/libs/data-access-layer/src/members/queryBuilder.ts
@@ -422,12 +422,14 @@ export const buildQuery = ({
     Boolean,
   )
 
+  const needsMemberEnrichments = filterHasMe || fields.includes('me.')
+
   const joins = [
     withAggregates
       ? `INNER JOIN "memberSegmentsAgg" msa ON msa."memberId" = m.id AND msa."segmentId" = $(segmentId)`
       : '',
     needsMemberOrgs ? `LEFT JOIN member_orgs mo ON mo."memberId" = m.id` : '',
-    `LEFT JOIN "memberEnrichments" me ON me."memberId" = m.id`,
+    needsMemberEnrichments ? `LEFT JOIN "memberEnrichments" me ON me."memberId" = m.id` : '',
     searchConfig.join,
   ].filter(Boolean)
 
@@ -464,9 +466,11 @@ export const buildCountQuery = ({
     searchConfig.join,
   ].filter(Boolean)
 
-  // When withAggregates is true the join is on memberSegmentsAgg_pkey (unique on memberId+segmentId),
-  // so there are no duplicate m.id values — COUNT(*) is equivalent to COUNT(DISTINCT m.id) but cheaper.
-  const countExpr = withAggregates ? 'COUNT(*)' : 'COUNT(DISTINCT m.id)'
+  // COUNT(*) is safe only when every join is guaranteed one-to-one per member:
+  // - memberSegmentsAgg is unique on (memberId, segmentId) with segmentId fixed → safe
+  // - member_orgs CTE uses ARRAY_AGG GROUP BY memberId → one row per member → safe
+  // - memberEnrichments may have multiple rows per member → COUNT(*) would overcount
+  const countExpr = withAggregates && !filterHasMe ? 'COUNT(*)' : 'COUNT(DISTINCT m.id)'
 
   return `
     ${ctes.length > 0 ? `WITH ${ctes.join(',\n')}` : ''}

--- a/services/libs/data-access-layer/src/members/queryCache.ts
+++ b/services/libs/data-access-layer/src/members/queryCache.ts
@@ -26,7 +26,6 @@ export class MemberQueryCache {
   }
 
   buildCacheKey(params: {
-    countOnly?: boolean
     fields?: string[]
     filter?: Record<string, unknown>
     include?: IncludeOptions
@@ -39,7 +38,6 @@ export class MemberQueryCache {
   }): string {
     const cleanParams = Object.fromEntries(
       Object.entries({
-        countOnly: params.countOnly,
         fields: params.fields?.sort(),
         filter: params.filter,
         include: params.include,
@@ -90,7 +88,11 @@ export class MemberQueryCache {
   }
 
   async setCount(cacheKey: string, count: number, ttlSeconds: number): Promise<void> {
-    await this.countCache.set(cacheKey, count.toString(), ttlSeconds)
+    try {
+      await this.countCache.set(cacheKey, count.toString(), ttlSeconds)
+    } catch (error) {
+      log.warn('Error saving count to cache', { error })
+    }
   }
 
   async invalidateAll(): Promise<void> {

--- a/services/libs/data-access-layer/src/members/queryCache.ts
+++ b/services/libs/data-access-layer/src/members/queryCache.ts
@@ -30,8 +30,8 @@ export class MemberQueryCache {
     filter?: Record<string, unknown>
     include?: IncludeOptions
     includeAllAttributes?: boolean
-    limit: number
-    offset: number
+    limit?: number
+    offset?: number
     orderBy?: string
     search?: string
     segmentId?: string
@@ -59,6 +59,18 @@ export class MemberQueryCache {
     }
 
     return `members_advanced:${hash}`
+  }
+
+  buildCountCacheKey(params: {
+    filter?: Record<string, unknown>
+    search?: string
+    segmentId?: string
+  }): string {
+    return this.buildCacheKey({
+      filter: params.filter,
+      search: params.search,
+      segmentId: params.segmentId,
+    })
   }
 
   async get(cacheKey: string): Promise<PageData<IDbMemberData> | null> {

--- a/services/libs/data-access-layer/src/members/queryCache.ts
+++ b/services/libs/data-access-layer/src/members/queryCache.ts
@@ -83,8 +83,15 @@ export class MemberQueryCache {
   }
 
   async getCount(cacheKey: string): Promise<number | null> {
-    const cachedCount = await this.countCache.get(cacheKey)
-    return cachedCount ? parseInt(cachedCount, 10) : null
+    try {
+      const cachedCount = await this.countCache.get(cacheKey)
+      if (!cachedCount) return null
+      const parsed = parseInt(cachedCount, 10)
+      return isNaN(parsed) ? null : parsed
+    } catch (error) {
+      log.warn('Error retrieving count from cache', { error })
+      return null
+    }
   }
 
   async setCount(cacheKey: string, count: number, ttlSeconds: number): Promise<void> {

--- a/services/libs/data-access-layer/src/members/queryCache.ts
+++ b/services/libs/data-access-layer/src/members/queryCache.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto'
+import { createHash, randomBytes } from 'crypto'
 
 import { getServiceLogger } from '@crowd/logging'
 import { RedisCache, RedisClient } from '@crowd/redis'
@@ -19,10 +19,33 @@ const log = getServiceLogger()
 export class MemberQueryCache {
   private cache: RedisCache
   private countCache: RedisCache
+  private lockCache: RedisCache
 
   constructor(redis: RedisClient) {
     this.cache = new RedisCache('members-advanced', redis, log)
     this.countCache = new RedisCache('members-count', redis, log)
+    this.lockCache = new RedisCache('members-refresh-lock', redis, log)
+  }
+
+  // Returns true if lock was acquired (no other refresh in progress for this key).
+  // Uses a cryptographically random token to distinguish "we set it" from "already existed".
+  // TTL ensures the lock auto-expires if the refresh crashes without releasing it.
+  async tryAcquireRefreshLock(cacheKey: string, ttlSeconds = 90): Promise<boolean> {
+    try {
+      const token = randomBytes(16).toString('hex')
+      const stored = await this.lockCache.setIfNotExistsOrGet(cacheKey, token, ttlSeconds)
+      return stored === token
+    } catch {
+      return true // fail open: if Redis is down, let the refresh proceed
+    }
+  }
+
+  async releaseRefreshLock(cacheKey: string): Promise<void> {
+    try {
+      await this.lockCache.delete(cacheKey)
+    } catch {
+      // best effort
+    }
   }
 
   buildCacheKey(params: {
@@ -116,12 +139,13 @@ export class MemberQueryCache {
 
   async invalidateAll(): Promise<void> {
     try {
-      const [resultsDeleted, countsDeleted] = await Promise.all([
+      const [resultsDeleted, countsDeleted, locksDeleted] = await Promise.all([
         this.cache.deleteAll(),
         this.countCache.deleteAll(),
+        this.lockCache.deleteAll(),
       ])
       log.info(
-        `Invalidated member query cache: ${resultsDeleted} result entries, ${countsDeleted} count entries`,
+        `Invalidated member query cache: ${resultsDeleted} result entries, ${countsDeleted} count entries, ${locksDeleted} locks`,
       )
     } catch (error) {
       log.warn('Error invalidating member query cache', { error })
@@ -130,12 +154,13 @@ export class MemberQueryCache {
 
   async invalidateByPattern(pattern: string): Promise<void> {
     try {
-      const [resultsDeleted, countsDeleted] = await Promise.all([
+      const [resultsDeleted, countsDeleted, locksDeleted] = await Promise.all([
         this.cache.deleteByKeyPattern(pattern),
         this.countCache.deleteByKeyPattern(pattern),
+        this.lockCache.deleteByKeyPattern(pattern),
       ])
       log.info(
-        `Invalidated member query cache by pattern: ${resultsDeleted} result entries, ${countsDeleted} count entries deleted for pattern ${pattern}`,
+        `Invalidated member query cache by pattern: ${resultsDeleted} result entries, ${countsDeleted} count entries, ${locksDeleted} locks deleted for pattern ${pattern}`,
       )
     } catch (error) {
       log.warn('Error invalidating member query cache by pattern', { error, pattern })

--- a/services/libs/data-access-layer/src/members/queryCache.ts
+++ b/services/libs/data-access-layer/src/members/queryCache.ts
@@ -118,9 +118,12 @@ export class MemberQueryCache {
 
   async invalidateByPattern(pattern: string): Promise<void> {
     try {
-      const keysDeleted = await this.cache.deleteByKeyPattern(pattern)
+      const [resultsDeleted, countsDeleted] = await Promise.all([
+        this.cache.deleteByKeyPattern(pattern),
+        this.countCache.deleteByKeyPattern(pattern),
+      ])
       log.info(
-        `Invalidated member query cache by pattern: ${keysDeleted} entries deleted for pattern ${pattern}`,
+        `Invalidated member query cache by pattern: ${resultsDeleted} result entries, ${countsDeleted} count entries deleted for pattern ${pattern}`,
       )
     } catch (error) {
       log.warn('Error invalidating member query cache by pattern', { error, pattern })

--- a/services/libs/data-access-layer/src/queryExecutor.ts
+++ b/services/libs/data-access-layer/src/queryExecutor.ts
@@ -20,10 +20,16 @@ export function formatQuery(query: string, params?: object): string {
 }
 
 export class SequelizeQueryExecutor implements QueryExecutor {
-  constructor(private readonly sequelize: Sequelize) {}
+  constructor(
+    private readonly sequelize: Sequelize,
+    private readonly noTransaction = false,
+  ) {}
 
   protected prepareOptions(options: any): any {
-    return options
+    // When noTransaction=true, explicitly opt out of any CLS or implicit
+    // transaction binding — used for background/fire-and-forget work that
+    // must not inherit a parent request's transaction.
+    return this.noTransaction ? { ...options, transaction: null } : options
   }
 
   select(query: string, params?: object): Promise<any> {
@@ -165,4 +171,13 @@ export function optionsQx(options: any): QueryExecutor {
   }
 
   return new SequelizeQueryExecutor(seq)
+}
+
+/**
+ * Creates a QueryExecutor for fire-and-forget background work.
+ * Always runs outside any transaction — safe to use after the caller's
+ * request transaction has been committed.
+ */
+export function optionsBgQx(options: any): QueryExecutor {
+  return new SequelizeQueryExecutor(options.database.sequelize, true)
 }


### PR DESCRIPTION
## Summary

Fixes multiple cache bugs in `queryMembersAdvanced` that were causing every member list count request to bypass Redis and hit Postgres directly. Also removes an unnecessary `member_orgs` CTE from the count query and replaces `COUNT(DISTINCT m.id)` with `COUNT(*)` where safe.

## Changes

- **Fix inverted ternary on `cachedCount`** (`base.ts`) — since commit `83bc45a18` (Jan 30), `cachedCount` was set to `null` whenever `countOnly=true`, making the check `if (countOnly && cachedCount !== null)` always false. Every count-only request was a DB hit. Restored the correct condition: `countOnly ? await cache.getCount(cacheKey) : null`.

- **Remove `countOnly` from cache key** (`queryCache.ts`, `base.ts`) — count and full-result queries for the same params were hashed to different keys, so a full query never warmed the count cache and vice versa. Since the two caches live in separate Redis namespaces (`members-advanced` / `members-count`), the same key string is safe for both.

- **Normalize `search: "" → null` in cache key** (`base.ts`) — `buildSearchCTE` treats `""` and `null` identically (both produce an empty CTE), but `""` was not filtered by the `null/undefined` check in `buildCacheKey`, creating duplicate cache entries for the same query.

- **Cross-populate count cache after full query** (`base.ts`) — a `countOnly=false` query now also writes to `members-count` via `Promise.all`, so a subsequent `countOnly=true` request with the same params hits Redis instead of Postgres.

- **Remove unnecessary `member_orgs` CTE from count query** (`base.ts`) — `buildCountQuery` was receiving `includeMemberOrgs: include.memberOrganizations` (always `true` for the member list endpoint), causing every count query to run a full `GROUP BY` scan on `memberOrganizations`. The count never selects org data; `filterHasMo` inside `buildCountQuery` already adds the join when the filter references `mo.*`.

- **`COUNT(*)` instead of `COUNT(DISTINCT m.id)` when `withAggregates=true`** (`queryBuilder.ts`) — the join is on `memberSegmentsAgg_pkey` (unique on `memberId + segmentId`), so duplicates are impossible and `DISTINCT` is dead work.

- **Add error handling to `setCount`** (`queryCache.ts`) — `setCount` had no try/catch unlike `set`, so a Redis failure during the new `Promise.all` would propagate and return a 500 even though data was already fetched successfully.


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core member list query, caching, and count SQL used on every list view; wrong count keys or `COUNT(*)` assumptions could skew totals or serve stale counts until TTL/invalidation.
> 
> **Overview**
> **Fixes `queryMembersAdvanced` caching** so member list counts and pages actually hit Redis instead of Postgres on every request.
> 
> The **count-only path** now reads `getCount` when `countOnly` is true (a prior inverted ternary always skipped the count cache). **Separate cache keys** separate full page results (pagination, fields, `include`) from totals (`filter`, `search`, `segmentId` only); full queries **also write** the count key, and **paginated list loads skip `COUNT(*)`** when the total is already cached. **Search** is normalized (`trim`, lowercase, `""` → `null`) so equivalent queries share one key.
> 
> **Query and refresh behavior:** count queries no longer force the `member_orgs` CTE unless filters need `mo.*`; **`COUNT(*)`** replaces `COUNT(DISTINCT m.id)` when segment aggregates apply and enrichments are not in the filter; **`memberEnrichments`** joins are omitted unless needed. Background refresh uses **`optionsBgQx`** (no request transaction), **Redis refresh locks**, no background refresh on count cache hits, and refresh on sync failure after a miss. **`MemberQueryCache`** gains safer count get/set, lock invalidation, and **`countOnly` removed from the result key hash**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55db60967876e179493e1a8c497fdd09f2b293ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->