### PR TITLE
feat: enable nuget in osv worker [CM-1276]

### DIFF
--- a/backend/.env.dist.local
+++ b/backend/.env.dist.local
@@ -195,7 +195,7 @@ OSSPCKGS_GCP_CREDENTIALS_B64=e30=
 # maven/all.zip 404s). The allowlist check and DB storage normalize to lowercase
 # internally per ADR-0001 §OSV "Ecosystem normalization", so downstream stays lowercase.
 OSV_BULK_BASE_URL=https://osv-vulnerabilities.storage.googleapis.com
-OSV_ECOSYSTEMS=npm,Maven,cargo
+OSV_ECOSYSTEMS=npm,Maven,cargo,NuGet
 OSV_TMP_DIR=/tmp/osv
 OSV_BATCH_SIZE=500
 OSV_DERIVE_BATCH_SIZE=1000

--- a/services/apps/packages_worker/src/osv/__tests__/versionCompare.test.ts
+++ b/services/apps/packages_worker/src/osv/__tests__/versionCompare.test.ts
@@ -83,6 +83,34 @@ describe('compareVersion — maven (ComparableVersion-style)', () => {
   })
 })
 
+describe('compareVersion — nuget (semver)', () => {
+  it.each([
+    ['1.0.0', '2.0.0', -1],
+    ['2.0.0', '1.0.0', 1],
+    ['1.0.0', '1.0.0', 0],
+    ['1.10.0', '1.9.0', 1], // numeric, not lex
+    ['1.0.0-alpha', '1.0.0', -1], // prerelease < release
+    ['1.0.0-beta', '1.0.0-rc', -1],
+    // Real-world CVE boundary: Newtonsoft.Json < 13.0.1 deserialization vuln
+    ['13.0.0', '13.0.1', -1],
+    ['13.0.1', '13.0.1', 0],
+    ['13.0.2', '13.0.1', 1],
+  ])('compareVersion("nuget", %s, %s) sign = %s', (a, b, expected) => {
+    expect(sign(compareVersion('nuget', a, b))).toBe(expected)
+  })
+
+  it('returns null for unparseable nuget versions', () => {
+    expect(compareVersion('nuget', 'not-a-version', '1.0.0')).toBeNull()
+  })
+
+  it('rejects titlecase "NuGet" — production storage is always lowercase', () => {
+    // OSV records arrive with ecosystem="NuGet"; parseOsvRecord lowercases to
+    // "nuget" before writing to packages-db. The comparator is keyed on the
+    // same lowercase form. A titlecase call means the caller skipped normalization.
+    expect(compareVersion('NuGet', '1.0.0', '2.0.0')).toBeNull()
+  })
+})
+
 describe('compareVersion — unsupported ecosystems', () => {
   it('returns null for ecosystems we have no comparator for', () => {
     expect(compareVersion('PyPI', '1.0.0', '2.0.0')).toBeNull()

--- a/services/apps/packages_worker/src/osv/schedule.ts
+++ b/services/apps/packages_worker/src/osv/schedule.ts
@@ -11,7 +11,7 @@ const SCHEDULE_ID = 'osv-advisories-sync'
 // validate the env input against this list and refuse to register the
 // schedule on a mismatch — better a loud startup error than a silent miss.
 // Add new entries here when v1 expands beyond npm + Maven.
-const VALID_ECOSYSTEMS = ['npm', 'Maven', 'cargo'] as const
+const VALID_ECOSYSTEMS = ['npm', 'Maven', 'cargo', 'NuGet'] as const
 
 function getEcosystems(): string[] {
   const raw = process.env.OSV_ECOSYSTEMS

--- a/services/apps/packages_worker/src/osv/versionCompare.ts
+++ b/services/apps/packages_worker/src/osv/versionCompare.ts
@@ -126,11 +126,13 @@ function compareMaven(a: string, b: string): number | null {
   return 0
 }
 
+const SEMVER_ECOSYSTEMS = new Set(['npm', 'cargo', 'nuget'])
+
 // Ecosystem names are stored lowercase in packages-db per ADR-0001 §OSV
 // "Ecosystem normalization" — 'npm', 'maven', 'cargo'. Callers (deriveCriticalFlag)
 // pull the value straight from the DB so the literals here must match.
 export function compareVersion(ecosystem: string, a: string, b: string): number | null {
-  if (ecosystem === 'npm' || ecosystem === 'cargo') return compareSemver(a, b)
+  if (SEMVER_ECOSYSTEMS.has(ecosystem)) return compareSemver(a, b)
   if (ecosystem === 'maven') return compareMaven(a, b)
   return null
 }


### PR DESCRIPTION
This pull request adds support for the `NuGet` ecosystem to the OSV advisories sync process. The main changes include updating environment variables, validation lists, and version comparison logic to recognize and handle `NuGet` advisories alongside existing ecosystems.

**NuGet ecosystem support:**

* Added `NuGet` to the `OSV_ECOSYSTEMS` environment variable in `backend/.env.dist.local`, enabling the sync process to include NuGet advisories.
* Updated the `VALID_ECOSYSTEMS` array in `osv/schedule.ts` to include `NuGet`, ensuring that validation and scheduling logic recognize it as a supported ecosystem.

**Version comparison improvements:**

* Introduced a `SEMVER_ECOSYSTEMS` set in `osv/versionCompare.ts` and updated the `compareVersion` function to treat `nuget` as a semver-based ecosystem, ensuring correct version comparison logic for NuGet advisories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends vulnerability range matching for a new ecosystem; incorrect semver handling could mis-flag `has_critical_vulnerability`, but the change follows the existing npm/cargo pattern with tests.
> 
> **Overview**
> **NuGet** is now included in the scheduled OSV bulk advisory sync alongside npm, Maven, and cargo.
> 
> Local env template `OSV_ECOSYSTEMS` and the worker allowlist in `schedule.ts` gain **`NuGet`** (OSV’s case-sensitive bucket path). `compareVersion` routes lowercase **`nuget`** through the same semver path as npm/cargo so introduced/fixed ranges can drive critical-vulnerability derivation. Tests cover semver ordering (including a Newtonsoft.Json CVE boundary) and reject titlecase **`NuGet`** at the comparator, matching DB normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dcc816b7fc6526c971a3a1856fc3862d8f8b45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->