### PR TITLE
fix: gitlab fixes (CM-1298)

### DIFF
--- a/backend/src/services/integrationService.ts
+++ b/backend/src/services/integrationService.ts
@@ -315,6 +315,11 @@ export default class IntegrationService {
   async destroyAll(ids) {
     const toRemoveRepo = new Set<string>()
     let segmentId
+    // Collect GitLab webhook info before opening the transaction so external HTTP calls
+    // don't hold the DB connection idle long enough to trigger a connection timeout.
+    const gitlabWebhookRemovals: Array<{ token: string; projectIds: number[]; hookIds: number[] }> =
+      []
+
     const transaction = await SequelizeRepository.createTransaction(this.options)
 
     try {
@@ -446,11 +451,11 @@ export default class IntegrationService {
         }
 
         if (integration.platform === PlatformType.GITLAB && integration.settings.webhooks) {
-          await removeGitlabWebhooks(
-            integration.token,
-            integration.settings.webhooks.map((hook) => hook.projectId),
-            integration.settings.webhooks.map((hook) => hook.hookId),
-          )
+          gitlabWebhookRemovals.push({
+            token: integration.token,
+            projectIds: integration.settings.webhooks.map((hook) => hook.projectId),
+            hookIds: integration.settings.webhooks.map((hook) => hook.hookId),
+          })
         }
 
         if (integration.platform === PlatformType.GIT) {
@@ -495,6 +500,14 @@ export default class IntegrationService {
       await SequelizeRepository.rollbackTransaction(transaction)
       throw error
     }
+
+    // Remove GitLab webhooks after the transaction commits — these are external HTTP calls
+    // and must not hold a DB connection open.
+    await Promise.all(
+      gitlabWebhookRemovals.map(({ token, projectIds, hookIds }) =>
+        removeGitlabWebhooks(token, projectIds, hookIds),
+      ),
+    )
   }
 
   async findById(id) {

--- a/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_baseline_merge_MV.pipe
@@ -115,7 +115,11 @@ SQL >
         argMin(
             updatedAt,
             if(
-                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                type IN (
+                    'pull_request-reviewed',
+                    'merge_request-review-changes-requested',
+                    'merge_request-review-approved'
+                )
                 OR (
                     type = 'patchset_approval-created'
                     AND splitByChar('-', sourceParentId)[1] = prSourceId
@@ -126,7 +130,11 @@ SQL >
         ) AS reviewedUpdatedAt,
         min(
             if(
-                type IN ('pull_request-reviewed', 'merge_request-review-changes-requested')
+                type IN (
+                    'pull_request-reviewed',
+                    'merge_request-review-changes-requested',
+                    'merge_request-review-approved'
+                )
                 OR (
                     type = 'patchset_approval-created'
                     AND splitByChar('-', sourceParentId)[1] = prSourceId

--- a/services/libs/tinybird/pipes/pull_request_analysis_initial_snapshot.pipe
+++ b/services/libs/tinybird/pipes/pull_request_analysis_initial_snapshot.pipe
@@ -98,6 +98,7 @@ SQL >
         and (
             type = 'pull_request-reviewed'
             OR type = 'merge_request-review-changes-requested'
+            OR type = 'merge_request-review-approved'
             OR type = 'patchset_approval-created'
         )
         {% if defined(bucket_id) %}


### PR DESCRIPTION
## Summary
- Add `merge_request-review-approved` as a recognized review activity type in the PR analysis Tinybird pipes
- Fixes `pull_request_analysis_baseline_merge_MV.pipe` and `pull_request_analysis_initial_snapshot.pipe` to include GitLab approval events alongside change-request reviews

## Test plan
- [ ] Verify Tinybird pipe deployments pick up the updated SQL
- [ ] Confirm GitLab MR approval events are reflected in PR analysis metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deferring webhook removal improves reliability but means webhooks may briefly remain if the process fails after commit; Tinybird pipe changes affect how GitLab MR metrics are computed after deployment.
> 
> **Overview**
> **GitLab integration teardown** no longer calls `removeGitlabWebhooks` inside the `destroyAll` database transaction. Webhook tokens, project IDs, and hook IDs are queued during the loop, then GitLab API cleanup runs in parallel **after** commit so long HTTP calls do not keep a connection open and trigger timeouts.
> 
> **PR analysis (Tinybird)** treats GitLab **`merge_request-review-approved`** like other review signals when computing first **reviewed** timestamps in `pull_request_analysis_baseline_merge_MV` and `pull_request_analysis_initial_snapshot`, so MR approval events are included alongside change-request reviews (and existing approval-specific logic where already present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16dd27c170562f911a1bfe58c4e86420d6e8fd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->