### PR TITLE
fix: add missing registries (CM-1299)

### DIFF
--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -22,33 +22,23 @@ describe('resolveRegistryBaseUrl', () => {
   })
 
   it('returns Gradle Plugin Portal for gradle.plugin namespace', () => {
-    expect(resolveRegistryBaseUrl('gradle.plugin.name.remal')).toBe(
-      'https://plugins.gradle.org/m2',
-    )
+    expect(resolveRegistryBaseUrl('gradle.plugin.name.remal')).toBe('https://plugins.gradle.org/m2')
   })
 
   it('returns Jenkins repo for org.jenkins-ci namespace', () => {
-    expect(resolveRegistryBaseUrl('org.jenkins-ci.main')).toBe(
-      'https://repo.jenkins-ci.org/public',
-    )
+    expect(resolveRegistryBaseUrl('org.jenkins-ci.main')).toBe('https://repo.jenkins-ci.org/public')
   })
 
   it('returns Jenkins repo for io.jenkins namespace', () => {
-    expect(resolveRegistryBaseUrl('io.jenkins.plugins')).toBe(
-      'https://repo.jenkins-ci.org/public',
-    )
+    expect(resolveRegistryBaseUrl('io.jenkins.plugins')).toBe('https://repo.jenkins-ci.org/public')
   })
 
   it('returns Maven Central for unknown namespace', () => {
-    expect(resolveRegistryBaseUrl('org.apache.commons')).toBe(
-      'https://repo1.maven.org/maven2',
-    )
+    expect(resolveRegistryBaseUrl('org.apache.commons')).toBe('https://repo1.maven.org/maven2')
   })
 
   it('does not match androidx prefix for unrelated namespace', () => {
-    expect(resolveRegistryBaseUrl('com.android.tools')).toBe(
-      'https://repo1.maven.org/maven2',
-    )
+    expect(resolveRegistryBaseUrl('com.android.tools')).toBe('https://repo1.maven.org/maven2')
   })
 })
 

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -79,6 +79,12 @@ describe('resolveRegistryBaseUrl', () => {
     expect(resolveRegistryBaseUrl('org.apache.commons')).toBe('https://repo1.maven.org/maven2')
   })
 
+  it('returns Google Maven for com.android.tools.analytics-library (Android Studio analytics)', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools.analytics-library')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
   it('returns Google Maven for com.android.tools.adblib (Android Debug Bridge Library)', () => {
     expect(resolveRegistryBaseUrl('com.android.tools.adblib')).toBe(
       'https://dl.google.com/dl/android/maven2',

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -9,8 +9,30 @@ describe('resolveRegistryBaseUrl', () => {
     )
   })
 
-  it('returns Google Maven for com.google.android namespace', () => {
+  it('returns Google Maven for com.google.android.gms sub-namespace', () => {
     expect(resolveRegistryBaseUrl('com.google.android.gms')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Maven Central for bare com.google.android (legacy SDK stubs on Central)', () => {
+    expect(resolveRegistryBaseUrl('com.google.android')).toBe('https://repo1.maven.org/maven2')
+  })
+
+  it('returns Google Maven for android.arch (pre-AndroidX Architecture Components)', () => {
+    expect(resolveRegistryBaseUrl('android.arch.core')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.android.support (pre-AndroidX support library)', () => {
+    expect(resolveRegistryBaseUrl('com.android.support')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.google.testing.platform', () => {
+    expect(resolveRegistryBaseUrl('com.google.testing.platform')).toBe(
       'https://dl.google.com/dl/android/maven2',
     )
   })
@@ -21,8 +43,18 @@ describe('resolveRegistryBaseUrl', () => {
     )
   })
 
+  it('returns Google Maven for com.google.mlkit namespace', () => {
+    expect(resolveRegistryBaseUrl('com.google.mlkit')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
   it('returns Gradle Plugin Portal for gradle.plugin namespace', () => {
     expect(resolveRegistryBaseUrl('gradle.plugin.name.remal')).toBe('https://plugins.gradle.org/m2')
+  })
+
+  it('returns Jenkins repo for org.kohsuke.stapler (Jenkins HTTP framework)', () => {
+    expect(resolveRegistryBaseUrl('org.kohsuke.stapler')).toBe('https://repo.jenkins-ci.org/public')
   })
 
   it('returns Jenkins repo for org.jenkins-ci namespace', () => {
@@ -34,7 +66,9 @@ describe('resolveRegistryBaseUrl', () => {
   })
 
   it('returns Jenkins repo for io.jenkins.blueocean namespace', () => {
-    expect(resolveRegistryBaseUrl('io.jenkins.blueocean')).toBe('https://repo.jenkins-ci.org/public')
+    expect(resolveRegistryBaseUrl('io.jenkins.blueocean')).toBe(
+      'https://repo.jenkins-ci.org/public',
+    )
   })
 
   it('returns Maven Central for io.jenkins.tools (publishes on Central, not Jenkins repo)', () => {
@@ -45,8 +79,56 @@ describe('resolveRegistryBaseUrl', () => {
     expect(resolveRegistryBaseUrl('org.apache.commons')).toBe('https://repo1.maven.org/maven2')
   })
 
-  it('does not match androidx prefix for unrelated namespace', () => {
+  it('returns Google Maven for com.android.tools.adblib (Android Debug Bridge Library)', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools.adblib')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.android.tools.build (Android Gradle Plugin)', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools.build')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.android.tools.build.jetifier (AndroidX migration tool)', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools.build.jetifier')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.android.tools.utp (Android Unified Test Platform)', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools.utp')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Maven Central for bare com.android.tools (ddmlib, lint-api publish on Central)', () => {
     expect(resolveRegistryBaseUrl('com.android.tools')).toBe('https://repo1.maven.org/maven2')
+  })
+
+  it('returns Google Maven for com.android.identity', () => {
+    expect(resolveRegistryBaseUrl('com.android.identity')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.google.mediapipe', () => {
+    expect(resolveRegistryBaseUrl('com.google.mediapipe')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Jenkins repo for org.jenkinsci.plugins', () => {
+    expect(resolveRegistryBaseUrl('org.jenkinsci.plugins')).toBe(
+      'https://repo.jenkins-ci.org/public',
+    )
+  })
+
+  it('returns Jenkins repo for com.cloudbees.plugins', () => {
+    expect(resolveRegistryBaseUrl('com.cloudbees.plugins')).toBe(
+      'https://repo.jenkins-ci.org/public',
+    )
   })
 })
 

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -29,8 +29,16 @@ describe('resolveRegistryBaseUrl', () => {
     expect(resolveRegistryBaseUrl('org.jenkins-ci.main')).toBe('https://repo.jenkins-ci.org/public')
   })
 
-  it('returns Jenkins repo for io.jenkins namespace', () => {
+  it('returns Jenkins repo for io.jenkins.plugins namespace', () => {
     expect(resolveRegistryBaseUrl('io.jenkins.plugins')).toBe('https://repo.jenkins-ci.org/public')
+  })
+
+  it('returns Jenkins repo for io.jenkins.blueocean namespace', () => {
+    expect(resolveRegistryBaseUrl('io.jenkins.blueocean')).toBe('https://repo.jenkins-ci.org/public')
+  })
+
+  it('returns Maven Central for io.jenkins.tools (publishes on Central, not Jenkins repo)', () => {
+    expect(resolveRegistryBaseUrl('io.jenkins.tools')).toBe('https://repo1.maven.org/maven2')
   })
 
   it('returns Maven Central for unknown namespace', () => {

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveRegistryBaseUrl, resolveRegistryPageUrl } from '../registry'
+
+describe('resolveRegistryBaseUrl', () => {
+  it('returns Google Maven for androidx namespace', () => {
+    expect(resolveRegistryBaseUrl('androidx.annotation')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.google.android namespace', () => {
+    expect(resolveRegistryBaseUrl('com.google.android.gms')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Google Maven for com.google.firebase namespace', () => {
+    expect(resolveRegistryBaseUrl('com.google.firebase')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
+  })
+
+  it('returns Gradle Plugin Portal for gradle.plugin namespace', () => {
+    expect(resolveRegistryBaseUrl('gradle.plugin.name.remal')).toBe(
+      'https://plugins.gradle.org/m2',
+    )
+  })
+
+  it('returns Jenkins repo for org.jenkins-ci namespace', () => {
+    expect(resolveRegistryBaseUrl('org.jenkins-ci.main')).toBe(
+      'https://repo.jenkins-ci.org/public',
+    )
+  })
+
+  it('returns Jenkins repo for io.jenkins namespace', () => {
+    expect(resolveRegistryBaseUrl('io.jenkins.plugins')).toBe(
+      'https://repo.jenkins-ci.org/public',
+    )
+  })
+
+  it('returns Maven Central for unknown namespace', () => {
+    expect(resolveRegistryBaseUrl('org.apache.commons')).toBe(
+      'https://repo1.maven.org/maven2',
+    )
+  })
+
+  it('does not match androidx prefix for unrelated namespace', () => {
+    expect(resolveRegistryBaseUrl('com.android.tools')).toBe(
+      'https://repo1.maven.org/maven2',
+    )
+  })
+})
+
+describe('resolveRegistryPageUrl', () => {
+  it('returns Google Maven browse URL for androidx', () => {
+    expect(resolveRegistryPageUrl('androidx.annotation', 'annotation')).toBe(
+      'https://maven.google.com/web/index.html#androidx.annotation:annotation',
+    )
+  })
+
+  it('returns Gradle Plugin Portal URL for gradle.plugin', () => {
+    expect(resolveRegistryPageUrl('gradle.plugin.name.remal', 'gradle-plugins')).toBe(
+      'https://plugins.gradle.org/m2/gradle/plugin/name/remal/gradle-plugins/',
+    )
+  })
+
+  it('returns Jenkins browse URL for org.jenkins-ci', () => {
+    expect(resolveRegistryPageUrl('org.jenkins-ci.main', 'jenkins-core')).toBe(
+      'https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-core/',
+    )
+  })
+
+  it('returns Maven Central URL for unknown namespace', () => {
+    expect(resolveRegistryPageUrl('org.apache.commons', 'commons-lang3')).toBe(
+      'https://central.sonatype.com/artifact/org.apache.commons/commons-lang3',
+    )
+  })
+})

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -7,6 +7,8 @@ import { XMLParser } from 'fast-xml-parser'
 
 import { getServiceChildLogger } from '@crowd/logging'
 
+import { resolveRegistryBaseUrl } from './registry'
+
 const log = getServiceChildLogger('maven')
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -56,14 +58,6 @@ interface PomPerson {
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 
-// Lazy getter — evaluated at call time so the entry point can set MAVEN_FETCHER_BASE_URL
-// before the first HTTP request without worrying about module load order.
-// Backfill sets MAVEN_FETCHER_BASE_URL from MAVEN_FETCHER_BASE_URL_BACKFILL (GCS mirror);
-// the incremental Temporal worker sets it from MAVEN_FETCHER_BASE_URL_INCREMENTAL (repo1).
-function getMavenRepo(): string {
-  return process.env.MAVEN_FETCHER_BASE_URL ?? 'https://repo1.maven.org/maven2'
-}
-
 const REQUEST_TIMEOUT_MS = 15_000
 
 const parser = new XMLParser({
@@ -108,9 +102,9 @@ async function getWithRetry(url: string): Promise<string> {
 
 // ─── POM fetch ────────────────────────────────────────────────────────────────
 
-export function buildPomUrl(groupId: string, artifactId: string, version: string): string {
+export function buildPomUrl(groupId: string, artifactId: string, version: string, baseUrl?: string): string {
   const groupPath = groupId.replace(/\./g, '/')
-  return `${getMavenRepo()}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`
+  return `${baseUrl ?? resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`
 }
 
 export async function fetchPom(
@@ -190,6 +184,7 @@ async function fetchPomCached(
   groupId: string,
   artifactId: string,
   version: string,
+  baseUrl?: string,
 ): Promise<PomData | null> {
   const key = pomCacheKey(groupId, artifactId, version)
 
@@ -208,7 +203,7 @@ async function fetchPomCached(
   }
 
   pomCacheStats.misses++
-  const promise = fetchPom(groupId, artifactId, version, buildPomUrl(groupId, artifactId, version))
+  const promise = fetchPom(groupId, artifactId, version, buildPomUrl(groupId, artifactId, version, baseUrl))
     .then((pom) => {
       if (pom) cacheSet(key, pom)
       return pom
@@ -270,8 +265,9 @@ async function resolveWithInheritance(
   version: string,
   depth = 0,
   visited = new Set<string>(),
+  baseUrl?: string,
 ): Promise<ResolvedFields> {
-  const pom = await fetchPomCached(groupId, artifactId, version)
+  const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
   if (!pom) return emptyFields(depth)
 
   const licenses = extractLicenses(pom)
@@ -299,6 +295,7 @@ async function resolveWithInheritance(
         parent.version,
         depth + 1,
         visited,
+        resolveRegistryBaseUrl(parent.groupId),
       )
       return {
         description: extractStr(pom.description) ?? parentFields.description,
@@ -337,10 +334,11 @@ export async function extractArtifactDirect(
   groupId: string,
   artifactId: string,
   version: string,
+  baseUrl?: string,
 ): Promise<PomExtractionResult> {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
-  const pomUrl = buildPomUrl(groupId, artifactId, version)
-  const pom = await fetchPomCached(groupId, artifactId, version)
+  const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
+  const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
 
   if (!pom) {
     return {
@@ -391,11 +389,12 @@ export async function extractArtifact(
   groupId: string,
   artifactId: string,
   version: string,
+  baseUrl?: string,
 ): Promise<PomExtractionResult> {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
 
-  const pomUrl = buildPomUrl(groupId, artifactId, version)
-  const rootPom = await fetchPomCached(groupId, artifactId, version)
+  const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
+  const rootPom = await fetchPomCached(groupId, artifactId, version, baseUrl)
   if (!rootPom) {
     return {
       groupId,
@@ -415,7 +414,7 @@ export async function extractArtifact(
   }
 
   try {
-    const resolved = await resolveWithInheritance(groupId, artifactId, version)
+    const resolved = await resolveWithInheritance(groupId, artifactId, version, 0, new Set(), baseUrl)
     return {
       groupId,
       artifactId,

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -72,11 +72,11 @@ const parser = new XMLParser({
 const MAX_RETRIES = 3
 const RETRY_BASE_MS = 2_000
 
-async function sleep(ms: number): Promise<void> {
+async function sleep(ms: number): Promise {
   return new Promise((r) => setTimeout(r, ms))
 }
 
-async function getWithRetry(url: string): Promise<string> {
+async function getWithRetry(url: string): Promise {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const res = await axios.get<string>(url, {
@@ -102,7 +102,12 @@ async function getWithRetry(url: string): Promise<string> {
 
 // ─── POM fetch ────────────────────────────────────────────────────────────────
 
-export function buildPomUrl(groupId: string, artifactId: string, version: string, baseUrl?: string): string {
+export function buildPomUrl(
+  groupId: string,
+  artifactId: string,
+  version: string,
+  baseUrl?: string,
+): string {
   const groupPath = groupId.replace(/\./g, '/')
   return `${baseUrl ?? resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`
 }
@@ -112,7 +117,7 @@ export async function fetchPom(
   artifactId: string,
   version: string,
   url: string,
-): Promise<PomData | null> {
+): Promise {
   try {
     const data = await getWithRetry(url)
     const parsed = parser.parse(data)
@@ -154,7 +159,7 @@ export async function fetchPom(
 const POM_CACHE_MAX_ENTRIES = 5_000
 
 const pomCache = new Map<string, PomData>()
-const inFlight = new Map<string, Promise<PomData | null>>()
+const inFlight = new Map<string, Promise>()
 const pomCacheStats = { hits: 0, coalesced: 0, misses: 0, evictions: 0 }
 
 function pomCacheKey(groupId: string, artifactId: string, version: string): string {
@@ -185,7 +190,7 @@ async function fetchPomCached(
   artifactId: string,
   version: string,
   baseUrl?: string,
-): Promise<PomData | null> {
+): Promise {
   const key = pomCacheKey(groupId, artifactId, version)
 
   const cached = pomCache.get(key)
@@ -203,7 +208,12 @@ async function fetchPomCached(
   }
 
   pomCacheStats.misses++
-  const promise = fetchPom(groupId, artifactId, version, buildPomUrl(groupId, artifactId, version, baseUrl))
+  const promise = fetchPom(
+    groupId,
+    artifactId,
+    version,
+    buildPomUrl(groupId, artifactId, version, baseUrl),
+  )
     .then((pom) => {
       if (pom) cacheSet(key, pom)
       return pom
@@ -266,7 +276,7 @@ async function resolveWithInheritance(
   depth = 0,
   visited = new Set<string>(),
   baseUrl?: string,
-): Promise<ResolvedFields> {
+): Promise {
   const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
   if (!pom) return emptyFields(depth)
 
@@ -335,7 +345,7 @@ export async function extractArtifactDirect(
   artifactId: string,
   version: string,
   baseUrl?: string,
-): Promise<PomExtractionResult> {
+): Promise {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
   const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
   const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
@@ -390,7 +400,7 @@ export async function extractArtifact(
   artifactId: string,
   version: string,
   baseUrl?: string,
-): Promise<PomExtractionResult> {
+): Promise {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
 
   const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
@@ -414,7 +424,14 @@ export async function extractArtifact(
   }
 
   try {
-    const resolved = await resolveWithInheritance(groupId, artifactId, version, 0, new Set(), baseUrl)
+    const resolved = await resolveWithInheritance(
+      groupId,
+      artifactId,
+      version,
+      0,
+      new Set(),
+      baseUrl,
+    )
     return {
       groupId,
       artifactId,
@@ -498,9 +515,7 @@ function extractLicenses(pom: PomData): string[] {
   const raw = pom.licenses?.license
   if (!raw) return []
   const list = Array.isArray(raw) ? raw : [raw]
-  return (list as Array<{ name?: unknown }>)
-    .map((l) => extractStr(l?.name))
-    .filter((n): n is string => n !== null)
+  return (list as Array).map((l) => extractStr(l?.name)).filter((n): n is string => n !== null)
 }
 
 function extractPersons(raw: unknown, role: 'author' | 'maintainer'): PomMaintainer[] {

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -72,11 +72,13 @@ const parser = new XMLParser({
 const MAX_RETRIES = 3
 const RETRY_BASE_MS = 2_000
 
-async function sleep(ms: number): Promise {
+// prettier-ignore
+async function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms))
 }
 
-async function getWithRetry(url: string): Promise {
+// prettier-ignore
+async function getWithRetry(url: string): Promise<string> {
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const res = await axios.get<string>(url, {
@@ -112,12 +114,8 @@ export function buildPomUrl(
   return `${baseUrl ?? resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`
 }
 
-export async function fetchPom(
-  groupId: string,
-  artifactId: string,
-  version: string,
-  url: string,
-): Promise {
+// prettier-ignore
+export async function fetchPom(groupId: string, artifactId: string, version: string, url: string): Promise<PomData | null> {
   try {
     const data = await getWithRetry(url)
     const parsed = parser.parse(data)
@@ -159,7 +157,8 @@ export async function fetchPom(
 const POM_CACHE_MAX_ENTRIES = 5_000
 
 const pomCache = new Map<string, PomData>()
-const inFlight = new Map<string, Promise>()
+// prettier-ignore
+const inFlight = new Map<string, Promise<PomData | null>>()
 const pomCacheStats = { hits: 0, coalesced: 0, misses: 0, evictions: 0 }
 
 function pomCacheKey(groupId: string, artifactId: string, version: string): string {
@@ -185,12 +184,8 @@ function cacheSet(key: string, pom: PomData): void {
  *                await it instead of issuing a duplicate request.
  * - Miss       → performs the network fetch; caches the result only if non-null.
  */
-async function fetchPomCached(
-  groupId: string,
-  artifactId: string,
-  version: string,
-  baseUrl?: string,
-): Promise {
+// prettier-ignore
+async function fetchPomCached(groupId: string, artifactId: string, version: string, baseUrl?: string): Promise<PomData | null> {
   const key = pomCacheKey(groupId, artifactId, version)
 
   const cached = pomCache.get(key)
@@ -269,14 +264,8 @@ interface ResolvedFields {
   hops: number
 }
 
-async function resolveWithInheritance(
-  groupId: string,
-  artifactId: string,
-  version: string,
-  depth = 0,
-  visited = new Set<string>(),
-  baseUrl?: string,
-): Promise {
+// prettier-ignore
+async function resolveWithInheritance(groupId: string, artifactId: string, version: string, depth = 0, visited = new Set<string>(), baseUrl?: string): Promise<ResolvedFields> {
   const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
   if (!pom) return emptyFields(depth)
 
@@ -340,12 +329,8 @@ async function resolveWithInheritance(
  * Currently unused: kept as a lightweight option for high-throughput paths that
  * don't need parent inheritance.
  */
-export async function extractArtifactDirect(
-  groupId: string,
-  artifactId: string,
-  version: string,
-  baseUrl?: string,
-): Promise {
+// prettier-ignore
+export async function extractArtifactDirect(groupId: string, artifactId: string, version: string, baseUrl?: string): Promise<PomExtractionResult> {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
   const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
   const pom = await fetchPomCached(groupId, artifactId, version, baseUrl)
@@ -395,12 +380,8 @@ export async function extractArtifactDirect(
  * the parent chain to inherit licenses and SCM when not in the direct POM.
  * Always returns a result object; errors are captured in `result.error`.
  */
-export async function extractArtifact(
-  groupId: string,
-  artifactId: string,
-  version: string,
-  baseUrl?: string,
-): Promise {
+// prettier-ignore
+export async function extractArtifact(groupId: string, artifactId: string, version: string, baseUrl?: string): Promise<PomExtractionResult> {
   const purl = `pkg:maven/${groupId}/${artifactId}@${version}`
 
   const pomUrl = buildPomUrl(groupId, artifactId, version, baseUrl)
@@ -515,7 +496,9 @@ function extractLicenses(pom: PomData): string[] {
   const raw = pom.licenses?.license
   if (!raw) return []
   const list = Array.isArray(raw) ? raw : [raw]
-  return (list as Array).map((l) => extractStr(l?.name)).filter((n): n is string => n !== null)
+  return (list as { name?: unknown }[])
+    .map((l) => extractStr(l?.name))
+    .filter((n): n is string => n !== null)
 }
 
 function extractPersons(raw: unknown, role: 'author' | 'maintainer'): PomMaintainer[] {

--- a/services/apps/packages_worker/src/maven/metadata.ts
+++ b/services/apps/packages_worker/src/maven/metadata.ts
@@ -12,10 +12,8 @@ import axios from 'axios'
 import { XMLParser } from 'fast-xml-parser'
 
 import { isPrerelease } from './normalize'
+import { resolveRegistryBaseUrl } from './registry'
 
-function getMavenRepo(): string {
-  return process.env.MAVEN_FETCHER_BASE_URL ?? 'https://repo1.maven.org/maven2'
-}
 const REQUEST_TIMEOUT_MS = 10_000
 const MAX_RETRIES = 3
 const RETRY_BASE_MS = 2_000
@@ -78,9 +76,10 @@ export function pickStableRelease(candidate: string | null, versions: string[]):
 export async function resolveVersionsList(
   groupId: string,
   artifactId: string,
+  baseUrl?: string,
 ): Promise<MavenVersionsMetadata | MavenFetchError> {
   const groupPath = groupId.replace(/\./g, '/')
-  const url = `${getMavenRepo()}/${groupPath}/${artifactId}/maven-metadata.xml`
+  const url = `${baseUrl ?? resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/maven-metadata.xml`
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
@@ -132,8 +131,9 @@ export async function resolveVersionsList(
 export async function resolveLatestVersion(
   groupId: string,
   artifactId: string,
+  baseUrl?: string,
 ): Promise<string | null> {
-  const meta = await resolveVersionsList(groupId, artifactId)
+  const meta = await resolveVersionsList(groupId, artifactId, baseUrl)
   if (isMavenFetchError(meta)) return null
   return meta.releaseVersion
 }

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -1,0 +1,80 @@
+/**
+ * Maps Maven groupId prefixes to their authoritative repository.
+ *
+ * Maven Central is the default, but several large ecosystems publish exclusively
+ * to their own Maven-compatible repository and will always 404 on Central:
+ *   - Google Maven  (androidx.*, com.google.android.*, com.google.firebase.*)
+ *   - Gradle Plugin Portal  (gradle.plugin.*)
+ *   - Jenkins  (org.jenkins-ci.*, io.jenkins.*)
+ *
+ * All these repos expose the standard Maven repository layout, so the same
+ * metadata.xml / POM fetch logic works — only the base URL changes.
+ */
+
+const MAVEN_CENTRAL_BASE_URL = 'https://repo1.maven.org/maven2'
+
+interface RegistryEntry {
+  prefix: string
+  baseUrl: string
+  pageUrl: (groupId: string, artifactId: string) => string
+}
+
+const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
+  {
+    prefix: 'androidx',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.google.android',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.google.firebase',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'gradle.plugin',
+    baseUrl: 'https://plugins.gradle.org/m2',
+    pageUrl: (g, a) => `https://plugins.gradle.org/m2/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  {
+    prefix: 'org.jenkins-ci',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  {
+    prefix: 'io.jenkins',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+]
+
+function findEntry(groupId: string): RegistryEntry | undefined {
+  return ALTERNATIVE_REGISTRIES.find((r) => groupId.startsWith(r.prefix))
+}
+
+/**
+ * Returns the Maven repository base URL for the given groupId.
+ *
+ * For known alternative-registry namespaces, always returns the hardcoded
+ * URL — the MAVEN_FETCHER_BASE_URL env var (used to point at a GCS mirror for
+ * backfill) is intentionally bypassed for these groups because no mirror exists.
+ * For everything else, falls back to MAVEN_FETCHER_BASE_URL ?? Maven Central.
+ */
+export function resolveRegistryBaseUrl(groupId: string): string {
+  const entry = findEntry(groupId)
+  if (entry) return entry.baseUrl
+  return process.env.MAVEN_FETCHER_BASE_URL ?? MAVEN_CENTRAL_BASE_URL
+}
+
+/**
+ * Returns a human-browsable URL for the given artifact in its authoritative registry.
+ */
+export function resolveRegistryPageUrl(groupId: string, artifactId: string): string {
+  const entry = findEntry(groupId)
+  if (entry) return entry.pageUrl(groupId, artifactId)
+  return `https://central.sonatype.com/artifact/${groupId}/${artifactId}`
+}

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -5,7 +5,7 @@
  * to their own Maven-compatible repository and will always 404 on Central:
  *   - Google Maven  (androidx.*, com.google.android.*, com.google.firebase.*)
  *   - Gradle Plugin Portal  (gradle.plugin.*)
- *   - Jenkins  (org.jenkins-ci.*, io.jenkins.*)
+ *   - Jenkins  (org.jenkins-ci.*, io.jenkins.plugins.*, io.jenkins.blueocean.*)
  *
  * All these repos expose the standard Maven repository layout, so the same
  * metadata.xml / POM fetch logic works — only the base URL changes.
@@ -45,8 +45,15 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
     baseUrl: 'https://repo.jenkins-ci.org/public',
     pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
   },
+  // io.jenkins.tools.*, io.jenkins.lib.*, io.jenkins.test.* publish on Maven Central —
+  // only the plugin and blueocean sub-namespaces are exclusive to Jenkins repo.
   {
-    prefix: 'io.jenkins',
+    prefix: 'io.jenkins.plugins',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  {
+    prefix: 'io.jenkins.blueocean',
     baseUrl: 'https://repo.jenkins-ci.org/public',
     pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
   },

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -55,6 +55,11 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
   {
+    prefix: 'com.android.tools.analytics-library',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
     prefix: 'com.android.tools.adblib',
     baseUrl: 'https://dl.google.com/dl/android/maven2',
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -25,8 +25,57 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
     baseUrl: 'https://dl.google.com/dl/android/maven2',
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
+  // com.google.android (bare, no sub-namespace) are legacy SDK stubs on Maven Central —
+  // only sub-namespaces like com.google.android.gms.* live on Google Maven.
   {
-    prefix: 'com.google.android',
+    prefix: 'com.google.android.',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  // Pre-AndroidX and Android tooling namespaces — all published on Google Maven.
+  // android.arch.* = old Architecture Components (pre-1.0 / pre-AndroidX)
+  // com.android.support = Support Library (pre-AndroidX; post-migration moved to androidx.*)
+  // com.android.support.test = old Android testing support (pre-AndroidX test, includes Espresso)
+  // com.android.tools.build = Android Gradle Plugin, Jetifier, and related build tooling
+  // com.android.tools.utp = Android Unified Test Platform
+  // com.android.identity = Android Identity Credential library
+  {
+    prefix: 'android.arch',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.android.identity',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.android.support',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.android.tools.adblib',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.android.tools.build',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.android.tools.utp',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.google.mediapipe',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
+    prefix: 'com.google.testing.platform',
     baseUrl: 'https://dl.google.com/dl/android/maven2',
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
@@ -36,12 +85,35 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
   {
+    prefix: 'com.google.mlkit',
+    baseUrl: 'https://dl.google.com/dl/android/maven2',
+    pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
+  },
+  {
     prefix: 'gradle.plugin',
     baseUrl: 'https://plugins.gradle.org/m2',
     pageUrl: (g, a) => `https://plugins.gradle.org/m2/${g.replace(/\./g, '/')}/${a}/`,
   },
   {
+    prefix: 'com.cloudbees.plugins',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  {
     prefix: 'org.jenkins-ci',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  // org.jenkinsci.plugins = standard Jenkins community plugin namespace
+  {
+    prefix: 'org.jenkinsci.plugins',
+    baseUrl: 'https://repo.jenkins-ci.org/public',
+    pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
+  },
+  // org.kohsuke.stapler is the Jenkins HTTP routing framework (by Jenkins creator Kohsuke
+  // Kawaguchi) — published on Jenkins repo, never on Maven Central.
+  {
+    prefix: 'org.kohsuke.stapler',
     baseUrl: 'https://repo.jenkins-ci.org/public',
     pageUrl: (g, a) => `https://repo.jenkins-ci.org/public/${g.replace(/\./g, '/')}/${a}/`,
   },

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -18,6 +18,7 @@ import { getMavenConfig } from '../config'
 import { extractArtifact, getPomCacheStats, normalizeScmUrl } from './extract'
 import { isMavenFetchError, resolveVersionsList } from './metadata'
 import { isPrerelease, parseRepoUrl } from './normalize'
+import { resolveRegistryBaseUrl, resolveRegistryPageUrl } from './registry'
 
 const log = getServiceChildLogger('maven')
 
@@ -41,9 +42,6 @@ type PackageRow = MavenPackageToSync
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function mavenRegistryUrl(groupId: string, artifactId: string): string {
-  return `https://central.sonatype.com/artifact/${groupId}/${artifactId}`
-}
 
 async function writeRepoLink(
   qx: QueryExecutor,
@@ -95,7 +93,7 @@ async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Pr
     name: pkg.name,
     description: null,
     homepage: null,
-    registryUrl: pkg.namespace ? mavenRegistryUrl(pkg.namespace, pkg.name) : null,
+    registryUrl: pkg.namespace ? resolveRegistryPageUrl(pkg.namespace, pkg.name) : null,
     declaredRepositoryUrl: null,
     repositoryUrl: null,
     licenses: null,
@@ -122,8 +120,10 @@ async function processCriticalPackage(
     return { status: 'skipped' }
   }
 
+  const baseUrl = resolveRegistryBaseUrl(groupId)
+
   // Phase 1: lightweight metadata fetch to get the current upstream version.
-  const metadata = await resolveVersionsList(groupId, artifactId)
+  const metadata = await resolveVersionsList(groupId, artifactId, baseUrl)
 
   if (isMavenFetchError(metadata)) {
     if (metadata.kind === 'NOT_FOUND') {
@@ -134,7 +134,7 @@ async function processCriticalPackage(
         name: artifactId,
         description: null,
         homepage: null,
-        registryUrl: mavenRegistryUrl(groupId, artifactId),
+        registryUrl: resolveRegistryPageUrl(groupId, artifactId),
         declaredRepositoryUrl: null,
         repositoryUrl: null,
         licenses: null,
@@ -144,7 +144,7 @@ async function processCriticalPackage(
         dependentPackagesCount: pkg.dependentPackagesCount,
         dependentReposCount: pkg.dependentReposCount,
       })
-      log.warn({ groupId, artifactId }, 'Not on Maven Central — writing minimal record')
+      log.warn({ groupId, artifactId, baseUrl }, 'Not found in registry — writing minimal record')
       return { status: 'skipped' }
     }
     if (metadata.kind === 'RATE_LIMIT') {
@@ -169,7 +169,7 @@ async function processCriticalPackage(
       name: artifactId,
       description: null,
       homepage: null,
-      registryUrl: mavenRegistryUrl(groupId, artifactId),
+      registryUrl: resolveRegistryPageUrl(groupId, artifactId),
       declaredRepositoryUrl: null,
       repositoryUrl: null,
       licenses: null,
@@ -195,7 +195,7 @@ async function processCriticalPackage(
 
   // Phase 3: full POM extraction with parent-chain resolution — wrapped in a
   // transaction so partial writes never leave the package in an inconsistent state.
-  const result = await extractArtifact(groupId, artifactId, version)
+  const result = await extractArtifact(groupId, artifactId, version, baseUrl)
 
   if (result.error) {
     log.warn({ groupId, artifactId, version, error: result.error }, 'POM extraction failed')
@@ -206,7 +206,7 @@ async function processCriticalPackage(
       name: artifactId,
       description: null,
       homepage: null,
-      registryUrl: mavenRegistryUrl(groupId, artifactId),
+      registryUrl: resolveRegistryPageUrl(groupId, artifactId),
       declaredRepositoryUrl: null,
       repositoryUrl: null,
       licenses: null,
@@ -232,7 +232,7 @@ async function processCriticalPackage(
         name: artifactId,
         description: result.description,
         homepage: result.homepageUrl,
-        registryUrl: mavenRegistryUrl(groupId, artifactId),
+        registryUrl: resolveRegistryPageUrl(groupId, artifactId),
         declaredRepositoryUrl: result.scmUrl,
         repositoryUrl,
         licenses: result.licenses.length > 0 ? result.licenses : null,

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -37,17 +37,14 @@ interface CriticalPackageResult {
   status: CriticalStatus
 }
 
-type MavenConfig = ReturnType
+// prettier-ignore
+type MavenConfig = ReturnType<typeof getMavenConfig>
 type PackageRow = MavenPackageToSync
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async function writeRepoLink(
-  qx: QueryExecutor,
-  packageId: number,
-  repositoryUrl: string | null,
-  changed: Set,
-): Promise {
+// prettier-ignore
+async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed: Set<string>): Promise<void> {
   if (!repositoryUrl) return
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) return
@@ -64,7 +61,8 @@ async function writeRepoLink(
 // Postgres deadlock (40P01) is transient: concurrent transactions upserting the same shared
 // rows (e.g. maintainer 'hboutemy' across many org.apache packages, or the shared apache repo)
 // can form a lock cycle. Re-running the whole transaction resolves it — the upserts are idempotent.
-async function withDeadlockRetry<T>(fn: () => Promise, maxAttempts = 4): Promise {
+// prettier-ignore
+async function withDeadlockRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     try {
       return await fn()
@@ -84,7 +82,8 @@ async function withDeadlockRetry<T>(fn: () => Promise, maxAttempts = 4): Promise
 
 // ─── Non-critical: copy universe stats into packages ─────────────────────────
 
-async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Promise {
+// prettier-ignore
+async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Promise<void> {
   await upsertPackage(qx, {
     purl: pkg.purl,
     ecosystem: 'maven',
@@ -106,11 +105,8 @@ async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Pr
 
 // ─── Critical: full POM extraction ───────────────────────────────────────────
 
-async function processCriticalPackage(
-  qx: QueryExecutor,
-  pkg: PackageRow,
-  forceFullExtraction: boolean,
-): Promise {
+// prettier-ignore
+async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceFullExtraction: boolean): Promise<CriticalPackageResult> {
   const groupId = pkg.namespace
   const artifactId = pkg.name
 
@@ -272,7 +268,7 @@ async function processCriticalPackage(
         return ka < kb ? -1 : ka > kb ? 1 : 0
       })
 
-      const maintainerLinks: Array = []
+      const maintainerLinks: Array<{ maintainerId: number; role: 'author' | 'maintainer' }> = []
       for (const person of allPeople) {
         const username = person.username ?? person.email ?? person.displayName
         if (!username) continue
@@ -316,12 +312,8 @@ async function processCriticalPackage(
 
 // ─── Batch processing ─────────────────────────────────────────────────────────
 
-export async function processBatch(
-  qx: QueryExecutor,
-  config: MavenConfig,
-  isCritical: boolean,
-  forceFullExtraction: boolean,
-): Promise {
+// prettier-ignore
+export async function processBatch(qx: QueryExecutor, config: MavenConfig, isCritical: boolean, forceFullExtraction: boolean): Promise<BatchResult> {
   const batchSize = isCritical ? config.batchSize : config.nonCriticalBatchSize
   const refreshDays = config.refreshDays
 
@@ -331,13 +323,8 @@ export async function processBatch(
 }
 
 // Runs a concrete list of packages through the enrichment pipeline.
-async function processPackages(
-  qx: QueryExecutor,
-  config: MavenConfig,
-  packages: PackageRow[],
-  isCritical: boolean,
-  forceFullExtraction: boolean,
-): Promise {
+// prettier-ignore
+async function processPackages(qx: QueryExecutor, config: MavenConfig, packages: PackageRow[], isCritical: boolean, forceFullExtraction: boolean): Promise<BatchResult> {
   const concurrency = isCritical ? config.concurrency : config.nonCriticalConcurrency
 
   if (packages.length === 0) return { processed: 0, skipped: 0, error: 0, unchanged: 0 }
@@ -400,12 +387,8 @@ async function processPackages(
 
 // ─── Phase runner ─────────────────────────────────────────────────────────────
 
-async function runPhase(
-  qx: QueryExecutor,
-  config: MavenConfig,
-  isCritical: boolean,
-  isShuttingDown: () => boolean,
-): Promise {
+// prettier-ignore
+async function runPhase(qx: QueryExecutor, config: MavenConfig, isCritical: boolean, isShuttingDown: () => boolean): Promise<BatchResult> {
   const label = isCritical ? 'critical' : 'non-critical'
   const total: BatchResult = {
     processed: 0,
@@ -460,10 +443,7 @@ async function runPhase(
  * triggered manually (e.g. `pnpm backfill:maven` execed into the packages-worker
  * container).
  */
-export async function runMavenCriticalBackfill(
-  qx: QueryExecutor,
-  config: MavenConfig,
-  isShuttingDown: () => boolean,
-): Promise {
+// prettier-ignore
+export async function runMavenCriticalBackfill(qx: QueryExecutor, config: MavenConfig, isShuttingDown: () => boolean): Promise<BatchResult> {
   return runPhase(qx, config, true, isShuttingDown)
 }

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -37,18 +37,17 @@ interface CriticalPackageResult {
   status: CriticalStatus
 }
 
-type MavenConfig = ReturnType<typeof getMavenConfig>
+type MavenConfig = ReturnType
 type PackageRow = MavenPackageToSync
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
 
 async function writeRepoLink(
   qx: QueryExecutor,
   packageId: number,
   repositoryUrl: string | null,
-  changed: Set<string>,
-): Promise<void> {
+  changed: Set,
+): Promise {
   if (!repositoryUrl) return
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) return
@@ -65,7 +64,7 @@ async function writeRepoLink(
 // Postgres deadlock (40P01) is transient: concurrent transactions upserting the same shared
 // rows (e.g. maintainer 'hboutemy' across many org.apache packages, or the shared apache repo)
 // can form a lock cycle. Re-running the whole transaction resolves it — the upserts are idempotent.
-async function withDeadlockRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Promise<T> {
+async function withDeadlockRetry<T>(fn: () => Promise, maxAttempts = 4): Promise {
   for (let attempt = 1; ; attempt++) {
     try {
       return await fn()
@@ -85,7 +84,7 @@ async function withDeadlockRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Prom
 
 // ─── Non-critical: copy universe stats into packages ─────────────────────────
 
-async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Promise<void> {
+async function processNonCriticalPackage(qx: QueryExecutor, pkg: PackageRow): Promise {
   await upsertPackage(qx, {
     purl: pkg.purl,
     ecosystem: 'maven',
@@ -111,7 +110,7 @@ async function processCriticalPackage(
   qx: QueryExecutor,
   pkg: PackageRow,
   forceFullExtraction: boolean,
-): Promise<CriticalPackageResult> {
+): Promise {
   const groupId = pkg.namespace
   const artifactId = pkg.name
 
@@ -273,7 +272,7 @@ async function processCriticalPackage(
         return ka < kb ? -1 : ka > kb ? 1 : 0
       })
 
-      const maintainerLinks: Array<{ maintainerId: number; role: 'author' | 'maintainer' }> = []
+      const maintainerLinks: Array = []
       for (const person of allPeople) {
         const username = person.username ?? person.email ?? person.displayName
         if (!username) continue
@@ -322,7 +321,7 @@ export async function processBatch(
   config: MavenConfig,
   isCritical: boolean,
   forceFullExtraction: boolean,
-): Promise<BatchResult> {
+): Promise {
   const batchSize = isCritical ? config.batchSize : config.nonCriticalBatchSize
   const refreshDays = config.refreshDays
 
@@ -338,7 +337,7 @@ async function processPackages(
   packages: PackageRow[],
   isCritical: boolean,
   forceFullExtraction: boolean,
-): Promise<BatchResult> {
+): Promise {
   const concurrency = isCritical ? config.concurrency : config.nonCriticalConcurrency
 
   if (packages.length === 0) return { processed: 0, skipped: 0, error: 0, unchanged: 0 }
@@ -406,7 +405,7 @@ async function runPhase(
   config: MavenConfig,
   isCritical: boolean,
   isShuttingDown: () => boolean,
-): Promise<BatchResult> {
+): Promise {
   const label = isCritical ? 'critical' : 'non-critical'
   const total: BatchResult = {
     processed: 0,
@@ -465,6 +464,6 @@ export async function runMavenCriticalBackfill(
   qx: QueryExecutor,
   config: MavenConfig,
   isShuttingDown: () => boolean,
-): Promise<BatchResult> {
+): Promise {
   return runPhase(qx, config, true, isShuttingDown)
 }


### PR DESCRIPTION
## Summary

The Maven enrichment worker was marking ~4,600 critical packages as `maven_not_on_central` and skipping them entirely. Investigation revealed the majority are not missing — they live on alternative Maven-compatible registries that the worker never tried:

- **Google Maven** (`dl.google.com/dl/android/maven2`) — `androidx.*`, `com.google.android.*`, `com.google.firebase.*`
- **Gradle Plugin Portal** (`plugins.gradle.org/m2`) — `gradle.plugin.*`
- **Jenkins** (`repo.jenkins-ci.org/public`) — `org.jenkins-ci.*`, `io.jenkins.*`

All these repos expose the standard Maven repository layout (same `maven-metadata.xml` + POM URL structure), so no new fetch logic was needed — only correct base URL routing.

Affected packages include high-impact artifacts: `jenkins-core` (1,519 direct dependents, 1,058 repos), the full `androidx.*` suite, all Google Play Services, and ~1,200 Gradle plugins.

## Changes

- **`registry.ts` (new)** — single routing authority mapping `groupId` prefixes to their authoritative registry base URL and browse page URL; replaces the hardcoded `central.sonatype.com` link that was used for all packages regardless of their actual registry.

- **`runMavenEnrichmentLoop.ts`** — `processCriticalPackage` now resolves the correct registry base URL once per package via `resolveRegistryBaseUrl(groupId)` and passes it through to both the metadata fetch and POM extraction phases.

- **`metadata.ts` / `extract.ts`** — `resolveVersionsList`, `buildPomUrl`, `fetchPomCached`, `resolveWithInheritance`, `extractArtifact`, `extractArtifactDirect` each accept an optional `baseUrl` parameter; when omitted, they self-route via `resolveRegistryBaseUrl(groupId)` instead of always defaulting to Maven Central. Removed the duplicated `getMavenRepo()` private function that existed independently in both files.

- **Parent POM bug fix** — `resolveWithInheritance` was passing the child's registry URL down the parent chain unconditionally. A parent whose `groupId` maps to a different registry (e.g. `com.google:google` on Maven Central, referenced by a `com.google.android.*` artifact) would get a 404, causing the child to inherit no license or SCM data. The recursive call now calls `resolveRegistryBaseUrl(parent.groupId)` independently for each hop.

- **`registry.test.ts` (new)** — 12 unit tests covering prefix routing for all six alternative-registry namespaces and the Maven Central fallback.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1299](https://linuxfoundation.atlassian.net/browse/CM-1299)


[CM-1299]: https://linuxfoundation.atlassian.net/browse/CM-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core package ingestion HTTP targets and parent-chain resolution; wrong prefix rules could mis-fetch or skip artifacts, but behavior is covered by new unit tests and scoped to the Maven worker.
> 
> **Overview**
> Fixes Maven enrichment treating many artifacts as missing because metadata and POM fetches always targeted Maven Central (or `MAVEN_FETCHER_BASE_URL`).
> 
> Adds **`registry.ts`** as the routing layer: `groupId` prefixes map to Google Maven, Gradle Plugin Portal, Jenkins, or Central, with matching browse URLs. Alternative registries use fixed upstream URLs and **ignore** the GCS mirror env var.
> 
> **`metadata.ts`** and **`extract.ts`** drop local `getMavenRepo()` helpers and accept an optional `baseUrl`; otherwise they call `resolveRegistryBaseUrl(groupId)`. Parent POM walks now resolve each hop’s registry via **`resolveRegistryBaseUrl(parent.groupId)`** instead of reusing the child’s base URL.
> 
> **`runMavenEnrichmentLoop.ts`** resolves `baseUrl` once per critical package for metadata + POM extraction, and stores **`resolveRegistryPageUrl`** instead of always linking Sonatype Central.
> 
> **`registry.test.ts`** adds unit coverage for prefix routing and page URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8166a202d464f33229ec10debd1a38e88233b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->