### PR TITLE
feat: add fallback for google maven (CM-1299)

### DIFF
--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveRegistryBaseUrl, resolveRegistryPageUrl } from '../registry'
+import {
+  MAVEN_CENTRAL_BASE_URL,
+  resolveRegistryBaseUrl,
+  resolveRegistryPageUrl,
+  resolveRegistryPageUrlFromBase,
+} from '../registry'
 
 describe('resolveRegistryBaseUrl', () => {
   it('returns Google Maven for androidx namespace', () => {
@@ -19,6 +24,11 @@ describe('resolveRegistryBaseUrl', () => {
     expect(resolveRegistryBaseUrl('com.google.android')).toBe(
       'https://dl.google.com/dl/android/maven2',
     )
+  })
+
+  it('does not match com.google.androidx — prefix boundary must end at a dot', () => {
+    // com.google.android prefix must not bleed into unrelated com.google.android* strings
+    expect(resolveRegistryBaseUrl('com.google.androidx')).toBe(MAVEN_CENTRAL_BASE_URL)
   })
 
   it('returns Google Maven for android.arch (pre-AndroidX Architecture Components)', () => {
@@ -163,5 +173,24 @@ describe('resolveRegistryPageUrl', () => {
     expect(resolveRegistryPageUrl('org.apache.commons', 'commons-lang3')).toBe(
       'https://central.sonatype.com/artifact/org.apache.commons/commons-lang3',
     )
+  })
+})
+
+describe('resolveRegistryPageUrlFromBase', () => {
+  it('returns Sonatype Central URL when resolvedBaseUrl is Maven Central', () => {
+    expect(
+      resolveRegistryPageUrlFromBase(
+        'com.google.firebase',
+        'firebase-admin',
+        MAVEN_CENTRAL_BASE_URL,
+      ),
+    ).toBe('https://central.sonatype.com/artifact/com.google.firebase/firebase-admin')
+  })
+
+  it('returns alternative registry page URL when resolvedBaseUrl is not Central', () => {
+    const googleMavenUrl = 'https://dl.google.com/dl/android/maven2'
+    expect(
+      resolveRegistryPageUrlFromBase('com.google.firebase', 'firebase-analytics', googleMavenUrl),
+    ).toBe('https://maven.google.com/web/index.html#com.google.firebase:firebase-analytics')
   })
 })

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -15,8 +15,10 @@ describe('resolveRegistryBaseUrl', () => {
     )
   })
 
-  it('returns Maven Central for bare com.google.android (legacy SDK stubs on Central)', () => {
-    expect(resolveRegistryBaseUrl('com.google.android')).toBe('https://repo1.maven.org/maven2')
+  it('returns Google Maven for bare com.google.android (legacy Android SDK stubs)', () => {
+    expect(resolveRegistryBaseUrl('com.google.android')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
   })
 
   it('returns Google Maven for android.arch (pre-AndroidX Architecture Components)', () => {

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -137,7 +137,9 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
 ]
 
 function findEntry(groupId: string): RegistryEntry | undefined {
-  return ALTERNATIVE_REGISTRIES.find((r) => groupId.startsWith(r.prefix))
+  return ALTERNATIVE_REGISTRIES.find(
+    (r) => groupId === r.prefix || groupId.startsWith(r.prefix + '.'),
+  )
 }
 
 /**
@@ -171,4 +173,24 @@ export function resolveRegistryPageUrl(groupId: string, artifactId: string): str
   const entry = findEntry(groupId)
   if (entry) return entry.pageUrl(groupId, artifactId)
   return `https://central.sonatype.com/artifact/${groupId}/${artifactId}`
+}
+
+/**
+ * Like resolveRegistryPageUrl, but uses the resolved base URL to determine which
+ * registry page to show. When the artifact was actually fetched from Maven Central
+ * (e.g. via the Central fallback after the primary alternative registry 404'd), the
+ * namespace-based routing would point at the wrong registry page — this overrides it.
+ */
+export function resolveRegistryPageUrlFromBase(
+  groupId: string,
+  artifactId: string,
+  resolvedBaseUrl: string,
+): string {
+  const isCentral =
+    resolvedBaseUrl === MAVEN_CENTRAL_BASE_URL ||
+    resolvedBaseUrl === process.env.MAVEN_FETCHER_BASE_URL
+  if (isCentral) {
+    return `https://central.sonatype.com/artifact/${groupId}/${artifactId}`
+  }
+  return resolveRegistryPageUrl(groupId, artifactId)
 }

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -11,7 +11,7 @@
  * metadata.xml / POM fetch logic works — only the base URL changes.
  */
 
-const MAVEN_CENTRAL_BASE_URL = 'https://repo1.maven.org/maven2'
+export const MAVEN_CENTRAL_BASE_URL = 'https://repo1.maven.org/maven2'
 
 interface RegistryEntry {
   prefix: string
@@ -25,10 +25,10 @@ const ALTERNATIVE_REGISTRIES: RegistryEntry[] = [
     baseUrl: 'https://dl.google.com/dl/android/maven2',
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
-  // com.google.android (bare, no sub-namespace) are legacy SDK stubs on Maven Central —
-  // only sub-namespaces like com.google.android.gms.* live on Google Maven.
+  // com.google.android — all artifacts (bare namespace and sub-namespaces like
+  // com.google.android.gms.*) are on Google Maven, not Maven Central.
   {
-    prefix: 'com.google.android.',
+    prefix: 'com.google.android',
     baseUrl: 'https://dl.google.com/dl/android/maven2',
     pageUrl: (g, a) => `https://maven.google.com/web/index.html#${g}:${a}`,
   },
@@ -152,6 +152,16 @@ export function resolveRegistryBaseUrl(groupId: string): string {
   const entry = findEntry(groupId)
   if (entry) return entry.baseUrl
   return process.env.MAVEN_FETCHER_BASE_URL ?? MAVEN_CENTRAL_BASE_URL
+}
+
+/**
+ * Returns true when the given groupId maps to a non-Central registry.
+ * Used in the enrichment loop to decide whether a Central fallback lookup is worth trying
+ * (e.g. com.google.firebase:firebase-admin is a server-side Java SDK on Central, while
+ * most com.google.firebase artifacts are Android SDKs on Google Maven).
+ */
+export function isAlternativeRegistry(groupId: string): boolean {
+  return findEntry(groupId) !== undefined
 }
 
 /**

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -18,7 +18,12 @@ import { getMavenConfig } from '../config'
 import { extractArtifact, getPomCacheStats, normalizeScmUrl } from './extract'
 import { isMavenFetchError, resolveVersionsList } from './metadata'
 import { isPrerelease, parseRepoUrl } from './normalize'
-import { resolveRegistryBaseUrl, resolveRegistryPageUrl } from './registry'
+import {
+  MAVEN_CENTRAL_BASE_URL,
+  isAlternativeRegistry,
+  resolveRegistryBaseUrl,
+  resolveRegistryPageUrl,
+} from './registry'
 
 const log = getServiceChildLogger('maven')
 
@@ -115,10 +120,25 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
     return { status: 'skipped' }
   }
 
-  const baseUrl = resolveRegistryBaseUrl(groupId)
+  let baseUrl = resolveRegistryBaseUrl(groupId)
 
   // Phase 1: lightweight metadata fetch to get the current upstream version.
-  const metadata = await resolveVersionsList(groupId, artifactId, baseUrl)
+  let metadata = await resolveVersionsList(groupId, artifactId, baseUrl)
+
+  // If the primary (non-Central) registry returned NOT_FOUND, try Maven Central as a
+  // fallback. This handles artifacts that share a namespace with non-Central packages but
+  // are themselves published on Central — e.g. com.google.firebase:firebase-admin is the
+  // server-side Java SDK on Central, while most com.google.firebase artifacts are Android
+  // SDKs on Google Maven.
+  if (isMavenFetchError(metadata) && metadata.kind === 'NOT_FOUND' && isAlternativeRegistry(groupId)) {
+    const centralUrl = process.env.MAVEN_FETCHER_BASE_URL ?? MAVEN_CENTRAL_BASE_URL
+    const centralMetadata = await resolveVersionsList(groupId, artifactId, centralUrl)
+    if (!isMavenFetchError(centralMetadata)) {
+      log.info({ groupId, artifactId }, 'Not found in primary registry — resolved via Maven Central fallback')
+      baseUrl = centralUrl
+      metadata = centralMetadata
+    }
+  }
 
   if (isMavenFetchError(metadata)) {
     if (metadata.kind === 'NOT_FOUND') {

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -23,6 +23,7 @@ import {
   isAlternativeRegistry,
   resolveRegistryBaseUrl,
   resolveRegistryPageUrl,
+  resolveRegistryPageUrlFromBase,
 } from './registry'
 
 const log = getServiceChildLogger('maven')
@@ -149,7 +150,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         name: artifactId,
         description: null,
         homepage: null,
-        registryUrl: resolveRegistryPageUrl(groupId, artifactId),
+        registryUrl: resolveRegistryPageUrlFromBase(groupId, artifactId, baseUrl),
         declaredRepositoryUrl: null,
         repositoryUrl: null,
         licenses: null,
@@ -184,7 +185,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
       name: artifactId,
       description: null,
       homepage: null,
-      registryUrl: resolveRegistryPageUrl(groupId, artifactId),
+      registryUrl: resolveRegistryPageUrlFromBase(groupId, artifactId, baseUrl),
       declaredRepositoryUrl: null,
       repositoryUrl: null,
       licenses: null,
@@ -221,7 +222,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
       name: artifactId,
       description: null,
       homepage: null,
-      registryUrl: resolveRegistryPageUrl(groupId, artifactId),
+      registryUrl: resolveRegistryPageUrlFromBase(groupId, artifactId, baseUrl),
       declaredRepositoryUrl: null,
       repositoryUrl: null,
       licenses: null,
@@ -247,7 +248,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
         name: artifactId,
         description: result.description,
         homepage: result.homepageUrl,
-        registryUrl: resolveRegistryPageUrl(groupId, artifactId),
+        registryUrl: resolveRegistryPageUrlFromBase(groupId, artifactId, baseUrl),
         declaredRepositoryUrl: result.scmUrl,
         repositoryUrl,
         licenses: result.licenses.length > 0 ? result.licenses : null,


### PR DESCRIPTION
## Summary

Two fixes to the Maven enrichment registry routing introduced in CM-1299.

1. **`com.google.android` bare namespace was routed to Maven Central** — the previous entry used prefix `com.google.android.` (with trailing dot), which matched sub-namespaces like `com.google.android.gms` but not the bare groupId `com.google.android`. As a result, artifacts like `com.google.android:android` (941 dependents), `com.google.android:annotations` (326), and `com.google.android:support-v4` (146) were still being looked up on Maven Central, getting 404, and written as `maven_not_on_central`.

2. **`com.google.firebase:firebase-admin` was being lost after CM-1299** — the previous PR correctly routes all `com.google.firebase.*` to Google Maven (where the Android Firebase SDKs live). However, `firebase-admin` is the server-side Java SDK, published on Maven Central, not Google Maven. With CM-1299 in place it was getting 404 from Google Maven and written as `maven_not_on_central` with no way out. A Central fallback is now attempted when any alternative-registry namespace returns NOT_FOUND.

## Changes

- **`registry.ts`** — remove trailing dot from `com.google.android.` prefix so the bare namespace also routes to Google Maven. Export `MAVEN_CENTRAL_BASE_URL` (was module-private) and add `isAlternativeRegistry()` helper.
- **`runMavenEnrichmentLoop.ts`** — after a NOT_FOUND from a non-Central primary registry, retry on Maven Central before writing `maven_not_on_central`. This covers any artifact whose namespace normally maps to an alternative registry but is itself published on Central.
- **`registry.test.ts`** — update the test that incorrectly asserted `com.google.android` (bare) routes to Maven Central.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1299](https://linuxfoundation.atlassian.net/browse/CM-1299)

[CM-1299]: https://linuxfoundation.atlassian.net/browse/CM-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Maven packages_worker enrichment and registry URL resolution; no auth or data-model changes, with behavior covered by updated unit tests.
> 
> **Overview**
> Fixes **Maven registry routing** so legacy **`com.google.android`** artifacts hit Google Maven (prefix boundary via `findEntry`, without matching **`com.google.androidx`**), and adds a **Maven Central retry** when an alternative-registry lookup returns NOT_FOUND (e.g. **`com.google.firebase:firebase-admin`**).
> 
> **`registryUrl`** on upserts now uses **`resolveRegistryPageUrlFromBase`** so browse links match the repo that actually served metadata after a Central fallback. Exports **`MAVEN_CENTRAL_BASE_URL`**, adds **`isAlternativeRegistry`**, and extends unit tests for routing and page URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f727f0a3d42a9932a315106d9ad8cf0614177df3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->