### PR TITLE
fix: test recoursive developers (CM-1299)

### DIFF
--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -46,7 +46,6 @@ interface PomData {
   scm?: { url?: unknown; connection?: unknown }
   developers?: { developer?: unknown }
   contributors?: { contributor?: unknown }
-  organization?: { name?: unknown; url?: unknown }
   parent?: { groupId?: unknown; artifactId?: unknown; version?: unknown }
 }
 
@@ -262,7 +261,6 @@ interface ResolvedFields {
   homepageUrl: string | null
   developers: PomMaintainer[]
   contributors: PomMaintainer[]
-  organization: { name: string; url: string | null } | null
   hops: number
 }
 
@@ -275,15 +273,13 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
   const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
   const developers = extractPersons(pom.developers?.developer, 'author')
   const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
-  const organization = extractOrganization(pom)
 
   const missingLicense = licenses.length === 0
   const missingScm = !scmUrl
   const missingDevelopers = developers.length === 0 || contributors.length === 0
-  const missingOrg = !organization
   const parent = extractParent(pom)
 
-  if (parent && (missingLicense || missingScm || missingDevelopers || missingOrg)) {
+  if (parent && (missingLicense || missingScm || missingDevelopers)) {
     const parentKey = `${parent.groupId}:${parent.artifactId}:${parent.version}`
     if (depth >= MAX_PARENT_DEPTH || visited.has(parentKey)) {
       log.warn(
@@ -309,7 +305,6 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
         homepageUrl: extractStr(pom.url) ?? parentFields.homepageUrl,
         developers: developers.length > 0 ? developers : parentFields.developers,
         contributors: contributors.length > 0 ? contributors : parentFields.contributors,
-        organization: organization ?? parentFields.organization,
         hops: parentFields.hops,
       }
     }
@@ -323,7 +318,6 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
     homepageUrl: extractStr(pom.url),
     developers,
     contributors,
-    organization,
     hops: depth,
   }
 }
@@ -363,13 +357,7 @@ export async function extractArtifactDirect(groupId: string, artifactId: string,
   const licenses = extractLicenses(pom)
   const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
   const developers = extractPersons(pom.developers?.developer, 'author')
-  const organization = extractOrganization(pom)
-  const rawContributors = extractPersons(pom.contributors?.contributor, 'maintainer')
-  const noPersonnel = developers.length === 0 && rawContributors.length === 0
-  const contributors =
-    noPersonnel && organization
-      ? [orgToMaintainer(organization)]
-      : rawContributors
+  const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
 
   return {
     groupId,
@@ -426,11 +414,6 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       new Set(),
       baseUrl,
     )
-    const noPersonnel = resolved.developers.length === 0 && resolved.contributors.length === 0
-    const contributors =
-      noPersonnel && resolved.organization
-        ? [orgToMaintainer(resolved.organization)]
-        : resolved.contributors
     return {
       groupId,
       artifactId,
@@ -442,7 +425,7 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       scmUrl: resolved.scmUrl,
       homepageUrl: resolved.homepageUrl,
       developers: resolved.developers,
-      contributors,
+      contributors: resolved.contributors,
       parentHops: resolved.hops,
       error: null,
     }
@@ -533,26 +516,6 @@ function extractPersons(raw: unknown, role: 'author' | 'maintainer'): PomMaintai
     }))
 }
 
-function extractOrganization(pom: PomData): { name: string; url: string | null } | null {
-  const name = extractStr(pom.organization?.name)
-  if (!name) return null
-  return { name, url: extractStr(pom.organization?.url) }
-}
-
-function orgToMaintainer(org: { name: string; url: string | null }): PomMaintainer {
-  const normalized = org.name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-  return {
-    username: normalized || null,
-    displayName: org.name,
-    email: null,
-    url: org.url,
-    role: 'maintainer',
-  }
-}
-
 function extractParent(
   pom: PomData,
 ): { groupId: string; artifactId: string; version: string } | null {
@@ -574,7 +537,6 @@ function emptyFields(hops: number): ResolvedFields {
     homepageUrl: null,
     developers: [],
     contributors: [],
-    organization: null,
     hops,
   }
 }

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -276,9 +276,10 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
 
   const missingLicense = licenses.length === 0
   const missingScm = !scmUrl
+  const missingDevelopers = developers.length === 0 || contributors.length === 0
   const parent = extractParent(pom)
 
-  if (parent && (missingLicense || missingScm)) {
+  if (parent && (missingLicense || missingScm || missingDevelopers)) {
     const parentKey = `${parent.groupId}:${parent.artifactId}:${parent.version}`
     if (depth >= MAX_PARENT_DEPTH || visited.has(parentKey)) {
       log.warn(

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -46,6 +46,7 @@ interface PomData {
   scm?: { url?: unknown; connection?: unknown }
   developers?: { developer?: unknown }
   contributors?: { contributor?: unknown }
+  organization?: { name?: unknown; url?: unknown }
   parent?: { groupId?: unknown; artifactId?: unknown; version?: unknown }
 }
 
@@ -261,6 +262,7 @@ interface ResolvedFields {
   homepageUrl: string | null
   developers: PomMaintainer[]
   contributors: PomMaintainer[]
+  organization: { name: string; url: string | null } | null
   hops: number
 }
 
@@ -273,13 +275,15 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
   const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
   const developers = extractPersons(pom.developers?.developer, 'author')
   const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
+  const organization = extractOrganization(pom)
 
   const missingLicense = licenses.length === 0
   const missingScm = !scmUrl
   const missingDevelopers = developers.length === 0 || contributors.length === 0
+  const missingOrg = !organization
   const parent = extractParent(pom)
 
-  if (parent && (missingLicense || missingScm || missingDevelopers)) {
+  if (parent && (missingLicense || missingScm || missingDevelopers || missingOrg)) {
     const parentKey = `${parent.groupId}:${parent.artifactId}:${parent.version}`
     if (depth >= MAX_PARENT_DEPTH || visited.has(parentKey)) {
       log.warn(
@@ -305,6 +309,7 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
         homepageUrl: extractStr(pom.url) ?? parentFields.homepageUrl,
         developers: developers.length > 0 ? developers : parentFields.developers,
         contributors: contributors.length > 0 ? contributors : parentFields.contributors,
+        organization: organization ?? parentFields.organization,
         hops: parentFields.hops,
       }
     }
@@ -318,6 +323,7 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
     homepageUrl: extractStr(pom.url),
     developers,
     contributors,
+    organization,
     hops: depth,
   }
 }
@@ -357,7 +363,13 @@ export async function extractArtifactDirect(groupId: string, artifactId: string,
   const licenses = extractLicenses(pom)
   const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
   const developers = extractPersons(pom.developers?.developer, 'author')
-  const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
+  const organization = extractOrganization(pom)
+  const rawContributors = extractPersons(pom.contributors?.contributor, 'maintainer')
+  const noPersonnel = developers.length === 0 && rawContributors.length === 0
+  const contributors =
+    noPersonnel && organization
+      ? [orgToMaintainer(organization)]
+      : rawContributors
 
   return {
     groupId,
@@ -414,6 +426,11 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       new Set(),
       baseUrl,
     )
+    const noPersonnel = resolved.developers.length === 0 && resolved.contributors.length === 0
+    const contributors =
+      noPersonnel && resolved.organization
+        ? [orgToMaintainer(resolved.organization)]
+        : resolved.contributors
     return {
       groupId,
       artifactId,
@@ -425,7 +442,7 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       scmUrl: resolved.scmUrl,
       homepageUrl: resolved.homepageUrl,
       developers: resolved.developers,
-      contributors: resolved.contributors,
+      contributors,
       parentHops: resolved.hops,
       error: null,
     }
@@ -516,6 +533,26 @@ function extractPersons(raw: unknown, role: 'author' | 'maintainer'): PomMaintai
     }))
 }
 
+function extractOrganization(pom: PomData): { name: string; url: string | null } | null {
+  const name = extractStr(pom.organization?.name)
+  if (!name) return null
+  return { name, url: extractStr(pom.organization?.url) }
+}
+
+function orgToMaintainer(org: { name: string; url: string | null }): PomMaintainer {
+  const normalized = org.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  return {
+    username: normalized || null,
+    displayName: org.name,
+    email: null,
+    url: org.url,
+    role: 'maintainer',
+  }
+}
+
 function extractParent(
   pom: PomData,
 ): { groupId: string; artifactId: string; version: string } | null {
@@ -537,6 +574,7 @@ function emptyFields(hops: number): ResolvedFields {
     homepageUrl: null,
     developers: [],
     contributors: [],
+    organization: null,
     hops,
   }
 }


### PR DESCRIPTION
## Summary

Fixes a bug in Maven POM parent chain resolution that caused ~9% of Maven packages (`maven-registry` ingestion source) to have 0 maintainers even after successful POM extraction.

The parent POM walk in `resolveWithInheritance` was only triggered when a package was missing a license or SCM URL. Many mature packages (e.g. FasterXML, Apache projects) declare their `<developers>` exclusively in a parent POM while the artifact POM already carries its own license and SCM URL — causing the parent chain to never be walked and developers to silently return empty.

## Changes

- **`services/apps/packages_worker/src/maven/extract.ts`**: extended the parent chain walk condition to also trigger when `developers` or `contributors` are missing from the artifact POM, using `||` so each field is evaluated independently (matching the independent fallback logic already present in the return block for each field)
- The walk respects the existing `MAX_PARENT_DEPTH = 8` cap and cycle guard — no new risk of infinite recursion
- Parent fetches are cached via `fetchPomCached`, so repeated walks on shared parent POMs (e.g. `org.apache:apache`) within a batch do not produce extra HTTP calls
- The extra parent walk is only costly on the first backfill per package; subsequent daily runs hit the `unchanged` branch (version unchanged → skip POM extraction entirely)

To apply retroactively to the ~17k packages already in DB with 0 maintainers, a backfill with `MAVEN_FETCHER_REFRESH_DAYS=0` is needed.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional change in enrichment logic; reuses existing parent-walk guards and caching, with possible extra parent HTTP on first enrichment for affected packages.
> 
> **Overview**
> Fixes Maven enrichment leaving **0 maintainers** when `<developers>` / `<contributors>` live only on a parent POM but the artifact already has license and SCM.
> 
> In `resolveWithInheritance`, parent-chain resolution now also runs when **developers or contributors are empty** on the current POM (`missingDevelopers`), not only when license or SCM is missing. Inherited maintainer lists still use the existing per-field fallbacks and the same **depth/cycle limits** and **cached parent fetches**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8824a6e45ef008f78940047f156dd23eb07f9ede. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->