### PR TITLE
chore: remove `AGENTS.md` symlink to reduce duplicate context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md


### PR DESCRIPTION
## Summary
- Remove the root `AGENTS.md` symlink that pointed to `CLAUDE.md`
- Keep `CLAUDE.md` as the single source of truth for agent instructions in Cursor and Claude Code
- Avoids duplicating the same workspace rules in the context window