### PR TITLE
fix: stewardship action status at time (CM-1291)

### DIFF
--- a/backend/src/api/public/v1/stewardships/getMyActivity.ts
+++ b/backend/src/api/public/v1/stewardships/getMyActivity.ts
@@ -65,7 +65,7 @@ export async function getMyActivityHandler(req: Request, res: Response): Promise
       description: r.content,
       actor: r.actor,
       createdAt: r.createdAt,
-      suggestedAction: SUGGESTED_ACTIONS[r.stewardshipStatus] ?? null,
+      suggestedAction: SUGGESTED_ACTIONS[r.currentStewardshipStatus] ?? null,
     })),
     meta: {
       total,

--- a/backend/src/bin/scripts/merge-members.ts
+++ b/backend/src/bin/scripts/merge-members.ts
@@ -38,8 +38,7 @@ const options = [
     alias: 'u',
     typeLabel: '{underline userId}',
     type: String,
-    description:
-      'User ID of the user performing the merge.',
+    description: 'User ID of the user performing the merge.',
   },
   {
     name: 'help',

--- a/backend/src/osspckgs/migrations/V1782400000__stewardship-activity-status-at-time.sql
+++ b/backend/src/osspckgs/migrations/V1782400000__stewardship-activity-status-at-time.sql
@@ -1,0 +1,4 @@
+-- Store the stewardship status as it was at the moment each activity was logged.
+-- Existing rows get NULL (no history to reconstruct); queries fall back to s.status for them.
+ALTER TABLE stewardship_activity
+  ADD COLUMN IF NOT EXISTS status_at_time TEXT;

--- a/services/libs/data-access-layer/src/osspckgs/stewardships.ts
+++ b/services/libs/data-access-layer/src/osspckgs/stewardships.ts
@@ -203,9 +203,9 @@ export async function openStewardshipByPurl(
     ),
     _log AS (
       INSERT INTO stewardship_activity
-        (stewardship_id, actor_user_id, actor_type, activity_type, content, actor_username, actor_display_name, actor_avatar_url)
+        (stewardship_id, actor_user_id, actor_type, activity_type, content, actor_username, actor_display_name, actor_avatar_url, status_at_time)
       SELECT upserted.id, $(actorUserId), 'user', 'state_changed', 'Opened for stewardship',
-             $(actorUsername), $(actorDisplayName), $(actorAvatarUrl)
+             $(actorUsername), $(actorDisplayName), $(actorAvatarUrl), 'open'
       FROM upserted
       WHERE NOT EXISTS (SELECT 1 FROM prev WHERE prev.old_status = 'open')
     )
@@ -278,9 +278,9 @@ export async function assignSteward(
 
     await tx.result(
       `INSERT INTO stewardship_activity
-         (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url)
+         (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url, status_at_time)
        VALUES ($(stewardshipId), $(actorUserId), 'user', 'steward_added', $(content), $(metadata)::jsonb,
-               $(actorUsername), $(actorDisplayName), $(actorAvatarUrl))`,
+               $(actorUsername), $(actorDisplayName), $(actorAvatarUrl), $(statusAtTime))`,
       {
         stewardshipId,
         actorUserId: data.assignedBy,
@@ -288,6 +288,7 @@ export async function assignSteward(
         actorDisplayName: data.actorDisplayName ?? null,
         actorAvatarUrl: data.actorAvatarUrl ?? null,
         content: `Assigned steward ${data.userId} as ${data.role}`,
+        statusAtTime: stewardship.status,
         metadata: JSON.stringify({
           userId: data.userId,
           role: data.role,
@@ -316,10 +317,10 @@ export async function assignSteward(
         ),
         _log AS (
           INSERT INTO stewardship_activity
-            (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url)
+            (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url, status_at_time)
           SELECT id, $(actorUserId), 'user', 'state_changed',
                  'Status updated to assessing', $(metadata)::jsonb,
-                 $(actorUsername), $(actorDisplayName), $(actorAvatarUrl)
+                 $(actorUsername), $(actorDisplayName), $(actorAvatarUrl), 'assessing'
           FROM upd
         )
         SELECT * FROM upd
@@ -380,6 +381,7 @@ export interface ActivityFeedRow {
   content: string | null
   metadata: Record<string, unknown> | null
   stewardshipStatus: string
+  currentStewardshipStatus: string
   createdAt: string
   total: string
 }
@@ -406,7 +408,8 @@ export async function listStewardshipActivity(
       sa.activity_type                   AS "activityType",
       sa.content                         AS content,
       ${STEWARD_DISPLAY_NAME_METADATA}   AS metadata,
-      s.status                           AS "stewardshipStatus",
+      COALESCE(sa.status_at_time, s.status) AS "stewardshipStatus",
+      s.status                           AS "currentStewardshipStatus",
       sa.created_at                      AS "createdAt",
       COUNT(*) OVER()::text              AS total
     FROM stewardship_activity sa
@@ -454,6 +457,7 @@ export async function listStewardshipActivity(
       ),
       metadata: row.metadata as Record<string, unknown> | null,
       stewardshipStatus: row.stewardshipStatus as string,
+      currentStewardshipStatus: row.currentStewardshipStatus as string,
       createdAt: toIso(row.createdAt),
     })),
     total,
@@ -797,6 +801,7 @@ export async function listMyActivity(
       sub.content,
       sub.metadata,
       sub."stewardshipStatus",
+      sub."currentStewardshipStatus",
       sub."createdAt",
       COUNT(*) OVER()::text AS total
     FROM (
@@ -814,7 +819,8 @@ export async function listMyActivity(
         sa.activity_type                   AS "activityType",
         sa.content                         AS content,
         ${STEWARD_DISPLAY_NAME_METADATA}   AS metadata,
-        s.status                           AS "stewardshipStatus",
+        COALESCE(sa.status_at_time, s.status) AS "stewardshipStatus",
+        s.status                           AS "currentStewardshipStatus",
         sa.created_at                      AS "createdAt"
       FROM stewardship_activity sa
       JOIN stewardships s ON s.id = sa.stewardship_id
@@ -879,6 +885,7 @@ export async function listMyActivity(
       ),
       metadata: row.metadata as Record<string, unknown> | null,
       stewardshipStatus: row.stewardshipStatus as string,
+      currentStewardshipStatus: row.currentStewardshipStatus as string,
       createdAt: toIso(row.createdAt),
     })),
     total,
@@ -961,9 +968,9 @@ export async function escalateStewardship(
     ),
     _log AS (
       INSERT INTO stewardship_activity
-        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url)
+        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url, status_at_time)
       SELECT id, $(actorUserId), 'user', 'escalation',
-             $(content), $(metadata)::jsonb, $(actorUsername), $(actorDisplayName), $(actorAvatarUrl)
+             $(content), $(metadata)::jsonb, $(actorUsername), $(actorDisplayName), $(actorAvatarUrl), 'escalated'
       FROM upd
     )
     SELECT * FROM upd
@@ -1037,9 +1044,9 @@ export async function updateStewardshipStatus(
     ),
     _log AS (
       INSERT INTO stewardship_activity
-        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url)
+        (stewardship_id, actor_user_id, actor_type, activity_type, content, metadata, actor_username, actor_display_name, actor_avatar_url, status_at_time)
       SELECT id, $(actorUserId), 'user', 'state_changed',
-             $(content), $(metadata)::jsonb, $(actorUsername), $(actorDisplayName), $(actorAvatarUrl)
+             $(content), $(metadata)::jsonb, $(actorUsername), $(actorDisplayName), $(actorAvatarUrl), $(status)
       FROM upd
     )
     SELECT * FROM upd


### PR DESCRIPTION
## Summary

The Latest Activity timeline was displaying the current/live stewardship status on every entry instead of the status that was in effect when the action occurred. For example, a "Package opened for stewardship" event (status was `open` at the time) would show `active` because that's the current status of the stewardship.

## Changes

- **Migration** `V1782400000__stewardship-activity-status-at-time.sql`: adds `status_at_time TEXT` column to `stewardship_activity`. Nullable so existing rows fall back gracefully.
- **`stewardships.ts` (DAL)**: all five `INSERT INTO stewardship_activity` statements now populate `status_at_time` with the status in effect at the moment of the event (`'open'`, `'assessing'`, `'escalated'`, `data.status`, or the pre-assignment `stewardship.status`).
- **`stewardships.ts` (DAL)**: `listStewardshipActivity` and `listMyActivity` queries now use `COALESCE(sa.status_at_time, s.status)` instead of `s.status` for the `stewardshipStatus` field — historical for new rows, current fallback for pre-migration rows.
- **`ActivityFeedRow`**: added `currentStewardshipStatus` field (always `s.status`) so consumers that need the live status can access it independently of the historical display value.
- **`getMyActivity.ts`**: `suggestedAction` lookup now uses `currentStewardshipStatus` (live status) instead of `stewardshipStatus` (historical) — suggested actions must reflect what the user should do *now*, not what was appropriate at the time of the activity.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1291](https://linuxfoundation.atlassian.net/browse/CM-1291)

[CM-1291]: https://linuxfoundation.atlassian.net/browse/CM-1291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches stewardship activity writes and feed SQL semantics; migration is additive with fallback, but wrong `status_at_time` values would mislabel timeline entries until corrected.
> 
> **Overview**
> Fixes activity timelines showing **today’s** stewardship status on every historical event by persisting status when each activity is logged and reading it back for display.
> 
> Adds nullable `status_at_time` on `stewardship_activity` (existing rows stay `NULL` and still fall back to the live `stewardships.status`). All stewardship activity inserts now set `status_at_time` for opens, steward assignment, assessing transitions, escalations, and generic status updates. Feed queries expose **historical** status via `COALESCE(sa.status_at_time, s.status)` as `stewardshipStatus`, plus a new `currentStewardshipStatus` for the live row.
> 
> `getMyActivity` keeps historical `stewardshipStatus` in the payload but drives **`suggestedAction`** from `currentStewardshipStatus` so CTAs match what the user should do now.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde6d1aad2be16b2b9c8d37cabef2b06cf4d1cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->