### PR TITLE
fix: split dissectMember backup fetch to avoid temporal payload limits

### DIFF
--- a/services/apps/script_executor_worker/src/activities.ts
+++ b/services/apps/script_executor_worker/src/activities.ts
@@ -37,6 +37,7 @@ import {
   findMemberById,
   findMemberIdentitiesGroupedByPlatform,
   findMemberMergeActions,
+  findMergeActionUnmergeBackup,
 } from './activities/dissect-member'
 import {
   getBotMembersWithOrgAffiliation,
@@ -66,6 +67,7 @@ export {
   findMembersWithSamePlatformIdentitiesDifferentCapitalization,
   mergeMembers,
   findMemberMergeActions,
+  findMergeActionUnmergeBackup,
   unmergeMembers,
   unmergeMembersPreview,
   waitForTemporalWorkflowExecutionFinish,

--- a/services/apps/script_executor_worker/src/activities/dissect-member/index.ts
+++ b/services/apps/script_executor_worker/src/activities/dissect-member/index.ts
@@ -30,6 +30,17 @@ export async function findMemberMergeActions(
   return mergeActions
 }
 
+export async function findMergeActionUnmergeBackup(
+  mergeActionId: string,
+): Promise<IMergeAction['unmergeBackup'] | null> {
+  try {
+    const mergeActionRepo = new MergeActionRepository(svc.postgres.reader.connection(), svc.log)
+    return await mergeActionRepo.findMergeActionUnmergeBackup(mergeActionId)
+  } catch (err) {
+    throw new Error(err)
+  }
+}
+
 export async function findMemberIdentitiesGroupedByPlatform(
   memberId: string,
 ): Promise<IFindMemberIdentitiesGroupedByPlatformResult[]> {

--- a/services/apps/script_executor_worker/src/workflows/dissectMember.ts
+++ b/services/apps/script_executor_worker/src/workflows/dissectMember.ts
@@ -89,9 +89,18 @@ export async function dissectMember(args: IDissectMemberArgs): Promise<void> {
       // 2. wait for temporal async stuff to complete
       // 3. call the same workflow again for the unmerged secondary member
 
+      // Fetch each backup in its own activity — listing 10 backups in one result can exceed
+      // Temporal's 2MB activity payload limit on polluted members.
+      const unmergeBackup = await activity.findMergeActionUnmergeBackup(mergeAction.id)
+
+      if (!unmergeBackup) {
+        console.log(`Merge action ${mergeAction.id} has no unmerge backup, skipping!`)
+        continue
+      }
+
       await common.unmergeMembers(
         mergeAction.primaryId,
-        mergeAction.unmergeBackup as IUnmergeBackup<IMemberUnmergeBackup>,
+        unmergeBackup as IUnmergeBackup<IMemberUnmergeBackup>,
       )
 
       const workflowId = `finishMemberUnmerging/${mergeAction.primaryId}/${mergeAction.secondaryId}`

--- a/services/libs/data-access-layer/src/old/apps/script_executor_worker/mergeAction.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/script_executor_worker/mergeAction.repo.ts
@@ -19,7 +19,16 @@ class MergeActionRepository {
   ) {
     let rows: IMergeAction[] = []
     let query = `
-        select * from "mergeActions" ma
+        select
+          ma.id,
+          ma.type,
+          ma."primaryId",
+          ma."secondaryId",
+          ma."createdAt",
+          ma."updatedAt",
+          ma.step,
+          ma.state
+        from "mergeActions" ma
         where 
           ma."state" = 'merged' and 
           ma."primaryId" = $(memberId) and 
@@ -60,6 +69,20 @@ class MergeActionRepository {
     }
 
     return rows
+  }
+
+  async findMergeActionUnmergeBackup(mergeActionId: string) {
+    const rows = await this.connection.query(
+      `
+      select ma."unmergeBackup"
+      from "mergeActions" ma
+      where ma.id = $(mergeActionId)
+        and ma."unmergeBackup" is not null
+      `,
+      { mergeActionId },
+    )
+
+    return rows[0]?.unmergeBackup ?? null
   }
 
   async findMergeActionsWithDeletedSecondaryEntities(


### PR DESCRIPTION
## Summary
Fixes `dissectMember` failures on polluted members by avoiding Temporal payload and workflow ID length limits.

## Changes
- Fetch merge action backups one at a time instead of returning them in `findMemberMergeActions` (prevents 2MB activity result limit errors)
- Add `findMergeActionUnmergeBackup` activity and slim merge-action list query in data-access-layer