### PR TITLE
fix: stabilize LFID enrichment child workflows under auth0 mutex

### DIFF
--- a/services/apps/members_enrichment_worker/src/workflows/lf-auth0/enrichMemberWithLFAuth0.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/lf-auth0/enrichMemberWithLFAuth0.ts
@@ -7,7 +7,6 @@ import * as activities from '../../activities'
 import { ILFIDEnrichmentGithubProfile } from '../../sources/lfid/types'
 
 const {
-  refreshToken,
   getEnrichmentLFAuth0,
   getIdentitiesExistInOtherMembers,
   updateMemberWithEnrichmentData,
@@ -22,8 +21,7 @@ const {
   },
 })
 
-export async function enrichMemberWithLFAuth0(member: IMember): Promise<void> {
-  const token = await refreshToken()
+export async function enrichMemberWithLFAuth0(token: string, member: IMember): Promise<void> {
   const enriched = await getEnrichmentLFAuth0(token, member)
 
   if (enriched) {

--- a/services/apps/members_enrichment_worker/src/workflows/lf-auth0/getMembersForLFIDEnrichment.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/lf-auth0/getMembersForLFIDEnrichment.ts
@@ -6,14 +6,21 @@ import {
   proxyActivities,
 } from '@temporalio/workflow'
 
-import { IMember } from '@crowd/types'
-
 import * as activities from '../../activities'
 import { IGetMembersForLFIDEnrichmentArgs } from '../../sources/lfid/types'
 import { enrichMemberWithLFAuth0 } from '../lf-auth0/enrichMemberWithLFAuth0'
 
 const { getLFIDEnrichableMembers } = proxyActivities<typeof activities>({
   startToCloseTimeout: '10 seconds',
+})
+
+const { refreshToken } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '2 minutes',
+  retry: {
+    initialInterval: '2 seconds',
+    backoffCoefficient: 2,
+    maximumAttempts: 3,
+  },
 })
 
 export async function getMembersForLFIDEnrichment(
@@ -27,23 +34,23 @@ export async function getMembersForLFIDEnrichment(
     return
   }
 
-  await Promise.all(
-    members.map((member: IMember) => {
-      return executeChild(enrichMemberWithLFAuth0, {
-        workflowId: 'member-enrichment-lfid/' + member.id,
-        cancellationType: ChildWorkflowCancellationType.ABANDON,
-        parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
-        workflowExecutionTimeout: '1 minute',
-        retry: {
-          backoffCoefficient: 2,
-          maximumAttempts: 10,
-          initialInterval: 2 * 1000,
-          maximumInterval: 30 * 1000,
-        },
-        args: [member],
-      })
-    }),
-  )
+  const token = await refreshToken()
+
+  for (const member of members) {
+    await executeChild(enrichMemberWithLFAuth0, {
+      workflowId: 'member-enrichment-lfid/' + member.id,
+      cancellationType: ChildWorkflowCancellationType.ABANDON,
+      parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON,
+      workflowExecutionTimeout: '10 minutes',
+      retry: {
+        backoffCoefficient: 2,
+        maximumAttempts: 10,
+        initialInterval: 2 * 1000,
+        maximumInterval: 30 * 1000,
+      },
+      args: [token, member],
+    })
+  }
 
   await continueAsNew<typeof getMembersForLFIDEnrichment>({
     afterId: members[members.length - 1].id,


### PR DESCRIPTION
## Summary

Fixes recurring `getMembersForLFIDEnrichment` failures in prod (`Child Workflow execution failed` / timed out).

The parent was fanning out 10 `enrichMemberWithLFAuth0` children in parallel, but Auth0 lookups are serialized behind a global Redis mutex for rate-limit safety. Children were also capped at a 1-minute workflow timeout while activities allow up to 2 minutes each — and the mutex can block for up to 100 seconds. That combination caused children to time out waiting in queue, which failed the parent's `Promise.all` and triggered Temporal alerts.

## Changes

- **Raise child `workflowExecutionTimeout`** from 1 minute to 10 minutes so a child can complete its full activity chain (Auth0 lookup, DB updates, OpenSearch sync, optional merge).
- **Process children sequentially** instead of `Promise.all(10)`. Auth0 throughput is already single-lane via the mutex; parallel children only added worker contention and workflow task timeouts without speeding up enrichment.
- **Hoist `refreshToken` to the parent** — one token fetch per batch of 10 members, passed into each child. Avoids redundant Redis/Auth0 calls and reduces per-child startup latency.
