### PR TITLE
feat: add region and subregion columns to country_mapping datasources (IN-1188)

### DIFF
--- a/services/libs/tinybird/datasources/country_mapping_ds.datasource
+++ b/services/libs/tinybird/datasources/country_mapping_ds.datasource
@@ -1,8 +1,10 @@
 SCHEMA >
-    `country` String,
-    `flag` String,
-    `country_code` String,
-    `timezone_offset` Int16
+    `country` String `json:$.country`,
+    `flag` String `json:$.flag`,
+    `country_code` String `json:$.country_code`,
+    `timezone_offset` Int16 `json:$.timezone_offset`,
+    `region` String `json:$.region`,
+    `subregion` String `json:$.subregion`
 
 ENGINE MergeTree
 ENGINE_SORTING_KEY flag, country_code, timezone_offset

--- a/services/libs/tinybird/datasources/country_mapping_no_flags_ds.datasource
+++ b/services/libs/tinybird/datasources/country_mapping_no_flags_ds.datasource
@@ -1,7 +1,9 @@
 SCHEMA >
-    `country` String,
-    `country_code` String,
-    `timezone_offset` Int16
+    `country` String `json:$.country`,
+    `country_code` String `json:$.country_code`,
+    `timezone_offset` Int16 `json:$.timezone_offset`,
+    `region` String `json:$.region`,
+    `subregion` String `json:$.subregion`
 
 ENGINE MergeTree
 ENGINE_SORTING_KEY country, timezone_offset

--- a/services/libs/tinybird/datasources/fixtures/country_mapping_ds.ndjson
+++ b/services/libs/tinybird/datasources/fixtures/country_mapping_ds.ndjson
@@ -1,0 +1,243 @@
+{"country":"Afghanistan","flag":"🇦🇫","country_code":"AF","timezone_offset":4,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Åland Islands","flag":"🇦🇽","country_code":"AX","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Albania","flag":"🇦🇱","country_code":"AL","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Algeria","flag":"🇩🇿","country_code":"DZ","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"American Samoa","flag":"🇦🇸","country_code":"AS","timezone_offset":-11,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Andorra","flag":"🇦🇩","country_code":"AD","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Angola","flag":"🇦🇴","country_code":"AO","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Anguilla","flag":"🇦🇮","country_code":"AI","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Antarctica","flag":"🇦🇶","country_code":"AQ","timezone_offset":12,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Antigua and Barbuda","flag":"🇦🇬","country_code":"AG","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Argentina","flag":"🇦🇷","country_code":"AR","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Armenia","flag":"🇦🇲","country_code":"AM","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Aruba","flag":"🇦🇼","country_code":"AW","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Australia","flag":"🇦🇺","country_code":"AU","timezone_offset":10,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Austria","flag":"🇦🇹","country_code":"AT","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Azerbaijan","flag":"🇦🇿","country_code":"AZ","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Bahamas","flag":"🇧🇸","country_code":"BS","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Bahrain","flag":"🇧🇭","country_code":"BH","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Bangladesh","flag":"🇧🇩","country_code":"BD","timezone_offset":6,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Barbados","flag":"🇧🇧","country_code":"BB","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Belarus","flag":"🇧🇾","country_code":"BY","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Belgium","flag":"🇧🇪","country_code":"BE","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Belize","flag":"🇧🇿","country_code":"BZ","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Benin","flag":"🇧🇯","country_code":"BJ","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Bermuda","flag":"🇧🇲","country_code":"BM","timezone_offset":-3,"region":"Americas","subregion":"North America"}
+{"country":"Bhutan","flag":"🇧🇹","country_code":"BT","timezone_offset":6,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Bolivia","flag":"🇧🇴","country_code":"BO","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Bosnia and Herzegovina","flag":"🇧🇦","country_code":"BA","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Botswana","flag":"🇧🇼","country_code":"BW","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Brazil","flag":"🇧🇷","country_code":"BR","timezone_offset":-2,"region":"Americas","subregion":"South America"}
+{"country":"British Indian Ocean Territory","flag":"🇮🇴","country_code":"IO","timezone_offset":6,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Brunei Darussalam","flag":"🇧🇳","country_code":"BN","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Bulgaria","flag":"🇧🇬","country_code":"BG","timezone_offset":3,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Burkina Faso","flag":"🇧🇫","country_code":"BF","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Burundi","flag":"🇧🇮","country_code":"BI","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Cambodia","flag":"🇰🇭","country_code":"KH","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Cameroon","flag":"🇨🇲","country_code":"CM","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Canada","flag":"🇨🇦","country_code":"CA","timezone_offset":-2,"region":"Americas","subregion":"North America"}
+{"country":"Cape Verde","flag":"🇨🇻","country_code":"CV","timezone_offset":-1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Cayman Islands","flag":"🇰🇾","country_code":"KY","timezone_offset":-5,"region":"Americas","subregion":"Caribbean"}
+{"country":"Central African Republic","flag":"🇨🇫","country_code":"CF","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Chad","flag":"🇹🇩","country_code":"TD","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Chile","flag":"🇨🇱","country_code":"CL","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"China","flag":"🇨🇳","country_code":"CN","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Christmas Island","flag":"🇨🇽","country_code":"CX","timezone_offset":7,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Cocos (Keeling) Islands","flag":"🇨🇨","country_code":"CC","timezone_offset":6,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Colombia","flag":"🇨🇴","country_code":"CO","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Comoros","flag":"🇰🇲","country_code":"KM","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Congo","flag":"🇨🇬","country_code":"CG","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Congo, The Democratic Republic of the Congo","flag":"🇨🇩","country_code":"CD","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Cook Islands","flag":"🇨🇰","country_code":"CK","timezone_offset":-10,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Costa Rica","flag":"🇨🇷","country_code":"CR","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Côte d'Ivoire","flag":"🇨🇮","country_code":"CI","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Croatia","flag":"🇭🇷","country_code":"HR","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Cuba","flag":"🇨🇺","country_code":"CU","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Cyprus","flag":"🇨🇾","country_code":"CY","timezone_offset":3,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Czech Republic","flag":"🇨🇿","country_code":"CZ","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Denmark","flag":"🇩🇰","country_code":"DK","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Djibouti","flag":"🇩🇯","country_code":"DJ","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Dominica","flag":"🇩🇲","country_code":"DM","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Dominican Republic","flag":"🇩🇴","country_code":"DO","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Ecuador","flag":"🇪🇨","country_code":"EC","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Egypt","flag":"🇪🇬","country_code":"EG","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"El Salvador","flag":"🇸🇻","country_code":"SV","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Equatorial Guinea","flag":"🇬🇶","country_code":"GQ","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Eritrea","flag":"🇪🇷","country_code":"ER","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Estonia","flag":"🇪🇪","country_code":"EE","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Ethiopia","flag":"🇪🇹","country_code":"ET","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Falkland Islands (Malvinas)","flag":"🇫🇰","country_code":"FK","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Faroe Islands","flag":"🇫🇴","country_code":"FO","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Fiji","flag":"🇫🇯","country_code":"FJ","timezone_offset":12,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Finland","flag":"🇫🇮","country_code":"FI","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"France","flag":"🇫🇷","country_code":"FR","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"French Guiana","flag":"🇬🇫","country_code":"GF","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"French Polynesia","flag":"🇵🇫","country_code":"PF","timezone_offset":-10,"region":"Oceania","subregion":"Polynesia"}
+{"country":"French Southern Territories","flag":"🇹🇫","country_code":"TF","timezone_offset":5,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Gabon","flag":"🇬🇦","country_code":"GA","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Gambia","flag":"🇬🇲","country_code":"GM","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Georgia","flag":"🇬🇪","country_code":"GE","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Germany","flag":"🇩🇪","country_code":"DE","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Ghana","flag":"🇬🇭","country_code":"GH","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Gibraltar","flag":"🇬🇮","country_code":"GI","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Greece","flag":"🇬🇷","country_code":"GR","timezone_offset":3,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Greenland","flag":"🇬🇱","country_code":"GL","timezone_offset":-1,"region":"Americas","subregion":"North America"}
+{"country":"Grenada","flag":"🇬🇩","country_code":"GD","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Guadeloupe","flag":"🇬🇵","country_code":"GP","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Guam","flag":"🇬🇺","country_code":"GU","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Guatemala","flag":"🇬🇹","country_code":"GT","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Guernsey","flag":"🇬🇬","country_code":"GG","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Guinea","flag":"🇬🇳","country_code":"GN","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Guinea-Bissau","flag":"🇬🇼","country_code":"GW","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Guyana","flag":"🇬🇾","country_code":"GY","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Haiti","flag":"🇭🇹","country_code":"HT","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Holy See (Vatican City State)","flag":"🇻🇦","country_code":"VA","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Honduras","flag":"🇭🇳","country_code":"HN","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Hong Kong","flag":"🇭🇰","country_code":"HK","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Hungary","flag":"🇭🇺","country_code":"HU","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Iceland","flag":"🇮🇸","country_code":"IS","timezone_offset":0,"region":"Europe","subregion":"Northern Europe"}
+{"country":"India","flag":"🇮🇳","country_code":"IN","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Indonesia","flag":"🇮🇩","country_code":"ID","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Iran","flag":"🇮🇷","country_code":"IR","timezone_offset":3,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Iraq","flag":"🇮🇶","country_code":"IQ","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Ireland","flag":"🇮🇪","country_code":"IE","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Isle of Man","flag":"🇮🇲","country_code":"IM","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Israel","flag":"🇮🇱","country_code":"IL","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Italy","flag":"🇮🇹","country_code":"IT","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Jamaica","flag":"🇯🇲","country_code":"JM","timezone_offset":-5,"region":"Americas","subregion":"Caribbean"}
+{"country":"Japan","flag":"🇯🇵","country_code":"JP","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Jersey","flag":"🇯🇪","country_code":"JE","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Jordan","flag":"🇯🇴","country_code":"JO","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Kazakhstan","flag":"🇰🇿","country_code":"KZ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Kenya","flag":"🇰🇪","country_code":"KE","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Kiribati","flag":"🇰🇮","country_code":"KI","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Korea, Democratic People's Republic of Korea","flag":"🇰🇵","country_code":"KP","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Korea, Republic of South Korea","flag":"🇰🇷","country_code":"KR","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Kuwait","flag":"🇰🇼","country_code":"KW","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Kyrgyzstan","flag":"🇰🇬","country_code":"KG","timezone_offset":6,"region":"Asia","subregion":"Central Asia"}
+{"country":"Laos","flag":"🇱🇦","country_code":"LA","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Latvia","flag":"🇱🇻","country_code":"LV","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Lebanon","flag":"🇱🇧","country_code":"LB","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Lesotho","flag":"🇱🇸","country_code":"LS","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Liberia","flag":"🇱🇷","country_code":"LR","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Libyan Arab Jamahiriya","flag":"🇱🇾","country_code":"LY","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Liechtenstein","flag":"🇱🇮","country_code":"LI","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Lithuania","flag":"🇱🇹","country_code":"LT","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Luxembourg","flag":"🇱🇺","country_code":"LU","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Macao","flag":"🇲🇴","country_code":"MO","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Macedonia","flag":"🇲🇰","country_code":"MK","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Madagascar","flag":"🇲🇬","country_code":"MG","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Malawi","flag":"🇲🇼","country_code":"MW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Malaysia","flag":"🇲🇾","country_code":"MY","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Maldives","flag":"🇲🇻","country_code":"MV","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Mali","flag":"🇲🇱","country_code":"ML","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Malta","flag":"🇲🇹","country_code":"MT","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Marshall Islands","flag":"🇲🇭","country_code":"MH","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Martinique","flag":"🇲🇶","country_code":"MQ","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Mauritania","flag":"🇲🇷","country_code":"MR","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Mauritius","flag":"🇲🇺","country_code":"MU","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Mayotte","flag":"🇾🇹","country_code":"YT","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Mexico","flag":"🇲🇽","country_code":"MX","timezone_offset":-6,"region":"Americas","subregion":"North America"}
+{"country":"Micronesia, Federated States of Micronesia","flag":"🇫🇲","country_code":"FM","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Moldova","flag":"🇲🇩","country_code":"MD","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Monaco","flag":"🇲🇨","country_code":"MC","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Mongolia","flag":"🇲🇳","country_code":"MN","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Montenegro","flag":"🇲🇪","country_code":"ME","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Montserrat","flag":"🇲🇸","country_code":"MS","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Morocco","flag":"🇲🇦","country_code":"MA","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Mozambique","flag":"🇲🇿","country_code":"MZ","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Myanmar","flag":"🇲🇲","country_code":"MM","timezone_offset":6,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Namibia","flag":"🇳🇦","country_code":"NA","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Nauru","flag":"🇳🇷","country_code":"NR","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Nepal","flag":"🇳🇵","country_code":"NP","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Netherlands","flag":"🇳🇱","country_code":"NL","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"New Caledonia","flag":"🇳🇨","country_code":"NC","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"New Zealand","flag":"🇳🇿","country_code":"NZ","timezone_offset":12,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Nicaragua","flag":"🇳🇮","country_code":"NI","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Niger","flag":"🇳🇪","country_code":"NE","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Nigeria","flag":"🇳🇬","country_code":"NG","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Niue","flag":"🇳🇺","country_code":"NU","timezone_offset":-11,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Norfolk Island","flag":"🇳🇫","country_code":"NF","timezone_offset":11,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Northern Mariana Islands","flag":"🇲🇵","country_code":"MP","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Norway","flag":"🇳🇴","country_code":"NO","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Oman","flag":"🇴🇲","country_code":"OM","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Pakistan","flag":"🇵🇰","country_code":"PK","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Palau","flag":"🇵🇼","country_code":"PW","timezone_offset":9,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Palestine","flag":"🇵🇸","country_code":"PS","timezone_offset":2,"region":"Asia","subregion":"Western Asia"}
+{"country":"Panama","flag":"🇵🇦","country_code":"PA","timezone_offset":-5,"region":"Americas","subregion":"Central America"}
+{"country":"Papua New Guinea","flag":"🇵🇬","country_code":"PG","timezone_offset":10,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Paraguay","flag":"🇵🇾","country_code":"PY","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Peru","flag":"🇵🇪","country_code":"PE","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Philippines","flag":"🇵🇭","country_code":"PH","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Pitcairn","flag":"🇵🇳","country_code":"PN","timezone_offset":-8,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Poland","flag":"🇵🇱","country_code":"PL","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Portugal","flag":"🇵🇹","country_code":"PT","timezone_offset":1,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Puerto Rico","flag":"🇵🇷","country_code":"PR","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Qatar","flag":"🇶🇦","country_code":"QA","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Romania","flag":"🇷🇴","country_code":"RO","timezone_offset":3,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Russia","flag":"🇷🇺","country_code":"RU","timezone_offset":2,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Rwanda","flag":"🇷🇼","country_code":"RW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Reunion","flag":"🇷🇪","country_code":"RE","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Saint Barthelemy","flag":"🇧🇱","country_code":"BL","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Helena, Ascension and Tristan Da Cunha","flag":"🇸🇭","country_code":"SH","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Saint Kitts and Nevis","flag":"🇰🇳","country_code":"KN","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Lucia","flag":"🇱🇨","country_code":"LC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Martin","flag":"🇲🇫","country_code":"MF","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Pierre and Miquelon","flag":"🇵🇲","country_code":"PM","timezone_offset":-2,"region":"Americas","subregion":"North America"}
+{"country":"Saint Vincent and the Grenadines","flag":"🇻🇨","country_code":"VC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Samoa","flag":"🇼🇸","country_code":"WS","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"San Marino","flag":"🇸🇲","country_code":"SM","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Sao Tome and Principe","flag":"🇸🇹","country_code":"ST","timezone_offset":0,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Saudi Arabia","flag":"🇸🇦","country_code":"SA","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Senegal","flag":"🇸🇳","country_code":"SN","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Serbia","flag":"🇷🇸","country_code":"RS","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Seychelles","flag":"🇸🇨","country_code":"SC","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Sierra Leone","flag":"🇸🇱","country_code":"SL","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Singapore","flag":"🇸🇬","country_code":"SG","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Slovakia","flag":"🇸🇰","country_code":"SK","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Slovenia","flag":"🇸🇮","country_code":"SI","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Solomon Islands","flag":"🇸🇧","country_code":"SB","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Somalia","flag":"🇸🇴","country_code":"SO","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"South Africa","flag":"🇿🇦","country_code":"ZA","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"South Sudan","flag":"🇸🇸","country_code":"SS","timezone_offset":2,"region":"Africa","subregion":"Middle Africa"}
+{"country":"South Georgia and the South Sandwich Islands","flag":"🇬🇸","country_code":"GS","timezone_offset":-2,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Spain","flag":"🇪🇸","country_code":"ES","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Sri Lanka","flag":"🇱🇰","country_code":"LK","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Sudan","flag":"🇸🇩","country_code":"SD","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Suriname","flag":"🇸🇷","country_code":"SR","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Svalbard and Jan Mayen","flag":"🇸🇯","country_code":"SJ","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Swaziland","flag":"🇸🇿","country_code":"SZ","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Sweden","flag":"🇸🇪","country_code":"SE","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Switzerland","flag":"🇨🇭","country_code":"CH","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Syrian Arab Republic","flag":"🇸🇾","country_code":"SY","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Taiwan","flag":"🇹🇼","country_code":"TW","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Tajikistan","flag":"🇹🇯","country_code":"TJ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Tanzania, United Republic of Tanzania","flag":"🇹🇿","country_code":"TZ","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Thailand","flag":"🇹🇭","country_code":"TH","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Timor-Leste","flag":"🇹🇱","country_code":"TL","timezone_offset":9,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Togo","flag":"🇹🇬","country_code":"TG","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Tokelau","flag":"🇹🇰","country_code":"TK","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Tonga","flag":"🇹🇴","country_code":"TO","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Trinidad and Tobago","flag":"🇹🇹","country_code":"TT","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Tunisia","flag":"🇹🇳","country_code":"TN","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Turkey","flag":"🇹🇷","country_code":"TR","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Turkmenistan","flag":"🇹🇲","country_code":"TM","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Turks and Caicos Islands","flag":"🇹🇨","country_code":"TC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Tuvalu","flag":"🇹🇻","country_code":"TV","timezone_offset":12,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Uganda","flag":"🇺🇬","country_code":"UG","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Ukraine","flag":"🇺🇦","country_code":"UA","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"United Arab Emirates","flag":"🇦🇪","country_code":"AE","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"United Kingdom","flag":"🇬🇧","country_code":"GB","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"United States","flag":"🇺🇸","country_code":"US","timezone_offset":-4,"region":"Americas","subregion":"North America"}
+{"country":"Uruguay","flag":"🇺🇾","country_code":"UY","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Uzbekistan","flag":"🇺🇿","country_code":"UZ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Vanuatu","flag":"🇻🇺","country_code":"VU","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Venezuela","flag":"🇻🇪","country_code":"VE","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Vietnam","flag":"🇻🇳","country_code":"VN","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Virgin Islands, British","flag":"🇻🇬","country_code":"VG","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Virgin Islands, U.S.","flag":"🇻🇮","country_code":"VI","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Wallis and Futuna","flag":"🇼🇫","country_code":"WF","timezone_offset":12,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Yemen","flag":"🇾🇪","country_code":"YE","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Zambia","flag":"🇿🇲","country_code":"ZM","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Zimbabwe","flag":"🇿🇼","country_code":"ZW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Unknown","flag":"❓","country_code":"XX","timezone_offset":0,"region":"Unknown","subregion":"Unknown"}

--- a/services/libs/tinybird/datasources/fixtures/country_mapping_no_flags_ds.ndjson
+++ b/services/libs/tinybird/datasources/fixtures/country_mapping_no_flags_ds.ndjson
@@ -1,0 +1,243 @@
+{"country":"Afghanistan","country_code":"AF","timezone_offset":4,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Åland Islands","country_code":"AX","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Albania","country_code":"AL","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Algeria","country_code":"DZ","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"American Samoa","country_code":"AS","timezone_offset":-11,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Andorra","country_code":"AD","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Angola","country_code":"AO","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Anguilla","country_code":"AI","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Antarctica","country_code":"AQ","timezone_offset":12,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Antigua and Barbuda","country_code":"AG","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Argentina","country_code":"AR","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Armenia","country_code":"AM","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Aruba","country_code":"AW","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Australia","country_code":"AU","timezone_offset":10,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Austria","country_code":"AT","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Azerbaijan","country_code":"AZ","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Bahamas","country_code":"BS","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Bahrain","country_code":"BH","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Bangladesh","country_code":"BD","timezone_offset":6,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Barbados","country_code":"BB","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Belarus","country_code":"BY","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Belgium","country_code":"BE","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Belize","country_code":"BZ","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Benin","country_code":"BJ","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Bermuda","country_code":"BM","timezone_offset":-3,"region":"Americas","subregion":"North America"}
+{"country":"Bhutan","country_code":"BT","timezone_offset":6,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Bolivia","country_code":"BO","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Bosnia and Herzegovina","country_code":"BA","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Botswana","country_code":"BW","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Brazil","country_code":"BR","timezone_offset":-2,"region":"Americas","subregion":"South America"}
+{"country":"British Indian Ocean Territory","country_code":"IO","timezone_offset":6,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Brunei Darussalam","country_code":"BN","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Bulgaria","country_code":"BG","timezone_offset":3,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Burkina Faso","country_code":"BF","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Burundi","country_code":"BI","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Cambodia","country_code":"KH","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Cameroon","country_code":"CM","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Canada","country_code":"CA","timezone_offset":-2,"region":"Americas","subregion":"North America"}
+{"country":"Cape Verde","country_code":"CV","timezone_offset":-1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Cayman Islands","country_code":"KY","timezone_offset":-5,"region":"Americas","subregion":"Caribbean"}
+{"country":"Central African Republic","country_code":"CF","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Chad","country_code":"TD","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Chile","country_code":"CL","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"China","country_code":"CN","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Christmas Island","country_code":"CX","timezone_offset":7,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Cocos (Keeling) Islands","country_code":"CC","timezone_offset":6,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Colombia","country_code":"CO","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Comoros","country_code":"KM","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Congo","country_code":"CG","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Congo, The Democratic Republic of the Congo","country_code":"CD","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Cook Islands","country_code":"CK","timezone_offset":-10,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Costa Rica","country_code":"CR","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Côte d'Ivoire","country_code":"CI","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Croatia","country_code":"HR","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Cuba","country_code":"CU","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Cyprus","country_code":"CY","timezone_offset":3,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Czech Republic","country_code":"CZ","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Denmark","country_code":"DK","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Djibouti","country_code":"DJ","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Dominica","country_code":"DM","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Dominican Republic","country_code":"DO","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Ecuador","country_code":"EC","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Egypt","country_code":"EG","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"El Salvador","country_code":"SV","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Equatorial Guinea","country_code":"GQ","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Eritrea","country_code":"ER","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Estonia","country_code":"EE","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Ethiopia","country_code":"ET","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Falkland Islands (Malvinas)","country_code":"FK","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Faroe Islands","country_code":"FO","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Fiji","country_code":"FJ","timezone_offset":12,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Finland","country_code":"FI","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"France","country_code":"FR","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"French Guiana","country_code":"GF","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"French Polynesia","country_code":"PF","timezone_offset":-10,"region":"Oceania","subregion":"Polynesia"}
+{"country":"French Southern Territories","country_code":"TF","timezone_offset":5,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Gabon","country_code":"GA","timezone_offset":1,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Gambia","country_code":"GM","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Georgia","country_code":"GE","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Germany","country_code":"DE","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Ghana","country_code":"GH","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Gibraltar","country_code":"GI","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Greece","country_code":"GR","timezone_offset":3,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Greenland","country_code":"GL","timezone_offset":-1,"region":"Americas","subregion":"North America"}
+{"country":"Grenada","country_code":"GD","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Guadeloupe","country_code":"GP","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Guam","country_code":"GU","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Guatemala","country_code":"GT","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Guernsey","country_code":"GG","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Guinea","country_code":"GN","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Guinea-Bissau","country_code":"GW","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Guyana","country_code":"GY","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Haiti","country_code":"HT","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Holy See (Vatican City State)","country_code":"VA","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Honduras","country_code":"HN","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Hong Kong","country_code":"HK","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Hungary","country_code":"HU","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Iceland","country_code":"IS","timezone_offset":0,"region":"Europe","subregion":"Northern Europe"}
+{"country":"India","country_code":"IN","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Indonesia","country_code":"ID","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Iran","country_code":"IR","timezone_offset":3,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Iraq","country_code":"IQ","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Ireland","country_code":"IE","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Isle of Man","country_code":"IM","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Israel","country_code":"IL","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Italy","country_code":"IT","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Jamaica","country_code":"JM","timezone_offset":-5,"region":"Americas","subregion":"Caribbean"}
+{"country":"Japan","country_code":"JP","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Jersey","country_code":"JE","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Jordan","country_code":"JO","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Kazakhstan","country_code":"KZ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Kenya","country_code":"KE","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Kiribati","country_code":"KI","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Korea, Democratic People's Republic of Korea","country_code":"KP","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Korea, Republic of South Korea","country_code":"KR","timezone_offset":9,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Kuwait","country_code":"KW","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Kyrgyzstan","country_code":"KG","timezone_offset":6,"region":"Asia","subregion":"Central Asia"}
+{"country":"Laos","country_code":"LA","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Latvia","country_code":"LV","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Lebanon","country_code":"LB","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Lesotho","country_code":"LS","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Liberia","country_code":"LR","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Libyan Arab Jamahiriya","country_code":"LY","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Liechtenstein","country_code":"LI","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Lithuania","country_code":"LT","timezone_offset":3,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Luxembourg","country_code":"LU","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Macao","country_code":"MO","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Macedonia","country_code":"MK","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Madagascar","country_code":"MG","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Malawi","country_code":"MW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Malaysia","country_code":"MY","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Maldives","country_code":"MV","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Mali","country_code":"ML","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Malta","country_code":"MT","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Marshall Islands","country_code":"MH","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Martinique","country_code":"MQ","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Mauritania","country_code":"MR","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Mauritius","country_code":"MU","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Mayotte","country_code":"YT","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Mexico","country_code":"MX","timezone_offset":-6,"region":"Americas","subregion":"North America"}
+{"country":"Micronesia, Federated States of Micronesia","country_code":"FM","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Moldova","country_code":"MD","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Monaco","country_code":"MC","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Mongolia","country_code":"MN","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Montenegro","country_code":"ME","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Montserrat","country_code":"MS","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Morocco","country_code":"MA","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Mozambique","country_code":"MZ","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Myanmar","country_code":"MM","timezone_offset":6,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Namibia","country_code":"NA","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Nauru","country_code":"NR","timezone_offset":12,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Nepal","country_code":"NP","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Netherlands","country_code":"NL","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"New Caledonia","country_code":"NC","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"New Zealand","country_code":"NZ","timezone_offset":12,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Nicaragua","country_code":"NI","timezone_offset":-6,"region":"Americas","subregion":"Central America"}
+{"country":"Niger","country_code":"NE","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Nigeria","country_code":"NG","timezone_offset":1,"region":"Africa","subregion":"Western Africa"}
+{"country":"Niue","country_code":"NU","timezone_offset":-11,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Norfolk Island","country_code":"NF","timezone_offset":11,"region":"Oceania","subregion":"Australia and New Zealand"}
+{"country":"Northern Mariana Islands","country_code":"MP","timezone_offset":10,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Norway","country_code":"NO","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Oman","country_code":"OM","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"Pakistan","country_code":"PK","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Palau","country_code":"PW","timezone_offset":9,"region":"Oceania","subregion":"Micronesia"}
+{"country":"Palestine","country_code":"PS","timezone_offset":2,"region":"Asia","subregion":"Western Asia"}
+{"country":"Panama","country_code":"PA","timezone_offset":-5,"region":"Americas","subregion":"Central America"}
+{"country":"Papua New Guinea","country_code":"PG","timezone_offset":10,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Paraguay","country_code":"PY","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Peru","country_code":"PE","timezone_offset":-5,"region":"Americas","subregion":"South America"}
+{"country":"Philippines","country_code":"PH","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Pitcairn","country_code":"PN","timezone_offset":-8,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Poland","country_code":"PL","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Portugal","country_code":"PT","timezone_offset":1,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Puerto Rico","country_code":"PR","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Qatar","country_code":"QA","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Romania","country_code":"RO","timezone_offset":3,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Russia","country_code":"RU","timezone_offset":2,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"Rwanda","country_code":"RW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Reunion","country_code":"RE","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Saint Barthelemy","country_code":"BL","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Helena, Ascension and Tristan Da Cunha","country_code":"SH","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Saint Kitts and Nevis","country_code":"KN","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Lucia","country_code":"LC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Martin","country_code":"MF","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Saint Pierre and Miquelon","country_code":"PM","timezone_offset":-2,"region":"Americas","subregion":"North America"}
+{"country":"Saint Vincent and the Grenadines","country_code":"VC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Samoa","country_code":"WS","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"San Marino","country_code":"SM","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Sao Tome and Principe","country_code":"ST","timezone_offset":0,"region":"Africa","subregion":"Middle Africa"}
+{"country":"Saudi Arabia","country_code":"SA","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Senegal","country_code":"SN","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Serbia","country_code":"RS","timezone_offset":2,"region":"Europe","subregion":"Southeast Europe"}
+{"country":"Seychelles","country_code":"SC","timezone_offset":4,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Sierra Leone","country_code":"SL","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Singapore","country_code":"SG","timezone_offset":8,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Slovakia","country_code":"SK","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Slovenia","country_code":"SI","timezone_offset":2,"region":"Europe","subregion":"Central Europe"}
+{"country":"Solomon Islands","country_code":"SB","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Somalia","country_code":"SO","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"South Africa","country_code":"ZA","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"South Sudan","country_code":"SS","timezone_offset":2,"region":"Africa","subregion":"Middle Africa"}
+{"country":"South Georgia and the South Sandwich Islands","country_code":"GS","timezone_offset":-2,"region":"Antarctic","subregion":"Unknown"}
+{"country":"Spain","country_code":"ES","timezone_offset":2,"region":"Europe","subregion":"Southern Europe"}
+{"country":"Sri Lanka","country_code":"LK","timezone_offset":5,"region":"Asia","subregion":"Southern Asia"}
+{"country":"Sudan","country_code":"SD","timezone_offset":2,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Suriname","country_code":"SR","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Svalbard and Jan Mayen","country_code":"SJ","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Swaziland","country_code":"SZ","timezone_offset":2,"region":"Africa","subregion":"Southern Africa"}
+{"country":"Sweden","country_code":"SE","timezone_offset":2,"region":"Europe","subregion":"Northern Europe"}
+{"country":"Switzerland","country_code":"CH","timezone_offset":2,"region":"Europe","subregion":"Western Europe"}
+{"country":"Syrian Arab Republic","country_code":"SY","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Taiwan","country_code":"TW","timezone_offset":8,"region":"Asia","subregion":"Eastern Asia"}
+{"country":"Tajikistan","country_code":"TJ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Tanzania, United Republic of Tanzania","country_code":"TZ","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Thailand","country_code":"TH","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Timor-Leste","country_code":"TL","timezone_offset":9,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Togo","country_code":"TG","timezone_offset":0,"region":"Africa","subregion":"Western Africa"}
+{"country":"Tokelau","country_code":"TK","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Tonga","country_code":"TO","timezone_offset":13,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Trinidad and Tobago","country_code":"TT","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Tunisia","country_code":"TN","timezone_offset":1,"region":"Africa","subregion":"Northern Africa"}
+{"country":"Turkey","country_code":"TR","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Turkmenistan","country_code":"TM","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Turks and Caicos Islands","country_code":"TC","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Tuvalu","country_code":"TV","timezone_offset":12,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Uganda","country_code":"UG","timezone_offset":3,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Ukraine","country_code":"UA","timezone_offset":3,"region":"Europe","subregion":"Eastern Europe"}
+{"country":"United Arab Emirates","country_code":"AE","timezone_offset":4,"region":"Asia","subregion":"Western Asia"}
+{"country":"United Kingdom","country_code":"GB","timezone_offset":1,"region":"Europe","subregion":"Northern Europe"}
+{"country":"United States","country_code":"US","timezone_offset":-4,"region":"Americas","subregion":"North America"}
+{"country":"Uruguay","country_code":"UY","timezone_offset":-3,"region":"Americas","subregion":"South America"}
+{"country":"Uzbekistan","country_code":"UZ","timezone_offset":5,"region":"Asia","subregion":"Central Asia"}
+{"country":"Vanuatu","country_code":"VU","timezone_offset":11,"region":"Oceania","subregion":"Melanesia"}
+{"country":"Venezuela","country_code":"VE","timezone_offset":-4,"region":"Americas","subregion":"South America"}
+{"country":"Vietnam","country_code":"VN","timezone_offset":7,"region":"Asia","subregion":"South-Eastern Asia"}
+{"country":"Virgin Islands, British","country_code":"VG","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Virgin Islands, U.S.","country_code":"VI","timezone_offset":-4,"region":"Americas","subregion":"Caribbean"}
+{"country":"Wallis and Futuna","country_code":"WF","timezone_offset":12,"region":"Oceania","subregion":"Polynesia"}
+{"country":"Yemen","country_code":"YE","timezone_offset":3,"region":"Asia","subregion":"Western Asia"}
+{"country":"Zambia","country_code":"ZM","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Zimbabwe","country_code":"ZW","timezone_offset":2,"region":"Africa","subregion":"Eastern Africa"}
+{"country":"Unknown","country_code":"XX","timezone_offset":0,"region":"Unknown","subregion":"Unknown"}

--- a/services/libs/tinybird/scripts/generate_country_region_fixtures.js
+++ b/services/libs/tinybird/scripts/generate_country_region_fixtures.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+//
+// Reads mledoze_countries_snapshot.json, a checked-in snapshot of countries.json
+// pinned at https://github.com/mledoze/countries/blob/09b28e3d03e6ca3fbbac996d716a50d929781e8c/countries.json
+// so re-running this script later doesn't depend on network access or pick up upstream drift.
+
+const fs = require('fs');
+const path = require('path');
+
+const PIPE_PATH = path.join(__dirname, '../pipes/country_mapping.pipe');
+const FIXTURES_DIR = path.join(__dirname, '../datasources/fixtures');
+const MLEDOZE_SNAPSHOT_PATH = path.join(__dirname, 'mledoze_countries_snapshot.json');
+
+const UNKNOWN = 'Unknown';
+
+// Sentinel row already present in the live country_mapping_ds/country_mapping_no_flags_ds
+// datasources (country_code 'XX') for unmapped/fuzzy-match-fallback locations. Not present
+// in country_mapping.pipe's literal, so it must be added explicitly to avoid dropping it
+// when fixtures are used to reload the live datasources.
+const UNKNOWN_COUNTRY_ROW = { country: 'Unknown', flag: '❓', country_code: 'XX', timezone_offset: 0 };
+
+// Extracts the ('Country', 'flag', 'CODE', offset) tuples from the arrayJoin([...]) literal
+// in country_mapping.pipe.
+function parsePipeCountries(pipeContent) {
+  const tupleRegex = /\(\s*'((?:[^'\\]|\\.|'')*)'\s*,\s*'((?:[^'\\]|\\.|'')*)'\s*,\s*'([A-Z]{2})'\s*,\s*(-?\d+)\s*\)/g;
+  const countries = [];
+  let match;
+  while ((match = tupleRegex.exec(pipeContent)) !== null) {
+    const unescape = (s) => s.replace(/''/g, "'");
+    countries.push({
+      country: unescape(match[1]),
+      flag: unescape(match[2]),
+      country_code: match[3],
+      timezone_offset: parseInt(match[4], 10),
+    });
+  }
+  return countries;
+}
+
+function main() {
+  const pipeContent = fs.readFileSync(PIPE_PATH, 'utf8');
+  const countries = parsePipeCountries(pipeContent);
+  countries.push(UNKNOWN_COUNTRY_ROW);
+  console.error(`Parsed ${countries.length - 1} countries from country_mapping.pipe, plus the 'XX' unknown-location sentinel row`);
+
+  const mledoze = JSON.parse(fs.readFileSync(MLEDOZE_SNAPSHOT_PATH, 'utf8'));
+
+  const byCca2 = new Map();
+  for (const entry of mledoze) {
+    if (entry.cca2) byCca2.set(entry.cca2, entry);
+  }
+
+  const rows = countries.map(({ country, flag, country_code, timezone_offset }) => {
+    const match = byCca2.get(country_code);
+    let region = UNKNOWN;
+    let subregion = UNKNOWN;
+    if (match) {
+      region = match.region || UNKNOWN;
+      subregion = match.subregion || UNKNOWN;
+    } else {
+      console.error(`WARNING: no mledoze match for country_code=${country_code} (${country}) — defaulting region/subregion to "${UNKNOWN}"`);
+    }
+    return { country, flag, country_code, timezone_offset, region, subregion };
+  });
+
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+
+  const withFlags = rows.map((row) => JSON.stringify(row));
+  fs.writeFileSync(path.join(FIXTURES_DIR, 'country_mapping_ds.ndjson'), withFlags.join('\n') + '\n');
+
+  const noFlags = rows.map(({ country, country_code, timezone_offset, region, subregion }) =>
+    JSON.stringify({ country, country_code, timezone_offset, region, subregion }),
+  );
+  fs.writeFileSync(path.join(FIXTURES_DIR, 'country_mapping_no_flags_ds.ndjson'), noFlags.join('\n') + '\n');
+
+  console.error(`Wrote ${rows.length} rows to country_mapping_ds.ndjson and country_mapping_no_flags_ds.ndjson`);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}

--- a/services/libs/tinybird/scripts/mledoze_countries_snapshot.json
+++ b/services/libs/tinybird/scripts/mledoze_countries_snapshot.json
@@ -1,0 +1,1252 @@
+[
+  {
+    "cca2": "AW",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "AF",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "AO",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "AI",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "AX",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "AL",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "AD",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "AE",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "AR",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "AM",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "AS",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "AQ",
+    "region": "Antarctic",
+    "subregion": ""
+  },
+  {
+    "cca2": "TF",
+    "region": "Antarctic",
+    "subregion": ""
+  },
+  {
+    "cca2": "AG",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "AU",
+    "region": "Oceania",
+    "subregion": "Australia and New Zealand"
+  },
+  {
+    "cca2": "AT",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "AZ",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "BI",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "BE",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "BJ",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "BF",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "BD",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "BG",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "BH",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "BS",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "BA",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "BL",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "SH",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "BY",
+    "region": "Europe",
+    "subregion": "Eastern Europe"
+  },
+  {
+    "cca2": "BZ",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "BM",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "BO",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "BQ",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "BR",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "BB",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "BN",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "BT",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "BV",
+    "region": "Antarctic",
+    "subregion": ""
+  },
+  {
+    "cca2": "BW",
+    "region": "Africa",
+    "subregion": "Southern Africa"
+  },
+  {
+    "cca2": "CF",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "CA",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "CC",
+    "region": "Oceania",
+    "subregion": "Australia and New Zealand"
+  },
+  {
+    "cca2": "CH",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "CL",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "CN",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "CI",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "CM",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "CD",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "CG",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "CK",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "CO",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "KM",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "CV",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "CR",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "CU",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "CW",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "CX",
+    "region": "Oceania",
+    "subregion": "Australia and New Zealand"
+  },
+  {
+    "cca2": "KY",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "CY",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "CZ",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "DE",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "DJ",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "DM",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "DK",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "DO",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "DZ",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "EC",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "EG",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "ER",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "EH",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "ES",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "EE",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "ET",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "FI",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "FJ",
+    "region": "Oceania",
+    "subregion": "Melanesia"
+  },
+  {
+    "cca2": "FK",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "FR",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "FO",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "FM",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "GA",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "GB",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "GE",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "GG",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "GH",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "GI",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "GN",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "GP",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "GM",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "GW",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "GQ",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "GR",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "GD",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "GL",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "GT",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "GF",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "GU",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "GY",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "HK",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "HM",
+    "region": "Antarctic",
+    "subregion": ""
+  },
+  {
+    "cca2": "HN",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "HR",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "HT",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "HU",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "ID",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "IM",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "IN",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "IO",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "IE",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "IR",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "IQ",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "IS",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "IL",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "IT",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "JM",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "JE",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "JO",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "JP",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "KZ",
+    "region": "Asia",
+    "subregion": "Central Asia"
+  },
+  {
+    "cca2": "KE",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "KG",
+    "region": "Asia",
+    "subregion": "Central Asia"
+  },
+  {
+    "cca2": "KH",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "KI",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "KN",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "KR",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "XK",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "KW",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "LA",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "LB",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "LR",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "LY",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "LC",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "LI",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "LK",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "LS",
+    "region": "Africa",
+    "subregion": "Southern Africa"
+  },
+  {
+    "cca2": "LT",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "LU",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "LV",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "MO",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "MF",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "MA",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "MC",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "MD",
+    "region": "Europe",
+    "subregion": "Eastern Europe"
+  },
+  {
+    "cca2": "MG",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "MV",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "MX",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "MH",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "MK",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "ML",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "MT",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "MM",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "ME",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "MN",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "MP",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "MZ",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "MR",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "MS",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "MQ",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "MU",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "MW",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "MY",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "YT",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "NA",
+    "region": "Africa",
+    "subregion": "Southern Africa"
+  },
+  {
+    "cca2": "NC",
+    "region": "Oceania",
+    "subregion": "Melanesia"
+  },
+  {
+    "cca2": "NE",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "NF",
+    "region": "Oceania",
+    "subregion": "Australia and New Zealand"
+  },
+  {
+    "cca2": "NG",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "NI",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "NU",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "NL",
+    "region": "Europe",
+    "subregion": "Western Europe"
+  },
+  {
+    "cca2": "NO",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "NP",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "NR",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "NZ",
+    "region": "Oceania",
+    "subregion": "Australia and New Zealand"
+  },
+  {
+    "cca2": "OM",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "PK",
+    "region": "Asia",
+    "subregion": "Southern Asia"
+  },
+  {
+    "cca2": "PA",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "PN",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "PE",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "PH",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "PW",
+    "region": "Oceania",
+    "subregion": "Micronesia"
+  },
+  {
+    "cca2": "PG",
+    "region": "Oceania",
+    "subregion": "Melanesia"
+  },
+  {
+    "cca2": "PL",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "PR",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "KP",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "PT",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "PY",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "PS",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "PF",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "QA",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "RE",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "RO",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "RU",
+    "region": "Europe",
+    "subregion": "Eastern Europe"
+  },
+  {
+    "cca2": "RW",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "SA",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "SD",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "SN",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "SG",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "GS",
+    "region": "Antarctic",
+    "subregion": ""
+  },
+  {
+    "cca2": "SJ",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "SB",
+    "region": "Oceania",
+    "subregion": "Melanesia"
+  },
+  {
+    "cca2": "SL",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "SV",
+    "region": "Americas",
+    "subregion": "Central America"
+  },
+  {
+    "cca2": "SM",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "SO",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "PM",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "RS",
+    "region": "Europe",
+    "subregion": "Southeast Europe"
+  },
+  {
+    "cca2": "SS",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "ST",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "SR",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "SK",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "SI",
+    "region": "Europe",
+    "subregion": "Central Europe"
+  },
+  {
+    "cca2": "SE",
+    "region": "Europe",
+    "subregion": "Northern Europe"
+  },
+  {
+    "cca2": "SZ",
+    "region": "Africa",
+    "subregion": "Southern Africa"
+  },
+  {
+    "cca2": "SX",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "SC",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "SY",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "TC",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "TD",
+    "region": "Africa",
+    "subregion": "Middle Africa"
+  },
+  {
+    "cca2": "TG",
+    "region": "Africa",
+    "subregion": "Western Africa"
+  },
+  {
+    "cca2": "TH",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "TJ",
+    "region": "Asia",
+    "subregion": "Central Asia"
+  },
+  {
+    "cca2": "TK",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "TM",
+    "region": "Asia",
+    "subregion": "Central Asia"
+  },
+  {
+    "cca2": "TL",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "TO",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "TT",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "TN",
+    "region": "Africa",
+    "subregion": "Northern Africa"
+  },
+  {
+    "cca2": "TR",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "TV",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "TW",
+    "region": "Asia",
+    "subregion": "Eastern Asia"
+  },
+  {
+    "cca2": "TZ",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "UG",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "UA",
+    "region": "Europe",
+    "subregion": "Eastern Europe"
+  },
+  {
+    "cca2": "UM",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "UY",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "US",
+    "region": "Americas",
+    "subregion": "North America"
+  },
+  {
+    "cca2": "UZ",
+    "region": "Asia",
+    "subregion": "Central Asia"
+  },
+  {
+    "cca2": "VA",
+    "region": "Europe",
+    "subregion": "Southern Europe"
+  },
+  {
+    "cca2": "VC",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "VE",
+    "region": "Americas",
+    "subregion": "South America"
+  },
+  {
+    "cca2": "VG",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "VI",
+    "region": "Americas",
+    "subregion": "Caribbean"
+  },
+  {
+    "cca2": "VN",
+    "region": "Asia",
+    "subregion": "South-Eastern Asia"
+  },
+  {
+    "cca2": "VU",
+    "region": "Oceania",
+    "subregion": "Melanesia"
+  },
+  {
+    "cca2": "WF",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "WS",
+    "region": "Oceania",
+    "subregion": "Polynesia"
+  },
+  {
+    "cca2": "YE",
+    "region": "Asia",
+    "subregion": "Western Asia"
+  },
+  {
+    "cca2": "ZA",
+    "region": "Africa",
+    "subregion": "Southern Africa"
+  },
+  {
+    "cca2": "ZM",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  },
+  {
+    "cca2": "ZW",
+    "region": "Africa",
+    "subregion": "Eastern Africa"
+  }
+]


### PR DESCRIPTION
## Summary

- Adds `region` and `subregion` String columns (trailing, non-breaking) to the `country_mapping_ds` and `country_mapping_no_flags_ds` Tinybird datasources, plus regenerated NDJSON fixtures, so a future Insights pipe can surface continent/sub-continent geography alongside the existing country/timezone mapping.
- The new fixtures are derived from a pinned snapshot of [mledoze/countries](https://github.com/mledoze/countries) (commit `09b28e3d03e6ca3fbbac996d716a50d929781e8c`), trimmed down to only the `cca2`, `region`, and `subregion` fields and checked into the repo as `services/libs/tinybird/scripts/mledoze_countries_snapshot.json` — this keeps fixture regeneration reproducible and independent of network access or upstream drift.
- A new one-off script, `services/libs/tinybird/scripts/generate_country_region_fixtures.js`, parses the existing hardcoded `(country, flag, code, offset)` tuple literal out of `pipes/country_mapping.pipe`, joins each row against the mledoze snapshot by ISO 3166-1 alpha-2 code, and writes the two NDJSON fixtures. It is not part of any build/deploy path — it's a generator, run once to produce the checked-in fixtures.
- Out of scope, intentionally: this PR does **not** wire region/subregion into any pipe or endpoint, and does **not** touch Insights frontend consumption — both are explicit follow-up work per the ticket. `pipes/country_mapping.pipe` itself (the source-of-truth pipe with the hardcoded literal) was **not modified** — it's a separate resource that happens to share a name prefix with the datasources touched here, easy to confuse but out of scope.

## Changes

| File | What changed |
|------|-------------|
| `services/libs/tinybird/datasources/country_mapping_ds.datasource` | Added trailing `region String, subregion String` columns to SCHEMA |
| `services/libs/tinybird/datasources/country_mapping_no_flags_ds.datasource` | Added trailing `region String, subregion String` columns to SCHEMA |
| `services/libs/tinybird/datasources/fixtures/country_mapping_ds.ndjson` | Regenerated, 242 rows, now includes region/subregion |
| `services/libs/tinybird/datasources/fixtures/country_mapping_no_flags_ds.ndjson` | Regenerated, 242 rows, now includes region/subregion |
| `services/libs/tinybird/scripts/generate_country_region_fixtures.js` | New one-off generator script: parses `country_mapping.pipe`'s tuple literal, joins against the mledoze snapshot, writes both fixtures |
| `services/libs/tinybird/scripts/mledoze_countries_snapshot.json` | New pinned snapshot of mledoze/countries at commit `09b28e3d03e6ca3fbbac996d716a50d929781e8c`, trimmed to cca2/region/subregion only |

## JIRA

IN-1188 — https://linuxfoundation.atlassian.net/browse/IN-1188 (Insights project ticket; the underlying Tinybird resources live in crowd.dev's `services/libs/tinybird/`, so the implementation PR is here by design)

## Deploy order

No deploy ordering constraints — self-contained to this repo. The new columns are trailing/additive on both datasources, and all 14 existing consumer pipes select explicit column tuples rather than `SELECT *`, so they are unaffected by this change and require no coordinated redeploy.

## DB migrations

No DB migrations. This is Tinybird datasource schema + fixture work, not a Postgres migration.

## Test plan

A full manual QA plan is saved to Obsidian at `LFX/qa/IN-1188-country-mapping-region-subregion.md`. Summary of what to verify:

1. Open both `.datasource` files and confirm `region` and `subregion` appear as trailing `String` columns after `timezone_offset`.
2. Using the `tb` CLI (see `services/libs/tinybird/README.md`), load both fixtures into a local Tinybird instance:
   - `tb datasource append country_mapping_ds services/libs/tinybird/datasources/fixtures/country_mapping_ds.ndjson`
   - `tb datasource append country_mapping_no_flags_ds services/libs/tinybird/datasources/fixtures/country_mapping_no_flags_ds.ndjson`
3. Confirm both datasources report a row count of 242 after loading.
4. Query both datasources and confirm: 0 rows have an empty-string `region`; exactly 3 rows have `subregion = "Unknown"` — Antarctica (AQ), French Southern Territories (TF), and South Georgia and the South Sandwich Islands (GS). All three should have `region = "Antarctic"` correctly populated (mledoze itself defines no subregion for Antarctic entries, so "Unknown" is expected and correct here, not a bug).
5. Spot check a handful of countries across different continents, e.g. US → region `Americas`, subregion `North America`; JP → region `Asia`, subregion `Eastern Asia`.
6. Push 1–2 of the existing consumer pipes locally (e.g. `contributions_with_local_time.pipe`) and confirm they still return correct results unchanged — they select explicit tuples like `(country, country_code, timezone_offset)`, never `SELECT *`, so the new trailing columns should not affect them.
7. Diff `pipes/country_mapping.pipe` against `main` and confirm it was NOT modified by this PR — it's a separate, unrelated pipe with a hardcoded literal and a confusingly similar name, explicitly out of scope here.
8. Grep all pipes under `services/libs/tinybird/pipes/` for `region` or `subregion` and confirm none reference the new columns yet — this ticket intentionally does not expose them via any pipe or endpoint; that's follow-up work.

## Checklist

- [x] `git commit --signoff -S` on every commit
- [x] MIT license header on the new source file (`generate_country_region_fixtures.js`)
- [x] PR diff under ~1000 lines of hand-authored change (raw diff is ~1821 lines but ~1736 of those are two generated NDJSON fixtures and a checked-in third-party JSON snapshot; hand-written logic is the two `.datasource` schema tweaks plus the ~80-line generator script)
- [x] No unrelated changes bundled
- [x] Cross-repo impact documented — none for this PR; Insights follow-up will be a separate PR once a pipe/endpoint exposes these columns

https://claude.ai/code/session_01Rk1S72wcPkhp1VPtckKVER

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive trailing schema and reference-data fixtures only; consumer pipes use explicit column lists so behavior should stay unchanged until follow-up work wires region/subregion.
> 
> **Overview**
> Adds **`region`** and **`subregion`** as trailing columns on `country_mapping_ds` and `country_mapping_no_flags_ds`, with JSON ingest paths on existing fields and the new geography fields.
> 
> Regenerates both NDJSON fixtures (~243 rows) so each country keeps the same name, code, flag, and timezone while gaining continent/sub-continent values from a pinned **mledoze/countries** snapshot joined by ISO `cca2`. The **`XX` Unknown** sentinel row is preserved explicitly because it is not in `country_mapping.pipe`.
> 
> Introduces **`generate_country_region_fixtures.js`** (one-off, not on the deploy path) plus checked-in **`mledoze_countries_snapshot.json`** for reproducible fixture generation. **No pipes or API endpoints** are updated in this PR; existing consumers still select explicit tuples like `(country, country_code, timezone_offset)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308b4d9d44104e4b0c1f9ed970fcbaf92bd2907b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->