### PR TITLE
feat: add sonatype fields (CM-1308)

### DIFF
--- a/backend/src/osspckgs/migrations/V1783123200__sonatype_popularity.sql
+++ b/backend/src/osspckgs/migrations/V1783123200__sonatype_popularity.sql
@@ -1,0 +1,12 @@
+-- Sonatype popularity signal (first delivery: Maven P0, top 500 components).
+-- Sonatype could not provide raw Maven download counts, so instead they deliver a
+-- popularity score derived from their SCA telemetry: normalized 0-100 per ecosystem,
+-- tiered P0-P3. Stored in dedicated columns (not JSONB) because score/rank/tier are
+-- queried independently. Only sonatype_popularity_score feeds rank_packages(); rank and
+-- tier are kept for display/audit. No index on first pass (dataset is small, 500-2k rows).
+ALTER TABLE packages
+    ADD COLUMN IF NOT EXISTS sonatype_popularity_score numeric,      -- 0-100, normalized per ecosystem; consumed by rank_packages()
+    ADD COLUMN IF NOT EXISTS sonatype_rank              int,         -- rank within the Sonatype list; display/audit only
+    ADD COLUMN IF NOT EXISTS sonatype_tier              text,        -- 'P0' | 'P1' | 'P2' | 'P3'
+    ADD COLUMN IF NOT EXISTS sonatype_snapshot_at       timestamptz, -- timestamp of the Sonatype snapshot the row came from
+    ADD COLUMN IF NOT EXISTS sonatype_updated_at        timestamptz; -- our last upsert of the sonatype_* fields


### PR DESCRIPTION
## Summary

Adds the schema foundation for the Sonatype popularity signal on Maven packages.

Sonatype could not deliver raw monthly Maven download counts, so instead they provide a **popularity score** derived from their SCA telemetry — normalized 0–100 per ecosystem, tiered P0–P3. Today the Maven ranking pipeline has no popularity signal at all (only `dependent_count` and `transitive_dependent_count` feed criticality), so industry-critical packages that are under-represented as dependency targets in our graph get missed.

This PR is **step 1 of 3**: it only introduces the columns that will hold the Sonatype data. The ingestion script and the ranking-function change land in follow-up PRs:
- **This PR** — schema: add `sonatype_*` columns to `packages`.
- Follow-up — one-shot CSV ingestion script (`--file`, insert-if-missing, idempotent).
- Follow-up — feed `sonatype_popularity_score` into `rank_packages()` as a 4th signal.

## Changes

- New Flyway migration `V1783123200__sonatype_popularity.sql` adding five columns to `packages`:
  - `sonatype_popularity_score numeric` — 0–100, normalized per ecosystem; the only column consumed by `rank_packages()`.
  - `sonatype_rank int` — rank within the Sonatype list; display/audit only, not consumed by ranking.
  - `sonatype_tier text` — `P0` | `P1` | `P2` | `P3`.
  - `sonatype_snapshot_at timestamptz` — timestamp of the Sonatype snapshot the row came from.
  - `sonatype_updated_at timestamptz` — timestamp of our last upsert of the `sonatype_*` fields.
- **Columns are nullable with no `DEFAULT`** — intentional. Existing rows (all non-Maven, plus Maven rows not in Sonatype's list) stay `NULL`, meaning "no Sonatype signal". This is what lets the follow-up ranking change drop the signal for other ecosystems automatically (`ecosystem_signal_total = 0` → excluded), with zero impact on npm/pypi.
- **Dedicated columns, not JSONB** — score/rank/tier are queried independently.
- **No index on first pass** — dataset is small (first delivery is P0 only, ~500 rows). Add later if a real query pattern demands it.
- Instant, non-blocking migration (`ADD COLUMN ... NULL` with no default → no table rewrite).


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1308](https://linuxfoundation.atlassian.net/browse/CM-1308)

[CM-1308]: https://linuxfoundation.atlassian.net/browse/CM-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only, nullable column additions with no behavior or ranking changes in this PR.
> 
> **Overview**
> Adds Flyway migration **`V1783123200__sonatype_popularity.sql`** that extends **`packages`** with five nullable Sonatype fields: **`sonatype_popularity_score`**, **`sonatype_rank`**, **`sonatype_tier`**, **`sonatype_snapshot_at`**, and **`sonatype_updated_at`**.
> 
> The migration is additive only (`ADD COLUMN IF NOT EXISTS`, no defaults, no indexes). Existing rows stay **`NULL`** until follow-up ingestion and **`rank_packages()`** wiring land in later PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec661c7e4c0795fe9bdda01f6b55b7e2801f504b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->