### PR TITLE
feat: expose org domains via work-history and org name search (CM-1266)

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -779,8 +779,14 @@ paths:
   /organizations:
     get:
       operationId: getOrganization
-      summary: Look up an organization by domain
-      description: Find a verified organization by its primary domain.
+      summary: Look up or search organizations
+      description: >
+        Look up a single verified organization by its primary domain (`domain`),
+        or search organizations by display name (`name`). Exactly one of the two
+        query parameters must be provided.
+
+        When `name` is provided the response is a paginated list; when `domain`
+        is provided the response is a single organization object.
       tags:
         - Organizations
       security:
@@ -789,23 +795,70 @@ paths:
       parameters:
         - name: domain
           in: query
-          required: true
-          description: Primary domain of the organization.
+          required: false
+          description: Primary domain of the organization. Mutually exclusive with `name`.
           schema:
             type: string
             minLength: 1
           example: linuxfoundation.org
+        - name: name
+          in: query
+          required: false
+          description: >
+            Display name to search for (case-insensitive substring match).
+            Mutually exclusive with `domain`.
+          schema:
+            type: string
+            minLength: 1
+          example: Linux Foundation
+        - name: page
+          in: query
+          required: false
+          description: Page number (1-based). Only used when `name` is provided.
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: pageSize
+          in: query
+          required: false
+          description: Number of results per page (max 100). Only used when `name` is provided.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
-          description: Organization found.
+          description: >
+            Organization found (domain lookup) or search results returned (name search).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Organization'
-              example:
-                id: 550e8400-e29b-41d4-a716-446655440000
-                name: Linux Foundation
-                logo: https://example.com/logo.png
+                oneOf:
+                  - $ref: '#/components/schemas/Organization'
+                  - $ref: '#/components/schemas/OrganizationSearchResponse'
+              examples:
+                domainLookup:
+                  summary: Single organization by domain
+                  value:
+                    id: 550e8400-e29b-41d4-a716-446655440000
+                    name: Linux Foundation
+                    logo: https://example.com/logo.png
+                nameSearch:
+                  summary: Paginated name search results
+                  value:
+                    organizations:
+                      - id: 550e8400-e29b-41d4-a716-446655440000
+                        name: Linux Foundation
+                        domains:
+                          - linuxfoundation.org
+                        logo: https://example.com/logo.png
+                    page: 1
+                    pageSize: 20
+                    total: 1
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1243,6 +1296,11 @@ components:
             - string
             - 'null'
           description: URL of the organization logo.
+        domains:
+          type: array
+          items:
+            type: string
+          description: Verified primary domains for the organization. Empty when none are on record.
         jobTitle:
           type:
             - string
@@ -1541,6 +1599,50 @@ components:
         logo:
           type: string
           description: URL of the organization logo. Only present if available.
+
+    OrganizationWithDomains:
+      type: object
+      required:
+        - id
+        - name
+        - domains
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: Display name of the organization.
+        domains:
+          type: array
+          items:
+            type: string
+          description: Verified primary domains for the organization.
+        logo:
+          type: string
+          description: URL of the organization logo. Only present if available.
+
+    OrganizationSearchResponse:
+      type: object
+      required:
+        - organizations
+        - page
+        - pageSize
+        - total
+      properties:
+        organizations:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrganizationWithDomains'
+        page:
+          type: integer
+          description: Current page number (1-based).
+        pageSize:
+          type: integer
+          description: Number of results per page.
+        total:
+          type: integer
+          description: Total number of matching organizations.
 
     HttpError:
       type: object

--- a/backend/src/api/public/v1/members/work-experiences/getMemberWorkExperiences.ts
+++ b/backend/src/api/public/v1/members/work-experiences/getMemberWorkExperiences.ts
@@ -5,6 +5,7 @@ import { NotFoundError } from '@crowd/common'
 import {
   MemberField,
   fetchManyMemberOrgsWithOrgData,
+  fetchManyOrganizationVerifiedPrimaryDomains,
   findMemberById,
   optionsQx,
 } from '@crowd/data-access-layer'
@@ -28,8 +29,14 @@ export async function getMemberWorkExperiences(req: Request, res: Response): Pro
   }
 
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId])
-  const workExperiences = groupMemberOrganizations(orgsMap.get(memberId) ?? []).map(
-    toMemberWorkExperience,
+  const grouped = groupMemberOrganizations(orgsMap.get(memberId) ?? [])
+
+  const orgIds = [...new Set(grouped.map((r) => r.organizationId).filter(Boolean))]
+  const primaryDomains = await fetchManyOrganizationVerifiedPrimaryDomains(qx, orgIds)
+  const domainsMap = new Map(primaryDomains.map((d) => [d.orgId, d.domains]))
+
+  const workExperiences = grouped.map((role) =>
+    toMemberWorkExperience(role, domainsMap.get(role.organizationId) ?? []),
   )
 
   ok(res, { memberId, workExperiences })

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -22,18 +22,14 @@ const DEFAULT_PAGE_SIZE = 20
 const MAX_PAGE_SIZE = 100
 
 const querySchema = z.union([
-  z
-    .object({
-      domain: z.string().trim().min(1),
-    })
-    .strict(),
-  z
-    .object({
-      name: z.string().trim().min(1),
-      page: z.coerce.number().int().min(1).default(1),
-      pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-    })
-    .strict(),
+  z.object({
+    domain: z.string().trim().min(1),
+  }),
+  z.object({
+    name: z.string().trim().min(1),
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+  }),
 ])
 
 export async function getOrganization(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -6,6 +6,7 @@ import {
   OrgIdentityField,
   OrganizationField,
   fetchManyOrganizationVerifiedPrimaryDomains,
+  findManyOrgAttributes,
   findOrgAttributes,
   findOrgById,
   optionsQx,
@@ -20,31 +21,32 @@ import { validateOrThrow } from '@/utils/validation'
 const DEFAULT_PAGE_SIZE = 20
 const MAX_PAGE_SIZE = 100
 
-const querySchema = z
-  .object({
-    domain: z.string().trim().min(1).optional(),
-    name: z.string().trim().min(1).optional(),
-    page: z.coerce.number().int().min(1).default(1),
-    pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
-  })
-  .refine((d) => !!(d.domain ?? d.name), {
-    message: 'Either domain or name is required',
-  })
-  .refine((d) => !(d.domain && d.name), {
-    message: 'Only one of domain or name may be provided',
-  })
+const querySchema = z.union([
+  z
+    .object({
+      domain: z.string().trim().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      name: z.string().trim().min(1),
+      page: z.coerce.number().int().min(1).default(1),
+      pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+    })
+    .strict(),
+])
 
 export async function getOrganization(req: Request, res: Response): Promise<void> {
-  const { domain, name, page, pageSize } = validateOrThrow(querySchema, req.query)
+  const query = validateOrThrow(querySchema, req.query)
 
   const qx = optionsQx(req)
 
-  if (domain) {
+  if ('domain' in query) {
     const results = await queryOrgIdentities(qx, {
       fields: [OrgIdentityField.ORGANIZATION_ID],
       filter: {
         and: [
-          { value: { eq: normalizeHostname(domain, false) } },
+          { value: { eq: normalizeHostname(query.domain, false) } },
           { type: { eq: OrganizationIdentityType.PRIMARY_DOMAIN } },
           { verified: { eq: true } },
         ],
@@ -74,19 +76,34 @@ export async function getOrganization(req: Request, res: Response): Promise<void
   }
 
   // name search — fuzzy, paginated
+  const { name, page, pageSize } = query
   const offset = (page - 1) * pageSize
   const { rows, total } = await searchOrganizationsByName(qx, name, { limit: pageSize, offset })
 
   const orgIds = rows.map((r) => r.id)
-  const primaryDomains = await fetchManyOrganizationVerifiedPrimaryDomains(qx, orgIds)
+  const [primaryDomains, attributesByOrg] = orgIds.length
+    ? await Promise.all([
+        fetchManyOrganizationVerifiedPrimaryDomains(qx, orgIds),
+        findManyOrgAttributes(qx, orgIds),
+      ])
+    : [[], []]
   const domainsMap = new Map(primaryDomains.map((d) => [d.orgId, d.domains]))
+  const logoMap = new Map(
+    attributesByOrg.map((a) => [
+      a.organizationId,
+      a.attributes.find((x) => x.name === 'logo')?.value,
+    ]),
+  )
 
-  const organizations = rows.map((r) => ({
-    id: r.id,
-    name: r.displayName,
-    domains: domainsMap.get(r.id) ?? [],
-    ...(r.logo ? { logo: r.logo } : {}),
-  }))
+  const organizations = rows.map((r) => {
+    const logo = logoMap.get(r.id)
+    return {
+      id: r.id,
+      name: r.displayName,
+      domains: domainsMap.get(r.id) ?? [],
+      ...(logo ? { logo } : {}),
+    }
+  })
 
   ok(res, { organizations, page, pageSize, total })
 }

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -5,53 +5,88 @@ import { NotFoundError, normalizeHostname } from '@crowd/common'
 import {
   OrgIdentityField,
   OrganizationField,
+  fetchManyOrganizationVerifiedPrimaryDomains,
   findOrgAttributes,
   findOrgById,
   optionsQx,
   queryOrgIdentities,
+  searchOrganizationsByName,
 } from '@crowd/data-access-layer'
 import { OrganizationIdentityType } from '@crowd/types'
 
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-const querySchema = z.object({
-  domain: z.string().trim().min(1),
-})
+const DEFAULT_PAGE_SIZE = 20
+const MAX_PAGE_SIZE = 100
+
+const querySchema = z
+  .object({
+    domain: z.string().trim().min(1).optional(),
+    name: z.string().trim().min(1).optional(),
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
+  })
+  .refine((d) => !!(d.domain ?? d.name), {
+    message: 'Either domain or name is required',
+  })
+  .refine((d) => !(d.domain && d.name), {
+    message: 'Only one of domain or name may be provided',
+  })
 
 export async function getOrganization(req: Request, res: Response): Promise<void> {
-  const { domain } = validateOrThrow(querySchema, req.query)
+  const { domain, name, page, pageSize } = validateOrThrow(querySchema, req.query)
 
   const qx = optionsQx(req)
 
-  const results = await queryOrgIdentities(qx, {
-    fields: [OrgIdentityField.ORGANIZATION_ID],
-    filter: {
-      and: [
-        { value: { eq: normalizeHostname(domain, false) } },
-        { type: { eq: OrganizationIdentityType.PRIMARY_DOMAIN } },
-        { verified: { eq: true } },
-      ],
-    },
-  })
+  if (domain) {
+    const results = await queryOrgIdentities(qx, {
+      fields: [OrgIdentityField.ORGANIZATION_ID],
+      filter: {
+        and: [
+          { value: { eq: normalizeHostname(domain, false) } },
+          { type: { eq: OrganizationIdentityType.PRIMARY_DOMAIN } },
+          { verified: { eq: true } },
+        ],
+      },
+    })
 
-  const organizationId = results[0]?.organizationId
+    const organizationId = results[0]?.organizationId
 
-  if (!organizationId) {
-    throw new NotFoundError('Organization not found')
+    if (!organizationId) {
+      throw new NotFoundError('Organization not found')
+    }
+
+    const org = await findOrgById(qx, organizationId, [
+      OrganizationField.ID,
+      OrganizationField.DISPLAY_NAME,
+    ])
+
+    const attributes = await findOrgAttributes(qx, organizationId)
+    const logo = attributes.find((a) => a.name === 'logo')?.value
+
+    ok(res, {
+      id: org.id,
+      name: org.displayName,
+      ...(logo ? { logo } : {}),
+    })
+    return
   }
 
-  const org = await findOrgById(qx, organizationId, [
-    OrganizationField.ID,
-    OrganizationField.DISPLAY_NAME,
-  ])
+  // name search — fuzzy, paginated
+  const offset = (page - 1) * pageSize
+  const { rows, total } = await searchOrganizationsByName(qx, name, { limit: pageSize, offset })
 
-  const attributes = await findOrgAttributes(qx, organizationId)
-  const logo = attributes.find((a) => a.name === 'logo')?.value
+  const orgIds = rows.map((r) => r.id)
+  const primaryDomains = await fetchManyOrganizationVerifiedPrimaryDomains(qx, orgIds)
+  const domainsMap = new Map(primaryDomains.map((d) => [d.orgId, d.domains]))
 
-  ok(res, {
-    id: org.id,
-    name: org.displayName,
-    ...(logo ? { logo } : {}),
-  })
+  const organizations = rows.map((r) => ({
+    id: r.id,
+    name: r.displayName,
+    domains: domainsMap.get(r.id) ?? [],
+    ...(r.logo ? { logo: r.logo } : {}),
+  }))
+
+  ok(res, { organizations, page, pageSize, total })
 }

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -24,9 +24,11 @@ const MAX_PAGE_SIZE = 100
 const querySchema = z.union([
   z.object({
     domain: z.string().trim().min(1),
+    name: z.undefined().optional(),
   }),
   z.object({
     name: z.string().trim().min(1),
+    domain: z.undefined().optional(),
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(MAX_PAGE_SIZE).default(DEFAULT_PAGE_SIZE),
   }),
@@ -58,7 +60,12 @@ export async function getOrganization(req: Request, res: Response): Promise<void
     const org = await findOrgById(qx, organizationId, [
       OrganizationField.ID,
       OrganizationField.DISPLAY_NAME,
+      OrganizationField.DELETED_AT,
     ])
+
+    if (!org || org.deletedAt) {
+      throw new NotFoundError('Organization not found')
+    }
 
     const attributes = await findOrgAttributes(qx, organizationId)
     const logo = attributes.find((a) => a.name === 'logo')?.value

--- a/backend/src/utils/mapper.ts
+++ b/backend/src/utils/mapper.ts
@@ -123,12 +123,13 @@ export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[
     })
 }
 
-export function toMemberWorkExperience(mo: IMemberRoleWithOrganization) {
+export function toMemberWorkExperience(mo: IMemberRoleWithOrganization, domains: string[] = []) {
   return {
     id: mo.id,
     organizationId: mo.organizationId,
     organizationName: mo.organizationName,
     organizationLogo: mo.organizationLogo,
+    domains,
     jobTitle: mo.title ?? null,
     verified: mo.verified ?? false,
     verifiedBy: mo.verifiedBy ?? null,

--- a/backend/src/utils/mapper.ts
+++ b/backend/src/utils/mapper.ts
@@ -123,13 +123,13 @@ export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[
     })
 }
 
-export function toMemberWorkExperience(mo: IMemberRoleWithOrganization, domains: string[] = []) {
+export function toMemberWorkExperience(mo: IMemberRoleWithOrganization, domains?: string[]) {
   return {
     id: mo.id,
     organizationId: mo.organizationId,
     organizationName: mo.organizationName,
     organizationLogo: mo.organizationLogo,
-    domains,
+    ...(domains !== undefined ? { domains } : {}),
     jobTitle: mo.title ?? null,
     verified: mo.verified ?? false,
     verifiedBy: mo.verifiedBy ?? null,

--- a/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
+++ b/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
@@ -20,19 +20,32 @@ vi.mock('../../segments', () => ({ findLfSegmentByName: vi.fn() }))
 
 describe('searchOrganizationsByName', () => {
   let mockSelect: ReturnType<typeof vi.fn>
+  let mockSelectOne: ReturnType<typeof vi.fn>
   let mockQx: QueryExecutor
 
   beforeEach(() => {
     mockSelect = vi.fn()
-    mockQx = { select: mockSelect } as unknown as QueryExecutor
+    mockSelectOne = vi.fn()
+    mockQx = { select: mockSelect, selectOne: mockSelectOne } as unknown as QueryExecutor
   })
 
-  it('returns empty rows and zero total when DB returns no rows', async () => {
+  it('returns empty rows and zero total when DB returns no rows at offset 0', async () => {
     mockSelect.mockResolvedValueOnce([])
 
     const result = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })
 
     expect(result).toEqual({ rows: [], total: 0 })
+    expect(mockSelectOne).not.toHaveBeenCalled()
+  })
+
+  it('runs a COUNT fallback when the page is empty but offset > 0', async () => {
+    mockSelect.mockResolvedValueOnce([])
+    mockSelectOne.mockResolvedValueOnce({ total: '42' })
+
+    const result = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 100 })
+
+    expect(mockSelectOne).toHaveBeenCalledOnce()
+    expect(result).toEqual({ rows: [], total: 42 })
   })
 
   it('strips the internal total column from returned rows', async () => {
@@ -64,8 +77,18 @@ describe('searchOrganizationsByName', () => {
     expect(params.pattern).toBe('%linux%')
   })
 
+  it('escapes % and _ wildcards in the user input', async () => {
+    mockSelect.mockResolvedValueOnce([])
+
+    await searchOrganizationsByName(mockQx, '50%_off', { limit: 10, offset: 0 })
+
+    const [, params] = mockSelect.mock.calls[0]
+    expect(params.pattern).toBe('%50\\%\\_off%')
+  })
+
   it('passes limit and offset to the query', async () => {
     mockSelect.mockResolvedValueOnce([])
+    mockSelectOne.mockResolvedValueOnce({ total: '0' })
 
     await searchOrganizationsByName(mockQx, 'linux', { limit: 5, offset: 40 })
 

--- a/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
+++ b/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { QueryExecutor } from '../../queryExecutor'
+import { searchOrganizationsByName } from '../base'
+
+vi.mock('@crowd/database', () => ({}))
+vi.mock('@crowd/logging', () => ({
+  getServiceLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  getServiceChildLogger: () => ({
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  LoggerBase: class {},
+}))
+vi.mock('@crowd/redis', () => ({}))
+// segments/index.ts imports @crowd/integrations which requires filesystem integration folders
+vi.mock('../../segments', () => ({ findLfSegmentByName: vi.fn() }))
+
+describe('searchOrganizationsByName', () => {
+  let mockSelect: ReturnType<typeof vi.fn>
+  let mockQx: QueryExecutor
+
+  beforeEach(() => {
+    mockSelect = vi.fn()
+    mockQx = { select: mockSelect } as unknown as QueryExecutor
+  })
+
+  it('returns empty rows and zero total when DB returns no rows', async () => {
+    mockSelect.mockResolvedValueOnce([])
+
+    const result = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })
+
+    expect(result).toEqual({ rows: [], total: 0 })
+  })
+
+  it('strips the internal total column from returned rows', async () => {
+    mockSelect.mockResolvedValueOnce([
+      { id: 'org-1', displayName: 'Acme Corp', logo: null, total: '1' },
+    ])
+
+    const { rows } = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })
+
+    expect(rows[0]).not.toHaveProperty('total')
+    expect(rows[0]).toEqual({ id: 'org-1', displayName: 'Acme Corp', logo: null })
+  })
+
+  it('reads total from the first row', async () => {
+    mockSelect.mockResolvedValueOnce([
+      { id: 'org-1', displayName: 'Acme Corp', logo: null, total: '42' },
+      { id: 'org-2', displayName: 'Acme Ltd', logo: null, total: '42' },
+    ])
+
+    const { total } = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })
+
+    expect(total).toBe(42)
+  })
+
+  it('passes ILIKE pattern wrapping the name in % wildcards', async () => {
+    mockSelect.mockResolvedValueOnce([])
+
+    await searchOrganizationsByName(mockQx, 'linux', { limit: 10, offset: 0 })
+
+    const [, params] = mockSelect.mock.calls[0]
+    expect(params.pattern).toBe('%linux%')
+  })
+
+  it('passes limit and offset to the query', async () => {
+    mockSelect.mockResolvedValueOnce([])
+
+    await searchOrganizationsByName(mockQx, 'linux', { limit: 5, offset: 40 })
+
+    const [, params] = mockSelect.mock.calls[0]
+    expect(params.limit).toBe(5)
+    expect(params.offset).toBe(40)
+  })
+
+  it('propagates errors thrown by qx.select', async () => {
+    mockSelect.mockRejectedValueOnce(new Error('DB unavailable'))
+
+    await expect(
+      searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 }),
+    ).rejects.toThrow('DB unavailable')
+  })
+})

--- a/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
+++ b/services/libs/data-access-layer/src/organizations/__tests__/searchOrganizationsByName.test.ts
@@ -36,20 +36,18 @@ describe('searchOrganizationsByName', () => {
   })
 
   it('strips the internal total column from returned rows', async () => {
-    mockSelect.mockResolvedValueOnce([
-      { id: 'org-1', displayName: 'Acme Corp', logo: null, total: '1' },
-    ])
+    mockSelect.mockResolvedValueOnce([{ id: 'org-1', displayName: 'Acme Corp', total: '1' }])
 
     const { rows } = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })
 
     expect(rows[0]).not.toHaveProperty('total')
-    expect(rows[0]).toEqual({ id: 'org-1', displayName: 'Acme Corp', logo: null })
+    expect(rows[0]).toEqual({ id: 'org-1', displayName: 'Acme Corp' })
   })
 
   it('reads total from the first row', async () => {
     mockSelect.mockResolvedValueOnce([
-      { id: 'org-1', displayName: 'Acme Corp', logo: null, total: '42' },
-      { id: 'org-2', displayName: 'Acme Ltd', logo: null, total: '42' },
+      { id: 'org-1', displayName: 'Acme Corp', total: '42' },
+      { id: 'org-2', displayName: 'Acme Ltd', total: '42' },
     ])
 
     const { total } = await searchOrganizationsByName(mockQx, 'acme', { limit: 20, offset: 0 })

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -152,8 +152,7 @@ export async function findOrganizationsByName(
 export interface IOrganizationSearchResult {
   id: string
   displayName: string
-  logo: string | null
-  total: number
+  total: string
 }
 
 export async function searchOrganizationsByName(
@@ -167,7 +166,6 @@ export async function searchOrganizationsByName(
       SELECT
         o.id,
         o."displayName",
-        o.logo,
         COUNT(*) OVER() AS total
       FROM organizations o
       WHERE o."displayName" ILIKE $(pattern)
@@ -179,7 +177,7 @@ export async function searchOrganizationsByName(
   )
   const total = rows.length > 0 ? Number(rows[0].total) : 0
   return {
-    rows: rows.map((r) => ({ id: r.id, displayName: r.displayName, logo: r.logo ?? null })),
+    rows: rows.map((r) => ({ id: r.id, displayName: r.displayName })),
     total,
   }
 }

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -149,6 +149,41 @@ export async function findOrganizationsByName(
   )
 }
 
+export interface IOrganizationSearchResult {
+  id: string
+  displayName: string
+  logo: string | null
+  total: number
+}
+
+export async function searchOrganizationsByName(
+  qx: QueryExecutor,
+  name: string,
+  options: { limit: number; offset: number },
+): Promise<{ rows: Omit<IOrganizationSearchResult, 'total'>[]; total: number }> {
+  const { limit, offset } = options
+  const rows: IOrganizationSearchResult[] = await qx.select(
+    `
+      SELECT
+        o.id,
+        o."displayName",
+        o.logo,
+        COUNT(*) OVER() AS total
+      FROM organizations o
+      WHERE o."displayName" ILIKE $(pattern)
+        AND o."deletedAt" IS NULL
+      ORDER BY o."displayName"
+      LIMIT $(limit) OFFSET $(offset)
+    `,
+    { pattern: `%${name}%`, limit, offset },
+  )
+  const total = rows.length > 0 ? Number(rows[0].total) : 0
+  return {
+    rows: rows.map((r) => ({ id: r.id, displayName: r.displayName, logo: r.logo ?? null })),
+    total,
+  }
+}
+
 export async function findOrgByVerifiedDomain(
   qx: QueryExecutor,
   identity: IOrganizationIdentity,

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -161,6 +161,10 @@ export async function searchOrganizationsByName(
   options: { limit: number; offset: number },
 ): Promise<{ rows: Omit<IOrganizationSearchResult, 'total'>[]; total: number }> {
   const { limit, offset } = options
+  // Escape LIKE wildcards in user input so callers can't broaden the match.
+  const escaped = name.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
+  const pattern = `%${escaped}%`
+
   const rows: IOrganizationSearchResult[] = await qx.select(
     `
       SELECT
@@ -168,18 +172,37 @@ export async function searchOrganizationsByName(
         o."displayName",
         COUNT(*) OVER() AS total
       FROM organizations o
-      WHERE o."displayName" ILIKE $(pattern)
+      WHERE o."displayName" ILIKE $(pattern) ESCAPE '\\'
         AND o."deletedAt" IS NULL
-      ORDER BY o."displayName"
+      ORDER BY o."displayName", o.id
       LIMIT $(limit) OFFSET $(offset)
     `,
-    { pattern: `%${name}%`, limit, offset },
+    { pattern, limit, offset },
   )
-  const total = rows.length > 0 ? Number(rows[0].total) : 0
-  return {
-    rows: rows.map((r) => ({ id: r.id, displayName: r.displayName })),
-    total,
+
+  if (rows.length > 0) {
+    return {
+      rows: rows.map((r) => ({ id: r.id, displayName: r.displayName })),
+      total: Number(rows[0].total),
+    }
   }
+
+  // Empty page. If offset > 0, matches may exist beyond it — run a real COUNT.
+  if (offset === 0) {
+    return { rows: [], total: 0 }
+  }
+
+  const countRow = await qx.selectOne(
+    `
+      SELECT COUNT(*)::text AS total
+      FROM organizations o
+      WHERE o."displayName" ILIKE $(pattern) ESCAPE '\\'
+        AND o."deletedAt" IS NULL
+    `,
+    { pattern },
+  )
+
+  return { rows: [], total: Number(countRow.total) }
 }
 
 export async function findOrgByVerifiedDomain(


### PR DESCRIPTION
## Summary

- **Option A**: enriches `GET /members/:memberId/work-experiences` — each work-experience entry now includes `domains: string[]` (verified primary domains for the organization), populated via a single bulk query using the existing `fetchManyOrganizationVerifiedPrimaryDomains` DAL function.
- **Option B**: extends `GET /organizations` to accept either `?domain=` (existing, unchanged) or `?name=` (new fuzzy/prefix search). The `?name=` path returns a paginated list `{ organizations, page, pageSize, total }` where each item includes `id`, `name`, `domains[]`, and optional `logo`.
- New `searchOrganizationsByName` DAL function with `ILIKE '%name%'` + `COUNT(*) OVER()` window for efficient pagination.
- `openapi.yaml` updated with new fields, `OrganizationWithDomains` and `OrganizationSearchResponse` component schemas, and revised `GET /organizations` path spec.
- 6 Vitest unit tests for `searchOrganizationsByName`.

Closes CM-1266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Backward-compatible domain lookup plus a new read-only search path; work-experience responses gain a new field only on the list endpoint, which may surprise clients that assume a uniform shape across work-experience routes.
> 
> **Overview**
> Extends the public API so clients can see **verified primary domains** on member work history and **search organizations by display name**.
> 
> **Work experiences:** `GET /members/:memberId/work-experiences` now bulk-loads verified primary domains per organization and returns a `domains` array on each entry (OpenAPI `WorkExperience` updated). `toMemberWorkExperience` accepts an optional `domains` argument; only the list handler passes it today.
> 
> **Organizations:** `GET /organizations` still supports `?domain=` for a single org (`id`, `name`, optional `logo`), with an added **deleted-org** check. New **`?name=`** mode runs case-insensitive substring search with `page` / `pageSize` (max 100) and returns `{ organizations, page, pageSize, total }` where each org includes `domains` and optional `logo`. Query validation requires exactly one of `domain` or `name`.
> 
> **DAL:** New `searchOrganizationsByName` uses `ILIKE` with escaped `%`/`_`, `COUNT(*) OVER()` for totals, and a COUNT fallback when a later page is empty. Vitest covers pagination, escaping, and error propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b8bd74a814186ed6a4e5ee0c9142787b9f2d9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->