### PR TITLE
fix: use remote with .git suffix as main clone url

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/clone/clone_service.py
@@ -47,7 +47,7 @@ RETRYABLE_CLONE_ERRORS = (RateLimitError, NetworkError, RemoteServerError)
 
 retry_on_clone_error = retry(
     retry=retry_if_exception_type(RETRYABLE_CLONE_ERRORS),
-    stop=stop_after_attempt(6),
+    stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=5, min=5, max=120),
     reraise=True,
 )
@@ -190,9 +190,14 @@ class CloneService(BaseService):
         Perform minimal clone of depth=1
         """
         self.logger.info("Initializing minimal clone")
-        await run_shell_command(
-            ["git", "clone", "--depth=1", "--no-tags", "--single-branch", remote, "."], cwd=path
-        )
+        base_cmd = ["git", "clone", "--depth=1", "--no-tags", "--single-branch"]
+        try:
+            await run_shell_command([*base_cmd, f"{remote}.git", "."], cwd=path)
+        except Exception:
+            self.logger.warning(
+                f"Clone with .git suffix failed, falling back to bare URL: {remote}"
+            )
+            await run_shell_command([*base_cmd, remote, "."], cwd=path)
         self.logger.info("Minimal clone initialized successfully")
 
     async def _get_repo_size_mb(self, repo_path: str) -> float:
@@ -377,9 +382,14 @@ class CloneService(BaseService):
     async def _perform_full_clone(self, repo_path: str, remote: str):
         """Perform full repository clone"""
         self.logger.info(f"Performing full clone for repo {remote}...")
-        await run_shell_command(
-            ["git", "clone", "--no-tags", "--single-branch", remote, "."], cwd=repo_path
-        )
+        base_cmd = ["git", "clone", "--no-tags", "--single-branch"]
+        try:
+            await run_shell_command([*base_cmd, f"{remote}.git", "."], cwd=repo_path)
+        except Exception:
+            self.logger.warning(
+                f"Clone with .git suffix failed, falling back to bare URL: {remote}"
+            )
+            await run_shell_command([*base_cmd, remote, "."], cwd=repo_path)
         self.logger.info(f"Successfully completed full clone of repository: {remote}")
 
     async def has_default_branch_changed(self, remote: str, saved_branch: str | None) -> bool:


### PR DESCRIPTION
This pull request improves the robustness of the git cloning process in `clone_service.py` by introducing fallback logic for repository URLs and adjusting retry behavior. The most important changes are:

**Cloning Robustness Improvements:**

* Both `_perform_minimal_clone` and `_perform_full_clone` now attempt to clone using the `.git` suffix on the remote URL first, and if that fails, they log a warning and retry with the original URL. This helps handle repositories that may or may not require the `.git` suffix. [[1]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL193-R200) [[2]](diffhunk://#diff-643fcf7aeabb2935acf1c4673b8de4ea667cc7418464737bb4c220a3a5cd2e9dL380-R392)

**Retry Behavior Adjustment:**

* The maximum number of retry attempts for clone errors has been reduced from 6 to 3, making failures surface sooner and reducing unnecessary retries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core onboarding clone paths and broad `except Exception` fallback could hide non-URL failures; fewer retries may increase clone failures under flaky networks.
> 
> **Overview**
> **Clone URL handling** in `_perform_minimal_clone` and `_perform_full_clone` now tries `git clone` against `{remote}.git` first, then on any failure logs a warning and retries with the stored bare `remote` (callers already normalize via `removesuffix(".git")`).
> 
> **Retry policy** for `@retry_on_clone_error` (minimal/full clone and batch deepen) drops max attempts from **6 → 3**, so transient rate-limit/network errors fail faster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ee591deaba5903f03a43b74618dc1684955889e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->