### PR TITLE
feat: enable project-registry affiliation writes (CM-361)

### DIFF
--- a/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
@@ -13,7 +13,7 @@ import {
 } from '@crowd/data-access-layer'
 
 import { noContent } from '@/utils/api'
-import { getOverlappingEmailDomainMemberOrganizations } from '@/utils/mapper'
+import { getOverlappingGroupedMemberOrganizations } from '@/utils/mapper'
 import { validateOrThrow } from '@/utils/validation'
 
 const paramsSchema = z.object({
@@ -39,14 +39,11 @@ export async function deleteMemberWorkExperience(req: Request, res: Response): P
     throw new NotFoundError('Work experience not found')
   }
 
-  const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
-    memberOrgs,
-    memberOrg,
-  )
+  const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
   const memberOrgIdsToDelete = [
     workExperienceId,
-    ...overlappingEmailDomainRows.flatMap((row) => (row.id ? [row.id] : [])),
+    ...overlappingGroupedRows.flatMap((row) => (row.id ? [row.id] : [])),
   ]
 
   // Delete hidden grouped rows with the visible row so read responses stay consistent

--- a/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
@@ -17,7 +17,7 @@ import type { MemberOrganizationDateRange, MemberOrganizationUpdate } from '@cro
 
 import { ok } from '@/utils/api'
 import {
-  getOverlappingEmailDomainMemberOrganizations,
+  getOverlappingGroupedMemberOrganizations,
   groupMemberOrganizations,
   toMemberWorkExperience,
 } from '@/utils/mapper'
@@ -88,7 +88,7 @@ export async function updateMemberWorkExperience(req: Request, res: Response): P
 
         const overlapBasis = { ...existing, ...update }
 
-        const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
+        const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(
           memberOrgs,
           overlapBasis,
         )
@@ -106,8 +106,8 @@ export async function updateMemberWorkExperience(req: Request, res: Response): P
           groupedUpdate.verifiedBy = data.verifiedBy
         }
 
-        if (overlappingEmailDomainRows.length > 0 && Object.keys(groupedUpdate).length > 0) {
-          for (const overlappingRow of overlappingEmailDomainRows.filter(
+        if (overlappingGroupedRows.length > 0 && Object.keys(groupedUpdate).length > 0) {
+          for (const overlappingRow of overlappingGroupedRows.filter(
             (row): row is typeof row & { id: string } => !!row.id,
           )) {
             await updateMemberOrganization(tx, memberId, overlappingRow.id, groupedUpdate)

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -17,7 +17,7 @@ import { IMemberOrganization, IMemberRoleWithOrganization } from '@crowd/types'
 
 import { ok } from '@/utils/api'
 import {
-  getOverlappingEmailDomainMemberOrganizations,
+  getOverlappingGroupedMemberOrganizations,
   groupMemberOrganizations,
   toMemberWorkExperience,
 } from '@/utils/mapper'
@@ -52,14 +52,11 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     throw new NotFoundError('Work experience not found')
   }
 
-  const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
-    memberOrgs,
-    memberOrg,
-  )
+  const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
   const memberOrgIdsToDelete = [
     workExperienceId,
-    ...overlappingEmailDomainRows.flatMap((row) => (row.id ? [row.id] : [])),
+    ...overlappingGroupedRows.flatMap((row) => (row.id ? [row.id] : [])),
   ]
 
   const verifiedUpdate = { verified, verifiedBy }
@@ -81,7 +78,7 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
             verifiedUpdate,
           )
 
-          for (const overlappingRow of overlappingEmailDomainRows.filter(
+          for (const overlappingRow of overlappingGroupedRows.filter(
             (row): row is typeof row & { id: string } => !!row.id,
           )) {
             await updateMemberOrganization(tx, memberId, overlappingRow.id, verifiedUpdate)

--- a/backend/src/services/member/memberAffiliationsService.ts
+++ b/backend/src/services/member/memberAffiliationsService.ts
@@ -20,7 +20,7 @@ import {
 
 import MemberAffiliationsRepository from '@/database/repositories/member/memberAffiliationsRepository'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
-import { getOverlappingEmailDomainMemberOrganizations } from '@/utils/mapper'
+import { getOverlappingGroupedMemberOrganizations } from '@/utils/mapper'
 
 import { IServiceOptions } from '../IServiceOptions'
 
@@ -113,13 +113,13 @@ export default class MemberAffiliationsService extends LoggerBase {
     const memberOrgs = await fetchMemberOrganizations(qx, data.memberId)
     const memberOrg = memberOrgs.find((mo) => mo.id === data.memberOrganizationId)
 
-    const overlappingEmailDomainRows = memberOrg
-      ? getOverlappingEmailDomainMemberOrganizations(memberOrgs, memberOrg)
+    const overlappingGroupedRows = memberOrg
+      ? getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
       : []
 
     const memberOrgIds = [
       data.memberOrganizationId,
-      ...overlappingEmailDomainRows.flatMap((row) => (row.id ? [row.id] : [])),
+      ...overlappingGroupedRows.flatMap((row) => (row.id ? [row.id] : [])),
     ]
 
     // Apply the override to hidden grouped rows so the merged work experience has one decision

--- a/backend/src/services/member/memberOrganizationsService.ts
+++ b/backend/src/services/member/memberOrganizationsService.ts
@@ -28,10 +28,7 @@ import {
 } from '@crowd/types'
 
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
-import {
-  getOverlappingEmailDomainMemberOrganizations,
-  groupMemberOrganizations,
-} from '@/utils/mapper'
+import { getOverlappingGroupedMemberOrganizations, groupMemberOrganizations } from '@/utils/mapper'
 
 import { IServiceOptions } from '../IServiceOptions'
 
@@ -106,12 +103,12 @@ export default class MemberOrganizationsService extends LoggerBase {
     const allOrganizations = groupedMemberOrganizations
       .filter((mo): mo is typeof mo & { id: string } => !!mo.id && !!orgById[mo.organizationId])
       .map((mo) => {
-        const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
+        const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(
           memberOrganizations,
           mo,
         )
 
-        const relatedIds = [mo.id, ...overlappingEmailDomainRows.map((row) => row.id)]
+        const relatedIds = [mo.id, ...overlappingGroupedRows.map((row) => row.id)]
 
         const relatedOverrides = relatedIds.map((memberOrganizationId) =>
           overridesByMemberOrganizationId.get(memberOrganizationId),
@@ -294,7 +291,7 @@ export default class MemberOrganizationsService extends LoggerBase {
 
       const overlapBasis = { ...existing, ...update }
 
-      const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
+      const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(
         memberOrganizations,
         overlapBasis,
       )
@@ -309,8 +306,8 @@ export default class MemberOrganizationsService extends LoggerBase {
         (value) => value !== undefined,
       ) as MemberOrganizationUpdate
 
-      if (overlappingEmailDomainRows.length > 0 && Object.keys(groupedUpdate).length > 0) {
-        for (const overlappingRow of overlappingEmailDomainRows) {
+      if (overlappingGroupedRows.length > 0 && Object.keys(groupedUpdate).length > 0) {
+        for (const overlappingRow of overlappingGroupedRows) {
           if (!overlappingRow.id) {
             continue
           }
@@ -355,14 +352,14 @@ export default class MemberOrganizationsService extends LoggerBase {
         throw new Error404(`Member organization with id ${id} not found!`)
       }
 
-      const overlappingEmailDomainRows = getOverlappingEmailDomainMemberOrganizations(
+      const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(
         existingMemberOrganizations,
         memberOrganizationToBeDeleted,
       )
 
       const memberOrganizationIdsToDelete = [
         id,
-        ...overlappingEmailDomainRows.flatMap((row) => (row.id ? [row.id] : [])),
+        ...overlappingGroupedRows.flatMap((row) => (row.id ? [row.id] : [])),
       ]
 
       // Delete hidden grouped rows with the visible row so list responses stay consistent

--- a/backend/src/utils/mapper.ts
+++ b/backend/src/utils/mapper.ts
@@ -24,10 +24,9 @@ function isCollapsibleMemberOrganization<T extends IMemberOrganization>(row: T):
     .split(',')
     .map((value) => value.trim())
     .some((value) =>
-      [
-        OrganizationSource.EMAIL_DOMAIN,
-        OrganizationSource.PROJECT_REGISTRY,
-      ].includes(value as OrganizationSource),
+      [OrganizationSource.EMAIL_DOMAIN, OrganizationSource.PROJECT_REGISTRY].includes(
+        value as OrganizationSource,
+      ),
     )
 }
 
@@ -107,9 +106,7 @@ export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[
   for (const collapsibleRow of collapsibleRows) {
     if (hiddenCollapsibleIds.has(collapsibleRow.id)) {
       const displayRowId = resolveDisplayRowId(collapsibleRow.id)
-      const displayRow = rows.find(
-        (row): row is T & { id: string } => row.id === displayRowId,
-      )
+      const displayRow = rows.find((row): row is T & { id: string } => row.id === displayRowId)
 
       if (displayRow) {
         const existingGroup = displayGroups.get(displayRowId)

--- a/backend/src/utils/mapper.ts
+++ b/backend/src/utils/mapper.ts
@@ -15,58 +15,110 @@ function memberOrganizationsOverlap<T extends IMemberOrganization>(a: T, b: T): 
   )
 }
 
-/**
- * Finds email-domain rows that are represented by the same visible work experience.
- */
-export function getOverlappingEmailDomainMemberOrganizations<T extends IMemberOrganization>(
+function isCollapsibleMemberOrganization<T extends IMemberOrganization>(row: T): boolean {
+  if (!row.source) {
+    return false
+  }
+
+  return row.source
+    .split(',')
+    .map((value) => value.trim())
+    .some((value) =>
+      [
+        OrganizationSource.EMAIL_DOMAIN,
+        OrganizationSource.PROJECT_REGISTRY,
+      ].includes(value as OrganizationSource),
+    )
+}
+
+function compareMemberOrganizationsBySourceRank(
+  a: IMemberOrganization,
+  b: IMemberOrganization,
+): number {
+  const rankDiff =
+    getMemberOrganizationSourceRank(a.source) - getMemberOrganizationSourceRank(b.source)
+  if (rankDiff !== 0) {
+    return rankDiff
+  }
+
+  return (a.id ?? '').localeCompare(b.id ?? '')
+}
+
+/** Hidden inferential rows that overlap a visible work experience (for delete/update/override). */
+export function getOverlappingGroupedMemberOrganizations<T extends IMemberOrganization>(
   rows: T[],
   memberOrganization: T,
 ): T[] {
   return rows.filter(
     (row) =>
       row.id !== memberOrganization.id &&
-      row.source === OrganizationSource.EMAIL_DOMAIN &&
+      isCollapsibleMemberOrganization(row) &&
       memberOrganizationsOverlap(row, memberOrganization),
   )
 }
 
-/**
- * Groups overlapping email-domain rows into the best non-email-domain display row.
- */
-export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[]): T[] {
-  const emailDomainRows = rows.filter((row) => row.source === OrganizationSource.EMAIL_DOMAIN)
-  const nonEmailRows = rows.filter((row) => row.source !== OrganizationSource.EMAIL_DOMAIN)
-  const hiddenEmailDomainIds = new Set<string>()
-  const displayGroups = new Map<string, { displayRow: T; groupedEmailDomainRows: T[] }>()
+function canDisplayCollapsibleRow<T extends IMemberOrganization>(
+  displayRow: T,
+  collapsibleRow: T,
+): boolean {
+  if (!isCollapsibleMemberOrganization(displayRow)) {
+    return true
+  }
 
-  for (const emailDomainRow of emailDomainRows.filter(
-    (row): row is T & { id: string } => !!row.id,
-  )) {
-    const overlappingNonEmailRows = nonEmailRows.filter((row) =>
-      memberOrganizationsOverlap(emailDomainRow, row),
+  return (
+    getMemberOrganizationSourceRank(displayRow.source) <
+    getMemberOrganizationSourceRank(collapsibleRow.source)
+  )
+}
+
+/** Collapse overlapping email-domain and project-registry rows into one work experience for display. */
+export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[]): T[] {
+  const collapsibleRows = rows.filter(
+    (row): row is T & { id: string } => !!row.id && isCollapsibleMemberOrganization(row),
+  )
+  const hiddenCollapsibleIds = new Set<string>()
+  const collapsibleParentDisplayId = new Map<string, string>()
+  const displayGroups = new Map<string, { displayRow: T & { id: string }; groupedRows: T[] }>()
+
+  for (const collapsibleRow of collapsibleRows) {
+    const overlappingDisplayRows = rows.filter(
+      (row): row is T & { id: string } =>
+        !!row.id &&
+        row.id !== collapsibleRow.id &&
+        memberOrganizationsOverlap(collapsibleRow, row) &&
+        canDisplayCollapsibleRow(row, collapsibleRow),
     )
 
-    if (overlappingNonEmailRows.length > 0) {
-      const displayRow = [...overlappingNonEmailRows].sort((a, b) => {
-        const rankDiff =
-          getMemberOrganizationSourceRank(a.source) - getMemberOrganizationSourceRank(b.source)
-        if (rankDiff !== 0) {
-          return rankDiff
-        }
+    if (overlappingDisplayRows.length > 0) {
+      const displayRow = [...overlappingDisplayRows].sort(compareMemberOrganizationsBySourceRank)[0]
+      hiddenCollapsibleIds.add(collapsibleRow.id)
+      collapsibleParentDisplayId.set(collapsibleRow.id, displayRow.id)
+    }
+  }
 
-        return (a.id ?? '').localeCompare(b.id ?? '')
-      })[0]
+  const resolveDisplayRowId = (collapsibleRowId: string): string => {
+    let displayRowId = collapsibleRowId
+    while (collapsibleParentDisplayId.has(displayRowId)) {
+      displayRowId = collapsibleParentDisplayId.get(displayRowId)!
+    }
+    return displayRowId
+  }
 
-      if (displayRow.id) {
-        hiddenEmailDomainIds.add(emailDomainRow.id)
+  for (const collapsibleRow of collapsibleRows) {
+    if (hiddenCollapsibleIds.has(collapsibleRow.id)) {
+      const displayRowId = resolveDisplayRowId(collapsibleRow.id)
+      const displayRow = rows.find(
+        (row): row is T & { id: string } => row.id === displayRowId,
+      )
 
-        const existingGroup = displayGroups.get(displayRow.id)
+      if (displayRow) {
+        const existingGroup = displayGroups.get(displayRowId)
         if (existingGroup) {
-          existingGroup.groupedEmailDomainRows.push(emailDomainRow)
+          existingGroup.groupedRows.push(collapsibleRow)
         } else {
-          displayGroups.set(displayRow.id, {
+          displayGroups.set(displayRowId, {
             displayRow,
-            groupedEmailDomainRows: [emailDomainRow],
+            groupedRows: [collapsibleRow],
           })
         }
       }
@@ -74,15 +126,14 @@ export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[
   }
 
   return rows
-    .filter((row): row is T & { id: string } => !!row.id && !hiddenEmailDomainIds.has(row.id))
+    .filter((row): row is T & { id: string } => !!row.id && !hiddenCollapsibleIds.has(row.id))
     .map((row) => {
       const group = displayGroups.get(row.id)
       if (!group) {
         return row
       }
 
-      // Preserve the visible row while surfacing the combined sources and date range
-      const groupedRows = [group.displayRow, ...group.groupedEmailDomainRows]
+      const groupedRows = [group.displayRow, ...group.groupedRows]
 
       const normalizedStarts = groupedRows
         .map((groupedRow) => normalizeMemberOrganizationDate(groupedRow.dateStart))
@@ -96,7 +147,12 @@ export function groupMemberOrganizations<T extends IMemberOrganization>(rows: T[
 
       for (const groupedRow of groupedRows) {
         if (groupedRow.source) {
-          sources.add(groupedRow.source)
+          for (const source of groupedRow.source.split(',')) {
+            const trimmed = source.trim()
+            if (trimmed) {
+              sources.add(trimmed)
+            }
+          }
         }
       }
 

--- a/services/apps/git_integration/src/crowdgit/database/crud.py
+++ b/services/apps/git_integration/src/crowdgit/database/crud.py
@@ -726,10 +726,9 @@ async def fetch_member_organizations(member_ids: list[str]) -> list[dict]:
 
     return await query(
         """
-        SELECT "memberId", "organizationId", "dateStart", "dateEnd", source
+        SELECT "memberId", "organizationId", "dateStart", "dateEnd", source, "deletedAt"
         FROM "memberOrganizations"
         WHERE "memberId" = ANY($1::uuid[])
-            AND "deletedAt" IS NULL
         """,
         (member_ids,),
     )
@@ -742,11 +741,10 @@ async def fetch_segment_affiliations(member_ids: list[str], segment_id: str) -> 
 
     return await query(
         """
-        SELECT "memberId", "segmentId", "organizationId", "dateStart", "dateEnd", verified
+        SELECT "memberId", "segmentId", "organizationId", "dateStart", "dateEnd", verified, "deletedAt"
         FROM "memberSegmentAffiliations"
         WHERE "memberId" = ANY($1::uuid[])
             AND "segmentId" = $2::uuid
-            AND "deletedAt" IS NULL
             AND "organizationId" IS NOT NULL
         """,
         (member_ids, segment_id),

--- a/services/apps/git_integration/src/crowdgit/services/affiliation/affiliation_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/affiliation/affiliation_service.py
@@ -617,6 +617,44 @@ class AffiliationService(BaseService):
                 return True
         return False
 
+    def is_blocked_by_deleted_row(
+        self,
+        deleted_rows: list[dict],
+        organization_id: str,
+        date_start: date | None,
+        date_end: date | None,
+    ) -> bool:
+        """True when a soft-deleted stint should not be re-created from the file."""
+        incoming_undated = date_start is None and date_end is None
+        for row in deleted_rows:
+            if str(row["organizationId"]) != organization_id:
+                continue
+
+            existing_start = row.get("dateStart")
+            existing_end = row.get("dateEnd")
+            if isinstance(existing_start, datetime):
+                existing_start = existing_start.date()
+            if isinstance(existing_end, datetime):
+                existing_end = existing_end.date()
+
+            if incoming_undated:
+                if existing_start is None and existing_end is None:
+                    return True
+                if self.is_undated_or_open_ended(existing_start, existing_end):
+                    return True
+                continue
+
+            if existing_start is None and existing_end is None:
+                continue
+
+            min_date = date.min
+            max_date = date.max
+            if (existing_start or min_date) <= (date_end or max_date) and (
+                existing_end or max_date
+            ) >= (date_start or min_date):
+                return True
+        return False
+
     @staticmethod
     def affiliation_stint_key(
         contributor: AffiliationContributor,
@@ -801,16 +839,30 @@ class AffiliationService(BaseService):
             return
 
         member_ids_to_fetch = list({member_id for member_id, _, _ in resolved_stints})
-        member_organizations = await fetch_member_organizations(member_ids_to_fetch)
-        segment_affiliations = await fetch_segment_affiliations(member_ids_to_fetch, segment_id)
+        all_member_organizations = await fetch_member_organizations(member_ids_to_fetch)
+        all_segment_affiliations = await fetch_segment_affiliations(
+            member_ids_to_fetch, segment_id
+        )
 
         member_organizations_by_member: dict[str, list[dict]] = {}
-        for row in member_organizations:
-            member_organizations_by_member.setdefault(str(row["memberId"]), []).append(row)
+        deleted_member_organizations_by_member: dict[str, list[dict]] = {}
+        for row in all_member_organizations:
+            member_id = str(row["memberId"])
+            if row.get("deletedAt"):
+                if row.get("source") != "project-registry":
+                    continue
+                deleted_member_organizations_by_member.setdefault(member_id, []).append(row)
+            else:
+                member_organizations_by_member.setdefault(member_id, []).append(row)
 
         segment_affiliations_by_member: dict[str, list[dict]] = {}
-        for row in segment_affiliations:
-            segment_affiliations_by_member.setdefault(str(row["memberId"]), []).append(row)
+        deleted_segment_affiliations_by_member: dict[str, list[dict]] = {}
+        for row in all_segment_affiliations:
+            member_id = str(row["memberId"])
+            if row.get("deletedAt"):
+                deleted_segment_affiliations_by_member.setdefault(member_id, []).append(row)
+            else:
+                segment_affiliations_by_member.setdefault(member_id, []).append(row)
 
         mo_inserts: list[dict] = []
         msa_inserts: list[dict] = []
@@ -818,10 +870,16 @@ class AffiliationService(BaseService):
         for member_id, organization_id, organization in resolved_stints:
             existing_mos = member_organizations_by_member.get(member_id, [])
             existing_msas = segment_affiliations_by_member.get(member_id, [])
+            deleted_mos = deleted_member_organizations_by_member.get(member_id, [])
+            deleted_msas = deleted_segment_affiliations_by_member.get(member_id, [])
             date_start = organization.date_start
             date_end = organization.date_end
 
-            if not self.has_existing_stint(existing_mos, organization_id, date_start, date_end):
+            if not self.has_existing_stint(
+                existing_mos, organization_id, date_start, date_end
+            ) and not self.is_blocked_by_deleted_row(
+                deleted_mos, organization_id, date_start, date_end
+            ):
                 mo_inserts.append(
                     {
                         "member_id": member_id,
@@ -832,7 +890,11 @@ class AffiliationService(BaseService):
                     }
                 )
 
-            if not self.has_existing_stint(existing_msas, organization_id, date_start, date_end):
+            if not self.has_existing_stint(
+                existing_msas, organization_id, date_start, date_end
+            ) and not self.is_blocked_by_deleted_row(
+                deleted_msas, organization_id, date_start, date_end
+            ):
                 msa_inserts.append(
                     {
                         "member_id": member_id,

--- a/services/apps/git_integration/src/crowdgit/services/affiliation/affiliation_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/affiliation/affiliation_service.py
@@ -15,6 +15,8 @@ from crowdgit.database.crud import (
     find_many_member_ids_by_identities,
     find_many_organization_ids_by_identities,
     get_repo_affiliation_registry,
+    insert_member_organizations,
+    insert_member_segment_affiliations,
     save_service_execution,
     upsert_repo_affiliation_registry,
 )
@@ -841,9 +843,8 @@ class AffiliationService(BaseService):
                     }
                 )
 
-        # TODO: Enable CDP writes after testing (import insert_member_* from crud)
-        # await insert_member_organizations(mo_inserts)
-        # await insert_member_segment_affiliations(msa_inserts)
+        await insert_member_organizations(mo_inserts)
+        await insert_member_segment_affiliations(msa_inserts)
 
     async def process_affiliations(
         self,

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -815,8 +815,11 @@ function prepareWorkExperiences(
   newVersion: IMemberEnrichmentDataNormalizedOrganization[],
   isHighConfidenceSourceSelectedForWorkExperiences: boolean,
 ): IWorkExperienceChanges {
-  // we delete all the work experiences that were not manually created
-  const toDelete = oldVersion.filter((c) => c.source !== OrganizationSource.UI)
+  // we delete all the work experiences that were not manually created or from the project registry.
+  const toDelete = oldVersion.filter(
+    (c) =>
+      c.source !== OrganizationSource.UI && c.source !== OrganizationSource.PROJECT_REGISTRY,
+  )
 
   const toCreate: IMemberEnrichmentDataNormalizedOrganization[] = []
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -817,8 +817,7 @@ function prepareWorkExperiences(
 ): IWorkExperienceChanges {
   // we delete all the work experiences that were not manually created or from the project registry.
   const toDelete = oldVersion.filter(
-    (c) =>
-      c.source !== OrganizationSource.UI && c.source !== OrganizationSource.PROJECT_REGISTRY,
+    (c) => c.source !== OrganizationSource.UI && c.source !== OrganizationSource.PROJECT_REGISTRY,
   )
 
   const toCreate: IMemberEnrichmentDataNormalizedOrganization[] = []

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -91,9 +91,10 @@ export const calculateReach = (oldReach: any, newReach: any): { total: number } 
  */
 export function getMemberOrganizationSourceRank(source: string | null | undefined): number {
   if (source === OrganizationSource.UI) return 0
-  if (source === OrganizationSource.EMAIL_DOMAIN) return 1
-  if (source?.startsWith('enrichment-')) return 2
-  return 3
+  if (source === OrganizationSource.PROJECT_REGISTRY) return 1
+  if (source === OrganizationSource.EMAIL_DOMAIN) return 2
+  if (source?.startsWith('enrichment-')) return 3
+  return 4
 }
 
 /**

--- a/services/libs/data-access-layer/src/members/segments.ts
+++ b/services/libs/data-access-layer/src/members/segments.ts
@@ -189,8 +189,9 @@ export async function findMemberManualAffiliation(
         AND (
           ("dateStart" <= $(timestamp) AND "dateEnd" >= $(timestamp))
           OR ("dateStart" <= $(timestamp) AND "dateEnd" IS NULL)
+          OR ("dateStart" IS NULL AND "dateEnd" IS NULL)
         )
-      ORDER BY "dateStart" DESC, id
+      ORDER BY "dateStart" DESC NULLS LAST, id
       LIMIT 1
     `,
     {

--- a/services/libs/types/src/enums/organizations.ts
+++ b/services/libs/types/src/enums/organizations.ts
@@ -7,6 +7,7 @@ export enum OrganizationAttributeName {
 
 export enum OrganizationSource {
   EMAIL_DOMAIN = 'email-domain',
+  PROJECT_REGISTRY = 'project-registry',
   ENRICHMENT_PROGAI = 'enrichment-progai',
   ENRICHMENT_CLEARBIT = 'enrichment-clearbit',
   ENRICHMENT_CRUSTDATA = 'enrichment-crustdata',


### PR DESCRIPTION
## Summary

Part 2 of CM-361. Part 1 (#4280) discovers and parses project-maintained affiliation files in `git_integration` but left MO/MSA writes disabled for validation. This PR turns on those writes, adds guards so user actions and enrichment are respected, and collapses overlapping inferential work experiences in the API/UI.

## Changes

### 1. Enable project-registry affiliation writes

- **git_integration:** call `insert_member_organizations` and `insert_member_segment_affiliations` after lookup/guard checks so parsed repo affiliations land in CDP
- **types:** add `OrganizationSource.PROJECT_REGISTRY` (`project-registry`)
- **common:** rank `project-registry` above email-domain and enrichment in `getMemberOrganizationSourceRank` (UI still wins)
- **data-access-layer:** include fully undated MSAs in `findMemberManualAffiliation` and order by `dateStart DESC NULLS LAST` so new activities resolve repo-derived affiliations the same way bulk refresh already does

### 2. Guards — prevent unwanted re-apply and enrichment overwrite

**git_integration (respect soft-deletes)**

- MO/MSA lookups return soft-deleted rows (`deletedAt` included; no `deletedAt IS NULL` filter on fetch)
- Apply logic splits active vs deleted rows
- `is_blocked_by_deleted_row()` skips re-insert when a user soft-deleted a matching stint (same org + overlapping or undated/open-ended dates)
- Effect: if someone removes a repo-derived affiliation in the UI, the next sync will not resurrect it from the file

**members_enrichment_worker (protect project-registry MO rows)**

- `prepareWorkExperiences` no longer deletes MO rows with source `ui` or `project-registry`
- Effect: enrichment refresh will not wipe project-registry affiliations that are not continuously re-derived like email-domain rows

### 3. Collapsible work experiences (email-domain + project-registry)

- Extend the existing email-domain collapse logic in `mapper.ts` to also treat `project-registry` as collapsible
- Overlapping rows for the same organization and date range are grouped into one displayed work experience; sources are merged as a comma-separated string and the date range is unioned
- Only `email-domain` and `project-registry` rows are collapsible; UI and enrichment rows are never hidden, but overlapping collapsible rows tuck under them
- Source rank for display: UI > project-registry > email-domain > enrichment
- Public work-experience APIs and internal CDP UI services use the grouped rows for list/delete/update/verify

**Generic examples**

| Stored rows (same org, overlapping dates) | What the user sees |
|---|---|
| `project-registry` + `email-domain` | One row; `project-registry` is the display row, sources merged |
| `enrichment` + `project-registry` + `email-domain` | One row under the enrichment entry; inferential sources collapsed beneath it |
| `ui` + `project-registry` | One row under the UI entry; `project-registry` collapsed into it, sources merged |