### PR TITLE
fix: deleting member fails when removing segments (CM-1312)

### DIFF
--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -244,6 +244,10 @@ class MemberRepository {
 
     const subprojectIds = await getSegmentSubprojectIds(qx, currentSegments)
 
+    if (subprojectIds.length === 0) {
+      return
+    }
+
     await seq.query(bulkDeleteMemberSegments, {
       replacements: {
         memberIds,

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -192,6 +192,10 @@ class OrganizationRepository {
     const qx = SequelizeRepository.getQueryExecutor(options)
     const subprojectIds = await getSegmentSubprojectIds(qx, currentSegments)
 
+    if (subprojectIds.length === 0) {
+      return
+    }
+
     await seq.query(bulkDeleteOrganizationSegments, {
       replacements: {
         organizationIds,


### PR DESCRIPTION
## Summary

DELETE `/member` returns 500 when the request includes a segment that resolves to no active subprojects — e.g. an archived project group. Segment expansion returns an empty list, producing invalid SQL (`segmentId in ()`).

## Changes

- Return early in `excludeMembersFromSegments` when there are no subproject IDs to delete
- Apply the same guard in `excludeOrganizationsFromSegments`