### PR TITLE
feat: expose security contacts via api [CM-1297]

### DIFF
--- a/backend/src/api/public/v1/akrites/openapi.yaml
+++ b/backend/src/api/public/v1/akrites/openapi.yaml
@@ -397,6 +397,31 @@ components:
           type: integer
           description: Total packages marked as critical (is_critical = true).
 
+    SecurityContactConfidence:
+      type: string
+      enum: [PRIMARY, SECONDARY, FALLBACK, NONE]
+
+    SecurityContact:
+      type: object
+      required: [channel, value, role, confidence, score]
+      properties:
+        channel:
+          type: string
+          enum: [email, github-pvr, url, github-handle, web-form]
+        value:
+          type: string
+          example: security@expressjs.com
+        role:
+          type: string
+          enum: [security-team, maintainer, admin, committer, org-owner]
+        confidence:
+          $ref: '#/components/schemas/SecurityContactConfidence'
+        score:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+
     Advisory:
       type: object
       required: [osvId, severity, resolution, isCritical]
@@ -522,8 +547,32 @@ components:
             securityContacts:
               type: array
               nullable: true
+              description: >-
+                null when the linked repo has not yet been swept by the security-contacts
+                pipeline; empty array when swept with no contacts found. Provenance and
+                internal scoring metadata are never included.
               items:
-                type: string
+                $ref: '#/components/schemas/SecurityContact'
+            packageConfidence:
+              allOf:
+                - $ref: '#/components/schemas/SecurityContactConfidence'
+              nullable: true
+              description: Confidence band of the highest-scoring contact in securityContacts.
+            securityPolicies:
+              type: object
+              properties:
+                securityPolicyUrl:
+                  type: string
+                  nullable: true
+                vulnerabilityReportingUrl:
+                  type: string
+                  nullable: true
+                bugBountyUrl:
+                  type: string
+                  nullable: true
+                pvrEnabled:
+                  type: boolean
+                  nullable: true
             advisories:
               type: array
               items:

--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -6,6 +6,7 @@ import {
   getAdvisoriesByPackageId,
   getPackageDetailByPurl,
   getStewardshipSummary,
+  securityContactConfidenceBand,
 } from '@crowd/data-access-layer'
 
 import { getPackagesQx } from '@/db/packagesDb'
@@ -50,6 +51,21 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
   const mappingConfidence =
     pkg.repoMappingConfidence != null ? Number(pkg.repoMappingConfidence) : null
 
+  const securityContacts =
+    pkg.contactsLastRefreshed == null
+      ? null
+      : (pkg.securityContacts ?? []).map((c) => ({
+          channel: c.channel,
+          value: c.value,
+          role: c.role,
+          confidence: c.confidence,
+          score: Number(c.score),
+        }))
+  const packageConfidence =
+    securityContacts && securityContacts.length > 0
+      ? securityContactConfidenceBand(Math.max(...securityContacts.map((c) => c.score)))
+      : null
+
   ok(res, {
     purl: pkg.purl,
     name: pkg.name,
@@ -92,7 +108,14 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     signalCoverageHealth: snakeToCamelKeys(pkg.signalCoverageHealth),
     assessment: null,
     security: {
-      securityContacts: null,
+      securityContacts,
+      packageConfidence,
+      securityPolicies: {
+        securityPolicyUrl: pkg.securityPolicyUrl ?? null,
+        vulnerabilityReportingUrl: pkg.vulnerabilityReportingUrl ?? null,
+        bugBountyUrl: pkg.bugBountyUrl ?? null,
+        pvrEnabled: pkg.pvrEnabled ?? null,
+      },
       advisories: advisories.map((a) => ({
         osvId: a.osvId,
         severity: a.severity,
@@ -100,7 +123,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
         isCritical: a.isCritical,
       })),
       cvd: {
-        isPvrEnabled: null,
+        isPvrEnabled: pkg.pvrEnabled ?? null,
         tier0Steward: null,
         criticalVulnerabilityFlag: pkg.hasCriticalVulnerability,
       },

--- a/services/apps/packages_worker/src/security-contacts/score.ts
+++ b/services/apps/packages_worker/src/security-contacts/score.ts
@@ -1,6 +1,9 @@
-import { securityContactConfidenceBand } from '@crowd/data-access-layer/src/osspckgs/api'
+import {
+  SecurityContactConfidence,
+  securityContactConfidenceBand,
+} from '@crowd/data-access-layer/src/osspckgs/api'
 
-import { ConfidenceBand, ContactChannel, ProvenanceEntry, RawContact, SourceTier } from './types'
+import { ContactChannel, ProvenanceEntry, RawContact, SourceTier } from './types'
 
 const WEIGHTS = { tier: 0.55, channel: 0.2, freshness: 0.15, corroboration: 0.1 }
 
@@ -86,14 +89,10 @@ function corroborationScore(provenance: ProvenanceEntry[]): number {
   return 0
 }
 
-export function confidenceBand(score: number): ConfidenceBand {
-  return securityContactConfidenceBand(score)
-}
-
 export function scoreContact(
   contact: RawContact,
   now: Date = new Date(),
-): { score: number; confidence: ConfidenceBand } {
+): { score: number; confidence: SecurityContactConfidence } {
   const raw =
     WEIGHTS.tier * TIER_SCORE[contact.tier] +
     WEIGHTS.channel * channelQuality(contact.channel, contact.value) +
@@ -102,5 +101,5 @@ export function scoreContact(
     (contact.channel === 'github-handle' ? HANDLE_ONLY_PENALTY : 0)
 
   const score = Math.round(Math.min(1, Math.max(0, raw)) * 1000) / 1000
-  return { score, confidence: confidenceBand(score) }
+  return { score, confidence: securityContactConfidenceBand(score) }
 }

--- a/services/apps/packages_worker/src/security-contacts/score.ts
+++ b/services/apps/packages_worker/src/security-contacts/score.ts
@@ -1,3 +1,5 @@
+import { securityContactConfidenceBand } from '@crowd/data-access-layer/src/osspckgs/api'
+
 import { ConfidenceBand, ContactChannel, ProvenanceEntry, RawContact, SourceTier } from './types'
 
 const WEIGHTS = { tier: 0.55, channel: 0.2, freshness: 0.15, corroboration: 0.1 }
@@ -85,10 +87,7 @@ function corroborationScore(provenance: ProvenanceEntry[]): number {
 }
 
 export function confidenceBand(score: number): ConfidenceBand {
-  if (score >= 0.8) return 'PRIMARY'
-  if (score >= 0.55) return 'SECONDARY'
-  if (score >= 0.3) return 'FALLBACK'
-  return 'NONE'
+  return securityContactConfidenceBand(score)
 }
 
 export function scoreContact(

--- a/services/apps/packages_worker/src/security-contacts/types.ts
+++ b/services/apps/packages_worker/src/security-contacts/types.ts
@@ -4,8 +4,6 @@ export type ContactChannel = 'email' | 'github-pvr' | 'url' | 'github-handle' | 
 
 export type ContactRole = 'security-team' | 'maintainer' | 'admin' | 'committer' | 'org-owner'
 
-export type ConfidenceBand = SecurityContactConfidence
-
 export type SourceTier = 'A' | 'B' | 'C' | 'D'
 
 /** Where a single contact value was observed, for auditability and corroboration scoring. */
@@ -31,7 +29,7 @@ export interface RawContact {
 
 export interface ScoredContact extends RawContact {
   score: number
-  confidence: ConfidenceBand
+  confidence: SecurityContactConfidence
 }
 
 export interface RepoPolicies {

--- a/services/apps/packages_worker/src/security-contacts/types.ts
+++ b/services/apps/packages_worker/src/security-contacts/types.ts
@@ -1,8 +1,10 @@
+import type { SecurityContactConfidence } from '@crowd/data-access-layer/src/osspckgs/api'
+
 export type ContactChannel = 'email' | 'github-pvr' | 'url' | 'github-handle' | 'web-form'
 
 export type ContactRole = 'security-team' | 'maintainer' | 'admin' | 'committer' | 'org-owner'
 
-export type ConfidenceBand = 'PRIMARY' | 'SECONDARY' | 'FALLBACK' | 'NONE'
+export type ConfidenceBand = SecurityContactConfidence
 
 export type SourceTier = 'A' | 'B' | 'C' | 'D'
 

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -595,6 +595,16 @@ export async function listPackagesForApi(
   return { rows, total }
 }
 
+export type SecurityContactConfidence = 'PRIMARY' | 'SECONDARY' | 'FALLBACK' | 'NONE'
+
+export interface SecurityContactRow {
+  channel: string
+  value: string
+  role: string
+  confidence: SecurityContactConfidence
+  score: number
+}
+
 export interface PackageDetailRow {
   id: string
   purl: string
@@ -625,6 +635,12 @@ export interface PackageDetailRow {
   hasSecurityFile: boolean | null
   hasSecurityPolicy: boolean | null
   branchProtectionEnabled: boolean | null
+  pvrEnabled: boolean | null
+  securityPolicyUrl: string | null
+  vulnerabilityReportingUrl: string | null
+  bugBountyUrl: string | null
+  contactsLastRefreshed: Date | null
+  securityContacts: SecurityContactRow[] | null
   // from downloads_last_30d
   downloadsLast30d: string | null
   maintainerCount: number
@@ -637,6 +653,13 @@ export interface PackageDetailRow {
   developmentActivityScore: number | null
   lifecycleLabel: string | null
   signalCoverageHealth: Record<string, unknown> | null
+}
+
+export function securityContactConfidenceBand(score: number): SecurityContactConfidence {
+  if (score >= 0.8) return 'PRIMARY'
+  if (score >= 0.55) return 'SECONDARY'
+  if (score >= 0.3) return 'FALLBACK'
+  return 'NONE'
 }
 
 export interface AdvisoryRow {
@@ -682,6 +705,21 @@ export async function getPackageDetailByPurl(
       r.security_file_enabled AS "hasSecurityFile",
       r.security_policy_enabled AS "hasSecurityPolicy",
       r.branch_protection_enabled AS "branchProtectionEnabled",
+      r.pvr_enabled AS "pvrEnabled",
+      r.security_policy_url AS "securityPolicyUrl",
+      r.vulnerability_reporting_url AS "vulnerabilityReportingUrl",
+      r.bug_bounty_url AS "bugBountyUrl",
+      r.contacts_last_refreshed AS "contactsLastRefreshed",
+      (
+        SELECT json_agg(sc ORDER BY sc.score DESC)
+        FROM (
+          SELECT channel, value, role, confidence, score
+          FROM security_contacts
+          WHERE repo_id = pr.repo_id AND deleted_at IS NULL
+          ORDER BY score DESC
+          LIMIT 5
+        ) sc
+      ) AS "securityContacts",
       -- latest 30-day download count
       (
         SELECT d.count::text


### PR DESCRIPTION
This pull request adds support for returning security contact information and related metadata for packages in the public API. It introduces new data structures for security contacts, exposes them in the API response, and updates the data-access layer to retrieve and process this information from the database.

**API Schema and Response Enhancements:**

* Added `SecurityContact` and `SecurityContactConfidence` types to the OpenAPI schema, and updated the `securityContacts` field to include detailed information and a new `packageConfidence` field. Also added a `securityPolicies` object with security-related URLs and flags. [[1]](diffhunk://#diff-b78169e34e776723a3b29d667e74eac18cbf56248d6f5886912f66ed4cde06f8R400-R424) [[2]](diffhunk://#diff-b78169e34e776723a3b29d667e74eac18cbf56248d6f5886912f66ed4cde06f8R550-R575)

**Backend and Data Layer Updates:**

* Updated the data-access layer (`api.ts`) to fetch security contacts and related fields from the database, including new fields for security policy URLs and contact refresh times. [[1]](diffhunk://#diff-3ae4be909cb900bbd5a092ffb375de97461458b4f635d02dcfd0661a03b7b0e1R638-R643) [[2]](diffhunk://#diff-3ae4be909cb900bbd5a092ffb375de97461458b4f635d02dcfd0661a03b7b0e1R708-R722)
* Added the `SecurityContactConfidence` type, `SecurityContactRow` interface, and a `securityContactConfidenceBand` function to map contact scores to confidence bands. [[1]](diffhunk://#diff-3ae4be909cb900bbd5a092ffb375de97461458b4f635d02dcfd0661a03b7b0e1R598-R607) [[2]](diffhunk://#diff-3ae4be909cb900bbd5a092ffb375de97461458b4f635d02dcfd0661a03b7b0e1R658-R664)
* Updated the API handler (`getPackage.ts`) to process and return security contact details, compute the highest-confidence band, and include the new `securityPolicies` object in responses. [[1]](diffhunk://#diff-560803e64a7431f999020c3350ab8695abfbad3a27214bd42383d0e5ad2b643aR9) [[2]](diffhunk://#diff-560803e64a7431f999020c3350ab8695abfbad3a27214bd42383d0e5ad2b643aR54-R68) [[3]](diffhunk://#diff-560803e64a7431f999020c3350ab8695abfbad3a27214bd42383d0e5ad2b643aL95-R126)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a public API contract that exposes contact channels/values (emails, handles, URLs) and changes null vs empty semantics for clients; logic is read-only but disclosure-sensitive.
> 
> **Overview**
> Package detail responses now surface **security contact** data from the linked repo instead of placeholders: up to five scored contacts (channel, value, role, confidence, score), a **packageConfidence** band from the top score, and **securityPolicies** URLs plus **pvrEnabled**. **securityContacts** is `null` until the security-contacts pipeline has swept the repo, and `[]` when swept with no hits; provenance stays internal.
> 
> OpenAPI adds `SecurityContact` / `SecurityContactConfidence` and documents that behavior. The data layer extends `getPackageDetailByPurl` to join repo policy fields and aggregate from `security_contacts`; `securityContactConfidenceBand` is shared with the packages worker scorer (local duplicate removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b724291df8a0e179c6408ef1efec286fd251234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->