### PR TITLE
fix: set null publishedDate for yanked versions

### DIFF
--- a/services/apps/packages_worker/src/nuget/normalize.ts
+++ b/services/apps/packages_worker/src/nuget/normalize.ts
@@ -19,6 +19,13 @@ function isPrerelease(version: string): boolean {
   return version.includes('-')
 }
 
+// NuGet stamps unlisted versions with 1900-01-01T00:00:00Z as a sentinel — treat as absent.
+function parsePublishedDate(published: string | undefined): Date | null {
+  if (!published) return null
+  const date = new Date(published)
+  return !isNaN(date.getTime()) && date.getUTCFullYear() > 1900 ? date : null
+}
+
 const SCM_HOSTS = ['github.com', 'gitlab.com', 'bitbucket.org']
 
 function normalizeRepoUrl(url: string | undefined): string | null {
@@ -105,25 +112,15 @@ export function normalizeNuGetPackage(
     status = 'active'
   }
 
-  // NuGet stamps unlisted versions with 1900-01-01T00:00:00Z as a sentinel — exclude them.
   const publishedDates = allEntries
-    .filter((e) => e.published)
-    .map((e) => new Date(e.published as string))
-    .filter((d) => !isNaN(d.getTime()) && d.getUTCFullYear() > 1900)
+    .map((e) => parsePublishedDate(e.published))
+    .filter((d): d is Date => d !== null)
     .sort((a, b) => a.getTime() - b.getTime())
 
   const firstReleaseAt = publishedDates.length > 0 ? publishedDates[0] : null
 
   const latestEntry4Date = latestListedEntry ?? latestEntry
-  const latestReleaseAtRaw = latestEntry4Date?.published
-    ? new Date(latestEntry4Date.published)
-    : null
-  const latestReleaseAt =
-    latestReleaseAtRaw &&
-    !isNaN(latestReleaseAtRaw.getTime()) &&
-    latestReleaseAtRaw.getUTCFullYear() > 1900
-      ? latestReleaseAtRaw
-      : null
+  const latestReleaseAt = parsePublishedDate(latestEntry4Date?.published)
 
   const totalDownloads = searchResult?.totalDownloads ?? 0
 
@@ -144,7 +141,7 @@ export function normalizeNuGetPackage(
     const { licenses: vLicenses } = parseLicense(entry.licenseExpression, entry.licenseUrl)
     return {
       number: ver,
-      publishedAt: entry.published ? new Date(entry.published) : null,
+      publishedAt: parsePublishedDate(entry.published),
       isLatest: ver === latestVersion,
       isPrerelease: isPrerelease(ver),
       isYanked: entry.listed === false,


### PR DESCRIPTION
This pull request refactors how NuGet package published dates are parsed and handled, centralizing the logic for filtering out sentinel "unlisted" dates and improving code clarity. The main changes are:

**Date Parsing Improvements:**

* Added a new `parsePublishedDate` function to handle NuGet's sentinel unlisted date (`1900-01-01T00:00:00Z`) and return `null` for absent or invalid dates.

**Refactoring and Consistency:**

* Replaced all direct `Date` parsing and filtering logic for published dates in `normalizeNuGetPackage` with calls to the new `parsePublishedDate` function, ensuring consistent handling of unlisted or invalid dates throughout the code.
* Updated the assignment of `publishedAt` in version objects to use `parsePublishedDate`, further centralizing date validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor in NuGet normalization with clearer date filtering; behavior change is limited to published metadata for unlisted versions.
> 
> **Overview**
> Centralizes NuGet **published** date handling in a new `parsePublishedDate` helper that returns `null` for missing values, invalid dates, and NuGet’s unlisted sentinel (`1900-01-01T00:00:00Z`).
> 
> **`normalizeNuGetPackage`** now uses that helper for `firstReleaseAt` / `latestReleaseAt` aggregation and for each version’s `publishedAt`, so yanked/unlisted versions no longer surface a bogus 1900 publish timestamp.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6580bdd34b6341725c779533abe4bae095006696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->