### PR TITLE
fix: stabilize `membersGlobalActivityCount` mv refresh (CM-1302)

### DIFF
--- a/backend/src/database/migrations/R__memberEnrichmentMaterializedViews.sql
+++ b/backend/src/database/migrations/R__memberEnrichmentMaterializedViews.sql
@@ -10,8 +10,7 @@ where msa."segmentId" IN (
         where "grandparentId" is not null
             and "parentId" is not null
     )
-group by msa."memberId"
-order by sum(msa."activityCount") desc;
+group by msa."memberId";
 create unique index ix_member_global_activity_count_member_id on "membersGlobalActivityCount" ("memberId");
 create index ix_member_global_activity_count on "membersGlobalActivityCount" (total_count);
 

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -765,7 +765,7 @@ export async function getObsoleteSourcesOfMember(
 }
 
 export async function refreshMemberEnrichmentMaterializedView(mvName: string): Promise<void> {
-  await refreshMaterializedView(svc.postgres.writer.connection(), mvName)
+  await refreshMaterializedView(svc.postgres.writer.connection(), mvName, true)
 }
 
 interface IWorkExperienceChanges {

--- a/services/apps/members_enrichment_worker/src/workflows/refreshMemberEnrichmentMaterializedViews.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/refreshMemberEnrichmentMaterializedViews.ts
@@ -5,7 +5,12 @@ import { MemberEnrichmentMaterializedView } from '@crowd/types'
 import * as activities from '../activities'
 
 const { refreshMemberEnrichmentMaterializedView } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '10 minutes',
+  startToCloseTimeout: '45 minutes',
+  retry: {
+    initialInterval: '15 seconds',
+    backoffCoefficient: 2,
+    maximumAttempts: 3,
+  },
 })
 
 export async function refreshMemberEnrichmentMaterializedViews(): Promise<void> {


### PR DESCRIPTION
## Summary

The `refreshMemberEnrichmentMaterializedViews` workflow was failing because `REFRESH MATERIALIZED VIEW "membersGlobalActivityCount"` exceeded the 10-minute activity timeout. As `memberSegmentsAgg` grew (~239M rows), refresh duration crossed that limit. Unlimited activity retries left zombie PG sessions holding exclusive locks, which also blocked member list queries.

## Changes

- Increase activity `startToCloseTimeout` from 10 to 45 minutes
- Cap activity retries at 3 attempts with backoff
- Use `REFRESH MATERIALIZED VIEW CONCURRENTLY` so reads on the MV are not blocked during refresh
- Remove `ORDER BY` from the `membersGlobalActivityCount` MV definition (enrichment already sorts in its own query; removes an extra sort over ~635K rows on each refresh)