### PR TITLE
feat: add rank packages function (CM-1310)

### DIFF
--- a/backend/src/osspckgs/migrations/V1783123201__rank_packages_sonatype_signal.sql
+++ b/backend/src/osspckgs/migrations/V1783123201__rank_packages_sonatype_signal.sql
@@ -1,0 +1,111 @@
+-- Add the Sonatype popularity score as a 4th ranking signal in rank_packages().
+--
+-- Sonatype could not deliver raw Maven download counts, so they provide a
+-- popularity score (0-100, normalized per ecosystem) as the substitute for the
+-- missing downloads signal. Maven previously had only dependent_count and
+-- transitive_dependent_count feeding criticality.
+--
+-- The signal slots into the existing cumulative-coverage machinery unchanged:
+--   * cumulative-share is scale-invariant, so a 0-100 score sorts identically
+--     to a raw count — no normalization needed;
+--   * non-maven rows are all-NULL -> ecosystem total = 0 -> the WHERE clause
+--     drops the signal for them, so npm/pypi ranking is untouched.
+--
+-- No tier short-circuit here (measurement-first): is_critical is a BOOL_OR, so
+-- adding a signal can only make more packages critical, never fewer. Whether a
+-- hard "P0 always critical" guarantee is needed is decided after measuring the
+-- impact shift on real data.
+
+CREATE OR REPLACE FUNCTION rank_packages(
+    coverage_cutoff numeric DEFAULT 0.90,
+    ecosystems      text[]  DEFAULT NULL
+)
+RETURNS TABLE(processed_rows int)
+LANGUAGE plpgsql AS $$
+DECLARE
+    processed_count      int;
+    effective_ecosystems text[];
+BEGIN
+    IF ecosystems IS NULL THEN
+        SELECT ARRAY_AGG(DISTINCT ecosystem)
+          INTO effective_ecosystems
+          FROM packages;
+    ELSE
+        effective_ecosystems := ecosystems;
+    END IF;
+
+    WITH base AS (
+        SELECT
+            id,
+            ecosystem,
+            COALESCE(downloads_last_30d,         0) AS downloads,
+            COALESCE(dependent_count,            0) AS direct_dependents,
+            COALESCE(transitive_dependent_count, 0) AS transitive_dependents,
+            COALESCE(sonatype_popularity_score,  0) AS sonatype_popularity,
+            SUM(COALESCE(downloads_last_30d,         0)) OVER (PARTITION BY ecosystem) AS ecosystem_total_downloads,
+            SUM(COALESCE(dependent_count,            0)) OVER (PARTITION BY ecosystem) AS ecosystem_total_direct_dependents,
+            SUM(COALESCE(transitive_dependent_count, 0)) OVER (PARTITION BY ecosystem) AS ecosystem_total_transitive_dependents,
+            SUM(COALESCE(sonatype_popularity_score,  0)) OVER (PARTITION BY ecosystem) AS ecosystem_total_sonatype
+        FROM packages
+        WHERE ecosystem = ANY(effective_ecosystems)
+    ),
+    walked AS (
+        -- One row per (package × signal). Signals with a zero ecosystem total are
+        -- excluded so they don't factor into the average (e.g. downloads for maven,
+        -- sonatype for npm/pypi).
+        -- cumulative_share_exclusive for the top-ranked package equals 0 by arithmetic
+        -- (sum of rows above it is 0), so the top package is always inside the critical set.
+        SELECT
+            id,
+            ecosystem,
+            SUM(signal_value) OVER coverage_window / ecosystem_signal_total::numeric                  AS cumulative_share_inclusive,
+            (SUM(signal_value) OVER coverage_window - signal_value) / ecosystem_signal_total::numeric AS cumulative_share_exclusive
+        FROM base
+        CROSS JOIN LATERAL (VALUES
+            ('downloads',             downloads,             ecosystem_total_downloads),
+            ('direct_dependents',     direct_dependents,     ecosystem_total_direct_dependents),
+            ('transitive_dependents', transitive_dependents, ecosystem_total_transitive_dependents),
+            ('sonatype_popularity',   sonatype_popularity,   ecosystem_total_sonatype)
+        ) AS signal(signal_name, signal_value, ecosystem_signal_total)
+        WHERE ecosystem_signal_total > 0
+        WINDOW coverage_window AS (
+            PARTITION BY ecosystem, signal_name
+            ORDER BY signal_value DESC, id
+            ROWS UNBOUNDED PRECEDING
+        )
+    ),
+    combined AS (
+        SELECT
+            id,
+            ecosystem,
+            AVG(1.0 - cumulative_share_inclusive)::numeric(10, 4) AS new_impact,
+            BOOL_OR(cumulative_share_exclusive < coverage_cutoff)  AS new_is_critical
+        FROM walked
+        GROUP BY id, ecosystem
+    ),
+    final AS (
+        SELECT
+            combined.id,
+            combined.new_impact,
+            combined.new_is_critical OR (spotlight.package_id IS NOT NULL) AS new_is_critical,
+            ROW_NUMBER() OVER (
+                PARTITION BY combined.ecosystem
+                ORDER BY combined.new_impact DESC NULLS LAST, combined.id
+            ) AS new_rank_in_ecosystem
+        FROM combined
+        LEFT JOIN package_criticality_spotlight spotlight ON spotlight.package_id = combined.id
+    )
+    UPDATE packages p
+       SET impact             = final.new_impact,
+           is_critical        = final.new_is_critical,
+           rank_in_ecosystem  = final.new_rank_in_ecosystem,
+           last_rank_pass_at  = NOW(),
+           last_synced_at     = NOW()
+      FROM final
+     WHERE p.id = final.id;
+
+    GET DIAGNOSTICS processed_count = ROW_COUNT;
+
+    RETURN QUERY SELECT processed_count;
+END;
+$$;


### PR DESCRIPTION
## Summary

Feeds `sonatype_popularity_score` into `rank_packages()` as a **4th signal**, so the Sonatype popularity score actually drives criticality.

Sonatype could not deliver raw monthly Maven download counts, so instead they provide a **popularity score** derived from their SCA telemetry — normalized 0–100 per ecosystem, tiered P0–P3. Until now Maven criticality relied only on `dependent_count` and `transitive_dependent_count`, so industry-critical Maven packages that are under-represented as dependency targets in our graph were missed. This signal is the substitute for the missing downloads data.

This is **step 3 of 3**:
- Step 1 (separate PR) — schema: `sonatype_*` columns on `packages`.
- Step 2 (separate PR) — one-shot CSV ingestion into those columns.
- **This PR** — feed `sonatype_popularity_score` into `rank_packages()` as a 4th signal.

## Changes

- **New migration** `V1783123201__rank_packages_sonatype_signal.sql` — `CREATE OR REPLACE FUNCTION rank_packages(...)` adding one signal. Only **3 lines** change versus the previous definition:
  - `base` CTE — the per-row value `COALESCE(sonatype_popularity_score, 0)` and the per-ecosystem total `SUM(...) OVER (PARTITION BY ecosystem)`.
  - the `VALUES` unpivot — one extra tuple `('sonatype_popularity', ...)`.

  Everything downstream (`walked`, `combined`, `final`, the `UPDATE`) is signal-agnostic, so no other change is needed. No hard-coded signal count, no per-ecosystem branch, no divisor to update.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1310](https://linuxfoundation.atlassian.net/browse/CM-1310)

[CM-1310]: https://linuxfoundation.atlassian.net/browse/CM-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the production ranking function and can shift `impact`, `is_critical`, and ranks for Maven (and any ecosystem with Sonatype scores); `BOOL_OR` criticality can only add critical packages, not remove them.
> 
> **Overview**
> **`rank_packages()`** now includes **`sonatype_popularity_score`** as a fourth cumulative-coverage signal alongside downloads and dependency counts, via migration `V1783123201__rank_packages_sonatype_signal.sql`.
> 
> The **`base`** CTE adds per-row `COALESCE(sonatype_popularity_score, 0)` and an ecosystem-level sum; the **`walked`** unpivot gains a `('sonatype_popularity', …)` row. Signals with zero ecosystem total are still skipped, so ecosystems without Sonatype data keep the same effective signal set as before.
> 
> **`impact`**, **`is_critical`**, **`rank_in_ecosystem`**, spotlight overrides, and **`last_synced_at`** stamping are unchanged in structure—only the averaged signal set can grow where Sonatype totals are non-zero (notably Maven as a downloads substitute).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f68b946d4081f51dbfe1bff253a58ac751823f7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->