### PR TITLE
feat: fix maven repo gap (CM-1305)

### DIFF
--- a/services/apps/packages_worker/package.json
+++ b/services/apps/packages_worker/package.json
@@ -54,6 +54,8 @@
     "dev:rubygems-worker:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && CROWD_TEMPORAL_TASKQUEUE=rubygems-worker SERVICE=rubygems-worker LOG_LEVEL=trace nodemon --watch src --watch ../../libs --ext ts --exec tsx --inspect=0.0.0.0:9244 src/bin/rubygems-worker.ts",
     "backfill:maven": "SERVICE=maven tsx src/bin/maven-backfill.ts",
     "backfill:maven:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=maven LOG_LEVEL=info tsx src/bin/maven-backfill.ts",
+    "backfill:maven-repo-url": "SERVICE=maven tsx src/bin/maven-repo-url-backfill.ts",
+    "backfill:maven-repo-url:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=maven LOG_LEVEL=info tsx src/bin/maven-repo-url-backfill.ts",
     "import:maven-maintainers": "SERVICE=maven tsx src/maven/scripts/importMaintainersFromCsv.ts",
     "import:maven-maintainers:local": "set -a && . ../../../backend/.env.dist.local && . ../../../backend/.env.override.local && set +a && SERVICE=maven tsx src/maven/scripts/importMaintainersFromCsv.ts",
     "import:sonatype-popularity": "SERVICE=maven tsx src/maven/scripts/importSonatypePopularityFromCsv.ts",

--- a/services/apps/packages_worker/src/bin/maven-backfill.ts
+++ b/services/apps/packages_worker/src/bin/maven-backfill.ts
@@ -2,7 +2,10 @@ import { getServiceLogger } from '@crowd/logging'
 
 import { getMavenConfig } from '../config'
 import { getPackagesDb } from '../db'
-import { runMavenCriticalBackfill } from '../maven/runMavenEnrichmentLoop'
+import {
+  runMavenCriticalBackfill,
+  runMavenCriticalForceBackfill,
+} from '../maven/runMavenEnrichmentLoop'
 
 const log = getServiceLogger()
 
@@ -25,7 +28,14 @@ const main = async () => {
     process.env.MAVEN_FETCHER_BASE_URL_BACKFILL ??
     'https://maven-central.storage-download.googleapis.com/maven2'
 
-  log.info('maven backfill starting (one-shot, full extraction)...')
+  // --force: re-run POM extraction over EVERY critical row, ignoring the
+  // staleness window. Use to fully re-apply extraction changes (e.g. SCM
+  // interpolation) after the queue has already drained. The default path only
+  // picks rows due by refreshDays and cannot be coaxed into a full pass by
+  // setting refreshDays=0 (that reprocesses the first batch forever).
+  const force = process.argv.includes('--force')
+
+  log.info({ force }, 'maven backfill starting (one-shot, full extraction)...')
 
   const config = getMavenConfig()
   log.info(config, 'Config loaded')
@@ -34,7 +44,9 @@ const main = async () => {
   await qx.selectOne('SELECT 1')
   log.info('Connected to packages-db.')
 
-  const totals = await runMavenCriticalBackfill(qx, config, () => shuttingDown)
+  const totals = force
+    ? await runMavenCriticalForceBackfill(qx, config, () => shuttingDown)
+    : await runMavenCriticalBackfill(qx, config, () => shuttingDown)
 
   log.info({ ...totals }, 'maven backfill complete')
   process.exit(0)

--- a/services/apps/packages_worker/src/bin/maven-repo-url-backfill.ts
+++ b/services/apps/packages_worker/src/bin/maven-repo-url-backfill.ts
@@ -23,6 +23,7 @@ const DEFAULT_BATCH_SIZE = 5000
 
 const main = async () => {
   const dryRun = process.argv.includes('--dry-run')
+  const criticalOnly = process.argv.includes('--critical-only')
   const rawBatchSize = process.env.MAVEN_REPO_URL_BACKFILL_BATCH_SIZE
   const parsedBatchSize = rawBatchSize === undefined ? DEFAULT_BATCH_SIZE : Number(rawBatchSize)
   if (!Number.isInteger(parsedBatchSize) || parsedBatchSize <= 0) {
@@ -35,7 +36,7 @@ const main = async () => {
   const batchSize = parsedBatchSize
 
   log.info(
-    { dryRun, batchSize },
+    { dryRun, criticalOnly, batchSize },
     'maven repo-url backfill starting (recompute normalizeScmUrl from declared_repository_url, no POM fetch)...',
   )
 
@@ -46,6 +47,7 @@ const main = async () => {
   const totals = await backfillMavenRepositoryUrls(qx, {
     batchSize,
     dryRun,
+    criticalOnly,
     isShuttingDown: () => shuttingDown,
   })
 

--- a/services/apps/packages_worker/src/bin/maven-repo-url-backfill.ts
+++ b/services/apps/packages_worker/src/bin/maven-repo-url-backfill.ts
@@ -1,0 +1,59 @@
+import { getServiceLogger } from '@crowd/logging'
+
+import { getPackagesDb } from '../db'
+import { backfillMavenRepositoryUrls } from '../maven/backfillRepositoryUrl'
+
+const log = getServiceLogger()
+
+let shuttingDown = false
+
+// Graceful stop: finish the in-flight batch, then exit. Safe to interrupt — every
+// write is an idempotent UPDATE recomputed from declared_repository_url, so
+// re-running simply reprocesses and skips rows that already match.
+const shutdown = () => {
+  if (shuttingDown) return
+  shuttingDown = true
+  log.info('Shutting down maven repo-url backfill (stopping after the current batch)...')
+}
+
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+
+const DEFAULT_BATCH_SIZE = 5000
+
+const main = async () => {
+  const dryRun = process.argv.includes('--dry-run')
+  const rawBatchSize = process.env.MAVEN_REPO_URL_BACKFILL_BATCH_SIZE
+  const parsedBatchSize = rawBatchSize === undefined ? DEFAULT_BATCH_SIZE : Number(rawBatchSize)
+  if (!Number.isInteger(parsedBatchSize) || parsedBatchSize <= 0) {
+    log.error(
+      { MAVEN_REPO_URL_BACKFILL_BATCH_SIZE: rawBatchSize },
+      'MAVEN_REPO_URL_BACKFILL_BATCH_SIZE must be a positive integer',
+    )
+    process.exit(1)
+  }
+  const batchSize = parsedBatchSize
+
+  log.info(
+    { dryRun, batchSize },
+    'maven repo-url backfill starting (recompute normalizeScmUrl from declared_repository_url, no POM fetch)...',
+  )
+
+  const qx = await getPackagesDb()
+  await qx.selectOne('SELECT 1')
+  log.info('Connected to packages-db.')
+
+  const totals = await backfillMavenRepositoryUrls(qx, {
+    batchSize,
+    dryRun,
+    isShuttingDown: () => shuttingDown,
+  })
+
+  log.info({ ...totals, dryRun }, 'maven repo-url backfill complete')
+  process.exit(0)
+}
+
+main().catch((err) => {
+  log.error({ err }, 'maven repo-url backfill fatal error')
+  process.exit(1)
+})

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -163,4 +163,35 @@ describe('normalizeScmUrl', () => {
   it('returns null for non-https result', () => {
     expect(normalizeScmUrl('svn://svn.apache.org/repos/commons-lang')).toBeNull()
   })
+
+  // Gap B — recover repository_url from inputs that were previously dropped
+  it('recovers scm:git: without a scheme', () => {
+    expect(normalizeScmUrl('scm:git:github.com/lum-ai/nxmlreader')).toBe(
+      'https://github.com/lum-ai/nxmlreader',
+    )
+  })
+
+  it('recovers a bare host/owner/repo without a scheme', () => {
+    expect(normalizeScmUrl('github.com/agiledigital/kamon-play-extensions')).toBe(
+      'https://github.com/agiledigital/kamon-play-extensions',
+    )
+  })
+
+  it('upgrades http to https and lower-cases the github path', () => {
+    expect(normalizeScmUrl('http://github.com/kevemueller/kTLSH/tree/master')).toBe(
+      'https://github.com/kevemueller/ktlsh',
+    )
+  })
+
+  // Gap C — reject non-repository URLs so they are never stored
+  it('returns null for website-only URLs', () => {
+    expect(normalizeScmUrl('https://meson.ai/')).toBeNull()
+    expect(normalizeScmUrl('http://source.android.com')).toBeNull()
+  })
+
+  it('returns null for placeholders and free-form text', () => {
+    expect(normalizeScmUrl('Private')).toBeNull()
+    expect(normalizeScmUrl('${scm-url}')).toBeNull()
+    expect(normalizeScmUrl('http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/foo')).toBeNull()
+  })
 })

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -484,6 +484,37 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('https://git.corp.adobe.com/team/project')).toBeNull()
     expect(normalizeScmUrl('https://gitlab.alibaba-inc.com/team/project')).toBeNull()
   })
+
+  it('preserves nested GitLab group namespaces instead of truncating to the group', () => {
+    expect(normalizeScmUrl('https://gitlab.com/group/subgroup/project')).toBe(
+      'https://gitlab.com/group/subgroup/project',
+    )
+    expect(normalizeScmUrl('scm:git:https://gitlab.inria.fr/group/subgroup/deep/project.git')).toBe(
+      'https://gitlab.inria.fr/group/subgroup/deep/project',
+    )
+  })
+
+  it('stops the GitLab repo path at the /-/ route marker and drops browse suffixes', () => {
+    expect(normalizeScmUrl('https://gitlab.com/group/subgroup/project/-/tree/main')).toBe(
+      'https://gitlab.com/group/subgroup/project',
+    )
+    expect(normalizeScmUrl('https://gitlab.com/owner/repo/-/blob/main/pom.xml')).toBe(
+      'https://gitlab.com/owner/repo',
+    )
+  })
+
+  it('still lower-cases gitlab.com paths but leaves self-hosted GitLab case intact', () => {
+    expect(normalizeScmUrl('https://gitlab.com/Group/SubGroup/Project')).toBe(
+      'https://gitlab.com/group/subgroup/project',
+    )
+    expect(normalizeScmUrl('https://gitlab.inria.fr/Group/Project')).toBe(
+      'https://gitlab.inria.fr/Group/Project',
+    )
+  })
+
+  it('returns null for a GitLab namespace with no project segment', () => {
+    expect(normalizeScmUrl('https://gitlab.com/onlygroup')).toBeNull()
+  })
 })
 
 describe('interpolateProperties', () => {

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -201,6 +201,41 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('scm:git:https://github.com/${owner}/repo.git')).toBeNull()
   })
 
+  it('ignores an unresolved placeholder in a trailing suffix once owner/repo are valid', () => {
+    // ${project.scm.tag} lands in the /tree/<ref> suffix, which is already ignored —
+    // only segments[0]/[1] (owner/repo) are inspected.
+    expect(
+      normalizeScmUrl('https://github.com/apache/httpcomponents-client/tree/${project.scm.tag}'),
+    ).toBe('https://github.com/apache/httpcomponents-client')
+    expect(normalizeScmUrl('https://github.com/apache/maven/tree/${project.scm.tag}')).toBe(
+      'https://github.com/apache/maven',
+    )
+  })
+
+  it('recovers Apache gitweb hosts (gitbox/git-wip-us/git.apache.org) in path form', () => {
+    expect(normalizeScmUrl('https://gitbox.apache.org/repos/asf/commons-lang.git')).toBe(
+      'https://gitbox.apache.org/repos/asf/commons-lang',
+    )
+    expect(normalizeScmUrl('https://git.apache.org/repos/asf/ant.git')).toBe(
+      'https://git.apache.org/repos/asf/ant',
+    )
+  })
+
+  it('recovers Apache gitweb hosts in classic ?p= query-string form', () => {
+    expect(normalizeScmUrl('https://gitbox.apache.org/repos/asf?p=commons-io.git')).toBe(
+      'https://gitbox.apache.org/repos/asf/commons-io',
+    )
+    expect(normalizeScmUrl('https://git-wip-us.apache.org/repos/asf?p=commons-math.git')).toBe(
+      'https://git-wip-us.apache.org/repos/asf/commons-math',
+    )
+  })
+
+  it('returns null for Apache gitweb hosts with no recoverable repo name', () => {
+    expect(normalizeScmUrl('https://gitbox.apache.org/')).toBeNull()
+    expect(normalizeScmUrl('https://gitbox.apache.org/repos/asf/')).toBeNull()
+    expect(normalizeScmUrl('https://gitbox.apache.org/some/other/path')).toBeNull()
+  })
+
   // SCP colon form: "host:owner/repo" where the colon is a path separator, not a port
   it('recovers bare host:owner/repo SCP colon form', () => {
     expect(normalizeScmUrl('github.com:japgolly/scalacss.git')).toBe(

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -236,6 +236,29 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('https://gitbox.apache.org/some/other/path')).toBeNull()
   })
 
+  it('recovers git.eclipse.org cgit URLs, keeping the /c/ prefix and dropping trailing tree paths', () => {
+    expect(normalizeScmUrl('http://git.eclipse.org/c/eclipselink/javax.persistence.git')).toBe(
+      'https://git.eclipse.org/c/eclipselink/javax.persistence',
+    )
+    expect(
+      normalizeScmUrl('https://git.eclipse.org/c/eclipsescada/org.eclipse.scada.utils.git'),
+    ).toBe('https://git.eclipse.org/c/eclipsescada/org.eclipse.scada.utils')
+    expect(
+      normalizeScmUrl('http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/tree'),
+    ).toBe('https://git.eclipse.org/c/jetty/org.eclipse.jetty.project')
+    expect(
+      normalizeScmUrl(
+        'http://git.eclipse.org/c/jetty/org.eclipse.jetty.orbit.git/tree/jetty-orbit',
+      ),
+    ).toBe('https://git.eclipse.org/c/jetty/org.eclipse.jetty.orbit')
+  })
+
+  it('returns null for git.eclipse.org URLs with no recoverable repo path', () => {
+    expect(normalizeScmUrl('https://git.eclipse.org/')).toBeNull()
+    expect(normalizeScmUrl('https://git.eclipse.org/c/')).toBeNull()
+    expect(normalizeScmUrl('https://git.eclipse.org/c/onlyowner')).toBeNull()
+  })
+
   // SCP colon form: "host:owner/repo" where the colon is a path separator, not a port
   it('recovers bare host:owner/repo SCP colon form', () => {
     expect(normalizeScmUrl('github.com:japgolly/scalacss.git')).toBe(

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeScmUrl } from '../extract'
+import { interpolateProperties, normalizeScmUrl } from '../extract'
 import { pickStableRelease } from '../metadata'
 import { isPrerelease, parseRepoUrl } from '../normalize'
 
@@ -195,6 +195,12 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/foo')).toBeNull()
   })
 
+  it('returns null when an unresolved placeholder is embedded in the repo path', () => {
+    // Would otherwise parse to github.com/owner/%7BartifactId%7D and slip through.
+    expect(normalizeScmUrl('https://github.com/owner/${artifactId}')).toBeNull()
+    expect(normalizeScmUrl('scm:git:https://github.com/${owner}/repo.git')).toBeNull()
+  })
+
   // SCP colon form: "host:owner/repo" where the colon is a path separator, not a port
   it('recovers bare host:owner/repo SCP colon form', () => {
     expect(normalizeScmUrl('github.com:japgolly/scalacss.git')).toBe(
@@ -241,5 +247,58 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('https://git.corp.adobe.com/team/project')).toBeNull()
     expect(normalizeScmUrl('https://gitlab.alibaba-inc.com/team/project')).toBeNull()
     expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base')).toBeNull()
+  })
+})
+
+describe('interpolateProperties', () => {
+  it('resolves a single ${...} placeholder from properties', () => {
+    expect(
+      interpolateProperties('${scm.github.url}', {
+        'scm.github.url': 'https://github.com/owner/repo',
+      }),
+    ).toBe('https://github.com/owner/repo')
+  })
+
+  it('resolves multiple placeholders in one string', () => {
+    expect(
+      interpolateProperties('https://gitlab.com/${projectPath}', {
+        projectPath: 'group/project',
+      }),
+    ).toBe('https://gitlab.com/group/project')
+  })
+
+  it('resolves nested placeholders recursively', () => {
+    expect(
+      interpolateProperties('${scm.url}', {
+        'scm.url': '${scm.base}/repo',
+        'scm.base': 'https://github.com/owner',
+      }),
+    ).toBe('https://github.com/owner/repo')
+  })
+
+  it('resolves built-in project.* style placeholders', () => {
+    expect(
+      interpolateProperties('https://github.com/acme/${project.artifactId}', {
+        'project.artifactId': 'my-lib',
+      }),
+    ).toBe('https://github.com/acme/my-lib')
+  })
+
+  it('leaves unresolved placeholders literal (missing property / method call)', () => {
+    expect(interpolateProperties('${scm.github.url}', {})).toBe('${scm.github.url}')
+    expect(
+      interpolateProperties('${pom.artifactId.substring(8)}', { 'pom.artifactId': 'foo' }),
+    ).toBe('${pom.artifactId.substring(8)}')
+  })
+
+  it('does not loop forever on self-referential placeholders', () => {
+    expect(interpolateProperties('${a}', { a: '${b}', b: '${a}' })).toContain('${')
+  })
+
+  it('composes with the normalizer end-to-end', () => {
+    const resolved = interpolateProperties('${scm.github.url}', {
+      'scm.github.url': 'scm:git:https://github.com/Owner/Repo.git',
+    })
+    expect(normalizeScmUrl(resolved)).toBe('https://github.com/owner/repo')
   })
 })

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -194,4 +194,44 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('${scm-url}')).toBeNull()
     expect(normalizeScmUrl('http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/foo')).toBeNull()
   })
+
+  // SCP colon form: "host:owner/repo" where the colon is a path separator, not a port
+  it('recovers bare host:owner/repo SCP colon form', () => {
+    expect(normalizeScmUrl('github.com:japgolly/scalacss.git')).toBe(
+      'https://github.com/japgolly/scalacss',
+    )
+  })
+
+  it('recovers scheme://host:owner/repo SCP colon form', () => {
+    expect(normalizeScmUrl('https://github.com:networknt/light-4j.git')).toBe(
+      'https://github.com/networknt/light-4j',
+    )
+  })
+
+  it('recovers ssh://git@host:owner/repo SCP colon form', () => {
+    expect(normalizeScmUrl('ssh://git@github.com:apache/iotdb.git')).toBe(
+      'https://github.com/apache/iotdb',
+    )
+    expect(normalizeScmUrl('ssh://git@bitbucket.org:eci-elements/web-services.git')).toBe(
+      'https://bitbucket.org/eci-elements/web-services',
+    )
+  })
+
+  it('does not treat a numeric port as an SCP separator', () => {
+    expect(normalizeScmUrl('https://gitlab.com:443/foo/bar')).toBe('https://gitlab.com/foo/bar')
+  })
+
+  it('accepts allowlisted self-hosted GitLab/Gitea hosts', () => {
+    expect(normalizeScmUrl('https://git.neckar.it/neckarit/neckar-hub')).toBe(
+      'https://git.neckar.it/neckarit/neckar-hub',
+    )
+    expect(normalizeScmUrl('scm:git:https://gitlab.inria.fr/owner/repo.git')).toBe(
+      'https://gitlab.inria.fr/owner/repo',
+    )
+  })
+
+  it('still returns null for hosts not in the allowlist', () => {
+    expect(normalizeScmUrl('https://git.corp.adobe.com/team/project')).toBeNull()
+    expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base')).toBeNull()
+  })
 })

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -221,6 +221,12 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('https://gitlab.com:443/foo/bar')).toBe('https://gitlab.com/foo/bar')
   })
 
+  it('recovers git://host:owner/repo SCP colon form', () => {
+    expect(normalizeScmUrl('git://github.com:appendium/objectlabkit.git')).toBe(
+      'https://github.com/appendium/objectlabkit',
+    )
+  })
+
   it('accepts allowlisted self-hosted GitLab/Gitea hosts', () => {
     expect(normalizeScmUrl('https://git.neckar.it/neckarit/neckar-hub')).toBe(
       'https://git.neckar.it/neckarit/neckar-hub',
@@ -228,10 +234,12 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('scm:git:https://gitlab.inria.fr/owner/repo.git')).toBe(
       'https://gitlab.inria.fr/owner/repo',
     )
+    expect(normalizeScmUrl('https://git.iem.at/owner/repo')).toBe('https://git.iem.at/owner/repo')
   })
 
-  it('still returns null for hosts not in the allowlist', () => {
+  it('still returns null for internal or non-allowlisted hosts', () => {
     expect(normalizeScmUrl('https://git.corp.adobe.com/team/project')).toBeNull()
+    expect(normalizeScmUrl('https://gitlab.alibaba-inc.com/team/project')).toBeNull()
     expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base')).toBeNull()
   })
 })

--- a/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/normalize.test.ts
@@ -236,6 +236,185 @@ describe('normalizeScmUrl', () => {
     expect(normalizeScmUrl('https://gitbox.apache.org/some/other/path')).toBeNull()
   })
 
+  it('recovers Apache gitweb ?p= urls with trailing `;`-separated gitweb params (a=, f=, h=, hb=)', () => {
+    expect(
+      normalizeScmUrl(
+        'https://gitbox.apache.org/repos/asf?p=lucene-solr.git;f=lucene/analysis/common',
+      ),
+    ).toBe('https://gitbox.apache.org/repos/asf/lucene-solr')
+    expect(
+      normalizeScmUrl(
+        'https://git-wip-us.apache.org/repos/asf?p=flume.git;a=tree;h=refs/heads/trunk;hb=trunk',
+      ),
+    ).toBe('https://git-wip-us.apache.org/repos/asf/flume')
+    expect(
+      normalizeScmUrl(
+        'https://git1-us-west.apache.org/repos/asf?p=lucene-solr.git;a=tree;f=lucene/analysis/uima',
+      ),
+    ).toBe('https://git1-us-west.apache.org/repos/asf/lucene-solr')
+  })
+
+  it('recovers Apache gitweb urls with a trailing subpath appended directly after .git', () => {
+    expect(
+      normalizeScmUrl('https://gitbox.apache.org/repos/asf?p=hbase.git/hbase-build-configuration'),
+    ).toBe('https://gitbox.apache.org/repos/asf/hbase')
+    expect(
+      normalizeScmUrl(
+        'https://gitbox.apache.org/repos/asf/ignite.git/ignite-parent-internal/ignite-core',
+      ),
+    ).toBe('https://gitbox.apache.org/repos/asf/ignite')
+  })
+
+  it('recovers git.apache.org repos declared at the bare root, without the /repos/asf/ prefix', () => {
+    expect(normalizeScmUrl('http://git.apache.org/clerezza.git/')).toBe(
+      'https://git.apache.org/repos/asf/clerezza',
+    )
+    expect(normalizeScmUrl('http://git.apache.org/kafka.git')).toBe(
+      'https://git.apache.org/repos/asf/kafka',
+    )
+  })
+
+  it('recovers git.shibboleth.net gitweb ?p= urls, dropping trailing gitweb params', () => {
+    expect(normalizeScmUrl('https://git.shibboleth.net/view/?p=java-opensaml.git')).toBe(
+      'https://git.shibboleth.net/view/?p=java-opensaml.git',
+    )
+    expect(normalizeScmUrl('https://git.shibboleth.net/view/?p=java-support.git;a=summary')).toBe(
+      'https://git.shibboleth.net/view/?p=java-support.git',
+    )
+  })
+
+  it('returns null for git.shibboleth.net urls with no recoverable repo name', () => {
+    expect(normalizeScmUrl('https://git.shibboleth.net/view/')).toBeNull()
+  })
+
+  it('recovers jogamp.org gitweb ?p= urls, dropping trailing subpath', () => {
+    expect(normalizeScmUrl('http://jogamp.org/git/?p=gluegen.git/')).toBe(
+      'https://jogamp.org/git/?p=gluegen.git',
+    )
+    expect(normalizeScmUrl('http://jogamp.org/git/?p=jogl.git;a=summary')).toBe(
+      'https://jogamp.org/git/?p=jogl.git',
+    )
+  })
+
+  it('returns null for jogamp.org urls with no recoverable repo name', () => {
+    expect(normalizeScmUrl('http://jogamp.org/git/')).toBeNull()
+  })
+
+  it('recovers additional verified self-hosted GitLab/Gitea/cgit/sourcehut hosts', () => {
+    expect(normalizeScmUrl('https://gitverse.ru/ys.kalyakin/commons-chain')).toBe(
+      'https://gitverse.ru/ys.kalyakin/commons-chain',
+    )
+    expect(normalizeScmUrl('https://git.sr.ht/~ajoberstar/grgit')).toBe(
+      'https://git.sr.ht/~ajoberstar/grgit',
+    )
+    expect(normalizeScmUrl('https://git.savannah.gnu.org/cgit/gettext')).toBe(
+      'https://git.savannah.gnu.org/cgit/gettext',
+    )
+    expect(normalizeScmUrl('https://oss.brouillard.fr/projects/jgitver')).toBe(
+      'https://oss.brouillard.fr/projects/jgitver',
+    )
+  })
+
+  it('normalizes Bitbucket Server clone and browse urls to the browse form', () => {
+    expect(
+      normalizeScmUrl('https://ec.europa.eu/digital-building-blocks/code/scm/esig/dss.git'),
+    ).toBe('https://ec.europa.eu/digital-building-blocks/code/projects/esig/repos/dss')
+    expect(normalizeScmUrl('https://source.opendof.org/scm/core/core-java.git')).toBe(
+      'https://source.opendof.org/projects/core/repos/core-java',
+    )
+  })
+
+  it('returns null for unrecognized Bitbucket Server hosts', () => {
+    expect(normalizeScmUrl('https://stash.openntf.org/scm/sbt/socialsdk.git')).toBeNull()
+  })
+
+  it('recovers Azure DevOps _git urls, dropping trailing branch/path suffix', () => {
+    expect(normalizeScmUrl('https://dev.azure.com/pumpitup/_git/pumpo-number-five')).toBe(
+      'https://dev.azure.com/pumpitup/_git/pumpo-number-five',
+    )
+    expect(normalizeScmUrl('https://dev.azure.com/myorg/myproject/_git/myrepo?path=/src')).toBe(
+      'https://dev.azure.com/myorg/myproject/_git/myrepo',
+    )
+  })
+
+  it('returns null for dev.azure.com urls with no _git marker', () => {
+    expect(normalizeScmUrl('https://dev.azure.com/pumpitup')).toBeNull()
+  })
+
+  it('recovers Aliyun Codeup urls, dropping the leading group-id segment', () => {
+    expect(
+      normalizeScmUrl(
+        'scm:git:git@codeup.aliyun.com:624f8224569a5e3edf2d4c1f/jihongbin12329/rock-1.0.git',
+      ),
+    ).toBe('https://codeup.aliyun.com/jihongbin12329/rock-1.0')
+  })
+
+  it('passes through android.googlesource.com urls unchanged', () => {
+    expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base')).toBe(
+      'https://android.googlesource.com/platform/tools/base',
+    )
+    expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base.git/')).toBe(
+      'https://android.googlesource.com/platform/tools/base',
+    )
+  })
+
+  it('returns null for android.googlesource.com urls with no path', () => {
+    expect(normalizeScmUrl('https://android.googlesource.com/')).toBeNull()
+  })
+
+  it('recovers GitHub Pages project-page urls (owner.github.io/repo)', () => {
+    expect(normalizeScmUrl('https://silentbalanceyh.github.io/vertx-zero/')).toBe(
+      'https://github.com/silentbalanceyh/vertx-zero',
+    )
+    expect(normalizeScmUrl('http://morn-team.github.io/morn-boot-projects/')).toBe(
+      'https://github.com/morn-team/morn-boot-projects',
+    )
+  })
+
+  it('recovers GitHub Pages user/org-page urls (bare owner.github.io, no path)', () => {
+    expect(normalizeScmUrl('https://qyg2297248353.github.io')).toBe(
+      'https://github.com/qyg2297248353/qyg2297248353.github.io',
+    )
+    expect(normalizeScmUrl('http://openbaton.github.io')).toBe(
+      'https://github.com/openbaton/openbaton.github.io',
+    )
+  })
+
+  it('recovers a bare github.io host with owner/repo in the path (missing subdomain)', () => {
+    expect(normalizeScmUrl('https://github.io/methrat0n/restruct')).toBe(
+      'https://github.com/methrat0n/restruct',
+    )
+  })
+
+  it('recovers the legacy owner.github.com Pages domain', () => {
+    expect(normalizeScmUrl('https://zqq90.github.com/webit-script')).toBe(
+      'https://github.com/zqq90/webit-script',
+    )
+    expect(normalizeScmUrl('http://mhellkamp.github.com/endpoint/')).toBe(
+      'https://github.com/mhellkamp/endpoint',
+    )
+  })
+
+  it('returns null for GitHub Pages urls whose path still has an unresolved placeholder', () => {
+    expect(normalizeScmUrl('http://dakusui.github.io/${project.name}')).toBeNull()
+  })
+
+  it('returns null for a bare github.io host with no owner/repo path', () => {
+    expect(normalizeScmUrl('https://github.io/')).toBeNull()
+    expect(normalizeScmUrl('https://github.io/onlyowner')).toBeNull()
+  })
+
+  it('recovers raw.githubusercontent.com and maven.pkg.github.com by remapping to github.com', () => {
+    expect(
+      normalizeScmUrl(
+        'https://raw.githubusercontent.com/crittercism/crittercism-android-agent/master/',
+      ),
+    ).toBe('https://github.com/crittercism/crittercism-android-agent')
+    expect(normalizeScmUrl('https://maven.pkg.github.com/CloudForgeCI/cfc-core')).toBe(
+      'https://github.com/cloudforgeci/cfc-core',
+    )
+  })
+
   it('recovers git.eclipse.org cgit URLs, keeping the /c/ prefix and dropping trailing tree paths', () => {
     expect(normalizeScmUrl('http://git.eclipse.org/c/eclipselink/javax.persistence.git')).toBe(
       'https://git.eclipse.org/c/eclipselink/javax.persistence',
@@ -304,7 +483,6 @@ describe('normalizeScmUrl', () => {
   it('still returns null for internal or non-allowlisted hosts', () => {
     expect(normalizeScmUrl('https://git.corp.adobe.com/team/project')).toBeNull()
     expect(normalizeScmUrl('https://gitlab.alibaba-inc.com/team/project')).toBeNull()
-    expect(normalizeScmUrl('https://android.googlesource.com/platform/tools/base')).toBeNull()
   })
 })
 

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -1,0 +1,76 @@
+import {
+  listMavenPackagesForRepoUrlRecompute,
+  updateMavenRepositoryUrls,
+} from '@crowd/data-access-layer'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+import { getServiceChildLogger } from '@crowd/logging'
+
+import { normalizeScmUrl } from './extract'
+
+const log = getServiceChildLogger('maven-repo-url-backfill')
+
+export type RepoUrlBackfillTotals = {
+  scanned: number
+  filled: number // Gap B: NULL → canonical value
+  cleared: number // Gap C: non-repo value → NULL
+  rewritten: number // non-canonical value → different canonical value
+  unchanged: number
+}
+
+/**
+ * Recomputes `repository_url` for every Maven row directly from the stored
+ * `declared_repository_url`, applying the current `normalizeScmUrl`. No POMs are
+ * fetched — the raw SCM value is already in the DB. Fills recoverable NULLs
+ * (Gap B) and clears non-repository values (Gap C) via direct UPDATE.
+ *
+ * Idempotent and resumable: the id cursor is derived from the scan, so a
+ * re-run after an interrupt simply reprocesses from the start and skips rows
+ * that already match.
+ */
+export async function backfillMavenRepositoryUrls(
+  qx: QueryExecutor,
+  options: { batchSize: number; dryRun: boolean; isShuttingDown: () => boolean },
+): Promise<RepoUrlBackfillTotals> {
+  const { batchSize, dryRun, isShuttingDown } = options
+  const totals: RepoUrlBackfillTotals = {
+    scanned: 0,
+    filled: 0,
+    cleared: 0,
+    rewritten: 0,
+    unchanged: 0,
+  }
+
+  let afterId = 0
+  for (;;) {
+    if (isShuttingDown()) {
+      log.info('Shutdown requested — stopping after the current batch.')
+      break
+    }
+
+    const rows = await listMavenPackagesForRepoUrlRecompute(qx, { afterId, limit: batchSize })
+    if (rows.length === 0) break
+
+    const updates: { id: number; repositoryUrl: string | null }[] = []
+    for (const row of rows) {
+      totals.scanned++
+      const desired = normalizeScmUrl(row.declaredRepositoryUrl)
+      if (desired === row.repositoryUrl) {
+        totals.unchanged++
+        continue
+      }
+      if (row.repositoryUrl === null) totals.filled++
+      else if (desired === null) totals.cleared++
+      else totals.rewritten++
+      updates.push({ id: row.id, repositoryUrl: desired })
+    }
+
+    if (updates.length > 0 && !dryRun) {
+      await updateMavenRepositoryUrls(qx, updates)
+    }
+
+    afterId = rows[rows.length - 1].id
+    log.info({ afterId, changes: updates.length, dryRun, ...totals }, 'Backfill progress')
+  }
+
+  return totals
+}

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -103,7 +103,7 @@ export async function backfillMavenRepositoryUrls(
       // so the inconsistency would never be repaired. On rollback the row stays
       // unchanged and is reprocessed on the next run.
       await withDeadlockRetry(() =>
-        qx.tx(async (t) => {
+        qx.tx(async (t: QueryExecutor) => {
           await updateMavenRepositoryUrls(t, updates)
           await deleteMavenPackageRepoLinks(t, pruneTargets)
           for (const target of linkTargets) {

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -1,4 +1,5 @@
 import {
+  deleteMavenPackageRepoLinks,
   listMavenPackagesForRepoUrlRecompute,
   updateMavenRepositoryUrls,
 } from '@crowd/data-access-layer'
@@ -6,6 +7,7 @@ import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceChildLogger } from '@crowd/logging'
 
 import { normalizeScmUrl } from './extract'
+import { writeRepoLink } from './runMavenEnrichmentLoop'
 
 const log = getServiceChildLogger('maven-repo-url-backfill')
 
@@ -15,6 +17,8 @@ export type RepoUrlBackfillTotals = {
   cleared: number // Gap C: non-repo value → NULL
   rewritten: number // non-canonical value → different canonical value
   unchanged: number
+  linked: number // repos/package_repos link (re)written for a fill or rewrite
+  pruned: number // stale 'declared' link removed for a clear or rewrite
 }
 
 /**
@@ -22,6 +26,15 @@ export type RepoUrlBackfillTotals = {
  * `declared_repository_url`, applying the current `normalizeScmUrl`. No POMs are
  * fetched — the raw SCM value is already in the DB. Fills recoverable NULLs
  * (Gap B) and clears non-repository values (Gap C) via direct UPDATE.
+ *
+ * Link tables: package_repos is kept consistent with the recomputed
+ * repository_url. For rows that had a value and now change (rewrites) or are
+ * cleared, the stale source='declared' link is deleted; for rows that gain a
+ * canonical URL (fills and rewrites) the correct link is (re)written via the
+ * same `writeRepoLink` the enrichment loop uses. This matters because consumers
+ * such as security-contacts read the repo through repos ⋈ package_repos, not
+ * packages.repository_url. Note this is stricter than the incremental
+ * enrichment path, which is upsert-only and never prunes.
  *
  * Idempotent and resumable: the id cursor is derived from the scan, so a
  * re-run after an interrupt simply reprocesses from the start and skips rows
@@ -38,6 +51,8 @@ export async function backfillMavenRepositoryUrls(
     cleared: 0,
     rewritten: 0,
     unchanged: 0,
+    linked: 0,
+    pruned: 0,
   }
 
   let afterId = 0
@@ -51,6 +66,10 @@ export async function backfillMavenRepositoryUrls(
     if (rows.length === 0) break
 
     const updates: { id: number; repositoryUrl: string | null }[] = []
+    // Rows that had a link and now change/clear — their stale 'declared' link is pruned.
+    const pruneTargets: number[] = []
+    // Rows that gained a canonical URL — their repo link is (re)written after the update.
+    const linkTargets: { id: number; repositoryUrl: string }[] = []
     for (const row of rows) {
       totals.scanned++
       const desired = normalizeScmUrl(row.declaredRepositoryUrl)
@@ -62,10 +81,27 @@ export async function backfillMavenRepositoryUrls(
       else if (desired === null) totals.cleared++
       else totals.rewritten++
       updates.push({ id: row.id, repositoryUrl: desired })
+      // A 'declared' link only exists when the row already had a value.
+      if (row.repositoryUrl !== null) pruneTargets.push(row.id)
+      if (desired !== null) linkTargets.push({ id: row.id, repositoryUrl: desired })
     }
 
     if (updates.length > 0 && !dryRun) {
-      await updateMavenRepositoryUrls(qx, updates)
+      // Atomic per batch: the repository_url UPDATE, the stale-link prune, and the
+      // relink must commit together. Otherwise an interrupt between them leaves
+      // packages.repository_url updated but package_repos out of sync — and on a
+      // re-run the row is skipped (its repository_url already matches `desired`),
+      // so the inconsistency would never be repaired. On rollback the row stays
+      // unchanged and is reprocessed on the next run.
+      await qx.tx(async (t) => {
+        await updateMavenRepositoryUrls(t, updates)
+        await deleteMavenPackageRepoLinks(t, pruneTargets)
+        for (const target of linkTargets) {
+          await writeRepoLink(t, target.id, target.repositoryUrl)
+        }
+      })
+      totals.pruned += pruneTargets.length
+      totals.linked += linkTargets.length
     }
 
     afterId = rows[rows.length - 1].id

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -7,7 +7,7 @@ import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 import { getServiceChildLogger } from '@crowd/logging'
 
 import { normalizeScmUrl } from './extract'
-import { writeRepoLink } from './runMavenEnrichmentLoop'
+import { withDeadlockRetry, writeRepoLink } from './runMavenEnrichmentLoop'
 
 const log = getServiceChildLogger('maven-repo-url-backfill')
 
@@ -102,13 +102,15 @@ export async function backfillMavenRepositoryUrls(
       // re-run the row is skipped (its repository_url already matches `desired`),
       // so the inconsistency would never be repaired. On rollback the row stays
       // unchanged and is reprocessed on the next run.
-      await qx.tx(async (t) => {
-        await updateMavenRepositoryUrls(t, updates)
-        await deleteMavenPackageRepoLinks(t, pruneTargets)
-        for (const target of linkTargets) {
-          await writeRepoLink(t, target.id, target.repositoryUrl)
-        }
-      })
+      await withDeadlockRetry(() =>
+        qx.tx(async (t) => {
+          await updateMavenRepositoryUrls(t, updates)
+          await deleteMavenPackageRepoLinks(t, pruneTargets)
+          for (const target of linkTargets) {
+            await writeRepoLink(t, target.id, target.repositoryUrl)
+          }
+        }),
+      )
       totals.pruned += pruneTargets.length
       totals.linked += linkTargets.length
     }

--- a/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
+++ b/services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts
@@ -42,9 +42,14 @@ export type RepoUrlBackfillTotals = {
  */
 export async function backfillMavenRepositoryUrls(
   qx: QueryExecutor,
-  options: { batchSize: number; dryRun: boolean; isShuttingDown: () => boolean },
+  options: {
+    batchSize: number
+    dryRun: boolean
+    criticalOnly: boolean
+    isShuttingDown: () => boolean
+  },
 ): Promise<RepoUrlBackfillTotals> {
-  const { batchSize, dryRun, isShuttingDown } = options
+  const { batchSize, dryRun, criticalOnly, isShuttingDown } = options
   const totals: RepoUrlBackfillTotals = {
     scanned: 0,
     filled: 0,
@@ -62,7 +67,11 @@ export async function backfillMavenRepositoryUrls(
       break
     }
 
-    const rows = await listMavenPackagesForRepoUrlRecompute(qx, { afterId, limit: batchSize })
+    const rows = await listMavenPackagesForRepoUrlRecompute(qx, {
+      afterId,
+      limit: batchSize,
+      criticalOnly,
+    })
     if (rows.length === 0) break
 
     const updates: { id: number; repositoryUrl: string | null }[] = []
@@ -105,7 +114,10 @@ export async function backfillMavenRepositoryUrls(
     }
 
     afterId = rows[rows.length - 1].id
-    log.info({ afterId, changes: updates.length, dryRun, ...totals }, 'Backfill progress')
+    log.info(
+      { afterId, changes: updates.length, dryRun, criticalOnly, ...totals },
+      'Backfill progress',
+    )
   }
 
   return totals

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -482,19 +482,20 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
  *
  * TODO(CM): host list pending product confirmation before rollout.
  *
- * Candidate additions found in Maven declared_repository_url (critical rows) but
- * intentionally NOT added yet, because they need more than a host allowlist:
- *   - git.eclipse.org (~180 rows): Gerrit `/c/<repo>` paths, not owner/repo.
- *   - eclipse.gerrithub.io (~10 rows): Gerrit admin-UI paths (`/admin/repos/...`),
- *     not a clone URL shape.
- *   - android.googlesource.com, ec.europa.eu (Bitbucket-Server /projects/x/repos/y):
- *     multi-segment paths, not owner/repo.
- *   - ambiguous `git.*` hosts (git.iem.at, git.i-novus.ru, git.oschina.net) and the
- *     internal git.corp.adobe.com: pending path/reachability confirmation.
+ * The ambiguous `git.*` hosts git.iem.at, git.i-novus.ru and git.oschina.net were
+ * curl-verified live and ARE included in SCM_HOSTS below. Other hosts found in Maven
+ * declared_repository_url that need more than a flat owner/repo allowlist are handled
+ * by their own dedicated normalizers below rather than here:
+ *   - git.eclipse.org: cgit `/c/<owner>/<repo>` paths → normalizeEclipseCgitUrl.
+ *   - android.googlesource.com: Gitiles identity paths → normalizeGooglesourceUrl.
+ *   - ec.europa.eu: Bitbucket-Server `/projects/x/repos/y` → normalizeBitbucketServerUrl.
+ *   - gitbox.apache.org / git.apache.org / git-wip-us.apache.org: gitweb
+ *     `/repos/asf/<repo>` or `?p=<repo>` → normalizeApacheGitwebUrl.
  *
- * gitbox.apache.org / git.apache.org / git-wip-us.apache.org are handled separately
- * below (normalizeApacheGitwebUrl) rather than through this allowlist — their paths
- * are `/repos/asf/<repo>` or `?p=<repo>` (classic gitweb query form), not owner/repo.
+ * Still NOT handled (need more than a host allowlist, or are unreachable):
+ *   - eclipse.gerrithub.io: Gerrit admin-UI paths (`/admin/repos/...`), not a clone shape.
+ *   - internal-only hosts (git.corp.adobe.com, gitlab.alibaba-inc.com): unreachable
+ *     for consumers, so intentionally excluded.
  */
 const SCM_HOSTS = new Set([
   'github.com',
@@ -769,6 +770,33 @@ function normalizeGooglesourceUrl(host: string, pathname: string): string | null
 }
 
 /**
+ * GitLab — gitlab.com and self-hosted instances — supports nested group
+ * namespaces (group/subgroup/.../project), so the repository path is NOT limited
+ * to owner/repo: taking only the first two segments would turn a valid repo like
+ * gitlab.com/group/subgroup/project into the group URL gitlab.com/group/subgroup.
+ * The full namespace/project path is everything up to GitLab's `/-/` route marker
+ * (which prefixes non-repo routes such as /-/tree, /-/blob, /-/merge_requests).
+ * Only applied to already-allowlisted hosts, so this never widens acceptance.
+ */
+function isGitlabHost(host: string): boolean {
+  return host === 'gitlab.com' || host.includes('gitlab')
+}
+
+function normalizeGitlabUrl(host: string, pathname: string): string | null {
+  const projectPath = pathname.split('/-/')[0]
+  const segments = projectPath.split('/').filter(Boolean)
+  if (segments.length < 2) return null
+
+  segments[segments.length - 1] = segments[segments.length - 1].replace(/\.git$/, '')
+  if (segments.some((s) => !s || /\$\{|%7B/i.test(s))) return null
+
+  const path = segments.join('/')
+  // gitlab.com paths are case-insensitive (see CASE_INSENSITIVE_HOSTS); self-hosted
+  // instances are left as-is since their case sensitivity is not guaranteed.
+  return `https://${host}/${host === 'gitlab.com' ? path.toLowerCase() : path}`
+}
+
+/**
  * Converts the raw SCM URL from a POM (declared_repository_url) into a clean,
  * canonical `https://<host>/<owner>/<repo>` repository URL suitable for storage
  * as repository_url. Returns null when the input does not resolve to a real
@@ -872,6 +900,10 @@ export function normalizeScmUrl(raw: string | null): string | null {
   }
 
   if (!SCM_HOSTS.has(host)) return null
+
+  // GitLab (incl. self-hosted) allows nested group namespaces, so its repo path is
+  // more than owner/repo — handled separately from the generic 2-segment logic.
+  if (isGitlabHost(host)) return normalizeGitlabUrl(host, parsed.pathname)
 
   // Require at least owner + repo path segments
   const segments = parsed.pathname.split('/').filter(Boolean)

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -458,6 +458,18 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
  * placeholders) yields null so it is never stored as a repository link.
  *
  * TODO(CM): host list pending product confirmation before rollout.
+ *
+ * Candidate additions found in Maven declared_repository_url (critical rows) but
+ * intentionally NOT added yet, because they need more than a host allowlist:
+ *   - gitbox.apache.org / git.apache.org / git-wip-us.apache.org (~1.3k rows):
+ *     paths are `/repos/asf/<repo>`, so the generic first-two-segments logic would
+ *     collapse every Apache repo to `repos/asf`. Needs path-aware handling (skip
+ *     the `/repos/asf/` prefix) or mapping to the github.com/apache mirror.
+ *   - git.eclipse.org (~180 rows): Gerrit paths, likewise not owner/repo.
+ *   - android.googlesource.com, ec.europa.eu (Bitbucket-Server /projects/x/repos/y):
+ *     multi-segment paths, not owner/repo.
+ *   - ambiguous `git.*` hosts (git.iem.at, git.i-novus.ru, git.oschina.net) and the
+ *     internal git.corp.adobe.com: pending path/reachability confirmation.
  */
 const SCM_HOSTS = new Set([
   'github.com',
@@ -465,6 +477,13 @@ const SCM_HOSTS = new Set([
   'bitbucket.org',
   'gitee.com',
   'codeberg.org',
+  // Self-hosted GitLab / Gitea instances seen in Maven POMs with clean
+  // /<owner>/<repo> paths (same shape as gitlab.com — handled by the generic logic).
+  'gitlab.smartb.city',
+  'gitlab.ow2.org',
+  'gitlab.nuiton.org',
+  'gitlab.inria.fr',
+  'git.neckar.it',
 ])
 
 /** Hosts whose owner/repo path is case-insensitive and should be lower-cased. */
@@ -483,6 +502,9 @@ const CASE_INSENSITIVE_HOSTS = new Set(['github.com', 'gitlab.com'])
  *   github.com/owner/repo (no scheme)        → https://github.com/owner/repo
  *   git://github.com/owner/repo.git          → https://github.com/owner/repo
  *   http://github.com/owner/repo/tree/...    → https://github.com/owner/repo
+ *   github.com:owner/repo.git (SCP colon)    → https://github.com/owner/repo
+ *   https://github.com:owner/repo            → https://github.com/owner/repo
+ *   ssh://git@github.com:owner/repo.git      → https://github.com/owner/repo
  *
  * Rejected (→ null): website-only URLs (https://meson.ai/), non-SCM hosts
  * (svn://…, http://source.android.com), placeholders (Private, ${scm-url}).
@@ -501,14 +523,25 @@ export function normalizeScmUrl(raw: string | null): string | null {
   // SCP form git@host:owner/repo → https://host/owner/repo
   s = s.replace(/^git@([^:/]+):(.+)$/, 'https://$1/$2')
 
+  // ssh://git@host:owner/repo → https://host/owner/repo (SCP colon under ssh)
+  s = s.replace(/^ssh:\/\/git@([^:/]+):(?=\D)/, 'https://$1/')
+
   // ssh://git@host/… → https://host/…
   s = s.replace(/^ssh:\/\/git@([^/]+)\//, 'https://$1/')
+
+  // scheme://host:owner/repo → scheme://host/owner/repo — the colon is an SCP path
+  // separator, not a port (guarded by \D so real numeric ports are left intact).
+  s = s.replace(/^(https?):\/\/([^:/]+):(?=\D)/, '$1://$2/')
 
   // git:// → https://, and upgrade http:// → https://
   s = s.replace(/^git:\/\//, 'https://').replace(/^http:\/\//, 'https://')
 
   // No scheme at all (e.g. "github.com/owner/repo") → assume https
-  if (!s.includes('://')) s = `https://${s}`
+  if (!s.includes('://')) {
+    // Bare SCP form "host:owner/repo" → "host/owner/repo" before assuming https.
+    s = s.replace(/^([^/:]+):(?=\D)/, '$1/')
+    s = `https://${s}`
+  }
 
   let parsed: URL
   try {

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -552,6 +552,28 @@ function normalizeApacheGitwebUrl(host: string, pathname: string, search: string
 }
 
 /**
+ * Eclipse's cgit instance serves repos as /c/<owner>/<repo>[.git][/tree/...], the
+ * same owner/repo shape as the generic hosts but under a fixed /c/ prefix that
+ * cgit requires for a working link (unlike GitHub-style hosts, a bare
+ * https://git.eclipse.org/<owner>/<repo> does not resolve) — so the prefix is
+ * kept in the output rather than stripped like the generic path logic would.
+ */
+const ECLIPSE_CGIT_HOSTS = new Set(['git.eclipse.org'])
+
+function normalizeEclipseCgitUrl(host: string, pathname: string): string | null {
+  if (!pathname.startsWith('/c/')) return null
+
+  const segments = pathname.slice('/c/'.length).split('/').filter(Boolean)
+  if (segments.length < 2) return null
+
+  const owner = segments[0]
+  const name = segments[1].replace(/\.git$/, '')
+  if (!owner || !name || /\$\{|%7B/i.test(owner) || /\$\{|%7B/i.test(name)) return null
+
+  return `https://${host}/c/${owner}/${name}`
+}
+
+/**
  * Converts the raw SCM URL from a POM (declared_repository_url) into a clean,
  * canonical `https://<host>/<owner>/<repo>` repository URL suitable for storage
  * as repository_url. Returns null when the input does not resolve to a real
@@ -619,6 +641,10 @@ export function normalizeScmUrl(raw: string | null): string | null {
 
   if (APACHE_GITWEB_HOSTS.has(host)) {
     return normalizeApacheGitwebUrl(host, parsed.pathname, parsed.search)
+  }
+
+  if (ECLIPSE_CGIT_HOSTS.has(host)) {
+    return normalizeEclipseCgitUrl(host, parsed.pathname)
   }
 
   if (!SCM_HOSTS.has(host)) return null

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -479,11 +479,21 @@ const SCM_HOSTS = new Set([
   'codeberg.org',
   // Self-hosted GitLab / Gitea instances seen in Maven POMs with clean
   // /<owner>/<repo> paths (same shape as gitlab.com — handled by the generic logic).
+  // Internal-only hosts (git.corp.adobe.com, gitlab.alibaba-inc.com) are excluded:
+  // their links are unreachable for consumers. The ≥2-segment owner/repo requirement
+  // acts as a safety net so a mis-classified host yields NULL, never a junk link.
   'gitlab.smartb.city',
   'gitlab.ow2.org',
   'gitlab.nuiton.org',
   'gitlab.inria.fr',
   'git.neckar.it',
+  'git.iem.at',
+  'git.oschina.net',
+  'git.i-novus.ru',
+  'gitlab.protontech.ch',
+  'git.catchpoint.net',
+  'git.dorkbox.com',
+  'git.adorsys.de',
 ])
 
 /** Hosts whose owner/repo path is case-insensitive and should be lower-cased. */
@@ -529,12 +539,13 @@ export function normalizeScmUrl(raw: string | null): string | null {
   // ssh://git@host/… → https://host/…
   s = s.replace(/^ssh:\/\/git@([^/]+)\//, 'https://$1/')
 
+  // git:// → https://, and upgrade http:// → https:// — done before the SCP-colon
+  // rule below so that git://host:owner/repo is normalised too.
+  s = s.replace(/^git:\/\//, 'https://').replace(/^http:\/\//, 'https://')
+
   // scheme://host:owner/repo → scheme://host/owner/repo — the colon is an SCP path
   // separator, not a port (guarded by \D so real numeric ports are left intact).
   s = s.replace(/^(https?):\/\/([^:/]+):(?=\D)/, '$1://$2/')
-
-  // git:// → https://, and upgrade http:// → https://
-  s = s.replace(/^git:\/\//, 'https://').replace(/^http:\/\//, 'https://')
 
   // No scheme at all (e.g. "github.com/owner/repo") → assume https
   if (!s.includes('://')) {

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -519,6 +519,35 @@ const SCM_HOSTS = new Set([
   'git.catchpoint.net',
   'git.dorkbox.com',
   'git.adorsys.de',
+  // Low-traffic residual hosts (1-6 rows each) found by re-classifying the
+  // remaining unresolved repository_url hosts — each individually curl-verified
+  // live at its reconstructed /<owner>/<repo> URL.
+  'code.briarproject.org',
+  'code.europa.eu',
+  'code.haverbeke.berlin',
+  'forgemia.inra.fr',
+  'git.chainmaker.org.cn',
+  'git.coding.net',
+  'git.flyfish.dev',
+  'git.infodavid.org',
+  'git.informatik.uni-rostock.de',
+  'git.jfronny.dev',
+  'git.qoto.org',
+  'git.savannah.gnu.org',
+  'git.sr.ht',
+  'git.struchkov.dev',
+  'gitlab.ceh.ac.uk',
+  'gitlab.cylab.be',
+  'gitlab.ontotext.com',
+  'gitlab.prodevelop.es',
+  'gitlab.uni-oldenburg.de',
+  'gitlab.waveinformatica.com',
+  'gitverse.ru',
+  'gl.kwarc.info',
+  'gricad-gitlab.univ-grenoble-alpes.fr',
+  'opensource.tbank.ru',
+  'oss.brouillard.fr',
+  'xbib.org',
 ])
 
 /** Hosts whose owner/repo path is case-insensitive and should be lower-cased. */
@@ -531,24 +560,114 @@ const CASE_INSENSITIVE_HOSTS = new Set(['github.com', 'gitlab.com'])
  * logic would either reject the query form (no second segment) or collapse every
  * repo to the literal segments "repos"/"asf" for the path form. Handled on the same
  * host rather than mapped to a github.com/apache mirror, since that mapping isn't
- * guaranteed to hold for every repo.
+ * guaranteed to hold for every repo. git.apache.org (ASF's pre-2016 mirror) also
+ * serves the same repos directly at the root (e.g. /kafka.git) — verified live
+ * alongside its /repos/asf/kafka.git equivalent — so that shape is accepted as a
+ * fallback for this host only.
  */
 const APACHE_GITWEB_HOSTS = new Set([
   'gitbox.apache.org',
   'git.apache.org',
   'git-wip-us.apache.org',
+  'git1-us-west.apache.org',
 ])
+
+/**
+ * gitweb's ?p=<repo>.git query param is frequently followed by further gitweb
+ * params (a=, f=, h=, hb=, ...) joined with `;` — gitweb's own separator,
+ * inherited from Perl CGI.pm — not `&`, so URLSearchParams alone can't isolate
+ * `p` from what follows it (e.g. `p=lucene-solr.git;f=lucene/analysis/common`
+ * comes back as one opaque value). The repo name can also have a subpath
+ * appended directly after `.git` with no separator at all (e.g.
+ * `p=hbase.git/hbase-build-configuration/hbase-client`, likely a hand-edited
+ * SCM url) — same problem in the /repos/asf/<repo>.git path form. Taking
+ * everything up to the first literal `.git` handles both without parsing
+ * gitweb's param syntax.
+ */
+function extractGitwebRepoName(raw: string): string | null {
+  const gitIndex = raw.indexOf('.git')
+  const name = (gitIndex === -1 ? raw : raw.slice(0, gitIndex)).replace(/^\/+|\/+$/g, '')
+  if (!name || name.includes('/') || /\$\{|%7B/i.test(name)) return null
+  return name
+}
+
+function wrapAsfRepo(host: string, name: string | null): string | null {
+  return name ? `https://${host}/repos/asf/${name}` : null
+}
 
 function normalizeApacheGitwebUrl(host: string, pathname: string, search: string): string | null {
   const queryRepo = new URLSearchParams(search).get('p')
-  const raw =
-    queryRepo ?? (pathname.startsWith('/repos/asf/') ? pathname.slice('/repos/asf/'.length) : null)
-  if (!raw) return null
+  if (queryRepo) return wrapAsfRepo(host, extractGitwebRepoName(queryRepo))
 
-  const name = raw.replace(/\.git$/, '').replace(/\/+$/, '')
-  if (!name || name.includes('/') || /\$\{|%7B/i.test(name)) return null
+  if (pathname.startsWith('/repos/asf/')) {
+    return wrapAsfRepo(host, extractGitwebRepoName(pathname.slice('/repos/asf/'.length)))
+  }
 
-  return `https://${host}/repos/asf/${name}`
+  if (host === 'git.apache.org') {
+    return wrapAsfRepo(host, extractGitwebRepoName(pathname))
+  }
+
+  return null
+}
+
+/**
+ * Hosts running plain gitweb outside Apache's fixed /repos/asf/ layout — the
+ * repo comes from the ?p=<repo>.git query param only; the map value is the
+ * gitweb script path itself (part of the working URL, not something to parse).
+ * Verified live: stripping a real URL down to just host+scriptPath+?p=<repo>.git
+ * (dropping any trailing ;a=/;h=/... params) still resolves.
+ */
+const GITWEB_QUERY_HOSTS = new Map([
+  ['git.shibboleth.net', '/view/'],
+  ['jogamp.org', '/git/'],
+])
+
+function normalizeGitwebQueryUrl(host: string, search: string): string | null {
+  const name = extractGitwebRepoName(new URLSearchParams(search).get('p') ?? '')
+  if (!name) return null
+  return `https://${host}${GITWEB_QUERY_HOSTS.get(host)}?p=${name}.git`
+}
+
+/**
+ * Hosts whose declared SCM URL points at a GitHub-adjacent surface (raw file
+ * CDN, Packages registry) rather than github.com itself, but whose path still
+ * carries owner/repo as its first two segments — same shape the generic
+ * SCM_HOSTS logic already expects, so only the host needs remapping. Verified
+ * live: github.com/<owner>/<repo> resolves for a same-shape sample from each.
+ */
+const GITHUB_HOST_ALIASES = new Map([
+  ['raw.githubusercontent.com', 'github.com'],
+  ['maven.pkg.github.com', 'github.com'],
+])
+
+/**
+ * Legacy pre-2013 GitHub Pages domain (github.io replaced it) — kept as an
+ * explicit set rather than matching *.github.com generally, since that
+ * pattern would also catch real non-Pages GitHub subdomains (api., raw., …).
+ */
+const LEGACY_GITHUB_PAGES_HOSTS = new Set(['zqq90.github.com', 'mhellkamp.github.com'])
+
+/**
+ * GitHub Pages URLs declared as scm.url: project pages (`<owner>.github.io/<repo>`)
+ * and user/org pages (`<owner>.github.io` with no path, which serve the repo
+ * literally named `<owner>.github.io`) both deterministically encode the source
+ * repo. Also covers a bare `github.io/<owner>/<repo>` (subdomain dropped by
+ * mistake) and the legacy `.github.com` Pages domain. Verified live for one
+ * sample of each shape. Skipped when the path carries an unresolved ${...}
+ * placeholder (interpolation failure upstream, not a Pages-mapping problem).
+ */
+function normalizeGithubPagesUrl(host: string, pathname: string): string | null {
+  const segments = pathname.split('/').filter(Boolean)
+  if (segments.some((s) => /\$\{|%7B/i.test(s))) return null
+
+  if (host === 'github.io') {
+    if (segments.length < 2) return null
+    return `https://github.com/${segments[0]}/${segments[1].replace(/\.git$/, '')}`.toLowerCase()
+  }
+
+  const owner = host.replace(/\.github\.(io|com)$/, '')
+  const repo = segments[0]?.replace(/\.git$/, '') || host
+  return `https://github.com/${owner}/${repo}`.toLowerCase()
 }
 
 /**
@@ -571,6 +690,82 @@ function normalizeEclipseCgitUrl(host: string, pathname: string): string | null 
   if (!owner || !name || /\$\{|%7B/i.test(owner) || /\$\{|%7B/i.test(name)) return null
 
   return `https://${host}/c/${owner}/${name}`
+}
+
+/**
+ * Self-hosted Atlassian Bitbucket Server ("Stash") instances. Both the git-clone
+ * form (/scm/<PROJECT>/<repo>.git) and the browse form
+ * (/projects/<PROJECT>/repos/<repo>/...) encode the same project+repo regardless
+ * of what context path precedes them — the clone form 501s over plain HTTP, so
+ * both are normalized to the browse form. Verified live for one sample per host;
+ * other Stash hosts seen in the data were dead (DNS failure / 503) and excluded.
+ */
+const BITBUCKET_SERVER_HOSTS = new Set(['ec.europa.eu', 'source.opendof.org'])
+
+function normalizeBitbucketServerUrl(host: string, pathname: string): string | null {
+  const match =
+    pathname.match(/^(.*)\/projects\/([^/]+)\/repos\/([^/]+)(?:\/|$)/) ??
+    pathname.match(/^(.*)\/scm\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/|$)/)
+  if (!match) return null
+
+  const [, prefix, project, repo] = match
+  if (!project || !repo || /\$\{|%7B/i.test(project) || /\$\{|%7B/i.test(repo)) return null
+
+  return `https://${host}${prefix}/projects/${project}/repos/${repo}`
+}
+
+/**
+ * Azure DevOps repos: /<org>/_git/<repo>, optionally with a /<project>/ segment
+ * between org and _git. The literal "_git" segment is the only reliable marker —
+ * everything before it is kept verbatim as-is, only a trailing branch/path suffix
+ * after the repo name is dropped.
+ */
+const AZURE_DEVOPS_HOSTS = new Set(['dev.azure.com'])
+
+function normalizeAzureDevOpsUrl(host: string, pathname: string): string | null {
+  const segments = pathname.split('/').filter(Boolean)
+  const gitIndex = segments.indexOf('_git')
+  if (gitIndex < 1 || gitIndex + 1 >= segments.length) return null
+
+  const scope = segments.slice(0, gitIndex)
+  const repo = segments[gitIndex + 1]
+  if (!repo || [...scope, repo].some((s) => /\$\{|%7B/i.test(s))) return null
+
+  return `https://${host}/${scope.join('/')}/_git/${repo}`
+}
+
+/**
+ * Aliyun Codeup group URLs prefix owner/repo with a 24-char hex group id
+ * (/<groupId>/<owner>/<repo>.git) that is not part of the repo path itself.
+ */
+const ALIYUN_CODEUP_HOSTS = new Set(['codeup.aliyun.com'])
+const ALIYUN_GROUP_ID_RE = /^[0-9a-f]{24}$/i
+
+function normalizeAliyunCodeupUrl(host: string, pathname: string): string | null {
+  const segments = pathname.split('/').filter(Boolean)
+  const parts =
+    segments.length >= 3 && ALIYUN_GROUP_ID_RE.test(segments[0]) ? segments.slice(1) : segments
+  if (parts.length < 2) return null
+
+  const owner = parts[0]
+  const name = parts[1].replace(/\.git$/, '')
+  if (!owner || !name || /\$\{|%7B/i.test(owner) || /\$\{|%7B/i.test(name)) return null
+
+  return `https://${host}/${owner}/${name}`
+}
+
+/**
+ * Android's Gerrit/Gitiles mirror already uses its full path as the canonical,
+ * resolvable repo name (e.g. /platform/tools/base) — nested repo naming is normal
+ * here, so this is an identity passthrough rather than an owner/repo split.
+ */
+const GOOGLESOURCE_IDENTITY_HOSTS = new Set(['android.googlesource.com'])
+
+function normalizeGooglesourceUrl(host: string, pathname: string): string | null {
+  const path = pathname.replace(/\/+$/, '').replace(/\.git$/, '')
+  if (!path || /\$\{|%7B/i.test(path)) return null
+
+  return `https://${host}${path}`
 }
 
 /**
@@ -637,14 +832,43 @@ export function normalizeScmUrl(raw: string | null): string | null {
 
   if (parsed.protocol !== 'https:') return null
 
-  const host = parsed.hostname.toLowerCase().replace(/^www\./, '')
+  const rawHost = parsed.hostname.toLowerCase().replace(/^www\./, '')
+  const host = GITHUB_HOST_ALIASES.get(rawHost) ?? rawHost
+
+  if (
+    rawHost === 'github.io' ||
+    rawHost.endsWith('.github.io') ||
+    LEGACY_GITHUB_PAGES_HOSTS.has(rawHost)
+  ) {
+    return normalizeGithubPagesUrl(rawHost, parsed.pathname)
+  }
 
   if (APACHE_GITWEB_HOSTS.has(host)) {
     return normalizeApacheGitwebUrl(host, parsed.pathname, parsed.search)
   }
 
+  if (GITWEB_QUERY_HOSTS.has(host)) {
+    return normalizeGitwebQueryUrl(host, parsed.search)
+  }
+
   if (ECLIPSE_CGIT_HOSTS.has(host)) {
     return normalizeEclipseCgitUrl(host, parsed.pathname)
+  }
+
+  if (BITBUCKET_SERVER_HOSTS.has(host)) {
+    return normalizeBitbucketServerUrl(host, parsed.pathname)
+  }
+
+  if (AZURE_DEVOPS_HOSTS.has(host)) {
+    return normalizeAzureDevOpsUrl(host, parsed.pathname)
+  }
+
+  if (ALIYUN_CODEUP_HOSTS.has(host)) {
+    return normalizeAliyunCodeupUrl(host, parsed.pathname)
+  }
+
+  if (GOOGLESOURCE_IDENTITY_HOSTS.has(host)) {
+    return normalizeGooglesourceUrl(host, parsed.pathname)
   }
 
   if (!SCM_HOSTS.has(host)) return null

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -453,37 +453,89 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
 // ─── SCM URL normalisation ───────────────────────────────────────────────────
 
 /**
- * Converts the raw SCM URL from a POM (declared_repository_url) into a clean
- * HTTPS repository URL suitable for storage as repository_url.
+ * Known source-code-hosting hosts. A normalised repository_url is only produced
+ * when the URL resolves to one of these — anything else (homepages, doc sites,
+ * placeholders) yields null so it is never stored as a repository link.
+ *
+ * TODO(CM): host list pending product confirmation before rollout.
+ */
+const SCM_HOSTS = new Set([
+  'github.com',
+  'gitlab.com',
+  'bitbucket.org',
+  'gitee.com',
+  'codeberg.org',
+])
+
+/** Hosts whose owner/repo path is case-insensitive and should be lower-cased. */
+const CASE_INSENSITIVE_HOSTS = new Set(['github.com', 'gitlab.com'])
+
+/**
+ * Converts the raw SCM URL from a POM (declared_repository_url) into a clean,
+ * canonical `https://<host>/<owner>/<repo>` repository URL suitable for storage
+ * as repository_url. Returns null when the input does not resolve to a real
+ * repository on a known SCM host.
  *
  * Handles common Maven SCM URL forms:
- *   scm:git:git@github.com:owner/repo.git  → https://github.com/owner/repo
- *   scm:git:https://github.com/owner/repo  → https://github.com/owner/repo
- *   git://github.com/owner/repo.git        → https://github.com/owner/repo
- *   https://github.com/owner/repo/tree/... → https://github.com/owner/repo
+ *   scm:git:git@github.com:owner/repo.git    → https://github.com/owner/repo
+ *   scm:git:https://github.com/owner/repo    → https://github.com/owner/repo
+ *   scm:git:github.com/owner/repo            → https://github.com/owner/repo
+ *   github.com/owner/repo (no scheme)        → https://github.com/owner/repo
+ *   git://github.com/owner/repo.git          → https://github.com/owner/repo
+ *   http://github.com/owner/repo/tree/...    → https://github.com/owner/repo
+ *
+ * Rejected (→ null): website-only URLs (https://meson.ai/), non-SCM hosts
+ * (svn://…, http://source.android.com), placeholders (Private, ${scm-url}).
  */
 export function normalizeScmUrl(raw: string | null): string | null {
   if (!raw) return null
-  let url = raw.trim()
+  let s = raw.trim()
+  if (!s) return null
 
-  // Strip scm:git: or scm: prefix
-  url = url.replace(/^scm:git:/i, '').replace(/^scm:/i, '')
+  // Strip Maven scm:git: / scm: prefix
+  s = s.replace(/^scm:git:/i, '').replace(/^scm:/i, '')
 
-  // Convert SSH git@host:owner/repo → https://host/owner/repo
-  url = url.replace(/^git@([^:]+):(.+)$/, 'https://$1/$2')
+  // git+https://… → https://…
+  s = s.replace(/^git\+/, '')
 
-  // Convert git:// → https://
-  url = url.replace(/^git:\/\//, 'https://')
+  // SCP form git@host:owner/repo → https://host/owner/repo
+  s = s.replace(/^git@([^:/]+):(.+)$/, 'https://$1/$2')
 
-  // Strip trailing .git
-  url = url.replace(/\.git$/, '')
+  // ssh://git@host/… → https://host/…
+  s = s.replace(/^ssh:\/\/git@([^/]+)\//, 'https://$1/')
 
-  // Strip /tree/... or /blob/... path suffixes (keep only host + owner + repo)
-  url = url.replace(/\/(tree|blob)(\/.*)?$/, '')
+  // git:// → https://, and upgrade http:// → https://
+  s = s.replace(/^git:\/\//, 'https://').replace(/^http:\/\//, 'https://')
 
-  if (!url.startsWith('https://')) return null
+  // No scheme at all (e.g. "github.com/owner/repo") → assume https
+  if (!s.includes('://')) s = `https://${s}`
 
-  return url.replace(/\/$/, '')
+  let parsed: URL
+  try {
+    parsed = new URL(s)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'https:') return null
+
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, '')
+  if (!SCM_HOSTS.has(host)) return null
+
+  // Require at least owner + repo path segments
+  const segments = parsed.pathname.split('/').filter(Boolean)
+  if (segments.length < 2) return null
+
+  let owner = segments[0]
+  let name = segments[1].replace(/\.git$/, '')
+  if (!owner || !name) return null
+
+  if (CASE_INSENSITIVE_HOSTS.has(host)) {
+    owner = owner.toLowerCase()
+    name = name.toLowerCase()
+  }
+
+  return `https://${host}/${owner}/${name}`
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -484,15 +484,17 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
  *
  * Candidate additions found in Maven declared_repository_url (critical rows) but
  * intentionally NOT added yet, because they need more than a host allowlist:
- *   - gitbox.apache.org / git.apache.org / git-wip-us.apache.org (~1.3k rows):
- *     paths are `/repos/asf/<repo>`, so the generic first-two-segments logic would
- *     collapse every Apache repo to `repos/asf`. Needs path-aware handling (skip
- *     the `/repos/asf/` prefix) or mapping to the github.com/apache mirror.
- *   - git.eclipse.org (~180 rows): Gerrit paths, likewise not owner/repo.
+ *   - git.eclipse.org (~180 rows): Gerrit `/c/<repo>` paths, not owner/repo.
+ *   - eclipse.gerrithub.io (~10 rows): Gerrit admin-UI paths (`/admin/repos/...`),
+ *     not a clone URL shape.
  *   - android.googlesource.com, ec.europa.eu (Bitbucket-Server /projects/x/repos/y):
  *     multi-segment paths, not owner/repo.
  *   - ambiguous `git.*` hosts (git.iem.at, git.i-novus.ru, git.oschina.net) and the
  *     internal git.corp.adobe.com: pending path/reachability confirmation.
+ *
+ * gitbox.apache.org / git.apache.org / git-wip-us.apache.org are handled separately
+ * below (normalizeApacheGitwebUrl) rather than through this allowlist — their paths
+ * are `/repos/asf/<repo>` or `?p=<repo>` (classic gitweb query form), not owner/repo.
  */
 const SCM_HOSTS = new Set([
   'github.com',
@@ -523,6 +525,33 @@ const SCM_HOSTS = new Set([
 const CASE_INSENSITIVE_HOSTS = new Set(['github.com', 'gitlab.com'])
 
 /**
+ * Apache's gitweb-based hosts serve every repo under a fixed /repos/asf/ prefix,
+ * in two equivalent forms: /repos/asf/<repo>.git (path) or /repos/asf?p=<repo>.git
+ * (classic gitweb query-string). Neither is an owner/repo shape — the generic path
+ * logic would either reject the query form (no second segment) or collapse every
+ * repo to the literal segments "repos"/"asf" for the path form. Handled on the same
+ * host rather than mapped to a github.com/apache mirror, since that mapping isn't
+ * guaranteed to hold for every repo.
+ */
+const APACHE_GITWEB_HOSTS = new Set([
+  'gitbox.apache.org',
+  'git.apache.org',
+  'git-wip-us.apache.org',
+])
+
+function normalizeApacheGitwebUrl(host: string, pathname: string, search: string): string | null {
+  const queryRepo = new URLSearchParams(search).get('p')
+  const raw =
+    queryRepo ?? (pathname.startsWith('/repos/asf/') ? pathname.slice('/repos/asf/'.length) : null)
+  if (!raw) return null
+
+  const name = raw.replace(/\.git$/, '').replace(/\/+$/, '')
+  if (!name || name.includes('/') || /\$\{|%7B/i.test(name)) return null
+
+  return `https://${host}/repos/asf/${name}`
+}
+
+/**
  * Converts the raw SCM URL from a POM (declared_repository_url) into a clean,
  * canonical `https://<host>/<owner>/<repo>` repository URL suitable for storage
  * as repository_url. Returns null when the input does not resolve to a real
@@ -546,12 +575,6 @@ export function normalizeScmUrl(raw: string | null): string | null {
   if (!raw) return null
   let s = raw.trim()
   if (!s) return null
-
-  // A leftover ${...} means best-effort interpolation upstream could not resolve it.
-  // Reject outright: a placeholder embedded in the path (e.g. github.com/owner/${x})
-  // otherwise survives URL parsing (percent-encoded to %7B…%7D) and would yield a junk
-  // repository_url instead of null.
-  if (s.includes('${')) return null
 
   // Strip Maven scm:git: / scm: prefix
   s = s.replace(/^scm:git:/i, '').replace(/^scm:/i, '')
@@ -593,6 +616,11 @@ export function normalizeScmUrl(raw: string | null): string | null {
   if (parsed.protocol !== 'https:') return null
 
   const host = parsed.hostname.toLowerCase().replace(/^www\./, '')
+
+  if (APACHE_GITWEB_HOSTS.has(host)) {
+    return normalizeApacheGitwebUrl(host, parsed.pathname, parsed.search)
+  }
+
   if (!SCM_HOSTS.has(host)) return null
 
   // Require at least owner + repo path segments
@@ -602,6 +630,14 @@ export function normalizeScmUrl(raw: string | null): string | null {
   let owner = segments[0]
   let name = segments[1].replace(/\.git$/, '')
   if (!owner || !name) return null
+
+  // A leftover ${...} in owner/repo means best-effort interpolation upstream could
+  // not resolve it — reject rather than store a junk link. The URL parser
+  // percent-encodes { and } in the path, so check both forms. Placeholders in a
+  // trailing suffix (e.g. /tree/${project.scm.tag}) are irrelevant here since only
+  // segments[0]/[1] are inspected — that suffix is simply never read.
+  const hasPlaceholder = (seg: string) => /\$\{|%7B/i.test(seg)
+  if (hasPlaceholder(owner) || hasPlaceholder(name)) return null
 
   if (CASE_INSENSITIVE_HOSTS.has(host)) {
     owner = owner.toLowerCase()

--- a/services/apps/packages_worker/src/maven/extract.ts
+++ b/services/apps/packages_worker/src/maven/extract.ts
@@ -47,6 +47,7 @@ interface PomData {
   developers?: { developer?: unknown }
   contributors?: { contributor?: unknown }
   parent?: { groupId?: unknown; artifactId?: unknown; version?: unknown }
+  properties?: unknown
 }
 
 interface PomPerson {
@@ -262,6 +263,9 @@ interface ResolvedFields {
   developers: PomMaintainer[]
   contributors: PomMaintainer[]
   hops: number
+  // Merged <properties> across the resolved parent chain (child overrides parent),
+  // used to interpolate ${...} placeholders in the SCM URL.
+  properties: Record<string, string>
 }
 
 // prettier-ignore
@@ -273,9 +277,12 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
   const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
   const developers = extractPersons(pom.developers?.developer, 'author')
   const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
+  const properties = extractProperties(pom)
 
   const missingLicense = licenses.length === 0
-  const missingScm = !scmUrl
+  // An unresolved ${...} placeholder counts as missing: the property that defines it
+  // may live in a parent POM, so we still need to walk the chain to collect it.
+  const missingScm = !scmUrl || scmUrl.includes('${')
   const missingDevelopers = developers.length === 0 || contributors.length === 0
   const parent = extractParent(pom)
 
@@ -306,6 +313,8 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
         developers: developers.length > 0 ? developers : parentFields.developers,
         contributors: contributors.length > 0 ? contributors : parentFields.contributors,
         hops: parentFields.hops,
+        // Child properties override the parent's.
+        properties: { ...parentFields.properties, ...properties },
       }
     }
   }
@@ -319,6 +328,7 @@ async function resolveWithInheritance(groupId: string, artifactId: string, versi
     developers,
     contributors,
     hops: depth,
+    properties,
   }
 }
 
@@ -355,7 +365,12 @@ export async function extractArtifactDirect(groupId: string, artifactId: string,
   }
 
   const licenses = extractLicenses(pom)
-  const scmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
+  const rawScmUrl = extractStr(pom.scm?.url ?? pom.scm?.connection)
+  const props = {
+    ...extractProperties(pom),
+    ...builtinProjectProperties(groupId, artifactId, version),
+  }
+  const scmUrl = rawScmUrl ? interpolateProperties(rawScmUrl, props) : null
   const developers = extractPersons(pom.developers?.developer, 'author')
   const contributors = extractPersons(pom.contributors?.contributor, 'maintainer')
 
@@ -414,6 +429,14 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       new Set(),
       baseUrl,
     )
+    // Resolve ${...} placeholders in the SCM URL using the merged chain properties
+    // plus the leaf's built-in project.* values. Best-effort: unresolved placeholders
+    // stay literal and are rejected downstream by normalizeScmUrl.
+    const props = {
+      ...resolved.properties,
+      ...builtinProjectProperties(groupId, artifactId, version),
+    }
+    const scmUrl = resolved.scmUrl ? interpolateProperties(resolved.scmUrl, props) : null
     return {
       groupId,
       artifactId,
@@ -422,7 +445,7 @@ export async function extractArtifact(groupId: string, artifactId: string, versi
       description: resolved.description,
       licenses: resolved.licenses,
       licensesRaw: resolved.licensesRaw,
-      scmUrl: resolved.scmUrl,
+      scmUrl,
       homepageUrl: resolved.homepageUrl,
       developers: resolved.developers,
       contributors: resolved.contributors,
@@ -524,6 +547,12 @@ export function normalizeScmUrl(raw: string | null): string | null {
   let s = raw.trim()
   if (!s) return null
 
+  // A leftover ${...} means best-effort interpolation upstream could not resolve it.
+  // Reject outright: a placeholder embedded in the path (e.g. github.com/owner/${x})
+  // otherwise survives URL parsing (percent-encoded to %7B…%7D) and would yield a junk
+  // repository_url instead of null.
+  if (s.includes('${')) return null
+
   // Strip Maven scm:git: / scm: prefix
   s = s.replace(/^scm:git:/i, '').replace(/^scm:/i, '')
 
@@ -612,6 +641,59 @@ function extractPersons(raw: unknown, role: 'author' | 'maintainer'): PomMaintai
     }))
 }
 
+/** Flattens a POM's <properties> block into a string→string map (non-string values skipped). */
+function extractProperties(pom: PomData): Record<string, string> {
+  const raw = pom.properties
+  if (!raw || typeof raw !== 'object') return {}
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string') out[key] = value
+    else if (typeof value === 'number') out[key] = String(value)
+  }
+  return out
+}
+
+/** Maven built-in project.* / pom.* properties for the leaf coordinates. */
+function builtinProjectProperties(
+  groupId: string,
+  artifactId: string,
+  version: string,
+): Record<string, string> {
+  return {
+    'project.groupId': groupId,
+    'project.artifactId': artifactId,
+    'project.version': version,
+    'pom.groupId': groupId,
+    'pom.artifactId': artifactId,
+    'pom.version': version,
+    groupId,
+    artifactId,
+    version,
+  }
+}
+
+const MAX_INTERPOLATION_DEPTH = 10
+
+/**
+ * Best-effort Maven property interpolation of ${...} placeholders. Resolves
+ * recursively (a property value may itself reference another) up to a depth cap
+ * to guard against cycles. Placeholders with no matching property (e.g. defined
+ * in a profile/settings, or method calls like ${x.substring(8)}) are left as-is
+ * so the SCM normaliser rejects them.
+ */
+export function interpolateProperties(value: string, props: Record<string, string>): string {
+  let current = value
+  for (let i = 0; i < MAX_INTERPOLATION_DEPTH && current.includes('${'); i++) {
+    const next = current.replace(/\$\{([^{}]+)\}/g, (match, key) => {
+      const resolved = props[(key as string).trim()]
+      return resolved !== undefined ? resolved : match
+    })
+    if (next === current) break
+    current = next
+  }
+  return current
+}
+
 function extractParent(
   pom: PomData,
 ): { groupId: string; artifactId: string; version: string } | null {
@@ -634,5 +716,6 @@ function emptyFields(hops: number): ResolvedFields {
     developers: [],
     contributors: [],
     hops,
+    properties: {},
   }
 }

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -53,7 +53,7 @@ type PackageRow = MavenPackageToSync
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 // prettier-ignore
-async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed: Set<string>): Promise<void> {
+export async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl: string | null, changed?: Set<string>): Promise<void> {
   if (!repositoryUrl) return
   const parsed = parseRepoUrl(repositoryUrl)
   if (!parsed) return
@@ -64,7 +64,7 @@ async function writeRepoLink(qx: QueryExecutor, packageId: number, repositoryUrl
     source: 'declared',
     confidence: 0.8,
   })
-  repoChanged.forEach((f) => changed.add(f))
+  repoChanged.forEach((f) => changed?.add(f))
 }
 
 // Postgres deadlock (40P01) is transient: concurrent transactions upserting the same shared

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -268,7 +268,7 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
   const repositoryUrl = normalizeScmUrl(result.scmUrl)
 
   await withDeadlockRetry(() =>
-    qx.tx(async (t) => {
+    qx.tx(async (t: QueryExecutor) => {
       const changed = new Set<string>()
 
       const { id: packageId, changedFields: pkgChanged } = await upsertPackage(t, {

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -1,6 +1,7 @@
 import {
   MavenPackageToSync,
   QueryExecutor,
+  listMavenCriticalPackagesById,
   listMavenPackagesToSync,
   logAuditFieldChange,
   replacePackageMaintainers,
@@ -496,4 +497,64 @@ async function runPhase(qx: QueryExecutor, config: MavenConfig, isCritical: bool
 // prettier-ignore
 export async function runMavenCriticalBackfill(qx: QueryExecutor, config: MavenConfig, isShuttingDown: () => boolean): Promise<BatchResult> {
   return runPhase(qx, config, true, isShuttingDown)
+}
+
+/**
+ * Force full-refresh backfill: re-runs POM extraction over EVERY critical Maven
+ * row, ignoring the staleness window. Unlike runMavenCriticalBackfill (which
+ * drains listMavenPackagesToSync by predicate and cannot terminate with
+ * refreshDays=0 — the freshly-synced top rows re-qualify every batch), this pages
+ * strictly by `id > afterId`, so each row is processed exactly once and the scan
+ * always terminates. Every page runs with forceFullExtraction=true.
+ *
+ * Trade-off vs. the normal path: rows are visited in id order, not
+ * dependent_count order, so if interrupted the most-depended-on packages are not
+ * guaranteed to be done first. Restart re-scans from id 0 (idempotent upserts).
+ */
+// prettier-ignore
+export async function runMavenCriticalForceBackfill(qx: QueryExecutor, config: MavenConfig, isShuttingDown: () => boolean): Promise<BatchResult> {
+  const total: BatchResult = { processed: 0, skipped: 0, error: 0, unchanged: 0 }
+  const startedAt = Date.now()
+  // Cursor kept as a string: id is a Postgres bigint, and Number() coercion would
+  // silently lose precision above 2^53, corrupting the cursor and skipping rows.
+  let afterId = '0'
+  let batchNum = 0
+
+  log.info('Force full-refresh started (all critical rows, keyset by id, ignoring refreshDays)')
+
+  while (!isShuttingDown()) {
+    const page = await listMavenCriticalPackagesById(qx, { afterId, limit: config.batchSize })
+    if (page.length === 0) break
+
+    // Capture the cursor before processPackages reorders the page in place (it
+    // clusters by namespace for the parent-POM cache). Rows come back id-ordered,
+    // so the max id is the last element — kept as a string to preserve bigint precision.
+    afterId = page[page.length - 1].id
+
+    const result = await processPackages(qx, config, page, true, true)
+    batchNum++
+    total.processed += result.processed
+    total.skipped += result.skipped
+    total.error += result.error
+    total.unchanged += result.unchanged
+
+    log.info(
+      {
+        batch: batchNum,
+        afterId,
+        totalProcessed: total.processed,
+        totalSkipped: total.skipped,
+        totalUnchanged: total.unchanged,
+        totalErrors: total.error,
+        elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+      },
+      'Force batch done',
+    )
+  }
+
+  log.info(
+    { ...total, durationSec: Math.round((Date.now() - startedAt) / 1000) },
+    'Force full-refresh complete',
+  )
+  return total
 }

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -72,7 +72,7 @@ export async function writeRepoLink(qx: QueryExecutor, packageId: number, reposi
 // rows (e.g. maintainer 'hboutemy' across many org.apache packages, or the shared apache repo)
 // can form a lock cycle. Re-running the whole transaction resolves it — the upserts are idempotent.
 // prettier-ignore
-async function withDeadlockRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Promise<T> {
+export async function withDeadlockRetry<T>(fn: () => Promise<T>, maxAttempts = 4): Promise<T> {
   for (let attempt = 1; ; attempt++) {
     try {
       return await fn()

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -118,6 +118,41 @@ export async function listMavenPackagesToSync(
   )
 }
 
+/**
+ * Keyset-paginated scan of every critical Maven package, independent of the
+ * staleness window. Unlike `listMavenPackagesToSync` — which drains by predicate
+ * (a row leaves the set once it is fresh) and therefore cannot terminate with
+ * refreshDays=0 — this pages strictly by `id > afterId`, so each row is visited
+ * exactly once and the scan always terminates. Used by the `--force` full-refresh
+ * backfill to re-run POM extraction over the entire critical set regardless of
+ * last_synced_at / ingestion_source.
+ */
+export async function listMavenCriticalPackagesById(
+  qx: QueryExecutor,
+  options: { afterId: string; limit: number },
+): Promise<MavenPackageToSync[]> {
+  return qx.select(
+    `
+    SELECT
+      p.id,
+      p.purl,
+      p.namespace,
+      p.name,
+      p.dependent_count          AS "dependentPackagesCount",
+      p.dependent_repos_count    AS "dependentReposCount",
+      p.latest_version           AS "latestVersion"
+    FROM packages p
+    WHERE p.ecosystem = 'maven'
+      AND p.is_critical
+      AND p.namespace IS NOT NULL
+      AND p.id > $(afterId)::bigint
+    ORDER BY p.id ASC
+    LIMIT $(limit)
+    `,
+    { afterId: options.afterId, limit: options.limit },
+  )
+}
+
 // ─── repository_url backfill ──────────────────────────────────────────────────
 
 export type MavenRepoUrlRow = {

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -131,10 +131,13 @@ export type MavenRepoUrlRow = {
  * canonical). Rows with neither are skipped — there is nothing to recompute.
  * Used by the repository_url backfill to re-run the normalizer over stored data
  * without re-fetching POMs from the registry.
+ *
+ * `criticalOnly` restricts the scan to is_critical rows (index-backed by the
+ * partial index on is_critical) — used for a fast, consumer-facing first pass.
  */
 export async function listMavenPackagesForRepoUrlRecompute(
   qx: QueryExecutor,
-  options: { afterId: number; limit: number },
+  options: { afterId: number; limit: number; criticalOnly?: boolean },
 ): Promise<MavenRepoUrlRow[]> {
   return qx.select(
     `
@@ -144,6 +147,7 @@ export async function listMavenPackagesForRepoUrlRecompute(
       repository_url          AS "repositoryUrl"
     FROM packages
     WHERE ecosystem = 'maven'
+      ${options.criticalOnly ? 'AND is_critical' : ''}
       AND id > $(afterId)
       AND (declared_repository_url IS NOT NULL OR repository_url IS NOT NULL)
     ORDER BY id ASC

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -162,10 +162,12 @@ export type MavenRepoUrlRow = {
 }
 
 /**
- * Keyset-paginated scan of Maven rows that carry a repository link (declared or
- * canonical). Rows with neither are skipped — there is nothing to recompute.
- * Used by the repository_url backfill to re-run the normalizer over stored data
- * without re-fetching POMs from the registry.
+ * Keyset-paginated scan of Maven rows that carry a declared repository value.
+ * The backfill recomputes repository_url *from* declared_repository_url, so rows
+ * with no declared value are skipped: there is nothing to recompute from, and a
+ * null declaration must never be used to clear an existing repository_url that a
+ * different source may have set.
+ * Used to re-run the normalizer over stored data without re-fetching POMs.
  *
  * `criticalOnly` restricts the scan to is_critical rows (index-backed by the
  * partial index on is_critical) — used for a fast, consumer-facing first pass.
@@ -184,7 +186,7 @@ export async function listMavenPackagesForRepoUrlRecompute(
     WHERE ecosystem = 'maven'
       ${options.criticalOnly ? 'AND is_critical' : ''}
       AND id > $(afterId)
-      AND (declared_repository_url IS NOT NULL OR repository_url IS NOT NULL)
+      AND declared_repository_url IS NOT NULL
     ORDER BY id ASC
     LIMIT $(limit)
     `,
@@ -197,6 +199,14 @@ export async function listMavenPackagesForRepoUrlRecompute(
  * only way to clear a stale value, since the enrichment upsert COALESCEs and
  * cannot write NULL. Splits clears (→ NULL) from sets to avoid NULLs inside a
  * text[] array literal.
+ *
+ * Both branches also bump last_synced_at. repository_url is exported to Tinybird
+ * (ossPackages datasource) via a ReplacingMergeTree whose ENGINE_VER is
+ * last_synced_at; without advancing it, a same-version CDC row may lose to the
+ * older one and the correction would never reach downstream consumers. The
+ * trade-off is that these rows look freshly synced to the enrichment freshness
+ * window (listMavenPackagesToSync/refreshDays) and are re-enriched slightly
+ * later — acceptable, since the recomputed value is already current.
  */
 export async function updateMavenRepositoryUrls(
   qx: QueryExecutor,
@@ -211,7 +221,7 @@ export async function updateMavenRepositoryUrls(
 
   if (toClear.length > 0) {
     await qx.result(
-      `UPDATE packages SET repository_url = NULL
+      `UPDATE packages SET repository_url = NULL, last_synced_at = NOW()
        WHERE id = ANY($(ids)::bigint[]) AND repository_url IS NOT NULL`,
       { ids: toClear },
     )
@@ -221,7 +231,7 @@ export async function updateMavenRepositoryUrls(
     await qx.result(
       `
       UPDATE packages p
-      SET repository_url = v.repository_url
+      SET repository_url = v.repository_url, last_synced_at = NOW()
       FROM (
         SELECT unnest($(ids)::bigint[]) AS id,
                unnest($(urls)::text[])  AS repository_url

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -118,6 +118,83 @@ export async function listMavenPackagesToSync(
   )
 }
 
+// ─── repository_url backfill ──────────────────────────────────────────────────
+
+export type MavenRepoUrlRow = {
+  id: number
+  declaredRepositoryUrl: string | null
+  repositoryUrl: string | null
+}
+
+/**
+ * Keyset-paginated scan of Maven rows that carry a repository link (declared or
+ * canonical). Rows with neither are skipped — there is nothing to recompute.
+ * Used by the repository_url backfill to re-run the normalizer over stored data
+ * without re-fetching POMs from the registry.
+ */
+export async function listMavenPackagesForRepoUrlRecompute(
+  qx: QueryExecutor,
+  options: { afterId: number; limit: number },
+): Promise<MavenRepoUrlRow[]> {
+  return qx.select(
+    `
+    SELECT
+      id,
+      declared_repository_url AS "declaredRepositoryUrl",
+      repository_url          AS "repositoryUrl"
+    FROM packages
+    WHERE ecosystem = 'maven'
+      AND id > $(afterId)
+      AND (declared_repository_url IS NOT NULL OR repository_url IS NOT NULL)
+    ORDER BY id ASC
+    LIMIT $(limit)
+    `,
+    { afterId: options.afterId, limit: options.limit },
+  )
+}
+
+/**
+ * Applies a batch of recomputed repository_url values via direct UPDATE — the
+ * only way to clear a stale value, since the enrichment upsert COALESCEs and
+ * cannot write NULL. Splits clears (→ NULL) from sets to avoid NULLs inside a
+ * text[] array literal.
+ */
+export async function updateMavenRepositoryUrls(
+  qx: QueryExecutor,
+  updates: { id: number; repositoryUrl: string | null }[],
+): Promise<void> {
+  if (updates.length === 0) return
+
+  const toClear = updates.filter((u) => u.repositoryUrl === null).map((u) => u.id)
+  const toSet = updates.filter(
+    (u): u is { id: number; repositoryUrl: string } => u.repositoryUrl !== null,
+  )
+
+  if (toClear.length > 0) {
+    await qx.result(
+      `UPDATE packages SET repository_url = NULL
+       WHERE id = ANY($(ids)::bigint[]) AND repository_url IS NOT NULL`,
+      { ids: toClear },
+    )
+  }
+
+  if (toSet.length > 0) {
+    await qx.result(
+      `
+      UPDATE packages p
+      SET repository_url = v.repository_url
+      FROM (
+        SELECT unnest($(ids)::bigint[]) AS id,
+               unnest($(urls)::text[])  AS repository_url
+      ) v
+      WHERE p.id = v.id
+        AND p.repository_url IS DISTINCT FROM v.repository_url
+      `,
+      { ids: toSet.map((u) => u.id), urls: toSet.map((u) => u.repositoryUrl) },
+    )
+  }
+}
+
 // ─── packages touch ───────────────────────────────────────────────────────────
 
 /**

--- a/services/libs/data-access-layer/src/osspckgs/repos.ts
+++ b/services/libs/data-access-layer/src/osspckgs/repos.ts
@@ -37,6 +37,26 @@ export async function upsertRepo(qx: QueryExecutor, item: IDbRepoUpsert): Promis
 }
 
 /**
+ * Removes the `declared` repo links for the given packages. Used by the
+ * repository_url backfill to drop stale links when a package's canonical URL
+ * changes or is cleared, keeping package_repos consistent with
+ * packages.repository_url. Only touches source='declared' (the link Maven
+ * owns) — links from other enrichers (deps.dev, heuristic, manual) are left
+ * untouched. The shared `repos` rows are never deleted.
+ */
+export async function deleteMavenPackageRepoLinks(
+  qx: QueryExecutor,
+  packageIds: number[],
+): Promise<void> {
+  if (packageIds.length === 0) return
+  await qx.result(
+    `DELETE FROM package_repos
+     WHERE package_id = ANY($(packageIds)::bigint[]) AND source = 'declared'`,
+    { packageIds },
+  )
+}
+
+/**
  * Links a package to a repo with provenance metadata.
  * On conflict keeps the higher confidence value and refreshes verified_at.
  * Returns the list of fields that actually changed.


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->

Fixes the Maven half of the `repository_url` normalization problem: `packages.repository_url` must always hold a canonical `https://<host>/<owner>/<repo>` link or `NULL`, never a website, placeholder, or free-form string. The Maven normalizer (`normalizeScmUrl`) had two defects:

- **Gap B — recoverable inputs dropped to NULL.** A regex chain gated on `startsWith('https://')` discarded inputs whose repo was clearly reconstructable: `scm:git:` prefixes without a scheme, bare `host/owner/repo` values, and `http://` URLs that were never upgraded to `https://`. This left `repository_url` NULL for ~18.8k critical Maven rows where the declared value was a valid GitHub URL.
- **Gap C — non-repository URLs written as repos.** After the https gate there was no shape validation, so homepages (e.g. `https://meson.ai/`) passed straight through and were stored as if they were repository links.

Since the public API falls back to `declared_repository_url` when `repository_url` is NULL, these gaps meant clients received either nothing or raw, non-normalized registry values.

This PR rewrites `normalizeScmUrl` to parse and validate instead of regex-guess, and adds a DB-only backfill to correct existing rows.

Scope: **Maven only.** Cargo/npm/NuGet gaps, the shared normalizer + ADR, and the API fallback removal are tracked separately.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->

- **Rewrote `normalizeScmUrl`** (`services/apps/packages_worker/src/maven/extract.ts`) to normalize via `URL()` parsing rather than a regex chain. It now: strips `scm:git:`/`scm:`/`git+` prefixes and SCP/`ssh://`/`git://` forms; prepends `https://` to schemeless inputs and upgrades `http://` → `https://` (Gap B); requires a known SCM host **and** an `owner/repo` path shape, returning NULL otherwise (Gap C); and lower-cases the path on case-insensitive hosts (github/gitlab).
- **The SCM host allowlist is provisional** — `SCM_HOSTS`/`CASE_INSENSITIVE_HOSTS` are marked `TODO(CM)` pending product confirmation of the final host list. The trade-off: an allowlist reliably rejects doc-sites but also drops self-hosted git (e.g. `gitbox.apache.org`); needs a decision before rollout.
- **Added tests** for the ticket's Gap B/Gap C cases (`maven/__tests__/normalize.test.ts`). All pre-existing cases still pass, including `svn://` → NULL.
- **Added a recompute-from-DB backfill** rather than reusing `backfill:maven`. The existing backfill re-fetches every POM over the network (~18.8k+ HTTP calls) and — critically — cannot clear Gap C junk, because the enrichment upsert `COALESCE`s and can never write NULL. The new path re-runs the normalizer over the already-stored `declared_repository_url` (zero network) and applies a **direct UPDATE**, so it both fills recoverable NULLs (Gap B) and clears non-repo values (Gap C).
  - `services/apps/packages_worker/src/maven/backfillRepositoryUrl.ts` — keyset-paginated, idempotent, resumable orchestration; counts filled/cleared/rewritten/unchanged/linked/pruned; supports `--dry-run`.
- **Keeps the repos / package_repos link tables consistent** with the recomputed `repository_url`. This matters because consumers like the security-contacts pipeline read the repository through `repos ⋈ package_repos`, not `packages.repository_url` — so a fill that only touched `packages` would stay invisible to them. On rewrites and clears the stale `source='declared'` link is pruned; on fills and rewrites the correct link is (re)written via the enrichment loop's `writeRepoLink` (now exported from `runMavenEnrichmentLoop.ts`). This is deliberately stricter than the incremental enrichment path, which is upsert-only and never prunes — so the backfill also cleans up pre-existing stale links rather than leaving zombies.
  - `services/apps/packages_worker/src/bin/maven-repo-url-backfill.ts` — bin entrypoint with graceful shutdown and positive-integer validation of the batch-size env var.
  - `services/libs/data-access-layer/src/osspckgs/packages.ts` — new `listMavenPackagesForRepoUrlRecompute` + `updateMavenRepositoryUrls` (splits clears from sets to avoid NULLs inside a `text[]` literal).
  - `services/libs/data-access-layer/src/osspckgs/repos.ts` — new `deleteMavenPackageRepoLinks` (removes only `source='declared'` links; never deletes shared `repos` rows).
  - `package.json` — new `backfill:maven-repo-url[:local]` scripts.
- The backfill does **not** bump `last_synced_at`, so it doesn't disturb the enrichment freshness window.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1305](https://linuxfoundation.atlassian.net/browse/CM-1305)

[CM-1305]: https://linuxfoundation.atlassian.net/browse/CM-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk updates to `packages.repository_url`, `package_repos`, and `last_synced_at` affect security-contacts and Tinybird CDC; host allowlist is provisional (TODO CM) so rollout may drop or remap links until confirmed.
> 
> **Overview**
> Rewrites Maven **`normalizeScmUrl`** to parse with `URL()`, recover previously dropped SCM shapes (schemeless/`http`/SCP), reject non-repo URLs via host allowlists and dedicated handlers (Apache gitweb, GitLab namespaces, GitHub Pages, etc.), and add **`interpolateProperties`** so POM extraction resolves `${...}` in SCM URLs from merged parent-chain properties.
> 
> Adds a **DB-only repo-url backfill** (`backfill:maven-repo-url`) that recomputes `repository_url` from stored `declared_repository_url` (no POM fetch), can **NULL out** junk values the enrichment upsert cannot clear, and keeps **`package_repos`** in sync via transactional UPDATE + prune/relink of `source='declared'` links.
> 
> **`backfill:maven --force`** runs a terminating id-keyset full critical POM re-extraction (`runMavenCriticalForceBackfill` + `listMavenCriticalPackagesById`) for rolling out interpolation/normalizer changes without re-fetching only via the staleness queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc09d51e8ee6d83d3d9940bd0db0f6c375b43d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->