### PR TITLE
fix(tinybird): exclude disabled projects from all pipes

### DIFF
--- a/services/libs/tinybird/pipes/activityRepositories_filtered.pipe
+++ b/services/libs/tinybird/pipes/activityRepositories_filtered.pipe
@@ -17,7 +17,7 @@ SQL >
     JOIN
         repositories r FINAL ON r.insightsProjectId = i.id AND isNull (r.deletedAt) AND r.enabled = true
     where
-        isNull (i.deletedAt)
+        isNull (i.deletedAt) AND i.enabled = 1
         {% if defined(repos) %}
             AND r.url
             IN {{ Array(repos, 'String', description="Filter activity repo list", required=False) }}

--- a/services/libs/tinybird/pipes/collections_filtered.pipe
+++ b/services/libs/tinybird/pipes/collections_filtered.pipe
@@ -17,6 +17,7 @@ SQL >
     left join
         insightsProjects ip FINAL
         on ip.id = collectionsInsightsProjects.insightsProjectId
+        and isNull (ip.deletedAt)
     where
         isNull (collections.deletedAt) AND isNull (collections.ssoUserId)
         {% if defined(slug) %}

--- a/services/libs/tinybird/pipes/collections_filtered.pipe
+++ b/services/libs/tinybird/pipes/collections_filtered.pipe
@@ -7,7 +7,11 @@ SQL >
     SELECT
         collections.*,
         SUM(
-            CASE WHEN collectionsInsightsProjects.insightsProjectId != '' AND ip.enabled = 1 THEN 1 ELSE 0 END
+            CASE
+                WHEN collectionsInsightsProjects.insightsProjectId != '' AND ip.enabled = 1
+                THEN 1
+                ELSE 0
+            END
         ) as "projectCount"
     FROM collections FINAL
     left join

--- a/services/libs/tinybird/pipes/collections_filtered.pipe
+++ b/services/libs/tinybird/pipes/collections_filtered.pipe
@@ -7,13 +7,16 @@ SQL >
     SELECT
         collections.*,
         SUM(
-            CASE WHEN collectionsInsightsProjects.insightsProjectId != '' THEN 1 ELSE 0 END
+            CASE WHEN collectionsInsightsProjects.insightsProjectId != '' AND ip.enabled = 1 THEN 1 ELSE 0 END
         ) as "projectCount"
     FROM collections FINAL
     left join
         collectionsInsightsProjects
         on collectionsInsightsProjects.collectionId = collections.id
         and isNull (collectionsInsightsProjects.deletedAt)
+    left join
+        insightsProjects ip FINAL
+        on ip.id = collectionsInsightsProjects.insightsProjectId
     where
         isNull (collections.deletedAt) AND isNull (collections.ssoUserId)
         {% if defined(slug) %}

--- a/services/libs/tinybird/pipes/contributors_leaderboard.pipe
+++ b/services/libs/tinybird/pipes/contributors_leaderboard.pipe
@@ -42,7 +42,8 @@ SQL >
     SELECT not isLF AS result
     FROM insightsProjects final
     WHERE
-        isNull (deletedAt) AND enabled = 1
+        isNull (deletedAt)
+        AND enabled = 1
         and slug = {{ String(project, description="Filter by project slug", required=True) }}
 
 NODE contributors_leaderboard_2

--- a/services/libs/tinybird/pipes/contributors_leaderboard.pipe
+++ b/services/libs/tinybird/pipes/contributors_leaderboard.pipe
@@ -42,7 +42,7 @@ SQL >
     SELECT not isLF AS result
     FROM insightsProjects final
     WHERE
-        isNull (deletedAt)
+        isNull (deletedAt) AND enabled = 1
         and slug = {{ String(project, description="Filter by project slug", required=True) }}
 
 NODE contributors_leaderboard_2

--- a/services/libs/tinybird/pipes/health_score_copy.pipe
+++ b/services/libs/tinybird/pipes/health_score_copy.pipe
@@ -5,7 +5,7 @@ DESCRIPTION >
 SQL >
     SELECT id, segmentId, slug, widgets
     from insightsProjects FINAL
-    WHERE isNull (deletedAt) and segmentId != ''
+    WHERE isNull (deletedAt) AND enabled = 1 AND segmentId != ''
 
 NODE health_score_copy_data
 SQL >

--- a/services/libs/tinybird/pipes/health_score_security.pipe
+++ b/services/libs/tinybird/pipes/health_score_security.pipe
@@ -5,7 +5,11 @@ SQL >
     FROM insightsProjects i FINAL
     JOIN repositories r FINAL ON r.insightsProjectId = i.id
     WHERE
-        isNull (i.deletedAt) AND i.enabled = 1 AND isNull (r.deletedAt) AND r.enabled = true AND r.excluded = false
+        isNull (i.deletedAt)
+        AND i.enabled = 1
+        AND isNull (r.deletedAt)
+        AND r.enabled = true
+        AND r.excluded = false
         {% if defined(project) %}
             AND i.id = (SELECT insightsProjectId FROM segments_filtered)
             AND r.url in (select arrayJoin(repositories) from segments_filtered)

--- a/services/libs/tinybird/pipes/health_score_security.pipe
+++ b/services/libs/tinybird/pipes/health_score_security.pipe
@@ -5,7 +5,7 @@ SQL >
     FROM insightsProjects i FINAL
     JOIN repositories r FINAL ON r.insightsProjectId = i.id
     WHERE
-        isNull (i.deletedAt) AND isNull (r.deletedAt) AND r.enabled = true AND r.excluded = false
+        isNull (i.deletedAt) AND i.enabled = 1 AND isNull (r.deletedAt) AND r.enabled = true AND r.excluded = false
         {% if defined(project) %}
             AND i.id = (SELECT insightsProjectId FROM segments_filtered)
             AND r.url in (select arrayJoin(repositories) from segments_filtered)

--- a/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
@@ -268,7 +268,7 @@ SQL >
         last_vulnerability_scan_status
         ON last_vulnerability_scan_status.insightsProjectId = insightsProjects.id
     LEFT JOIN segments ON segments.id = insightsProjects.segmentId
-    WHERE isNull (insightsProjects.deletedAt)
+    WHERE isNull (insightsProjects.deletedAt) AND insightsProjects.enabled = 1
     group by 1
 
 TYPE COPY

--- a/services/libs/tinybird/pipes/maintainers_roles_copy.pipe
+++ b/services/libs/tinybird/pipes/maintainers_roles_copy.pipe
@@ -3,7 +3,7 @@ SQL >
     SELECT i.id, r.url AS repository
     FROM insightsProjects i FINAL
     JOIN repositories r FINAL ON r.insightsProjectId = i.id
-    WHERE isNull (i.deletedAt) AND isNull (r.deletedAt) AND r.enabled = true
+    WHERE isNull (i.deletedAt) AND i.enabled = 1 AND isNull (r.deletedAt) AND r.enabled = true
 
 NODE maintainers_roles_copy_member_identities_deduplicated
 SQL >

--- a/services/libs/tinybird/pipes/members_public_names_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/members_public_names_copy_pipe.pipe
@@ -1,6 +1,6 @@
 NODE segmentIds_in_nonlf_projects
 SQL >
-    select segmentId from insightsProjects where isLF = 0 and segmentId != '' and isNull (deletedAt)
+    select segmentId from insightsProjects where isLF = 0 and segmentId != '' and isNull (deletedAt) and enabled = 1
 
 NODE members_public_names_result
 SQL >

--- a/services/libs/tinybird/pipes/members_public_names_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/members_public_names_copy_pipe.pipe
@@ -1,6 +1,8 @@
 NODE segmentIds_in_nonlf_projects
 SQL >
-    select segmentId from insightsProjects where isLF = 0 and segmentId != '' and isNull (deletedAt) and enabled = 1
+    select segmentId
+    from insightsProjects
+    where isLF = 0 and segmentId != '' and isNull (deletedAt) and enabled = 1
 
 NODE members_public_names_result
 SQL >

--- a/services/libs/tinybird/pipes/repos_to_channels.pipe
+++ b/services/libs/tinybird/pipes/repos_to_channels.pipe
@@ -45,7 +45,8 @@ SQL >
         i.platform = 'gerrit'
         AND isNull (r.deletedAt)
         AND r.enabled = true
-        AND isNull (p.deletedAt) AND p.enabled = 1
+        AND isNull (p.deletedAt)
+        AND p.enabled = 1
         AND r.url IN (SELECT url FROM repos_to_expand)
 
 NODE expanded_urls

--- a/services/libs/tinybird/pipes/repos_to_channels.pipe
+++ b/services/libs/tinybird/pipes/repos_to_channels.pipe
@@ -27,7 +27,7 @@ SQL >
         FROM repositories r FINAL
         INNER JOIN insightsProjects i FINAL ON r.insightsProjectId = i.id
         WHERE
-            isNull (r.deletedAt) AND r.enabled = true AND isNull (i.deletedAt)
+            isNull (r.deletedAt) AND r.enabled = true AND isNull (i.deletedAt) AND i.enabled = 1
             {% if defined(excluded) and excluded %} AND r.excluded = true
             {% end %}
     {% end %}
@@ -45,7 +45,7 @@ SQL >
         i.platform = 'gerrit'
         AND isNull (r.deletedAt)
         AND r.enabled = true
-        AND isNull (p.deletedAt)
+        AND isNull (p.deletedAt) AND p.enabled = 1
         AND r.url IN (SELECT url FROM repos_to_expand)
 
 NODE expanded_urls

--- a/services/libs/tinybird/pipes/segments_aggregates_with_ids_copy.pipe
+++ b/services/libs/tinybird/pipes/segments_aggregates_with_ids_copy.pipe
@@ -2,7 +2,7 @@ NODE segments_aggregates_with_ids_projects
 SQL >
     SELECT insightsProjects.id, insightsProjects.segmentId
     FROM insightsProjects FINAL
-    WHERE insightsProjects.segmentId != '' and isNull (insightsProjects.deletedAt)
+    WHERE insightsProjects.segmentId != '' AND isNull (insightsProjects.deletedAt) AND insightsProjects.enabled = 1
 
 NODE segments_aggregates_with_ids_collections_projects
 SQL >

--- a/services/libs/tinybird/pipes/segments_aggregates_with_ids_copy.pipe
+++ b/services/libs/tinybird/pipes/segments_aggregates_with_ids_copy.pipe
@@ -2,7 +2,10 @@ NODE segments_aggregates_with_ids_projects
 SQL >
     SELECT insightsProjects.id, insightsProjects.segmentId
     FROM insightsProjects FINAL
-    WHERE insightsProjects.segmentId != '' AND isNull (insightsProjects.deletedAt) AND insightsProjects.enabled = 1
+    WHERE
+        insightsProjects.segmentId != ''
+        AND isNull (insightsProjects.deletedAt)
+        AND insightsProjects.enabled = 1
 
 NODE segments_aggregates_with_ids_collections_projects
 SQL >

--- a/services/libs/tinybird/pipes/sitemap_projects.pipe
+++ b/services/libs/tinybird/pipes/sitemap_projects.pipe
@@ -1,3 +1,3 @@
 NODE sitemap_projects_slugs
 SQL >
-    SELECT slug FROM insightsProjects FINAL WHERE isNull (deletedAt)
+    SELECT slug FROM insightsProjects FINAL WHERE isNull (deletedAt) AND enabled = 1


### PR DESCRIPTION
## Summary

- `enabled` was ignored across Tinybird pipes despite existing on `insightsProjects` — disabled projects appeared on collection profile pages and contributed to aggregates (projectCount, softwareValue, contributorCount, leaderboards, health scores, sitemap, etc.)
- Added `enabled = 1` gate at `insights_projects_populated_copy` (cascades to ~14 downstream COPY pipes) and at every pipe that reads `insightsProjects` directly

## Pipes changed

| Pipe | Role |
|---|---|
| `insights_projects_populated_copy` | Base denormalized copy — cascades to leaderboards, org pages, project insights, agentic AI, Kafka sink |
| `segments_aggregates_with_ids_copy` | Collection/category aggregates (softwareValue, contributorCount) |
| `collections_filtered` | projectCount per collection |
| `sitemap_projects` | Project sitemap |
| `health_score_copy` | Health score base data |
| `health_score_security` | Security health inputs |
| `maintainers_roles_copy` | Maintainer roles |
| `activityRepositories_filtered` | Repo search |
| `repos_to_channels` | Repo → activity channel expansion |
| `contributors_leaderboard` | LF/non-LF project check |
| `members_public_names_copy_pipe` | Public names for non-LF project members |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad analytics and public-facing listing behavior changes when projects are disabled; incorrect `enabled` data could hide or expose projects incorrectly, but the change is additive filtering with no auth or write-path changes.
> 
> **Overview**
> **Disabled `insightsProjects` are now filtered out** wherever project lists and aggregates are built, by adding **`enabled = 1`** (with existing `deletedAt` checks) on reads from `insightsProjects`.
> 
> The main gate is **`insights_projects_populated_copy`**, which limits rows written to `insights_projects_populated_ds` and therefore what downstream COPY consumers (leaderboards, org pages, Kafka sink, etc.) see. **`segments_aggregates_with_ids_copy`**, **`collections_filtered`** (join to `insightsProjects` so **`projectCount`** ignores disabled links), **`sitemap_projects`**, health score pipes (**`health_score_copy`**, **`health_score_security`**), **`maintainers_roles_copy`**, **`activityRepositories_filtered`**, **`repos_to_channels`**, **`contributors_leaderboard`** (non-LF name logic), and **`members_public_names_copy_pipe`** get the same filter on direct project queries.
> 
> **Expected product effect:** disabled projects should stop appearing on collection profiles, sitemaps, repo search, channel expansion, leaderboards, health scores, and related rollups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5625c1e1a307cd387138fe88f41810e34dd69111. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->