### PR TITLE
feat: expose organization domains in public APIs (CM-1266)

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -815,7 +815,7 @@ paths:
                 $ref: '#/components/schemas/Organization'
               example:
                 id: 550e8400-e29b-41d4-a716-446655440000
-                displayName: Linux Foundation
+                name: Linux Foundation
                 domain: linuxfoundation.org
                 logo: https://example.com/logo.png
         '401':
@@ -1559,13 +1559,13 @@ components:
       type: object
       required:
         - id
-        - displayName
+        - name
         - domain
       properties:
         id:
           type: string
           format: uuid
-        displayName:
+        name:
           type: string
           description: Display name of the organization.
         domain:

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -779,8 +779,11 @@ paths:
   /organizations:
     get:
       operationId: getOrganization
-      summary: Look up an organization by domain
-      description: Find a verified organization by its primary domain.
+      summary: Look up an organization by domain or name
+      description: >
+        Provide domain, name, or both. When both are provided, the domain and
+        name must belong to the same organization. If multiple organizations
+        match, the most active one is returned.
       tags:
         - Organizations
       security:
@@ -789,12 +792,20 @@ paths:
       parameters:
         - name: domain
           in: query
-          required: true
+          required: false
           description: Primary domain of the organization.
           schema:
             type: string
             minLength: 1
           example: linuxfoundation.org
+        - name: name
+          in: query
+          required: false
+          description: Exact display name of the organization.
+          schema:
+            type: string
+            minLength: 1
+          example: Linux Foundation
       responses:
         '200':
           description: Organization found.
@@ -804,14 +815,15 @@ paths:
                 $ref: '#/components/schemas/Organization'
               example:
                 id: 550e8400-e29b-41d4-a716-446655440000
-                name: Linux Foundation
+                displayName: Linux Foundation
+                domain: linuxfoundation.org
                 logo: https://example.com/logo.png
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':
-          description: No verified organization found for the given domain.
+          description: No organization found for the given domain or name.
           content:
             application/json:
               schema:
@@ -876,15 +888,26 @@ paths:
                 required:
                   - id
                   - name
+                  - domain
                 properties:
                   id:
                     type: string
                     format: uuid
                   name:
                     type: string
+                  domain:
+                    type: string
+                    description: Verified primary domain of the organization.
+                  logo:
+                    type:
+                      - string
+                      - 'null'
+                    description: URL of the organization logo.
               example:
                 id: 550e8400-e29b-41d4-a716-446655440000
                 name: Acme Corp
+                domain: acme.com
+                logo: https://example.com/logo.png
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1218,6 +1241,7 @@ components:
         - id
         - organizationId
         - organizationName
+        - organizationDomains
         - jobTitle
         - verified
         - verifiedBy
@@ -1243,6 +1267,11 @@ components:
             - string
             - 'null'
           description: URL of the organization logo.
+        organizationDomains:
+          type: array
+          items:
+            type: string
+          description: Verified primary domains for the organization, in alphabetical order.
         jobTitle:
           type:
             - string
@@ -1530,14 +1559,18 @@ components:
       type: object
       required:
         - id
-        - name
+        - displayName
+        - domain
       properties:
         id:
           type: string
           format: uuid
-        name:
+        displayName:
           type: string
           description: Display name of the organization.
+        domain:
+          type: string
+          description: Verified primary domain.
         logo:
           type: string
           description: URL of the organization logo. Only present if available.

--- a/backend/src/api/public/v1/members/work-experiences/createMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/createMemberWorkExperience.ts
@@ -117,7 +117,7 @@ export async function createMemberWorkExperience(req: Request, res: Response): P
         memberOrganizationIds: [data.organizationId],
       })
 
-      const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId])
+      const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
       createdMo = (orgsMap.get(memberId) ?? []).find((mo) => mo.id === newMemberOrgId)
 
       captureNewState(createdMo ?? null)

--- a/backend/src/api/public/v1/members/work-experiences/getMemberWorkExperiences.ts
+++ b/backend/src/api/public/v1/members/work-experiences/getMemberWorkExperiences.ts
@@ -27,7 +27,7 @@ export async function getMemberWorkExperiences(req: Request, res: Response): Pro
     throw new NotFoundError('Member not found')
   }
 
-  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId])
+  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
   const workExperiences = groupMemberOrganizations(orgsMap.get(memberId) ?? []).map(
     toMemberWorkExperience,
   )

--- a/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
@@ -120,7 +120,7 @@ export async function updateMemberWorkExperience(req: Request, res: Response): P
         memberOrganizationIds: [data.organizationId],
       })
 
-      const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId])
+      const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
       const updatedMo = groupMemberOrganizations(orgsMap.get(memberId) ?? []).find(
         (mo) => mo.id === workExperienceId,

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -100,13 +100,19 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     }),
   )
 
-  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId])
+  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
   const responseMo: IMemberRoleWithOrganization =
     groupMemberOrganizations(orgsMap.get(memberId) ?? []).find(
       (mo) => mo.id === workExperienceId,
     ) ??
-    ({ ...memberOrg, ...updatedMemberOrg, verified, verifiedBy } as IMemberRoleWithOrganization)
+    ({
+      ...memberOrg,
+      ...updatedMemberOrg,
+      verified,
+      verifiedBy,
+      organizationDomains: [],
+    } as IMemberRoleWithOrganization)
 
   ok(res, toMemberWorkExperience(responseMo))
 }

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -52,6 +52,18 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     throw new NotFoundError('Work experience not found')
   }
 
+  const orgsMapBeforeChange = await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
+    withDomains: true,
+  })
+
+  const workExperienceWithOrgData = groupMemberOrganizations(
+    orgsMapBeforeChange.get(memberId) ?? [],
+  ).find((mo) => mo.id === workExperienceId)
+
+  if (!workExperienceWithOrgData) {
+    throw new NotFoundError('Work experience not found')
+  }
+
   const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
   const memberOrgIdsToDelete = [
@@ -102,17 +114,14 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
 
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
-  const responseMo: IMemberRoleWithOrganization =
-    groupMemberOrganizations(orgsMap.get(memberId) ?? []).find(
-      (mo) => mo.id === workExperienceId,
-    ) ??
-    ({
-      ...memberOrg,
-      ...updatedMemberOrg,
-      verified,
-      verifiedBy,
-      organizationDomains: [],
-    } as IMemberRoleWithOrganization)
+  const responseMo: IMemberRoleWithOrganization = groupMemberOrganizations(
+    orgsMap.get(memberId) ?? [],
+  ).find((mo) => mo.id === workExperienceId) ?? {
+    ...workExperienceWithOrgData,
+    ...updatedMemberOrg,
+    verified,
+    verifiedBy,
+  }
 
   ok(res, toMemberWorkExperience(responseMo))
 }

--- a/backend/src/api/public/v1/organizations/createOrganization.ts
+++ b/backend/src/api/public/v1/organizations/createOrganization.ts
@@ -61,5 +61,5 @@ export async function createOrganization(req: Request, res: Response): Promise<v
     )
   })
 
-  created(res, { id: organizationId, name, logo })
+  created(res, { id: organizationId, name, logo, domain })
 }

--- a/backend/src/api/public/v1/organizations/createOrganization.ts
+++ b/backend/src/api/public/v1/organizations/createOrganization.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, organizationCreateAction } from '@crowd/audit-logs'
-import { InternalError } from '@crowd/common'
+import { BadRequestError, InternalError, normalizeHostname } from '@crowd/common'
 import { findOrCreateOrganization, optionsQx } from '@crowd/data-access-layer'
 import { OrganizationAttributeSource, OrganizationIdentityType } from '@crowd/types'
 
@@ -17,16 +17,20 @@ const bodySchema = z.object({
 })
 
 export async function createOrganization(req: Request, res: Response): Promise<void> {
-  const { name, domain, source, logo } = validateOrThrow(bodySchema, req.body)
+  const { name, domain: rawDomain, source, logo } = validateOrThrow(bodySchema, req.body)
+
+  const domain = normalizeHostname(rawDomain, false)
+
+  if (!domain) {
+    throw new BadRequestError(`Invalid domain: ${rawDomain}`)
+  }
 
   const qx = optionsQx(req)
 
-  let organizationId: string | undefined
-
-  await qx.tx(async (tx) => {
+  const organizationId = await qx.tx(async (tx) => {
     const orgSource = OrganizationAttributeSource.LFX_SERVE
 
-    organizationId = await findOrCreateOrganization(tx, orgSource, {
+    const organizationId = await findOrCreateOrganization(tx, orgSource, {
       displayName: name,
       logo,
       identities: [
@@ -59,6 +63,8 @@ export async function createOrganization(req: Request, res: Response): Promise<v
         })
       }),
     )
+
+    return organizationId
   })
 
   created(res, { id: organizationId, name, logo, domain })

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -20,7 +20,7 @@ export async function getOrganization(req: Request, res: Response): Promise<void
   const { name, domain: rawDomain } = validateOrThrow(querySchema, req.query)
 
   const domain = rawDomain ? normalizeHostname(rawDomain, false) : undefined
-  
+
   if (rawDomain && !domain) {
     throw new BadRequestError(`Invalid domain: ${rawDomain}`)
   }

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -29,5 +29,6 @@ export async function getOrganization(req: Request, res: Response): Promise<void
     throw new NotFoundError('Organization not found')
   }
 
-  ok(res, organization)
+  const { logo, ...rest } = organization
+  ok(res, { ...rest, ...(logo ? { logo } : {}) })
 }

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 import { z } from 'zod'
 
-import { NotFoundError, normalizeHostname } from '@crowd/common'
+import { BadRequestError, NotFoundError, normalizeHostname } from '@crowd/common'
 import { findOrganizationByNameOrDomain, optionsQx } from '@crowd/data-access-layer'
 
 import { ok } from '@/utils/api'
@@ -17,12 +17,19 @@ const querySchema = z
   })
 
 export async function getOrganization(req: Request, res: Response): Promise<void> {
-  const { name, domain } = validateOrThrow(querySchema, req.query)
+  const { name, domain: rawDomain } = validateOrThrow(querySchema, req.query)
+
+  const domain = rawDomain ? normalizeHostname(rawDomain, false) : undefined
+  
+  if (rawDomain && !domain) {
+    throw new BadRequestError(`Invalid domain: ${rawDomain}`)
+  }
+
   const qx = optionsQx(req)
 
   const organization = await findOrganizationByNameOrDomain(qx, {
     name,
-    domain: domain ? normalizeHostname(domain, false) : undefined,
+    domain,
   })
 
   if (!organization) {

--- a/backend/src/api/public/v1/organizations/getOrganization.ts
+++ b/backend/src/api/public/v1/organizations/getOrganization.ts
@@ -2,56 +2,32 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { NotFoundError, normalizeHostname } from '@crowd/common'
-import {
-  OrgIdentityField,
-  OrganizationField,
-  findOrgAttributes,
-  findOrgById,
-  optionsQx,
-  queryOrgIdentities,
-} from '@crowd/data-access-layer'
-import { OrganizationIdentityType } from '@crowd/types'
+import { findOrganizationByNameOrDomain, optionsQx } from '@crowd/data-access-layer'
 
 import { ok } from '@/utils/api'
 import { validateOrThrow } from '@/utils/validation'
 
-const querySchema = z.object({
-  domain: z.string().trim().min(1),
-})
-
-export async function getOrganization(req: Request, res: Response): Promise<void> {
-  const { domain } = validateOrThrow(querySchema, req.query)
-
-  const qx = optionsQx(req)
-
-  const results = await queryOrgIdentities(qx, {
-    fields: [OrgIdentityField.ORGANIZATION_ID],
-    filter: {
-      and: [
-        { value: { eq: normalizeHostname(domain, false) } },
-        { type: { eq: OrganizationIdentityType.PRIMARY_DOMAIN } },
-        { verified: { eq: true } },
-      ],
-    },
+const querySchema = z
+  .object({
+    name: z.string().trim().min(1).optional(),
+    domain: z.string().trim().min(1).optional(),
+  })
+  .refine((data) => data.name || data.domain, {
+    message: 'Either name or domain must be provided',
   })
 
-  const organizationId = results[0]?.organizationId
+export async function getOrganization(req: Request, res: Response): Promise<void> {
+  const { name, domain } = validateOrThrow(querySchema, req.query)
+  const qx = optionsQx(req)
 
-  if (!organizationId) {
+  const organization = await findOrganizationByNameOrDomain(qx, {
+    name,
+    domain: domain ? normalizeHostname(domain, false) : undefined,
+  })
+
+  if (!organization) {
     throw new NotFoundError('Organization not found')
   }
 
-  const org = await findOrgById(qx, organizationId, [
-    OrganizationField.ID,
-    OrganizationField.DISPLAY_NAME,
-  ])
-
-  const attributes = await findOrgAttributes(qx, organizationId)
-  const logo = attributes.find((a) => a.name === 'logo')?.value
-
-  ok(res, {
-    id: org.id,
-    name: org.displayName,
-    ...(logo ? { logo } : {}),
-  })
+  ok(res, organization)
 }

--- a/backend/src/utils/mapper.ts
+++ b/backend/src/utils/mapper.ts
@@ -182,6 +182,7 @@ export function toMemberWorkExperience(mo: IMemberRoleWithOrganization) {
     organizationId: mo.organizationId,
     organizationName: mo.organizationName,
     organizationLogo: mo.organizationLogo,
+    organizationDomains: mo.organizationDomains ?? [],
     jobTitle: mo.title ?? null,
     verified: mo.verified ?? false,
     verifiedBy: mo.verifiedBy ?? null,

--- a/services/libs/common/src/domain.ts
+++ b/services/libs/common/src/domain.ts
@@ -14,7 +14,7 @@ interface ParseResult {
 }
 
 export const cleanURL = (url: string): string =>
-  url.replace(/^(?:https?:\/\/)?(?:www\.)?([^/]+)(?:\/.*)?$/, '$1')
+  url.replace(/^(?:https?:\/\/)?(?:www\.)?([^/]+)(?:\/.*)?$/i, '$1')
 
 export const isValidDomain = (parsed: ParseResult): boolean =>
   Boolean(parsed.domain && parsed.isIcann)

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -217,7 +217,7 @@ export async function fetchManyMemberOrgsWithOrgData(
 ): Promise<Map<string, IMemberRoleWithOrganization[]>> {
   const domainSelect = withDomains
     ? `,
-      COALESCE(oid.domains, '{}') AS "organizationDomains"`
+      COALESCE(oid.domains, '{}'::text[]) AS "organizationDomains"`
     : ''
 
   const domainJoin = withDomains

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -213,27 +213,60 @@ export async function fetchManyMemberOrgs(
 export async function fetchManyMemberOrgsWithOrgData(
   qx: QueryExecutor,
   memberIds: string[],
+  { withDomains = false }: { withDomains?: boolean } = {},
 ): Promise<Map<string, IMemberRoleWithOrganization[]>> {
-  const memberRoles = (await qx.select(
-    `
-      SELECT mo.*, o."displayName" as "organizationName", o.logo as "organizationLogo"
-      FROM "memberOrganizations" mo
-      join "organizations" o on mo."organizationId" = o.id
-      WHERE mo."memberId" in ($(memberIds:csv))
-      AND mo."deletedAt" IS NULL;
-    `,
-    {
-      memberIds,
-    },
-  )) as IMemberRoleWithOrganization[]
+  const domainSelect = withDomains
+    ? `,
+      COALESCE(oid.domains, '{}') AS "organizationDomains"`
+    : ''
 
-  const resultMap = new Map<string, IMemberRoleWithOrganization[]>()
+  const domainJoin = withDomains
+    ? `
+      LEFT JOIN (
+        SELECT
+          oi."organizationId",
+          array_agg(DISTINCT lower(oi.value) ORDER BY lower(oi.value)) AS domains
+        FROM "organizationIdentities" oi
+        WHERE oi.type = 'primary-domain'
+          AND oi.verified = true
+          AND oi."organizationId" IN (
+            SELECT DISTINCT mo2."organizationId"
+            FROM "memberOrganizations" mo2
+            WHERE mo2."memberId" IN ($(memberIds:csv))
+              AND mo2."deletedAt" IS NULL
+          )
+        GROUP BY oi."organizationId"
+      ) oid ON oid."organizationId" = mo."organizationId"`
+    : ''
+
+  const sql = `
+    SELECT
+      mo.*,
+      o."displayName" AS "organizationName",
+      o.logo AS "organizationLogo"
+      ${domainSelect}
+    FROM "memberOrganizations" mo
+    JOIN organizations o ON o.id = mo."organizationId"
+    ${domainJoin}
+    WHERE mo."memberId" IN ($(memberIds:csv))
+      AND mo."deletedAt" IS NULL;
+  `
+
+  const memberRoles = (await qx.select(sql, {
+    memberIds,
+  })) as IMemberRoleWithOrganization[]
+
+  const result = new Map<string, IMemberRoleWithOrganization[]>()
+
   for (const memberId of memberIds) {
-    const roles = memberRoles.filter((r) => r.memberId === memberId)
-    resultMap.set(memberId, roles)
+    result.set(memberId, [])
   }
 
-  return resultMap
+  for (const role of memberRoles) {
+    result.get(role.memberId)!.push(role)
+  }
+
+  return result
 }
 
 export async function fetchManyOrganizationAffiliationPolicies(

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -263,7 +263,10 @@ export async function fetchManyMemberOrgsWithOrgData(
   }
 
   for (const role of memberRoles) {
-    result.get(role.memberId)!.push(role)
+    const roles = result.get(role.memberId)
+    if (roles) {
+      roles.push(role)
+    }
   }
 
   return result

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -728,3 +728,81 @@ export async function findNonExistingOrganizationIds(
 
   return rows.map((r: { id: string }) => r.id)
 }
+
+type OrganizationSummary = Pick<IDbOrganization, 'id' | 'displayName' | 'logo'> & {
+  domain: string
+}
+
+export async function findOrganizationByNameOrDomain(
+  qx: QueryExecutor,
+  { name, domain }: { name?: string; domain?: string },
+): Promise<OrganizationSummary | null> {
+  if (!name && !domain) {
+    return null
+  }
+
+  const domainJoin = domain
+    ? `
+      INNER JOIN "organizationIdentities" oi
+        ON oi."organizationId" = o.id
+       AND oi.type = 'primary-domain'
+       AND oi.verified = true
+       AND lower(oi.value) = lower($(domain))`
+    : ''
+
+  const filters = ['o."deletedAt" IS NULL']
+
+  if (name) {
+    filters.push(
+      `trim(lower(o."displayName")) = trim(lower($(name)))`,
+      `EXISTS (
+        SELECT 1
+        FROM "organizationIdentities" oi_check
+        WHERE oi_check."organizationId" = o.id
+          AND oi_check.type = 'primary-domain'
+          AND oi_check.verified = true
+      )`,
+    )
+  }
+
+  const domainSelect = domain
+    ? 'lower($(domain)) AS domain'
+    : `(
+        SELECT lower(oi_domain.value)
+        FROM "organizationIdentities" oi_domain
+        WHERE oi_domain."organizationId" = o.id
+          AND oi_domain.type = 'primary-domain'
+          AND oi_domain.verified = true
+        ORDER BY lower(oi_domain.value)
+        LIMIT 1
+      ) AS domain`
+
+  const sql = `
+    SELECT
+      o.id,
+      o."displayName",
+      o.logo,
+      ${domainSelect}
+    FROM "organizations" o
+    ${domainJoin}
+    LEFT JOIN "organizationsGlobalActivityCount" gac
+      ON gac."organizationId" = o.id
+    WHERE
+      ${filters.join(' AND ')}
+    ORDER BY
+      COALESCE(gac.total_count_estimate, 0) DESC,
+      (
+        SELECT COUNT(DISTINCT mo."memberId")
+        FROM "memberOrganizations" mo
+        WHERE mo."organizationId" = o.id
+          AND mo."deletedAt" IS NULL
+      ) DESC,
+      o.id
+    LIMIT 1;
+  `
+
+  return qx.selectOneOrNone(sql, {
+    name,
+    domain,
+  })
+}

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -729,7 +729,8 @@ export async function findNonExistingOrganizationIds(
   return rows.map((r: { id: string }) => r.id)
 }
 
-type OrganizationSummary = Pick<IDbOrganization, 'id' | 'displayName' | 'logo'> & {
+type OrganizationSummary = Pick<IDbOrganization, 'id' | 'logo'> & {
+  name: string
   domain: string
 }
 
@@ -780,7 +781,7 @@ export async function findOrganizationByNameOrDomain(
   const sql = `
     SELECT
       o.id,
-      o."displayName",
+      o."displayName" AS name,
       o.logo,
       ${domainSelect}
     FROM "organizations" o

--- a/services/libs/data-access-layer/src/organizations/base.ts
+++ b/services/libs/data-access-layer/src/organizations/base.ts
@@ -766,7 +766,7 @@ export async function findOrganizationByNameOrDomain(
   }
 
   const domainSelect = domain
-    ? 'lower($(domain)) AS domain'
+    ? 'lower(oi.value) AS domain'
     : `(
         SELECT lower(oi_domain.value)
         FROM "organizationIdentities" oi_domain

--- a/services/libs/types/src/organizations.ts
+++ b/services/libs/types/src/organizations.ts
@@ -94,6 +94,7 @@ export interface IRenderFriendlyMemberOrganization {
 export interface IMemberRoleWithOrganization extends IMemberOrganization {
   organizationName: string
   organizationLogo: string
+  organizationDomains?: string[]
 }
 
 export interface MemberOrgDate {


### PR DESCRIPTION
## Summary

This PR adds organization domain support to the public APIs. 

Work experience responses now include organization domains, and the organization lookup endpoint can now find organizations by either primary domain or exact display name.

## Changes

- Added `organizationDomains` to public work experience responses
- Made domain enrichment optional in `fetchManyMemberOrgsWithOrgData` so existing callers are unaffected
- Extended `GET /organizations` to support lookups by `domain` or `name`
- Added deterministic ranking when multiple organizations match
- Included the resolved primary `domain` in organization create and lookup responses
- Updated the public OpenAPI spec