### PR TITLE
fix: remove unnecessary grouped lookup in verify work experience

### DIFF
--- a/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
@@ -122,9 +122,11 @@ export async function updateMemberWorkExperience(req: Request, res: Response): P
 
       const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
-      const updatedMo = groupMemberOrganizations(orgsMap.get(memberId) ?? []).find(
-        (mo) => mo.id === workExperienceId,
-      )
+      const memberOrgsWithData = orgsMap.get(memberId) ?? []
+
+      const updatedMo =
+        groupMemberOrganizations(memberOrgsWithData).find((mo) => mo.id === workExperienceId) ??
+        memberOrgsWithData.find((mo) => mo.id === workExperienceId)
 
       if (!updatedMo) {
         throw new NotFoundError('Work experience not found')

--- a/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
@@ -122,11 +122,9 @@ export async function updateMemberWorkExperience(req: Request, res: Response): P
 
       const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
-      const memberOrgsWithData = orgsMap.get(memberId) ?? []
-
-      const updatedMo =
-        groupMemberOrganizations(memberOrgsWithData).find((mo) => mo.id === workExperienceId) ??
-        memberOrgsWithData.find((mo) => mo.id === workExperienceId)
+      const updatedMo = groupMemberOrganizations(orgsMap.get(memberId) ?? []).find(
+        (mo) => mo.id === workExperienceId,
+      )
 
       if (!updatedMo) {
         throw new NotFoundError('Work experience not found')

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -52,6 +52,17 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     throw new NotFoundError('Work experience not found')
   }
 
+  // Stash org fields for response fallback when reject soft-deletes the row.
+  const orgsMapBeforeChange = await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
+    withDomains: true,
+  })
+
+  const memberOrgsWithOrgDataBeforeChange = orgsMapBeforeChange.get(memberId) ?? []
+
+  const workExperienceWithOrgDataBeforeChange = memberOrgsWithOrgDataBeforeChange.find(
+    (mo) => mo.id === workExperienceId,
+  )
+
   const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
   const memberOrgIdsToDelete = [
@@ -103,14 +114,22 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
   const memberOrgsWithData = orgsMap.get(memberId) ?? []
 
-  const responseMo: IMemberRoleWithOrganization =
-    groupMemberOrganizations(memberOrgsWithData).find((mo) => mo.id === workExperienceId) ??
-    ({
-      ...(memberOrgsWithData.find((mo) => mo.id === workExperienceId) ?? memberOrg),
-      ...updatedMemberOrg,
-      verified,
-      verifiedBy,
-    } as IMemberRoleWithOrganization)
+  const fallbackMo =
+    memberOrgsWithData.find((mo) => mo.id === workExperienceId) ??
+    workExperienceWithOrgDataBeforeChange
+
+  if (!fallbackMo) {
+    throw new NotFoundError('Work experience not found')
+  }
+
+  const responseMo: IMemberRoleWithOrganization = groupMemberOrganizations(memberOrgsWithData).find(
+    (mo) => mo.id === workExperienceId,
+  ) ?? {
+    ...fallbackMo,
+    ...updatedMemberOrg,
+    verified,
+    verifiedBy,
+  }
 
   ok(res, toMemberWorkExperience(responseMo))
 }

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -33,21 +33,6 @@ const bodySchema = z.object({
   verifiedBy: z.string(),
 })
 
-function resolveWorkExperience(
-  workExperienceId: string,
-  ...collections: IMemberRoleWithOrganization[][]
-): IMemberRoleWithOrganization | undefined {
-  for (const collection of collections) {
-    const match = collection.find((mo) => mo.id === workExperienceId)
-
-    if (match) {
-      return match
-    }
-  }
-
-  return undefined
-}
-
 export async function verifyMemberWorkExperience(req: Request, res: Response): Promise<void> {
   const { memberId, workExperienceId } = validateOrThrow(paramsSchema, req.params)
   const { verified, verifiedBy } = validateOrThrow(bodySchema, req.body)
@@ -127,27 +112,19 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     withDomains: true,
   })
 
-  const memberOrgsWithData = orgsMap.get(memberId) ?? []
-  const groupedMemberOrgs = groupMemberOrganizations(memberOrgsWithData)
+  const groupedMemberOrgs = groupMemberOrganizations(orgsMap.get(memberId) ?? [])
   const groupedMemberOrgsBeforeChange = groupMemberOrganizations(memberOrgsWithOrgDataBeforeChange)
 
-  const fallbackMo = resolveWorkExperience(
-    workExperienceId,
-    memberOrgsWithData,
-    groupedMemberOrgsBeforeChange,
-    memberOrgsWithOrgDataBeforeChange,
-  )
+  const fallbackMo = groupedMemberOrgsBeforeChange.find((mo) => mo.id === workExperienceId)
 
-  if (!fallbackMo) {
+  const responseMo: IMemberRoleWithOrganization =
+    groupedMemberOrgs.find((mo) => mo.id === workExperienceId) ??
+    (fallbackMo
+      ? { ...fallbackMo, ...updatedMemberOrg, ...verifiedUpdate }
+      : undefined)
+
+  if (!responseMo) {
     throw new NotFoundError('Work experience not found')
-  }
-
-  const responseMo: IMemberRoleWithOrganization = groupedMemberOrgs.find(
-    (mo) => mo.id === workExperienceId,
-  ) ?? {
-    ...fallbackMo,
-    ...updatedMemberOrg,
-    ...verifiedUpdate,
   }
 
   ok(res, toMemberWorkExperience(responseMo))

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -56,9 +56,9 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     withDomains: true,
   })
 
-  const workExperienceWithOrgData = groupMemberOrganizations(
-    orgsMapBeforeChange.get(memberId) ?? [],
-  ).find((mo) => mo.id === workExperienceId)
+  const memberOrgsWithData = orgsMapBeforeChange.get(memberId) ?? []
+
+  const workExperienceWithOrgData = memberOrgsWithData.find((mo) => mo.id === workExperienceId)
 
   if (!workExperienceWithOrgData) {
     throw new NotFoundError('Work experience not found')
@@ -114,8 +114,10 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
 
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
 
+  const memberOrgsWithDataAfterChange = orgsMap.get(memberId) ?? []
+
   const responseMo: IMemberRoleWithOrganization = groupMemberOrganizations(
-    orgsMap.get(memberId) ?? [],
+    memberOrgsWithDataAfterChange,
   ).find((mo) => mo.id === workExperienceId) ?? {
     ...workExperienceWithOrgData,
     ...updatedMemberOrg,

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -52,18 +52,6 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
     throw new NotFoundError('Work experience not found')
   }
 
-  const orgsMapBeforeChange = await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
-    withDomains: true,
-  })
-
-  const memberOrgsWithData = orgsMapBeforeChange.get(memberId) ?? []
-
-  const workExperienceWithOrgData = memberOrgsWithData.find((mo) => mo.id === workExperienceId)
-
-  if (!workExperienceWithOrgData) {
-    throw new NotFoundError('Work experience not found')
-  }
-
   const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
   const memberOrgIdsToDelete = [
@@ -113,17 +101,16 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
   )
 
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
+  const memberOrgsWithData = orgsMap.get(memberId) ?? []
 
-  const memberOrgsWithDataAfterChange = orgsMap.get(memberId) ?? []
-
-  const responseMo: IMemberRoleWithOrganization = groupMemberOrganizations(
-    memberOrgsWithDataAfterChange,
-  ).find((mo) => mo.id === workExperienceId) ?? {
-    ...workExperienceWithOrgData,
-    ...updatedMemberOrg,
-    verified,
-    verifiedBy,
-  }
+  const responseMo: IMemberRoleWithOrganization =
+    groupMemberOrganizations(memberOrgsWithData).find((mo) => mo.id === workExperienceId) ??
+    ({
+      ...(memberOrgsWithData.find((mo) => mo.id === workExperienceId) ?? memberOrg),
+      ...updatedMemberOrg,
+      verified,
+      verifiedBy,
+    } as IMemberRoleWithOrganization)
 
   ok(res, toMemberWorkExperience(responseMo))
 }

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -119,7 +119,7 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
 
   const responseMo: IMemberRoleWithOrganization =
     groupedMemberOrgs.find((mo) => mo.id === workExperienceId) ??
-    (fallbackMo ? { ...fallbackMo, ...updatedMemberOrg, ...verifiedUpdate } : undefined)
+    (fallbackMo ? { ...fallbackMo, ...verifiedUpdate } : undefined)
 
   if (!responseMo) {
     throw new NotFoundError('Work experience not found')

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -33,6 +33,21 @@ const bodySchema = z.object({
   verifiedBy: z.string(),
 })
 
+function resolveWorkExperience(
+  workExperienceId: string,
+  ...collections: IMemberRoleWithOrganization[][]
+): IMemberRoleWithOrganization | undefined {
+  for (const collection of collections) {
+    const match = collection.find((mo) => mo.id === workExperienceId)
+
+    if (match) {
+      return match
+    }
+  }
+
+  return undefined
+}
+
 export async function verifyMemberWorkExperience(req: Request, res: Response): Promise<void> {
   const { memberId, workExperienceId } = validateOrThrow(paramsSchema, req.params)
   const { verified, verifiedBy } = validateOrThrow(bodySchema, req.body)
@@ -53,22 +68,21 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
   }
 
   // Stash org fields for response fallback when reject soft-deletes the row.
-  const orgsMapBeforeChange = await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
-    withDomains: true,
-  })
-
-  const memberOrgsWithOrgDataBeforeChange = orgsMapBeforeChange.get(memberId) ?? []
-
-  const workExperienceWithOrgDataBeforeChange = memberOrgsWithOrgDataBeforeChange.find(
-    (mo) => mo.id === workExperienceId,
-  )
+  const memberOrgsWithOrgDataBeforeChange = verified
+    ? []
+    : ((
+        await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
+          withDomains: true,
+        })
+      ).get(memberId) ?? [])
 
   const overlappingGroupedRows = getOverlappingGroupedMemberOrganizations(memberOrgs, memberOrg)
 
-  const memberOrgIdsToDelete = [
-    workExperienceId,
-    ...overlappingGroupedRows.flatMap((row) => (row.id ? [row.id] : [])),
-  ]
+  const overlappingRowsWithIds = overlappingGroupedRows.filter(
+    (row): row is typeof row & { id: string } => !!row.id,
+  )
+
+  const memberOrgIdsToDelete = [workExperienceId, ...overlappingRowsWithIds.map((row) => row.id)]
 
   const verifiedUpdate = { verified, verifiedBy }
 
@@ -89,9 +103,7 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
             verifiedUpdate,
           )
 
-          for (const overlappingRow of overlappingGroupedRows.filter(
-            (row): row is typeof row & { id: string } => !!row.id,
-          )) {
+          for (const overlappingRow of overlappingRowsWithIds) {
             await updateMemberOrganization(tx, memberId, overlappingRow.id, verifiedUpdate)
           }
         } else {
@@ -107,30 +119,35 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
         })
       }
 
-      captureNewState(updatedMemberOrg ?? { ...memberOrg, verified, verifiedBy })
+      captureNewState(updatedMemberOrg ?? { ...memberOrg, ...verifiedUpdate })
     }),
   )
 
-  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
+  const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], {
+    withDomains: true,
+  })
+
   const memberOrgsWithData = orgsMap.get(memberId) ?? []
+  const groupedMemberOrgs = groupMemberOrganizations(memberOrgsWithData)
   const groupedMemberOrgsBeforeChange = groupMemberOrganizations(memberOrgsWithOrgDataBeforeChange)
 
-  const fallbackMo =
-    memberOrgsWithData.find((mo) => mo.id === workExperienceId) ??
-    groupedMemberOrgsBeforeChange.find((mo) => mo.id === workExperienceId) ??
-    workExperienceWithOrgDataBeforeChange
+  const fallbackMo = resolveWorkExperience(
+    workExperienceId,
+    memberOrgsWithData,
+    groupedMemberOrgsBeforeChange,
+    memberOrgsWithOrgDataBeforeChange,
+  )
 
   if (!fallbackMo) {
     throw new NotFoundError('Work experience not found')
   }
 
-  const responseMo: IMemberRoleWithOrganization = groupMemberOrganizations(memberOrgsWithData).find(
+  const responseMo: IMemberRoleWithOrganization = groupedMemberOrgs.find(
     (mo) => mo.id === workExperienceId,
   ) ?? {
     ...fallbackMo,
     ...updatedMemberOrg,
-    verified,
-    verifiedBy,
+    ...verifiedUpdate,
   }
 
   ok(res, toMemberWorkExperience(responseMo))

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -119,9 +119,7 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
 
   const responseMo: IMemberRoleWithOrganization =
     groupedMemberOrgs.find((mo) => mo.id === workExperienceId) ??
-    (fallbackMo
-      ? { ...fallbackMo, ...updatedMemberOrg, ...verifiedUpdate }
-      : undefined)
+    (fallbackMo ? { ...fallbackMo, ...updatedMemberOrg, ...verifiedUpdate } : undefined)
 
   if (!responseMo) {
     throw new NotFoundError('Work experience not found')

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -113,9 +113,11 @@ export async function verifyMemberWorkExperience(req: Request, res: Response): P
 
   const orgsMap = await fetchManyMemberOrgsWithOrgData(qx, [memberId], { withDomains: true })
   const memberOrgsWithData = orgsMap.get(memberId) ?? []
+  const groupedMemberOrgsBeforeChange = groupMemberOrganizations(memberOrgsWithOrgDataBeforeChange)
 
   const fallbackMo =
     memberOrgsWithData.find((mo) => mo.id === workExperienceId) ??
+    groupedMemberOrgsBeforeChange.find((mo) => mo.id === workExperienceId) ??
     workExperienceWithOrgDataBeforeChange
 
   if (!fallbackMo) {


### PR DESCRIPTION
## Summary
Follow-up fix to CM-1266. Cleans up `verifyMemberWorkExperience` after the domains change accidentally added a pre-transaction grouped lookup that could block the handler before the transaction runs.

Clients call this endpoint with the display work experience ID returned by the list API, not hidden grouped row IDs.

## Changes
- Remove pre-transaction grouped lookup and extra `NotFoundError` check (the CM-1266 regression)
- Keep row lookup on `fetchMemberOrganizations` only
- Keep `withDomains: true` on the post-transaction response fetch
- On reject (`verified: false`), stash org data before soft-delete and use grouped before-data for the response fallback (org name/logo/domains + merged dates/source)
- Skip the pre-transaction fetch on verify (`verified: true`) since the row still exists post-transaction

## Test plan
- [x] Staging smoke script (`test-lfxOne-cdp-auth.sh`) — verify, reject, grouping, domains
