### PR TITLE
fix: cargo repo gap (CM-1305)

### DIFF
--- a/services/apps/packages_worker/src/activities.ts
+++ b/services/apps/packages_worker/src/activities.ts
@@ -16,6 +16,7 @@ export { processMavenCriticalBatch } from './maven/activities'
 export { criticalityComputePageRank, rankPackages } from './criticality/activities'
 export {
   cargoDownloadAndLoad,
+  cargoNormalizeRepos,
   cargoEnrichPackages,
   cargoEnrichVersions,
   cargoEnrichRepos,

--- a/services/apps/packages_worker/src/cargo/activities.ts
+++ b/services/apps/packages_worker/src/cargo/activities.ts
@@ -15,6 +15,7 @@ import {
   flushAudit,
 } from './enrich'
 import { STAGING_SCHEMA, loadDump } from './loadDump'
+import { normalizeRepos } from './normalizeRepos'
 import {
   EnrichDownloadsDailyResult,
   EnrichMaintainersResult,
@@ -22,6 +23,7 @@ import {
   EnrichReposResult,
   EnrichVersionsResult,
   LoadResult,
+  NormalizeReposResult,
 } from './types'
 
 const log = getServiceChildLogger('cargo-activity')
@@ -35,6 +37,10 @@ export async function cargoDownloadAndLoad(): Promise<LoadResult> {
   const result = await loadDump(qx, conn, dumpDir)
   log.info({ ...result }, 'cargo dump loaded')
   return result
+}
+
+export async function cargoNormalizeRepos(): Promise<NormalizeReposResult> {
+  return normalizeRepos(await getPackagesDb())
 }
 
 export async function cargoEnrichPackages(): Promise<EnrichPackagesResult> {

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -192,8 +192,12 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
     )
 
-    // Prunes stale 'declared' links before relinking — covers junk declared values
-    // (no canonical → target NULL) and rewrites (declared URL now maps elsewhere).
+    // Prunes stale 'declared' links before relinking — covers junk/unparseable declared
+    // values, rewrites (declared URL now maps elsewhere), and removals (this dump's
+    // declared_repository_url is NULL, meaning the crate no longer declares a repo at
+    // all — loadDump.ts stages every matched crate every run, so NULL here is
+    // authoritative, not "no data this run"). Safe to always prune on that signal because
+    // the DELETE is scoped to source = 'declared' — cargo only ever removes links it owns.
     // Without this, package_repos would accumulate a link to a repo no crate declares
     // anymore, and consumers such as security-contacts (which join through
     // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
@@ -203,7 +207,6 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          FROM ${STAGING_SCHEMA}.enrich_packages e
          LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
          LEFT JOIN repos r ON r.url = rn.repository_url
-         WHERE e.declared_repository_url IS NOT NULL
        ),
        del AS (
          DELETE FROM package_repos pr
@@ -212,6 +215,11 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
            AND pr.source = $(source)
            AND (t.repo_id IS NULL OR pr.repo_id IS DISTINCT FROM t.repo_id)
          RETURNING pr.package_id
+       ),
+       ins_audit AS (
+         INSERT INTO ${STAGING_SCHEMA}.audit_changes (package_id, field)
+         SELECT package_id, 'package_repos.repo_id' FROM del
+         RETURNING 1
        )
        SELECT (SELECT COUNT(*) FROM del)::int AS pruned`,
       { source: REPO_LINK_SOURCE },
@@ -231,9 +239,11 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          FROM ${STAGING_SCHEMA}.enrich_packages e
          JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
          JOIN repos r ON r.url = rn.repository_url
+         -- Leaves source untouched on conflict — a link another enricher already owns for
+         -- this (package_id, repo_id) keeps its provenance instead of being reassigned to
+         -- 'declared', matching upsertMavenPackageRepo's confidence-only merge.
          ON CONFLICT (package_id, repo_id) DO UPDATE SET
-           source      = EXCLUDED.source,
-           confidence  = EXCLUDED.confidence,
+           confidence  = GREATEST(EXCLUDED.confidence, package_repos.confidence),
            verified_at = NOW()
          RETURNING package_id, repo_id, source, confidence
        ),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -48,6 +48,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
     tx.selectOne(
       `WITH snap AS (
          SELECT p.id, p.status, p.description, p.homepage, p.declared_repository_url,
+                p.repository_url,
                 p.licenses, p.licenses_raw, p.keywords, p.versions_count, p.latest_version,
                 p.first_release_at, p.latest_release_at, p.dependent_count,
                 p.dependent_repos_count, p.downloads_last_30d
@@ -60,6 +61,8 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            description             = COALESCE(e.description, p.description),
            homepage                = COALESCE(e.homepage, p.homepage),
            declared_repository_url = COALESCE(e.declared_repository_url, p.declared_repository_url),
+           repository_url          = CASE WHEN e.declared_repository_url IS NOT NULL
+                                          THEN rn.repository_url ELSE p.repository_url END,
            licenses                = COALESCE(e.licenses, p.licenses),
            licenses_raw            = COALESCE(e.licenses_raw, p.licenses_raw),
            keywords                = COALESCE(e.keywords, p.keywords),
@@ -73,6 +76,7 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
            ingestion_source        = $(ingestionSource),
            last_synced_at          = NOW()
          FROM ${STAGING_SCHEMA}.enrich_packages e
+         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
          WHERE p.id = e.package_id
          RETURNING p.id
        ),
@@ -80,11 +84,14 @@ export async function enrichPackages(qx: QueryExecutor): Promise<EnrichPackagesR
          SELECT s.id AS package_id, f.field
          FROM snap s
          JOIN ${STAGING_SCHEMA}.enrich_packages e ON e.package_id = s.id
+         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
          CROSS JOIN LATERAL (VALUES
            ('packages.status',                  s.status                  IS DISTINCT FROM e.status),
            ('packages.description',             s.description             IS DISTINCT FROM COALESCE(e.description, s.description)),
            ('packages.homepage',                s.homepage                IS DISTINCT FROM COALESCE(e.homepage, s.homepage)),
            ('packages.declared_repository_url', s.declared_repository_url IS DISTINCT FROM COALESCE(e.declared_repository_url, s.declared_repository_url)),
+           ('packages.repository_url',          s.repository_url          IS DISTINCT FROM
+               CASE WHEN e.declared_repository_url IS NOT NULL THEN rn.repository_url ELSE s.repository_url END),
            ('packages.licenses',                s.licenses                IS DISTINCT FROM COALESCE(e.licenses, s.licenses)),
            ('packages.licenses_raw',            s.licenses_raw            IS DISTINCT FROM COALESCE(e.licenses_raw, s.licenses_raw)),
            ('packages.keywords',                s.keywords                IS DISTINCT FROM COALESCE(e.keywords, s.keywords)),

--- a/services/apps/packages_worker/src/cargo/enrich.ts
+++ b/services/apps/packages_worker/src/cargo/enrich.ts
@@ -166,22 +166,17 @@ export async function enrichVersions(qx: QueryExecutor): Promise<EnrichVersionsR
   return { upserted: row.upserted }
 }
 
-// Writes only url + host — other repo fields belong to the GitHub enricher.
+// Writes only url + host — other repo fields belong to the GitHub enricher. Uses
+// repo_norm (built by normalizeRepos) so repos.url/package_repos always agree with
+// the canonical packages.repository_url — never the raw declared_repository_url.
 export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult> {
   return withTunedSession(qx, 'repos', async (tx) => {
     const repoRow = await tx.selectOne(
       `WITH new_repos AS (
          INSERT INTO repos (url, host, updated_at)
-         SELECT DISTINCT e.declared_repository_url,
-           CASE
-             WHEN e.declared_repository_url ~* '://([^/]+\\.)?github\\.com(/|$)'    THEN 'github'
-             WHEN e.declared_repository_url ~* '://[^/]*gitlab'                     THEN 'gitlab'
-             WHEN e.declared_repository_url ~* '://([^/]+\\.)?bitbucket\\.org(/|$)' THEN 'bitbucket'
-             ELSE 'other'
-           END,
-           NOW()
+         SELECT DISTINCT rn.repository_url, rn.host, NOW()
          FROM ${STAGING_SCHEMA}.enrich_packages e
-         WHERE e.declared_repository_url IS NOT NULL AND e.declared_repository_url LIKE 'http%'
+         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
          ON CONFLICT (url) DO NOTHING
          RETURNING url
        ),
@@ -189,11 +184,37 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          INSERT INTO ${STAGING_SCHEMA}.audit_changes (package_id, field)
          SELECT e.package_id, f.field
          FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN new_repos nr ON nr.url = e.declared_repository_url
+         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         JOIN new_repos nr ON nr.url = rn.repository_url
          CROSS JOIN LATERAL (VALUES ('repos.url'), ('repos.host')) AS f(field)
          RETURNING 1
        )
        SELECT (SELECT COUNT(*) FROM new_repos)::int AS repos`,
+    )
+
+    // Prunes stale 'declared' links before relinking — covers junk declared values
+    // (no canonical → target NULL) and rewrites (declared URL now maps elsewhere).
+    // Without this, package_repos would accumulate a link to a repo no crate declares
+    // anymore, and consumers such as security-contacts (which join through
+    // repos ⋈ package_repos, not packages.repository_url) would keep reading it.
+    const pruneRow = await tx.selectOne(
+      `WITH targets AS (
+         SELECT e.package_id, r.id AS repo_id
+         FROM ${STAGING_SCHEMA}.enrich_packages e
+         LEFT JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         LEFT JOIN repos r ON r.url = rn.repository_url
+         WHERE e.declared_repository_url IS NOT NULL
+       ),
+       del AS (
+         DELETE FROM package_repos pr
+         USING targets t
+         WHERE pr.package_id = t.package_id
+           AND pr.source = $(source)
+           AND (t.repo_id IS NULL OR pr.repo_id IS DISTINCT FROM t.repo_id)
+         RETURNING pr.package_id
+       )
+       SELECT (SELECT COUNT(*) FROM del)::int AS pruned`,
+      { source: REPO_LINK_SOURCE },
     )
 
     const linkRow = await tx.selectOne(
@@ -208,8 +229,8 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
          INSERT INTO package_repos (package_id, repo_id, source, confidence, created_at, verified_at)
          SELECT e.package_id, r.id, $(source), $(confidence), NOW(), NOW()
          FROM ${STAGING_SCHEMA}.enrich_packages e
-         JOIN repos r ON r.url = e.declared_repository_url
-         WHERE e.declared_repository_url IS NOT NULL
+         JOIN ${STAGING_SCHEMA}.repo_norm rn ON rn.declared = e.declared_repository_url
+         JOIN repos r ON r.url = rn.repository_url
          ON CONFLICT (package_id, repo_id) DO UPDATE SET
            source      = EXCLUDED.source,
            confidence  = EXCLUDED.confidence,
@@ -235,7 +256,7 @@ export async function enrichRepos(qx: QueryExecutor): Promise<EnrichReposResult>
       { source: REPO_LINK_SOURCE, confidence: REPO_LINK_CONFIDENCE },
     )
 
-    return { repos: repoRow.repos, links: linkRow.links }
+    return { repos: repoRow.repos, links: linkRow.links, pruned: pruneRow.pruned }
   })
 }
 

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -1,0 +1,69 @@
+import { QueryExecutor } from '@crowd/data-access-layer'
+import { getServiceChildLogger } from '@crowd/logging'
+
+import { CanonicalRepo, canonicalizeRepoUrl } from '../utils/canonicalizeRepoUrl'
+
+import { STAGING_SCHEMA } from './loadDump'
+import { NormalizeReposResult } from './types'
+
+const log = getServiceChildLogger('cargo-normalize')
+
+// Batch size for the mapping upsert — keeps parameter arrays well under Postgres limits.
+const INSERT_BATCH = 5000
+
+/**
+ * Builds `cargo_sync.repo_norm(declared, repository_url, host)`, mapping every
+ * distinct `declared_repository_url` staged in `enrich_packages` to its canonical
+ * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
+ * (same normalizer npm/pypi use — no per-ecosystem fork).
+ *
+ * Only successfully-canonicalized inputs are stored; non-repository values
+ * (placeholders, homepages, free-form text) are omitted, so a LEFT JOIN from
+ * `enrich_packages` yields NULL — that both recovers derivable URLs (Gap A) and
+ * clears junk that could otherwise land in `packages.repository_url` (Gap C).
+ *
+ * Normalization runs in TypeScript because the bulk set-based cargo pipeline
+ * cannot call the parser per row; the resulting mapping table lets the SQL
+ * enrich phases join back to it. Idempotent: the table is rebuilt each run.
+ */
+export async function normalizeRepos(qx: QueryExecutor): Promise<NormalizeReposResult> {
+  const rows: Array<{ declared_repository_url: string }> = await qx.select(
+    `SELECT DISTINCT declared_repository_url
+       FROM ${STAGING_SCHEMA}.enrich_packages
+      WHERE declared_repository_url IS NOT NULL`,
+  )
+
+  await qx.result(
+    `DROP TABLE IF EXISTS ${STAGING_SCHEMA}.repo_norm CASCADE;
+     CREATE TABLE ${STAGING_SCHEMA}.repo_norm (
+       declared       text PRIMARY KEY,
+       repository_url text NOT NULL,
+       host           text NOT NULL
+     )`,
+  )
+
+  const mapped = rows
+    .map(({ declared_repository_url }) => ({
+      declared: declared_repository_url,
+      canonical: canonicalizeRepoUrl(declared_repository_url),
+    }))
+    .filter((r): r is { declared: string; canonical: CanonicalRepo } => r.canonical !== null)
+
+  for (let i = 0; i < mapped.length; i += INSERT_BATCH) {
+    const batch = mapped.slice(i, i + INSERT_BATCH)
+    await qx.result(
+      `INSERT INTO ${STAGING_SCHEMA}.repo_norm (declared, repository_url, host)
+       SELECT * FROM unnest($(declared)::text[], $(urls)::text[], $(hosts)::text[])
+       ON CONFLICT (declared) DO NOTHING`,
+      {
+        declared: batch.map((r) => r.declared),
+        urls: batch.map((r) => r.canonical.url),
+        hosts: batch.map((r) => r.canonical.host),
+      },
+    )
+  }
+
+  const result: NormalizeReposResult = { scanned: rows.length, normalized: mapped.length }
+  log.info(result, 'cargo repo normalization complete')
+  return result
+}

--- a/services/apps/packages_worker/src/cargo/normalizeRepos.ts
+++ b/services/apps/packages_worker/src/cargo/normalizeRepos.ts
@@ -17,10 +17,13 @@ const INSERT_BATCH = 5000
  * `https://<host>/<owner>/<name>` form via the shared `canonicalizeRepoUrl`
  * (same normalizer npm/pypi use — no per-ecosystem fork).
  *
- * Only successfully-canonicalized inputs are stored; non-repository values
- * (placeholders, homepages, free-form text) are omitted, so a LEFT JOIN from
- * `enrich_packages` yields NULL — that both recovers derivable URLs (Gap A) and
- * clears junk that could otherwise land in `packages.repository_url` (Gap C).
+ * Only inputs `canonicalizeRepoUrl` can reduce to an owner/name pair are stored;
+ * unparseable URLs or those with fewer than two path segments are omitted, so a
+ * LEFT JOIN from `enrich_packages` yields NULL — that both recovers derivable
+ * URLs (Gap A) and clears that class of junk from `packages.repository_url`
+ * (Gap C). Note this does not validate that the result is an actual repository
+ * host — a URL-shaped homepage with ≥2 path segments (e.g.
+ * `https://example.com/owner/repo`) still canonicalizes and is stored.
  *
  * Normalization runs in TypeScript because the bulk set-based cargo pipeline
  * cannot call the parser per row; the resulting mapping table lets the SQL

--- a/services/apps/packages_worker/src/cargo/types.ts
+++ b/services/apps/packages_worker/src/cargo/types.ts
@@ -12,6 +12,11 @@ export interface LoadResult {
   durationMs: number
 }
 
+export interface NormalizeReposResult {
+  scanned: number
+  normalized: number
+}
+
 export interface EnrichPackagesResult {
   updated: number
 }

--- a/services/apps/packages_worker/src/cargo/types.ts
+++ b/services/apps/packages_worker/src/cargo/types.ts
@@ -28,6 +28,7 @@ export interface EnrichVersionsResult {
 export interface EnrichReposResult {
   repos: number
   links: number
+  pruned: number
 }
 
 export interface EnrichMaintainersResult {

--- a/services/apps/packages_worker/src/cargo/workflows.ts
+++ b/services/apps/packages_worker/src/cargo/workflows.ts
@@ -14,6 +14,7 @@ const { cargoDownloadAndLoad } = proxyActivities<typeof activities>({
 })
 
 const {
+  cargoNormalizeRepos,
   cargoEnrichPackages,
   cargoEnrichVersions,
   cargoEnrichRepos,
@@ -31,6 +32,8 @@ export async function cargoSyncWorkflow(): Promise<void> {
   const load = await cargoDownloadAndLoad()
   log.info('cargoSync loaded dump', { ...load })
 
+  const normalizedRepos = await cargoNormalizeRepos()
+  log.info('cargoSync normalized repos', { ...normalizedRepos })
   const packages = await cargoEnrichPackages()
   const versions = await cargoEnrichVersions()
   const repos = await cargoEnrichRepos()
@@ -41,6 +44,7 @@ export async function cargoSyncWorkflow(): Promise<void> {
 
   log.info('cargoSync complete', {
     matched: load.matched,
+    normalizedRepos,
     packages,
     versions,
     repos,


### PR DESCRIPTION
## Summary

Fixes the cargo repo-normalization gap (CM-1305 follow-up): declared repo URLs from crates.io often arrive in shorthand (`github:owner/repo`), SSH (`git@github.com:owner/repo.git`), or junk/homepage form instead of a canonical `https://<host>/<owner>/<name>` URL. `packages.repository_url` was left null or wrong for these cases, and `repos`/`package_repos` could drift out of sync with it entirely.

Adds a `normalizeRepos` step that canonicalizes every distinct `declared_repository_url` staged in a dump into `cargo_sync.repo_norm`, then wires that canonical mapping into both `enrichPackages` (`packages.repository_url`) and `enrichRepos` (`repos.url` / `package_repos`), so both tables always agree on the same canonical value.

## Changes

- Add `normalizeRepos` (`cargo/normalizeRepos.ts`): builds `cargo_sync.repo_norm(declared, repository_url, host)` via the shared `canonicalizeRepoUrl` (same normalizer npm/pypi use). Only inputs reducible to an owner/name pair are stored; unparseable declared URLs are omitted, so a `LEFT JOIN` naturally yields `NULL`.
- Wire `enrichPackages` to write `packages.repository_url` from `repo_norm` only when the current dump supplies a `declared_repository_url` — preserves the existing value when a dump omits the field, instead of wiping it.
- Rewrite `enrichRepos` to join through `repo_norm` instead of the raw declared URL, and to prune stale `source='declared'` `package_repos` links before relinking (mirrors the existing pattern in `maven/backfillRepositoryUrl.ts`) — covers both junk declared values (no canonical → link removed) and rewrites (declared URL now maps to a different repo).
- Register `cargoNormalizeRepos` in the top-level activities barrel (`src/activities.ts`) — it was implemented but never exported, so the Temporal worker could not dispatch it.
- Extend `EnrichReposResult` with a `pruned` count for observability.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1305](https://linuxfoundation.atlassian.net/browse/CM-1305)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package–repo linkage and `packages.repository_url` for all cargo sync runs; incorrect canonicalization or pruning could affect downstream consumers (e.g. security-contacts) that join via `package_repos`.
> 
> **Overview**
> Fixes cargo repo handling so **canonical** repository URLs stay aligned across `packages`, `repos`, and `package_repos` instead of using raw crates.io `declared_repository_url` values (shorthand, SSH, junk, etc.).
> 
> Adds a **`cargoNormalizeRepos`** step after dump load that rebuilds staging table `repo_norm` by mapping each distinct declared URL through shared **`canonicalizeRepoUrl`** (same as npm/pypi). **`enrichPackages`** now sets **`packages.repository_url`** from that mapping when the dump includes a declared URL, and leaves the existing value when the field is absent. **`enrichRepos`** inserts repos and **`package_repos`** via `repo_norm`, **prunes** stale `source='declared'` links before relinking, and on link conflict only bumps **confidence** (does not overwrite **source**). The activity is exported and wired into **`cargoSyncWorkflow`**; **`EnrichReposResult`** gains a **`pruned`** count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b5bde25a771d1ad6ee9932164fb657220eff01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[CM-1305]: https://linuxfoundation.atlassian.net/browse/CM-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ