### PR TITLE
fix: remove backup for declared repository (CM-1305)

### DIFF
--- a/backend/src/api/public/v1/packages/getPackage.ts
+++ b/backend/src/api/public/v1/packages/getPackage.ts
@@ -130,7 +130,7 @@ export async function getPackage(req: Request, res: Response): Promise<void> {
     },
     provenance: {
       repositoryMapping: {
-        declaredRepo: pkg.repoUrl ?? pkg.repositoryUrl ?? pkg.declaredRepositoryUrl ?? null,
+        declaredRepo: pkg.repoUrl ?? pkg.repositoryUrl ?? null,
         mappingConfidence,
         mappingLabel: repoMappingLabel(mappingConfidence),
         lastCommitAt: pkg.repoLastCommitAt ? pkg.repoLastCommitAt.toISOString() : null,


### PR DESCRIPTION
## Summary
Removes the API-level fallback to `declared_repository_url` (the raw, non-normalized registry value) in the public package detail response, so `provenance.repositoryMapping.declaredRepo` never emits a website URL, placeholder, or free-form string — only a canonical repository link or `null`.

## Changes
- `backend/src/api/public/v1/packages/getPackage.ts`: `declaredRepo` is now `pkg.repoUrl ?? pkg.repositoryUrl ?? null` (dropped the trailing `?? pkg.declaredRepositoryUrl`). Both `/v1/packages/detail` and `/v1/akrites/packages/detail` share this handler, so the fix applies to both endpoints.
- No schema/route changes — same response shape, `declaredRepo` can now be `null` in cases where it previously returned a raw, non-canonical value.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1305](https://linuxfoundation.atlassian.net/browse/CM-1305)

[CM-1305]: https://linuxfoundation.atlassian.net/browse/CM-1305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ