### PR TITLE
fix: generate UUID when member identity id is empty on create

### DIFF
--- a/frontend/src/modules/contributor/components/edit/identity/contributor-identity-add.vue
+++ b/frontend/src/modules/contributor/components/edit/identity/contributor-identity-add.vue
@@ -166,7 +166,10 @@ const isModalOpen = computed<boolean>({
 
 const addIdentities = () => {
   sending.value = true;
-  createContributorIdentities(props.contributor.id, form)
+  createContributorIdentities(
+    props.contributor.id,
+    form.map(({ id, ...identity }) => identity),
+  )
     .then(() => {
       ToastStore.success('Identities successfully added');
       isModalOpen.value = false;

--- a/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
+++ b/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
@@ -1,5 +1,5 @@
 import authAxios from '@/shared/axios/auth-axios';
-import { ContributorIdentity, CreateContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
+import { CreateContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
 import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 

--- a/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
+++ b/frontend/src/modules/contributor/services/contributor.identities.api.service.ts
@@ -1,5 +1,5 @@
 import authAxios from '@/shared/axios/auth-axios';
-import { ContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
+import { ContributorIdentity, CreateContributorIdentity, UpdateContributorIdentityPayload } from '@/modules/contributor/types/Contributor';
 import { storeToRefs } from 'pinia';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 
@@ -22,7 +22,7 @@ export class ContributorIdentitiesApiService {
     ).then(({ data }) => Promise.resolve(data));
   }
 
-  static async createMultiple(memberId: string, identities: ContributorIdentity[]) {
+  static async createMultiple(memberId: string, identities: CreateContributorIdentity[]) {
     return authAxios.put(
       `/member/${memberId}/identity`,
       {

--- a/frontend/src/modules/contributor/store/contributor.actions.ts
+++ b/frontend/src/modules/contributor/store/contributor.actions.ts
@@ -2,7 +2,7 @@ import { useLfSegmentsStore } from '@/modules/lf/segments/store';
 import { storeToRefs } from 'pinia';
 import { ContributorApiService } from '@/modules/contributor/services/contributor.api.service';
 import {
-  Contributor, ContributorAffiliation, ContributorIdentity, UpdateContributorIdentityPayload,
+  Contributor, ContributorAffiliation, ContributorIdentity, CreateContributorIdentity, UpdateContributorIdentityPayload,
 } from '@/modules/contributor/types/Contributor';
 import { ContributorIdentitiesApiService } from '@/modules/contributor/services/contributor.identities.api.service';
 import { MergeActionsService } from '@/shared/modules/merge/services/merge-actions.service';
@@ -70,7 +70,7 @@ export default {
     return ContributorIdentitiesApiService.list(id, [selectedProjectGroup.value?.id as string])
       .then(this.setIdentities);
   },
-  createContributorIdentities(memberId: string, identities: ContributorIdentity[]): Promise<ContributorIdentity[]> {
+  createContributorIdentities(memberId: string, identities: CreateContributorIdentity[]): Promise<ContributorIdentity[]> {
     return ContributorIdentitiesApiService.createMultiple(memberId, identities)
       .then(this.setIdentities);
   },

--- a/frontend/src/modules/contributor/types/Contributor.ts
+++ b/frontend/src/modules/contributor/types/Contributor.ts
@@ -73,6 +73,11 @@ export interface ContributorIdentity {
   duplicatedIdentities?: ContributorIdentity[];
 }
 
+export type CreateContributorIdentity = Omit<
+  ContributorIdentity,
+  'id' | 'platforms' | 'url' | 'duplicatedIdentities'
+>;
+
 export interface UpdateContributorIdentityPayload {
   value?: string;
   type?: string;

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -273,7 +273,7 @@ export async function insertMemberIdentities(
     ],
     identities.map((i) => ({
       ...i,
-      id: i.id ?? generateUUIDv1(),
+      id: i.id || generateUUIDv1(),
       tenantId: DEFAULT_TENANT_ID,
     })),
     failOnConflict ? undefined : 'DO NOTHING',


### PR DESCRIPTION
## Summary

Fixes 500 errors on `PUT /member/:memberId/identity` when users add identities from the Contributor UI. New identity rows were sent with `id: ""`, which bypassed `?? generateUUIDv1()` and caused Postgres to reject the insert (`invalid input syntax for type uuid: ""`).

## Changes

- **DAL** (`services/libs/data-access-layer/src/members/identities.ts`): Use `i.id || generateUUIDv1()` in `insertMemberIdentities` so empty/falsy ids get a generated UUID.
- **Frontend** (`contributor-identity-add.vue`): Strip `id` from the create payload so new identities are sent without an id, matching the `NewMemberIdentity` contract.