### PR TITLE
fix: improve project group list perf and dropdown filter

### DIFF
--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -466,6 +466,7 @@ class SegmentRepository extends RepositoryBase<
       segmentsSearchQuery += `AND EXISTS (
         SELECT 1 FROM segments sp
         WHERE sp."grandparentSlug" = f.slug
+          AND sp."tenantId" = f."tenantId"
           AND sp.id IN (:adminSegments)
       )`
       replacements.adminSegments = adminSegments

--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -463,7 +463,11 @@ class SegmentRepository extends RepositoryBase<
       if (adminSegments.length === 0) {
         return { count: 0, rows: [], limit: criteria.limit, offset: criteria.offset }
       }
-      segmentsSearchQuery += `AND sp.id IN (:adminSegments)`
+      segmentsSearchQuery += `AND EXISTS (
+        SELECT 1 FROM segments sp
+        WHERE sp."grandparentSlug" = f.slug
+          AND sp.id IN (:adminSegments)
+      )`
       replacements.adminSegments = adminSegments
     }
 
@@ -474,51 +478,24 @@ class SegmentRepository extends RepositoryBase<
                   SELECT
                       f.id AS foundation_id,
                       f.name AS foundation_name,
-                      f.status,
-                      f."createdAt",
-                      f."updatedAt",
-                      f."sourceId",
-                      f."sourceParentId",
-                      f.slug,
-                      p.name AS project_name,
-                      p.id AS project_id,
-                      p.status AS project_status,
-                      p.slug AS project_slug,
-                      COUNT(DISTINCT sp.id) AS subproject_count,
-                      JSONB_AGG(JSONB_BUILD_OBJECT(
-                          'id', sp.id,
-                          'name', sp.name,
-                          'status', sp.status,
-                          'slug', sp.slug
-                          )) AS subprojects
+                      COUNT(DISTINCT p.id)::int AS project_count
                   FROM segments f
-                  JOIN segments p
+                  LEFT JOIN segments p
                       ON p."parentSlug" = f."slug"
                              AND p."grandparentSlug" IS NULL
                              AND p."tenantId" = f."tenantId"
-                  JOIN segments sp
-                      ON sp."parentSlug" = p."slug"
-                             AND sp."grandparentSlug" = f.slug
-                             AND sp."tenantId" = f."tenantId"
                   WHERE f."parentSlug" IS NULL
                     AND f."tenantId" = :tenantId
                     ${segmentsSearchQuery}
-                  GROUP BY f."id", p.id
+                  GROUP BY f.id
               )
           SELECT
               s.*,
               COUNT(*) OVER () AS "totalCount",
-              JSONB_AGG(JSONB_BUILD_OBJECT(
-                      'id', f.project_id,
-                      'name', f.project_name,
-                      'status', f.project_status,
-                      'slug', f.project_slug,
-                      'subprojects', f.subprojects
-                  )) AS projects
+              f.project_count AS "projectCount"
           FROM segments s
           JOIN foundations f ON s.id = f.foundation_id
           ${searchQuery}
-          GROUP BY s.id, f.foundation_name
           ORDER BY f.foundation_name
           ${this.getPaginationString(criteria)};
       `,

--- a/backend/src/database/repositories/segmentRepository.ts
+++ b/backend/src/database/repositories/segmentRepository.ts
@@ -480,10 +480,14 @@ class SegmentRepository extends RepositoryBase<
                       f.name AS foundation_name,
                       COUNT(DISTINCT p.id)::int AS project_count
                   FROM segments f
-                  LEFT JOIN segments p
+                  JOIN segments p
                       ON p."parentSlug" = f."slug"
                              AND p."grandparentSlug" IS NULL
                              AND p."tenantId" = f."tenantId"
+                  JOIN segments sp
+                      ON sp."parentSlug" = p."slug"
+                             AND sp."grandparentSlug" = f.slug
+                             AND sp."tenantId" = f."tenantId"
                   WHERE f."parentSlug" IS NULL
                     AND f."tenantId" = :tenantId
                     ${segmentsSearchQuery}

--- a/frontend/nginx.kube.conf
+++ b/frontend/nginx.kube.conf
@@ -18,6 +18,20 @@ http {
 
     charset utf-8;
 
+    gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_vary on;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        image/svg+xml;
+
     server {
         listen 8081 default_server;
         listen [::]:8081;

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -60,6 +60,10 @@ export default {
         if (tenant?.id && tenant.id !== oldTenant?.id) {
           this.fetchActivityTypes();
           this.fetchActivityChannels();
+          this.listProjectGroups({
+            limit: 20,
+            reset: true,
+          });
         }
       },
     },
@@ -72,10 +76,6 @@ export default {
     if (queryParameters.get('state') === 'noconnect' && window.location.pathname.includes('/integration')) {
       return;
     }
-    this.listProjectGroups({
-      limit: null,
-      reset: true,
-    });
     if (['/auth/callback'].includes(window.location.pathname)) {
       return;
     }

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -23,9 +23,7 @@
 <script>
 import { mapActions } from 'vuex';
 import AppResizePage from '@/modules/layout/pages/resize-page.vue';
-import { mapActions as piniaMapActions, storeToRefs } from 'pinia';
-import { useActivityStore } from '@/modules/activity/store/pinia';
-import { useActivityTypeStore } from '@/modules/activity/store/type';
+import { storeToRefs } from 'pinia';
 import { useAuthStore } from '@/modules/auth/store/auth.store';
 import useSessionTracking from '@/shared/modules/monitoring/useSessionTracking';
 import { useLfSegmentsStore } from '@/modules/lf/segments/store';
@@ -58,8 +56,6 @@ export default {
     tenant: {
       handler(tenant, oldTenant) {
         if (tenant?.id && tenant.id !== oldTenant?.id) {
-          this.fetchActivityTypes();
-          this.fetchActivityChannels();
           this.listProjectGroups({
             limit: 20,
             reset: true,
@@ -90,12 +86,6 @@ export default {
   methods: {
     ...mapActions({
       resize: 'layout/resize',
-    }),
-    ...piniaMapActions(useActivityStore, {
-      fetchActivityChannels: 'fetchActivityChannels',
-    }),
-    ...piniaMapActions(useActivityTypeStore, {
-      fetchActivityTypes: 'fetchActivityTypes',
     }),
 
     handleResize() {

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -284,7 +284,7 @@ const segments = computed(() => {
     return (
       getSegmentsFromProjectGroup(selectedProjectGroup.value)?.map(
         (s) => subprojects.value[s],
-      ) || []
+      ).filter((s) => !!s) || []
     );
   }
   return (

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -275,8 +275,8 @@ const selectedSegment = ref(props.selectedSegment || null);
 const isMemberEntity = computed(() => props.entityType === 'member');
 
 const subprojects = computed(() => projectGroups.value.list.reduce((acc, projectGroup) => {
-  projectGroup.projects.forEach((project) => {
-    project.subprojects.forEach((subproject) => {
+  (projectGroup.projects || []).forEach((project) => {
+    (project.subprojects || []).forEach((subproject) => {
       acc[subproject.id] = {
         id: subproject.id,
         name: subproject.name,

--- a/frontend/src/modules/activity/components/activity-timeline.vue
+++ b/frontend/src/modules/activity/components/activity-timeline.vue
@@ -257,7 +257,7 @@ const props = defineProps({
 });
 
 const lsSegmentsStore = useLfSegmentsStore();
-const { projectGroups, selectedProjectGroup } = storeToRefs(lsSegmentsStore);
+const { selectedProjectGroup, selectedProjectGroupSubprojects } = storeToRefs(lsSegmentsStore);
 
 const enabledPlatforms: IdentityConfig[] = Object.values(lfIdentities);
 
@@ -274,16 +274,8 @@ const selectedSegment = ref(props.selectedSegment || null);
 
 const isMemberEntity = computed(() => props.entityType === 'member');
 
-const subprojects = computed(() => projectGroups.value.list.reduce((acc, projectGroup) => {
-  (projectGroup.projects || []).forEach((project) => {
-    (project.subprojects || []).forEach((subproject) => {
-      acc[subproject.id] = {
-        id: subproject.id,
-        name: subproject.name,
-      };
-    });
-  });
-
+const subprojects = computed(() => selectedProjectGroupSubprojects.value.reduce((acc, sp) => {
+  acc[sp.id] = { id: sp.id, name: sp.name };
   return acc;
 }, {}));
 

--- a/frontend/src/modules/admin/modules/projects/components/view/lf-project-groups-table.vue
+++ b/frontend/src/modules/admin/modules/projects/components/view/lf-project-groups-table.vue
@@ -26,7 +26,10 @@
             </div>
           </lf-table-cell>
           <lf-table-cell>
-            <app-lf-project-column :projects="projectGroup.projects" />
+            <app-lf-project-column
+              :projects="projectGroup.projects || []"
+              :project-count="projectGroup.projectCount"
+            />
           </lf-table-cell>
           <lf-table-cell class="pr-2 flex justify-end">
             <app-lf-project-groups-dropdown

--- a/frontend/src/modules/admin/modules/projects/pages/project-groups-list.page.vue
+++ b/frontend/src/modules/admin/modules/projects/pages/project-groups-list.page.vue
@@ -84,7 +84,7 @@
 
             <div class="mb-8 flex flex-wrap gap-2.5">
               <div class="bg-gray-200 text-gray-900 text-2xs px-2 h-6 flex items-center w-fit rounded-md">
-                {{ pluralize('project', projectGroup.projects.length, true) }}
+                {{ pluralize('project', projectGroup.projectCount ?? projectGroup.projects?.length ?? 0, true) }}
               </div>
             </div>
 

--- a/frontend/src/modules/lf/layout/components/lf-banners.vue
+++ b/frontend/src/modules/lf/layout/components/lf-banners.vue
@@ -158,11 +158,11 @@ import LfButton from '@/ui-kit/button/Button.vue';
 const ERROR_BANNER_WORKING_DAYS_DISPLAY = 3;
 
 const lsSegmentsStore = useLfSegmentsStore();
-const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
+const { selectedProjectGroup, selectedProjectGroupSubprojects } = storeToRefs(lsSegmentsStore);
 const integrations = ref([]);
 const fetchIntegrationTimer = ref(null);
 const loading = ref(true);
-const subProjects = ref([]);
+const subProjects = computed(() => selectedProjectGroupSubprojects.value);
 
 const route = useRoute();
 
@@ -251,21 +251,6 @@ watch(selectedProjectGroup, (updatedProjectGroup, previousProjectGroup) => {
   if (previousProjectGroup?.id !== updatedProjectGroup?.id) {
     loading.value = true;
     fetchIntegrations(updatedProjectGroup);
-  }
-
-  if (!updatedProjectGroup) {
-    subProjects.value = [];
-  } else {
-    subProjects.value = updatedProjectGroup.projects
-      .reduce((acc, project) => {
-        project.subprojects.forEach((subproject) => {
-          if (subproject) {
-            acc.push(subproject);
-          }
-        });
-
-        return acc;
-      }, []);
   }
 }, {
   deep: true,

--- a/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
+++ b/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
@@ -9,7 +9,7 @@
   >
     <template #reference>
       <el-input
-        v-model="model"
+        :model-value="selectedProjectGroup?.name ?? ''"
         class="project-groups-select-input"
         placeholder="Select project group..."
         readonly
@@ -146,15 +146,6 @@ const isSearchVisible = computed(() => projectGroupsList.value.length > 5 || sea
 let scrollContainer: HTMLElement | null = null;
 
 const { trackEvent } = useProductTracking();
-
-const model = computed({
-  get() {
-    return selectedProjectGroup.value?.name;
-  },
-  set(id) {
-    updateSelectedProjectGroup(id);
-  },
-});
 
 const queryKey = computed(() => [
   TanstackKey.ADMIN_PROJECT_GROUPS,

--- a/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
+++ b/frontend/src/modules/lf/layout/components/lf-menu-project-group-selection.vue
@@ -64,7 +64,7 @@
                 {{ projectGroup.name }}
               </div>
               <div class="text-tiny text-gray-400">
-                {{ pluralize("project", projectGroup.projects.length, true) }}
+                {{ pluralize("project", projectGroup.projectCount ?? projectGroup.projects?.length ?? 0, true) }}
               </div>
             </div>
           </div>
@@ -230,18 +230,18 @@ onMounted(() => {
   });
 });
 
-const onOptionClick = ({ id, name }: ProjectGroup) => {
+const onOptionClick = (projectGroup: ProjectGroup) => {
   trackEvent({
     key: FeatureEventKey.SELECT_PROJECT_GROUP,
     type: EventType.FEATURE,
     properties: {
-      projectGroupId: id,
-      projectName: name,
+      projectGroupId: projectGroup.id,
+      projectName: projectGroup.name,
     },
   });
 
   isPopoverVisible.value = false;
-  updateSelectedProjectGroup(id);
+  updateSelectedProjectGroup(projectGroup);
 };
 
 onBeforeUnmount(() => {

--- a/frontend/src/modules/lf/segments/lf-segments-service.js
+++ b/frontend/src/modules/lf/segments/lf-segments-service.js
@@ -89,9 +89,9 @@ export class LfService {
     return response.data;
   }
 
-  static async querySubprojects(body) {
+  static async querySubprojectsLite(body) {
     const response = await authAxios.post(
-      '/segment/subproject/query',
+      '/segment/subproject/query-lite',
       {
         ...body,
         excludeSegments: true,

--- a/frontend/src/modules/lf/segments/lf-segments-service.js
+++ b/frontend/src/modules/lf/segments/lf-segments-service.js
@@ -89,6 +89,18 @@ export class LfService {
     return response.data;
   }
 
+  static async querySubprojects(body) {
+    const response = await authAxios.post(
+      '/segment/subproject/query',
+      {
+        ...body,
+        excludeSegments: true,
+      },
+    );
+
+    return response.data;
+  }
+
   // Sub-projects
 
   static async createSubProject(body) {

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -14,7 +14,6 @@ const isAdminOnly = () => {
   return roles.value.includes(LfRole.projectAdmin);
 };
 
-
 export default {
   // Project Groups
   listProjectGroups({

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -14,6 +14,32 @@ const isAdminOnly = () => {
   return roles.value.includes(LfRole.projectAdmin);
 };
 
+const hasNestedProjects = (projectGroup) => Array.isArray(projectGroup?.projects)
+  && projectGroup.projects.some((p) => Array.isArray(p.subprojects) && p.subprojects.length > 0);
+
+const resolveProjectGroupForSelection = async (projectGroupOrId, list) => {
+  if (!projectGroupOrId) {
+    return null;
+  }
+
+  const id = typeof projectGroupOrId === 'string' ? projectGroupOrId : projectGroupOrId.id;
+  if (!id) {
+    return null;
+  }
+
+  const fromArg = typeof projectGroupOrId === 'object' ? projectGroupOrId : null;
+  const fromList = list.find((p) => p.id === id) || null;
+
+  if (hasNestedProjects(fromArg)) {
+    return fromArg;
+  }
+  if (hasNestedProjects(fromList)) {
+    return fromList;
+  }
+
+  return LfService.findSegment(id);
+};
+
 export default {
   // Project Groups
   listProjectGroups({
@@ -270,19 +296,44 @@ export default {
 
     this.listProjects();
   },
-  updateSelectedProjectGroup(projectGroupId, sendToDashboard = true) {
-    if (projectGroupId) {
-      const projectGroup = this.projectGroups.list.find((p) => p.id === projectGroupId);
+  async updateSelectedProjectGroup(projectGroupOrId, sendToDashboard = true) {
+    if (!projectGroupOrId) {
+      this.selectedProjectGroup = null;
+      return;
+    }
+
+    try {
+      const projectGroup = await resolveProjectGroupForSelection(
+        projectGroupOrId,
+        this.projectGroups.list,
+      );
+
+      if (!projectGroup?.id) {
+        this.selectedProjectGroup = null;
+        ToastStore.error('Project group could not be loaded');
+        return;
+      }
 
       this.selectedProjectGroup = projectGroup;
+
+      const idx = this.projectGroups.list.findIndex((p) => p.id === projectGroup.id);
+      if (idx >= 0) {
+        this.projectGroups.list[idx] = {
+          ...this.projectGroups.list[idx],
+          ...projectGroup,
+        };
+      } else {
+        this.projectGroups.list = [...this.projectGroups.list, projectGroup];
+      }
 
       if (sendToDashboard) {
         router.push({
           name: 'member',
         });
       }
-    } else {
+    } catch (e) {
       this.selectedProjectGroup = null;
+      ToastStore.error('Something went wrong while selecting the project group');
     }
   },
   doChangeProjectGroupCurrentPage(currentPage) {

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -275,15 +275,22 @@ export default {
       this.selectedProjectGroupSubprojects = [];
       return;
     }
+
+    this.selectedProjectGroupSubprojects = [];
+
     try {
       const response = await LfService.querySubprojectsLite({
         limit: null,
         offset: 0,
         filter: { grandparentSlug },
       });
-      this.selectedProjectGroupSubprojects = response.rows || [];
+      if (this.selectedProjectGroup?.slug === grandparentSlug) {
+        this.selectedProjectGroupSubprojects = response.rows || [];
+      }
     } catch (e) {
-      this.selectedProjectGroupSubprojects = [];
+      if (this.selectedProjectGroup?.slug === grandparentSlug) {
+        this.selectedProjectGroupSubprojects = [];
+      }
     }
   },
 
@@ -316,7 +323,7 @@ export default {
       }
 
       this.selectedProjectGroup = projectGroup;
-      this.fetchSubprojectsForProjectGroup(projectGroup.slug);
+      await this.fetchSubprojectsForProjectGroup(projectGroup.slug);
 
       if (sendToDashboard) {
         router.push({

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -14,31 +14,6 @@ const isAdminOnly = () => {
   return roles.value.includes(LfRole.projectAdmin);
 };
 
-const hasNestedProjects = (projectGroup) => Array.isArray(projectGroup?.projects)
-  && projectGroup.projects.some((p) => Array.isArray(p.subprojects) && p.subprojects.length > 0);
-
-const resolveProjectGroupForSelection = async (projectGroupOrId, list) => {
-  if (!projectGroupOrId) {
-    return null;
-  }
-
-  const id = typeof projectGroupOrId === 'string' ? projectGroupOrId : projectGroupOrId.id;
-  if (!id) {
-    return null;
-  }
-
-  const fromArg = typeof projectGroupOrId === 'object' ? projectGroupOrId : null;
-  const fromList = list.find((p) => p.id === id) || null;
-
-  if (hasNestedProjects(fromArg)) {
-    return fromArg;
-  }
-  if (hasNestedProjects(fromList)) {
-    return fromList;
-  }
-
-  return LfService.findSegment(id);
-};
 
 export default {
   // Project Groups
@@ -296,35 +271,53 @@ export default {
 
     this.listProjects();
   },
+  async fetchSubprojectsForProjectGroup(grandparentSlug) {
+    if (!grandparentSlug) {
+      this.selectedProjectGroupSubprojects = [];
+      return;
+    }
+    try {
+      const response = await LfService.querySubprojects({
+        limit: null,
+        offset: 0,
+        filter: { grandparentSlug },
+      });
+      this.selectedProjectGroupSubprojects = response.rows || [];
+    } catch (e) {
+      this.selectedProjectGroupSubprojects = [];
+    }
+  },
+
   async updateSelectedProjectGroup(projectGroupOrId, sendToDashboard = true) {
     if (!projectGroupOrId) {
       this.selectedProjectGroup = null;
+      this.selectedProjectGroupSubprojects = [];
+      return;
+    }
+
+    const id = typeof projectGroupOrId === 'string' ? projectGroupOrId : projectGroupOrId.id;
+    if (!id) {
+      this.selectedProjectGroup = null;
+      this.selectedProjectGroupSubprojects = [];
       return;
     }
 
     try {
-      const projectGroup = await resolveProjectGroupForSelection(
-        projectGroupOrId,
-        this.projectGroups.list,
-      );
+      let projectGroup = this.projectGroups.list.find((p) => p.id === id) || null;
+      if (!projectGroup) {
+        await this.listProjectGroups({ limit: null, reset: true });
+        projectGroup = this.projectGroups.list.find((p) => p.id === id) || null;
+      }
 
       if (!projectGroup?.id) {
         this.selectedProjectGroup = null;
+        this.selectedProjectGroupSubprojects = [];
         ToastStore.error('Project group could not be loaded');
         return;
       }
 
       this.selectedProjectGroup = projectGroup;
-
-      const idx = this.projectGroups.list.findIndex((p) => p.id === projectGroup.id);
-      if (idx >= 0) {
-        this.projectGroups.list[idx] = {
-          ...this.projectGroups.list[idx],
-          ...projectGroup,
-        };
-      } else {
-        this.projectGroups.list = [...this.projectGroups.list, projectGroup];
-      }
+      this.fetchSubprojectsForProjectGroup(projectGroup.slug);
 
       if (sendToDashboard) {
         router.push({
@@ -333,6 +326,7 @@ export default {
       }
     } catch (e) {
       this.selectedProjectGroup = null;
+      this.selectedProjectGroupSubprojects = [];
       ToastStore.error('Something went wrong while selecting the project group');
     }
   },

--- a/frontend/src/modules/lf/segments/store/actions.js
+++ b/frontend/src/modules/lf/segments/store/actions.js
@@ -277,7 +277,7 @@ export default {
       return;
     }
     try {
-      const response = await LfService.querySubprojects({
+      const response = await LfService.querySubprojectsLite({
         limit: null,
         offset: 0,
         filter: { grandparentSlug },

--- a/frontend/src/modules/lf/segments/store/state.ts
+++ b/frontend/src/modules/lf/segments/store/state.ts
@@ -1,7 +1,8 @@
-import { ProjectGroup, Project } from '@/modules/lf/segments/types/Segments';
+import { ProjectGroup, Project, SubProject } from '@/modules/lf/segments/types/Segments';
 
 export interface SegmentsState {
   selectedProjectGroup: ProjectGroup | null
+  selectedProjectGroupSubprojects: SubProject[]
   adminProjectGroups: {
     list: ProjectGroup[]
   }
@@ -32,6 +33,7 @@ export interface SegmentsState {
 
 const state: SegmentsState = {
   selectedProjectGroup: null,
+  selectedProjectGroupSubprojects: [],
   adminProjectGroups: {
     list: [],
   },

--- a/frontend/src/modules/lf/segments/types/Segments.ts
+++ b/frontend/src/modules/lf/segments/types/Segments.ts
@@ -50,7 +50,8 @@ export interface ProjectGroup {
   activityChannels: object;
   createdAt: string;
   updatedAt: string;
-  projects: Project[];
+  projects?: Project[];
+  projectCount?: number;
   isLF: boolean;
 }
 

--- a/frontend/src/modules/overview/components/fragments/project-group-filter.vue
+++ b/frontend/src/modules/overview/components/fragments/project-group-filter.vue
@@ -185,9 +185,18 @@ watch(error, (err) => {
   }
 });
 
-watch(selectedProjectGroupId, (newVal) => {
+watch(selectedProjectGroupId, async (newVal) => {
   if (newVal && newVal !== '') {
-    selectedProjectGroup.value = projectGroupsList.value.find((pg) => pg.id === newVal) || null;
+    const fromList = projectGroupsList.value.find((pg) => pg.id === newVal) || null;
+    selectedProjectGroup.value = fromList;
+
+    if (!fromList?.projects?.length) {
+      try {
+        selectedProjectGroup.value = await segmentService.getSegmentById(newVal) as ProjectGroup;
+      } catch (e) {
+        ToastStore.error('Something went wrong while loading the project group');
+      }
+    }
   } else {
     selectedProjectGroup.value = null;
     selectedProjectId.value = '';

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -62,7 +62,7 @@ export const createRouter = () => {
     router.beforeEach(async (to, from, next) => {
       const lsSegmentsStore = useLfSegmentsStore();
       const { selectedProjectGroup } = storeToRefs(lsSegmentsStore);
-      const { listProjectGroups, updateSelectedProjectGroup } = lsSegmentsStore;
+      const { updateSelectedProjectGroup } = lsSegmentsStore;
 
       // Set title to pages
       document.title = `LFX Community Data Platform${to.meta.title ? ` | ${to.meta.title}` : ''}`;
@@ -111,12 +111,11 @@ export const createRouter = () => {
 
           if (!selectedProjectGroup.value) {
             try {
-              await listProjectGroups({
-                limit: null,
-                reset: true,
-              });
-
-              updateSelectedProjectGroup(to.query.projectGroup, false);
+              await updateSelectedProjectGroup(to.query.projectGroup, false);
+              if (!selectedProjectGroup.value) {
+                next('/project-groups');
+                return;
+              }
             } catch (e) {
               next('/project-groups');
               return;

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -85,9 +85,10 @@ export const createRouter = () => {
           store,
         };
 
-        await middlewareArray.forEach(async (middleware) => {
+        for (const middleware of middlewareArray) {
+          // eslint-disable-next-line no-await-in-loop
           await middleware(context);
-        });
+        }
 
         // Redirect to project group landing pages if routes that require a selected project group
         // And no project group is selected

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -85,10 +85,10 @@ export const createRouter = () => {
           store,
         };
 
-        for (const middleware of middlewareArray) {
-          // eslint-disable-next-line no-await-in-loop
-          await middleware(context);
-        }
+        await middlewareArray.reduce(
+          (promise, middleware) => promise.then(() => middleware(context)),
+          Promise.resolve(),
+        );
 
         // Redirect to project group landing pages if routes that require a selected project group
         // And no project group is selected

--- a/frontend/src/shared/project-column/lf-project-column.vue
+++ b/frontend/src/shared/project-column/lf-project-column.vue
@@ -1,12 +1,13 @@
 <template>
-  <div v-if="props.projects.length" class="flex flex-wrap gap-2">
+  <div v-if="displayCount > 0" class="flex flex-wrap gap-2">
     <el-popover
+      v-if="projects.length"
       placement="top"
       :width="250"
       trigger="hover"
     >
       <template #reference>
-        <app-lf-project-count :title="props.title" :icon="props.icon" :count="projects.length" />
+        <app-lf-project-count :title="props.title" :icon="props.icon" :count="displayCount" />
       </template>
       <template #default>
         <div class="flex flex-wrap gap-1 overflow-hidden">
@@ -22,25 +23,36 @@
         </div>
       </template>
     </el-popover>
+    <app-lf-project-count
+      v-else
+      :title="props.title"
+      :icon="props.icon"
+      :count="displayCount"
+    />
   </div>
   <span v-else class="text-gray-500 text-sm">No {{ props.title }}</span>
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue';
 import AppLfProjectCount from './lf-project-count.vue';
 
 const props = withDefaults(defineProps<{
-  projects: {
+  projects?: {
     id: string;
     name: string;
   }[];
+  projectCount?: number;
   icon?: string;
   title?: string;
 }>(), {
   projects: () => [],
+  projectCount: undefined,
   title: () => 'Projects',
   icon: () => 'layer-group',
 });
+
+const displayCount = computed(() => props.projectCount ?? props.projects?.length ?? 0);
 </script>
 
 <script lang="ts">

--- a/frontend/src/utils/segments.js
+++ b/frontend/src/utils/segments.js
@@ -19,17 +19,14 @@ export const getSegmentsFromProjectGroup = (
     return [projectGroup.id];
   }
 
-  if (!projectGroup.projects?.length) {
+  const lsSegmentsStore = useLfSegmentsStore();
+  const { selectedProjectGroupSubprojects } = storeToRefs(lsSegmentsStore);
+
+  if (!selectedProjectGroupSubprojects.value.length) {
     return [projectGroup.id];
   }
 
-  return projectGroup.projects.reduce((acc, project) => {
-    (project.subprojects || []).forEach((subproject) => {
-      acc.push(subproject.id);
-    });
-
-    return acc;
-  }, []);
+  return selectedProjectGroupSubprojects.value.map((sp) => sp.id);
 };
 
 export const getProjectGroupsThroughSegments = (segments) => {

--- a/frontend/src/utils/segments.js
+++ b/frontend/src/utils/segments.js
@@ -19,8 +19,12 @@ export const getSegmentsFromProjectGroup = (
     return [projectGroup.id];
   }
 
+  if (!projectGroup.projects?.length) {
+    return [projectGroup.id];
+  }
+
   return projectGroup.projects.reduce((acc, project) => {
-    project.subprojects.forEach((subproject) => {
+    (project.subprojects || []).forEach((subproject) => {
       acc.push(subproject.id);
     });
 


### PR DESCRIPTION
## Summary

- Slim project group list payload and hydrate selected group on demand
- Enable gzip for frontend static assets in kube nginx config
- Defer subproject fetch and remove duplicate activity calls on load
- Use `subproject/query-lite` for selected project group hydration
- Exclude project groups with 0 projects or subprojects from the dropdown