### PR TITLE
feat: add advisories api (CM-1335)

### DIFF
--- a/backend/src/api/public/v1/akrites-external/index.ts
+++ b/backend/src/api/public/v1/akrites-external/index.ts
@@ -5,6 +5,8 @@ import { requireScopes } from '@/api/public/middlewares/requireScopes'
 import { safeWrap } from '@/middlewares/errorMiddleware'
 import { SCOPES } from '@/security/scopes'
 
+import { getAkritesExternalAdvisoryDetail } from '../packages/getAkritesExternalAdvisoryDetail'
+import { getAkritesExternalAdvisoryDetailBatch } from '../packages/getAkritesExternalAdvisoryDetailBatch'
 import { getAkritesExternalPackageDetail } from '../packages/getAkritesExternalPackageDetail'
 import { getAkritesExternalPackageDetailBatch } from '../packages/getAkritesExternalPackageDetailBatch'
 
@@ -22,6 +24,17 @@ export function akritesExternalRouter(): Router {
   packagesSubRouter.get('/detail', safeWrap(getAkritesExternalPackageDetail))
   packagesSubRouter.post(/^\/detail:batch\/?$/, safeWrap(getAkritesExternalPackageDetailBatch))
   router.use('/packages', packagesSubRouter)
+
+  // TODO: the contract gates advisories behind a dedicated read:advisories scope
+  // (see the scope-naming note in the akrites-external OpenAPI). That scope isn't
+  // issued by Auth0 yet, so reuse READ_PACKAGES for now — advisories are package
+  // security data and, unlike the packages endpoints above, need no stewardship read.
+  const advisoriesSubRouter = Router()
+  advisoriesSubRouter.use(rateLimiter)
+  advisoriesSubRouter.use(requireScopes([SCOPES.READ_PACKAGES]))
+  advisoriesSubRouter.get('/detail', safeWrap(getAkritesExternalAdvisoryDetail))
+  advisoriesSubRouter.post(/^\/detail:batch\/?$/, safeWrap(getAkritesExternalAdvisoryDetailBatch))
+  router.use('/advisories', advisoriesSubRouter)
 
   return router
 }

--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -9,8 +9,8 @@ info:
     entirely between Akrites and Auth0.
 
 
-    Only the Packages endpoints are implemented so far. Advisories, Blast
-    Radius, and Contacts are specced separately and not yet built.
+    Packages and Advisories endpoints are implemented. Blast Radius and
+    Contacts are specced separately and not yet built.
 
 
     TODO: scopes below (read:packages, read:stewardships) are the existing
@@ -30,6 +30,13 @@ security:
 tags:
   - name: Packages
     description: Package detail — requires read:packages and read:stewardships (see TODO above).
+  - name: Advisories
+    description: >
+      Security advisories for a package, split out of package detail. The draft
+      contract gates these behind a dedicated read:advisories scope; until Auth0
+      issues it, the implementation reuses read:packages (advisories need no
+      stewardship read). Confirm the final scope name (read:advisories vs
+      cdp:advisories:read) with Akrites/product.
 
 components:
   securitySchemes:
@@ -298,6 +305,57 @@ components:
           allOf:
             - $ref: '#/components/schemas/PackageDetail'
 
+    Advisory:
+      type: object
+      required: [osvId, severity, resolution, isCritical]
+      properties:
+        osvId:
+          type: string
+          example: GHSA-xxxx-xxxx-xxxx
+        severity:
+          type: string
+          enum: [critical, high, moderate, low, null]
+          nullable: true
+          description: >
+            Lowercased advisory severity. Any stored value outside this enum is
+            returned as null rather than echoed verbatim.
+        resolution:
+          type: string
+          enum: [open, patched, null]
+          nullable: true
+          description: >
+            Whether the package's latest version is still affected. Null when it
+            can't be determined (no latest version, or no affected ranges recorded).
+        isCritical:
+          type: boolean
+          nullable: true
+          description: cvss >= 7.0. Null when the advisory has no CVSS score.
+
+    AdvisoryDetail:
+      type: object
+      required: [purl, advisories]
+      properties:
+        purl:
+          type: string
+        advisories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Advisory'
+
+    AdvisoryDetailBulkEntry:
+      type: object
+      required: [requestedPurl, found, advisories]
+      properties:
+        requestedPurl:
+          type: string
+        found:
+          type: boolean
+        advisories:
+          type: object
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AdvisoryDetail'
+
 paths:
   /akrites-external/packages/detail:
     get:
@@ -397,6 +455,107 @@ paths:
                 $ref: '#/components/schemas/Error'
         '403':
           description: Token missing read:packages or read:stewardships scope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /akrites-external/advisories/detail:
+    get:
+      operationId: getAdvisoryDetail
+      summary: Get advisories for a package by PURL
+      tags: [Advisories]
+      security:
+        - M2MBearer:
+            - read:packages
+      parameters:
+        - name: purl
+          in: query
+          required: true
+          schema:
+            type: string
+            example: pkg:npm/%40angular/core
+      responses:
+        '200':
+          description: Advisories for the package (empty array when the package has none).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdvisoryDetail'
+        '400':
+          description: Malformed purl.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Token missing read:packages scope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Package not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /akrites-external/advisories/detail:batch:
+    post:
+      operationId: getAdvisoryDetailBatch
+      summary: Bulk advisory lookup
+      tags: [Advisories]
+      security:
+        - M2MBearer:
+            - read:packages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [purls]
+              properties:
+                purls:
+                  type: array
+                  minItems: 1
+                  maxItems: 100
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Results in the same order as the request.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [results]
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AdvisoryDetailBulkEntry'
+        '400':
+          description: Validation error (empty array, >100 items, malformed purl).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Token missing read:packages scope.
           content:
             application/json:
               schema:

--- a/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.test.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AkritesExternalAdvisoryRow } from '@crowd/data-access-layer'
+
+import { toAkritesExternalAdvisoryDetail } from './akritesExternalAdvisoryDetail'
+
+const purl = 'pkg:npm/lodash'
+
+function row(overrides: Partial<AkritesExternalAdvisoryRow> = {}): AkritesExternalAdvisoryRow {
+  return {
+    purl,
+    osvId: 'GHSA-1111-1111-1111',
+    severity: 'critical',
+    resolution: 'open',
+    isCritical: true,
+    ...overrides,
+  }
+}
+
+describe('toAkritesExternalAdvisoryDetail', () => {
+  it('maps well-formed advisory rows to the akrites-external shape', () => {
+    const result = toAkritesExternalAdvisoryDetail(purl, [
+      row({ osvId: 'GHSA-aaaa', severity: 'critical', resolution: 'open', isCritical: true }),
+      row({ osvId: 'GHSA-bbbb', severity: 'high', resolution: 'patched', isCritical: false }),
+    ])
+    expect(result.purl).toBe(purl)
+    expect(result.advisories).toEqual([
+      { osvId: 'GHSA-aaaa', severity: 'critical', resolution: 'open', isCritical: true },
+      { osvId: 'GHSA-bbbb', severity: 'high', resolution: 'patched', isCritical: false },
+    ])
+  })
+
+  it('returns an empty advisories array for the found-but-advisory-less sentinel row', () => {
+    // A found package with no advisories comes back as a single null-osvId row.
+    const result = toAkritesExternalAdvisoryDetail(purl, [
+      row({ osvId: null, severity: null, resolution: null, isCritical: null }),
+    ])
+    expect(result.advisories).toEqual([])
+  })
+
+  it('coerces a severity outside the contract enum (e.g. medium) to null', () => {
+    // DB may store MEDIUM; the contract enum only allows critical/high/moderate/low.
+    const result = toAkritesExternalAdvisoryDetail(purl, [row({ severity: 'medium' })])
+    expect(result.advisories[0].severity).toBeNull()
+  })
+
+  it('passes through null severity and null isCritical (unscored advisory)', () => {
+    const result = toAkritesExternalAdvisoryDetail(purl, [
+      row({ osvId: 'GHSA-cccc', severity: null, resolution: 'open', isCritical: null }),
+    ])
+    expect(result.advisories[0]).toEqual({
+      osvId: 'GHSA-cccc',
+      severity: null,
+      resolution: 'open',
+      isCritical: null,
+    })
+  })
+
+  it('keeps the accepted moderate severity value', () => {
+    const result = toAkritesExternalAdvisoryDetail(purl, [row({ severity: 'moderate' })])
+    expect(result.advisories[0].severity).toBe('moderate')
+  })
+})

--- a/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.test.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.test.ts
@@ -38,9 +38,14 @@ describe('toAkritesExternalAdvisoryDetail', () => {
     expect(result.advisories).toEqual([])
   })
 
-  it('coerces a severity outside the contract enum (e.g. medium) to null', () => {
-    // DB may store MEDIUM; the contract enum only allows critical/high/moderate/low.
+  it('crosswalks the DB medium severity to the contract moderate value', () => {
+    // The DB normalizes the middle band to MEDIUM; the contract calls it moderate.
     const result = toAkritesExternalAdvisoryDetail(purl, [row({ severity: 'medium' })])
+    expect(result.advisories[0].severity).toBe('moderate')
+  })
+
+  it('coerces a severity outside the known vocabulary to null', () => {
+    const result = toAkritesExternalAdvisoryDetail(purl, [row({ severity: 'info' })])
     expect(result.advisories[0].severity).toBeNull()
   })
 

--- a/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.ts
@@ -21,14 +21,22 @@ export interface AdvisoryDetailBulkEntry {
   advisories: AkritesExternalAdvisoryDetail | null
 }
 
-// Severity values the contract's enum accepts. The DB stores severity uppercase and
-// the query lowercases it; anything outside this set (or null) maps to null rather
-// than being echoed verbatim, so the response never violates the published enum.
-const SEVERITY_SET = new Set<string>(['critical', 'high', 'moderate', 'low'])
+// Maps the DB's (lowercased) severity vocabulary to the contract's enum. The DB
+// normalizes the middle band to MEDIUM (initial_schema.sql; osv/extractSeverity.ts),
+// whereas the Akrites contract calls that same level `moderate` — hence the explicit
+// medium → moderate crosswalk. Anything unrecognized (or null) maps to null so the
+// response never violates the published enum.
+const SEVERITY_CROSSWALK: Record<string, AkritesExternalAdvisorySeverity> = {
+  critical: 'critical',
+  high: 'high',
+  medium: 'moderate',
+  moderate: 'moderate',
+  low: 'low',
+}
 
 function toAkritesSeverity(severity: string | null): AkritesExternalAdvisorySeverity {
-  if (severity === null || !SEVERITY_SET.has(severity)) return null
-  return severity as AkritesExternalAdvisorySeverity
+  if (severity === null) return null
+  return SEVERITY_CROSSWALK[severity] ?? null
 }
 
 // Builds the AdvisoryDetail for a single purl from its DAL rows. Rows carry a null

--- a/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalAdvisoryDetail.ts
@@ -1,0 +1,51 @@
+import type { AkritesExternalAdvisoryRow } from '@crowd/data-access-layer'
+
+export type AkritesExternalAdvisorySeverity = 'critical' | 'high' | 'moderate' | 'low' | null
+export type AkritesExternalAdvisoryResolution = 'open' | 'patched' | null
+
+export interface AkritesExternalAdvisory {
+  osvId: string
+  severity: AkritesExternalAdvisorySeverity
+  resolution: AkritesExternalAdvisoryResolution
+  isCritical: boolean | null
+}
+
+export interface AkritesExternalAdvisoryDetail {
+  purl: string
+  advisories: AkritesExternalAdvisory[]
+}
+
+export interface AdvisoryDetailBulkEntry {
+  requestedPurl: string
+  found: boolean
+  advisories: AkritesExternalAdvisoryDetail | null
+}
+
+// Severity values the contract's enum accepts. The DB stores severity uppercase and
+// the query lowercases it; anything outside this set (or null) maps to null rather
+// than being echoed verbatim, so the response never violates the published enum.
+const SEVERITY_SET = new Set<string>(['critical', 'high', 'moderate', 'low'])
+
+function toAkritesSeverity(severity: string | null): AkritesExternalAdvisorySeverity {
+  if (severity === null || !SEVERITY_SET.has(severity)) return null
+  return severity as AkritesExternalAdvisorySeverity
+}
+
+// Builds the AdvisoryDetail for a single purl from its DAL rows. Rows carry a null
+// osvId sentinel for a found-but-advisory-less package (see AkritesExternalAdvisoryRow) —
+// those are dropped here so `advisories` is an empty array, not a list with a null entry.
+export function toAkritesExternalAdvisoryDetail(
+  purl: string,
+  rows: AkritesExternalAdvisoryRow[],
+): AkritesExternalAdvisoryDetail {
+  const advisories: AkritesExternalAdvisory[] = rows
+    .filter((r): r is AkritesExternalAdvisoryRow & { osvId: string } => r.osvId !== null)
+    .map((r) => ({
+      osvId: r.osvId,
+      severity: toAkritesSeverity(r.severity),
+      resolution: r.resolution,
+      isCritical: r.isCritical,
+    }))
+
+  return { purl, advisories }
+}

--- a/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetail.ts
+++ b/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetail.ts
@@ -1,0 +1,26 @@
+import type { Request, Response } from 'express'
+
+import { NotFoundError } from '@crowd/common'
+import { getAdvisoriesByPurls } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { toAkritesExternalAdvisoryDetail } from './akritesExternalAdvisoryDetail'
+import { purlQuerySchema } from './purl'
+
+export async function getAkritesExternalAdvisoryDetail(req: Request, res: Response): Promise<void> {
+  const { purl } = validateOrThrow(purlQuerySchema, req.query)
+
+  const qx = await getPackagesQx()
+  const rows = await getAdvisoriesByPurls(qx, [purl])
+
+  // No rows at all means the package itself doesn't exist. A package that exists but
+  // has no advisories still yields one (null-osvId) sentinel row, so it 200s with [].
+  if (rows.length === 0) {
+    throw new NotFoundError()
+  }
+
+  ok(res, toAkritesExternalAdvisoryDetail(purl, rows))
+}

--- a/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetailBatch.ts
+++ b/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetailBatch.ts
@@ -1,0 +1,48 @@
+import type { Request, Response } from 'express'
+
+import { type AkritesExternalAdvisoryRow, getAdvisoriesByPurls } from '@crowd/data-access-layer'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import {
+  type AdvisoryDetailBulkEntry,
+  toAkritesExternalAdvisoryDetail,
+} from './akritesExternalAdvisoryDetail'
+import { normalizePurl, purlsBodySchema } from './purl'
+
+const bodySchema = purlsBodySchema()
+
+export async function getAkritesExternalAdvisoryDetailBatch(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
+  // Normalize after parsing (not in the schema) so rawPurls keeps the client's
+  // original form — echoed back as requestedPurl so callers can self-correlate.
+  const normalizedPurls = rawPurls.map(normalizePurl)
+
+  const qx = await getPackagesQx()
+  const rows = await getAdvisoriesByPurls(qx, normalizedPurls)
+
+  // Group the flat rows by purl. A found package always has >= 1 row (a null-osvId
+  // sentinel when it has no advisories), so map presence == package found.
+  const byPurl = new Map<string, AkritesExternalAdvisoryRow[]>()
+  for (const row of rows) {
+    const existing = byPurl.get(row.purl)
+    if (existing) existing.push(row)
+    else byPurl.set(row.purl, [row])
+  }
+
+  const results: AdvisoryDetailBulkEntry[] = rawPurls.map((requestedPurl, i) => {
+    const purlRows = byPurl.get(normalizedPurls[i])
+    return {
+      requestedPurl,
+      found: purlRows !== undefined,
+      advisories: purlRows ? toAkritesExternalAdvisoryDetail(purlRows[0].purl, purlRows) : null,
+    }
+  })
+
+  ok(res, { results })
+}

--- a/services/libs/data-access-layer/src/osspckgs/advisoryResolution.test.ts
+++ b/services/libs/data-access-layer/src/osspckgs/advisoryResolution.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import { type AdvisoryAffectedRange, resolveAdvisory } from './advisoryResolution'
+
+function range(overrides: Partial<AdvisoryAffectedRange> = {}): AdvisoryAffectedRange {
+  return {
+    introduced: null,
+    fixed: null,
+    lastAffected: null,
+    rangeRaw: null,
+    unaffectedRaw: null,
+    ...overrides,
+  }
+}
+
+describe('resolveAdvisory', () => {
+  it('reports open when the latest version is inside an affected range', () => {
+    expect(resolveAdvisory('2.0.0', [range({ introduced: '1.0.0', fixed: '3.0.0' })])).toBe('open')
+  })
+
+  it('reports patched when the latest version is at or past the fix', () => {
+    expect(resolveAdvisory('2.0.0', [range({ introduced: '1.0.0', fixed: '1.5.0' })])).toBe(
+      'patched',
+    )
+  })
+
+  // #4: lexicographic text comparison said 1.9.0 >= 1.10.0 → wrongly "patched".
+  it('compares versions numerically, not lexicographically (1.9.0 < 1.10.0)', () => {
+    expect(resolveAdvisory('1.9.0', [range({ introduced: '1.0.0', fixed: '1.10.0' })])).toBe('open')
+  })
+
+  // #3: a version predating the range start must not be reported as still affected.
+  it('reports patched when the latest version predates the introduced bound', () => {
+    expect(resolveAdvisory('1.0.0', [range({ introduced: '2.0.0', fixed: '3.0.0' })])).toBe(
+      'patched',
+    )
+  })
+
+  it('honors last_affected (inclusive upper bound) when there is no fix', () => {
+    expect(resolveAdvisory('2.5.0', [range({ introduced: '1.0.0', lastAffected: '2.0.0' })])).toBe(
+      'patched',
+    )
+    expect(resolveAdvisory('2.0.0', [range({ introduced: '1.0.0', lastAffected: '2.0.0' })])).toBe(
+      'open',
+    )
+  })
+
+  // #2: deps.dev raw-only rows are unknowable, not "no fix" — they must not force open.
+  it('ignores raw-only rows and resolves from the structured OSV row', () => {
+    const rows = [
+      range({ rangeRaw: '>=1.0.0 <1.5.0' }), // raw-only, no structured bounds
+      range({ introduced: '1.0.0', fixed: '1.5.0' }), // OSV structured → patched at 2.0.0
+    ]
+    expect(resolveAdvisory('2.0.0', rows)).toBe('patched')
+  })
+
+  it('returns null when the only ranges are raw-only', () => {
+    expect(resolveAdvisory('2.0.0', [range({ rangeRaw: '>=1.0.0' })])).toBeNull()
+  })
+
+  // OSV MAL-* rows are all-null structured with no raw payload → "always vulnerable".
+  it('keeps all-null structured (MAL) ranges and resolves them to open', () => {
+    expect(resolveAdvisory('2.0.0', [range()])).toBe('open')
+  })
+
+  it('returns null when there is no latest version', () => {
+    expect(resolveAdvisory(null, [range({ introduced: '1.0.0', fixed: '2.0.0' })])).toBeNull()
+  })
+
+  it('returns null (unknown) rather than guessing on an unparseable version', () => {
+    expect(
+      resolveAdvisory('1.2.3-rc.1', [range({ introduced: '1.0.0', fixed: '2.0.0' })]),
+    ).toBeNull()
+  })
+
+  it('does not claim patched when a determinable miss coexists with an unknown range', () => {
+    const rows = [
+      range({ introduced: '1.0.0', fixed: '1.5.0' }), // 2.0.0 not in range (miss)
+      range({ introduced: 'weird', fixed: 'alsoweird' }), // undeterminable → unknown
+    ]
+    expect(resolveAdvisory('2.0.0', rows)).toBeNull()
+  })
+})

--- a/services/libs/data-access-layer/src/osspckgs/advisoryResolution.ts
+++ b/services/libs/data-access-layer/src/osspckgs/advisoryResolution.ts
@@ -1,0 +1,111 @@
+// Advisory resolution (open | patched | null) for the akrites-external Advisories API.
+//
+// This is computed in TypeScript, NOT in SQL, on purpose: correct resolution needs
+// real version-range membership, and the codebase already establishes that this must
+// live in application code — see packages_worker/src/osv/deriveCriticalFlag.ts
+// ("We compute the vulnerability decision in TypeScript because the comparator is
+// ecosystem-specific ... and not expressible in SQL"). The internal
+// getAdvisoriesByPackageId still uses the lexicographic SQL expression; only this
+// external path was moved to correct TS logic for now.
+//
+// TODO(consolidate): packages_worker/src/osv/versionCompare.ts is the canonical
+// ecosystem-aware comparator (npm semver + Maven), but it depends on `semver` and
+// lives in an app, so it isn't importable here yet. This interim comparator handles
+// clean dotted-numeric versions (the dominant OSV/npm shape) and returns null —
+// i.e. "unknown", never a guessed open/patched — for anything it can't parse
+// (prerelease/build metadata, non-numeric ecosystems). Unify on the shared
+// comparator once it moves into a lib.
+
+export interface AdvisoryAffectedRange {
+  introduced: string | null
+  fixed: string | null
+  lastAffected: string | null
+  rangeRaw: string | null
+  unaffectedRaw: string | null
+}
+
+function parseNumeric(version: string): number[] | null {
+  const trimmed = version.trim().replace(/^v/i, '')
+  if (trimmed === '') return null
+  const segments = trimmed.split('.')
+  const out: number[] = []
+  for (const seg of segments) {
+    if (!/^\d+$/.test(seg)) return null
+    out.push(parseInt(seg, 10))
+  }
+  return out
+}
+
+// -1 / 0 / 1 like Array#sort, or null when either operand isn't cleanly
+// dotted-numeric (leading "v" tolerated). Null propagates to a null resolution
+// so the API reports "unknown" instead of risking a wrong verdict.
+function compareNumericVersion(a: string, b: string): number | null {
+  const pa = parseNumeric(a)
+  const pb = parseNumeric(b)
+  if (!pa || !pb) return null
+  const len = Math.max(pa.length, pb.length)
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0
+    const y = pb[i] ?? 0
+    if (x !== y) return x < y ? -1 : 1
+  }
+  return 0
+}
+
+// true = version is inside the affected range, false = outside, null = undeterminable.
+// OSV semantics: introduced-inclusive, fixed-exclusive, last_affected-inclusive;
+// introduced null/'0' means "from the beginning". Unlike deriveCriticalFlag (which
+// treats an unparseable comparison as "no match" to under-flag), here an unparseable
+// comparison yields null so resolution stays "unknown" rather than a false patched/open.
+function isInRange(version: string, range: AdvisoryAffectedRange): boolean | null {
+  if (range.introduced && range.introduced !== '0') {
+    const c = compareNumericVersion(version, range.introduced)
+    if (c === null) return null
+    if (c < 0) return false
+  }
+  if (range.fixed) {
+    const c = compareNumericVersion(version, range.fixed)
+    if (c === null) return null
+    if (c >= 0) return false
+  }
+  if (range.lastAffected) {
+    const c = compareNumericVersion(version, range.lastAffected)
+    if (c === null) return null
+    if (c > 0) return false
+  }
+  return true
+}
+
+// deps.dev inserts raw-only rows (range_raw / unaffected_raw set, all structured
+// bounds null). Those are unknowable, not "no fix" — excluding them prevents a
+// raw-only row from dragging an otherwise-patched advisory to open. An OSV all-null
+// MAL range (no raw payload) is NOT raw-only, so it's kept and resolves to open.
+function isRawOnly(range: AdvisoryAffectedRange): boolean {
+  return (
+    range.introduced === null &&
+    range.fixed === null &&
+    range.lastAffected === null &&
+    (range.rangeRaw !== null || range.unaffectedRaw !== null)
+  )
+}
+
+export function resolveAdvisory(
+  latestVersion: string | null,
+  ranges: AdvisoryAffectedRange[],
+): 'open' | 'patched' | null {
+  if (!latestVersion) return null
+
+  const structured = ranges.filter((r) => !isRawOnly(r))
+  if (structured.length === 0) return null
+
+  let anyUnknown = false
+  for (const range of structured) {
+    const inRange = isInRange(latestVersion, range)
+    if (inRange === null) anyUnknown = true
+    // In any affected range → still vulnerable, regardless of other undeterminable rows.
+    else if (inRange) return 'open'
+  }
+  // Not inside any determinable range. If some rows were undeterminable we can't
+  // claim it's patched — report unknown instead.
+  return anyUnknown ? null : 'patched'
+}

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -3,6 +3,7 @@ import type { PackageDbRow } from '@crowd/types'
 import { QueryExecutor } from '../queryExecutor'
 
 import {
+  ADVISORY_RESOLUTION_EXPR,
   BEST_REPO_LINK_JOIN,
   DOWNLOADS_LAST_30D_SUBQUERY,
   MAINTAINER_COUNT_SUBQUERY,
@@ -968,22 +969,7 @@ export async function getAdvisoriesByPackageId(
         a.osv_id AS "osvId",
         LOWER(a.severity) AS severity,
         a.is_critical AS "isCritical",
-        CASE
-          WHEN p.latest_version IS NULL THEN NULL
-          WHEN COUNT(ar.id) = 0 THEN NULL
-          -- TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
-          -- Replace with a proper semver comparison function when one is available in the DB.
-          WHEN BOOL_AND(
-            CASE
-              WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
-              WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
-              WHEN ar.fixed_version IS NOT NULL THEN FALSE
-              WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
-              ELSE FALSE
-            END
-          ) THEN 'patched'
-          ELSE 'open'
-        END AS resolution
+        ${ADVISORY_RESOLUTION_EXPR} AS resolution
       FROM advisory_packages ap
       JOIN advisories a ON a.id = ap.advisory_id
       LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
@@ -1036,4 +1022,51 @@ export async function getAdvisoriesByPackageId(
   )) as { total: string }
 
   return { rows, total: Number(countResult.total) }
+}
+
+// One row per (package, advisory) for the akrites-external Advisories contract.
+// Uses the same osv_id / severity / is_critical / resolution shape as
+// getAdvisoriesByPackageId (via the shared ADVISORY_RESOLUTION_EXPR), but keyed by
+// purl and batched across many packages in a single query. Packages that exist but
+// have zero advisories still yield exactly one row, with osvId null — this is how the
+// caller distinguishes "package not found" (no row at all) from "found, no advisories".
+export interface AkritesExternalAdvisoryRow {
+  purl: string
+  // null only on the sentinel row emitted for a found package with no advisories.
+  osvId: string | null
+  // LOWER(a.severity); null when the advisory has no recorded severity.
+  severity: string | null
+  resolution: 'open' | 'patched' | null
+  // a.is_critical is GENERATED AS (cvss >= 7.0); null when cvss is unknown.
+  isCritical: boolean | null
+}
+
+export async function getAdvisoriesByPurls(
+  qx: QueryExecutor,
+  purls: string[],
+): Promise<AkritesExternalAdvisoryRow[]> {
+  if (purls.length === 0) return []
+  return qx.select(
+    `
+    SELECT
+      p.purl,
+      a.osv_id                AS "osvId",
+      LOWER(a.severity)       AS severity,
+      a.is_critical           AS "isCritical",
+      ${ADVISORY_RESOLUTION_EXPR} AS resolution
+    FROM packages p
+    LEFT JOIN advisory_packages ap ON ap.package_id = p.id
+    LEFT JOIN advisories a ON a.id = ap.advisory_id
+    LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
+    WHERE p.purl = ANY($(purls))
+    GROUP BY p.purl, a.osv_id, a.severity, a.is_critical, p.latest_version
+    ORDER BY
+      p.purl,
+      CASE LOWER(a.severity)
+        WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'low' THEN 4 ELSE 5
+      END,
+      a.osv_id
+    `,
+    { purls },
+  )
 }

--- a/services/libs/data-access-layer/src/osspckgs/api.ts
+++ b/services/libs/data-access-layer/src/osspckgs/api.ts
@@ -2,6 +2,7 @@ import type { PackageDbRow } from '@crowd/types'
 
 import { QueryExecutor } from '../queryExecutor'
 
+import { type AdvisoryAffectedRange, resolveAdvisory } from './advisoryResolution'
 import {
   ADVISORY_RESOLUTION_EXPR,
   BEST_REPO_LINK_JOIN,
@@ -1024,12 +1025,13 @@ export async function getAdvisoriesByPackageId(
   return { rows, total: Number(countResult.total) }
 }
 
-// One row per (package, advisory) for the akrites-external Advisories contract.
-// Uses the same osv_id / severity / is_critical / resolution shape as
-// getAdvisoriesByPackageId (via the shared ADVISORY_RESOLUTION_EXPR), but keyed by
-// purl and batched across many packages in a single query. Packages that exist but
-// have zero advisories still yield exactly one row, with osvId null — this is how the
-// caller distinguishes "package not found" (no row at all) from "found, no advisories".
+// One row per (package, advisory) for the akrites-external Advisories contract,
+// keyed by purl and batched across many packages in a single query. Packages that
+// exist but have zero advisories still yield exactly one row, with osvId null — this
+// is how the caller distinguishes "package not found" (no row at all) from "found, no
+// advisories". Unlike the internal getAdvisoriesByPackageId, `resolution` is computed
+// in TypeScript (resolveAdvisory) from the affected ranges rather than via the
+// lexicographic SQL expression — see advisoryResolution.ts for why.
 export interface AkritesExternalAdvisoryRow {
   purl: string
   // null only on the sentinel row emitted for a found package with no advisories.
@@ -1041,32 +1043,62 @@ export interface AkritesExternalAdvisoryRow {
   isCritical: boolean | null
 }
 
+interface AdvisoryRangesRow {
+  purl: string
+  osvId: string | null
+  severity: string | null
+  isCritical: boolean | null
+  latestVersion: string | null
+  // jsonb, parsed by the pg driver into an array of range objects (empty on the sentinel row).
+  ranges: AdvisoryAffectedRange[]
+}
+
 export async function getAdvisoriesByPurls(
   qx: QueryExecutor,
   purls: string[],
 ): Promise<AkritesExternalAdvisoryRow[]> {
   if (purls.length === 0) return []
-  return qx.select(
+  const rows: AdvisoryRangesRow[] = await qx.select(
     `
     SELECT
       p.purl,
-      a.osv_id                AS "osvId",
-      LOWER(a.severity)       AS severity,
-      a.is_critical           AS "isCritical",
-      ${ADVISORY_RESOLUTION_EXPR} AS resolution
+      p.latest_version  AS "latestVersion",
+      a.osv_id          AS "osvId",
+      LOWER(a.severity) AS severity,
+      a.is_critical     AS "isCritical",
+      COALESCE(
+        JSONB_AGG(
+          JSONB_BUILD_OBJECT(
+            'introduced', ar.introduced_version,
+            'fixed', ar.fixed_version,
+            'lastAffected', ar.last_affected,
+            'rangeRaw', ar.range_raw,
+            'unaffectedRaw', ar.unaffected_raw
+          )
+        ) FILTER (WHERE ar.id IS NOT NULL),
+        '[]'::jsonb
+      ) AS ranges
     FROM packages p
     LEFT JOIN advisory_packages ap ON ap.package_id = p.id
     LEFT JOIN advisories a ON a.id = ap.advisory_id
     LEFT JOIN advisory_affected_ranges ar ON ar.advisory_package_id = ap.id
     WHERE p.purl = ANY($(purls))
-    GROUP BY p.purl, a.osv_id, a.severity, a.is_critical, p.latest_version
+    GROUP BY p.purl, p.latest_version, a.osv_id, a.severity, a.is_critical
     ORDER BY
       p.purl,
       CASE LOWER(a.severity)
-        WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'low' THEN 4 ELSE 5
+        WHEN 'critical' THEN 1 WHEN 'high' THEN 2 WHEN 'moderate' THEN 3 WHEN 'medium' THEN 3 WHEN 'low' THEN 4 ELSE 5
       END,
       a.osv_id
     `,
     { purls },
   )
+
+  return rows.map((r) => ({
+    purl: r.purl,
+    osvId: r.osvId,
+    severity: r.severity,
+    resolution: r.osvId === null ? null : resolveAdvisory(r.latestVersion, r.ranges),
+    isCritical: r.isCritical,
+  }))
 }

--- a/services/libs/data-access-layer/src/osspckgs/getAdvisoriesByPurls.integration.test.ts
+++ b/services/libs/data-access-layer/src/osspckgs/getAdvisoriesByPurls.integration.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { getDbConnection } from '@crowd/database'
+
+import type { QueryExecutor } from '../queryExecutor'
+import { pgpQx } from '../queryExecutor'
+
+import { getAdvisoriesByPurls } from './api'
+
+// Integration test: hits the running packages-db. Skipped automatically when
+// any of the DB env vars are missing so unit-test runs in CI stay green.
+const HAVE_DB =
+  !!process.env.CROWD_PACKAGES_DB_WRITE_HOST &&
+  !!process.env.CROWD_PACKAGES_DB_PORT &&
+  !!process.env.CROWD_PACKAGES_DB_USERNAME &&
+  !!process.env.CROWD_PACKAGES_DB_DATABASE &&
+  !!process.env.CROWD_PACKAGES_DB_PASSWORD
+
+const FIXTURE_TAG = 'akrites-external-advisory-fixture'
+const OSV_OPEN = `${FIXTURE_TAG}-GHSA-critical-open`
+const OSV_PATCHED = `${FIXTURE_TAG}-GHSA-high-patched`
+
+describe.skipIf(!HAVE_DB)('getAdvisoriesByPurls — real packages-db', () => {
+  let qx: QueryExecutor
+
+  const withAdvisoriesPurl = `pkg:test-fixture/${FIXTURE_TAG}/with-advisories`
+  const noAdvisoriesPurl = `pkg:test-fixture/${FIXTURE_TAG}/no-advisories`
+  const missingPurl = `pkg:test-fixture/${FIXTURE_TAG}/does-not-exist`
+
+  async function cleanupFixtures(): Promise<void> {
+    await qx.result(
+      `DELETE FROM advisory_affected_ranges WHERE advisory_package_id IN (
+         SELECT ap.id FROM advisory_packages ap
+         JOIN packages p ON p.id = ap.package_id
+         WHERE p.ingestion_source = $(tag))`,
+      { tag: FIXTURE_TAG },
+    )
+    await qx.result(
+      `DELETE FROM advisory_packages WHERE package_id IN (SELECT id FROM packages WHERE ingestion_source = $(tag))`,
+      { tag: FIXTURE_TAG },
+    )
+    await qx.result(`DELETE FROM advisories WHERE osv_id LIKE $(prefix)`, {
+      prefix: `${FIXTURE_TAG}-%`,
+    })
+    await qx.result(`DELETE FROM packages WHERE ingestion_source = $(tag)`, { tag: FIXTURE_TAG })
+  }
+
+  beforeAll(async () => {
+    const conn = await getDbConnection({
+      host: process.env.CROWD_PACKAGES_DB_WRITE_HOST ?? '',
+      port: parseInt(process.env.CROWD_PACKAGES_DB_PORT ?? '0', 10),
+      database: process.env.CROWD_PACKAGES_DB_DATABASE ?? '',
+      user: process.env.CROWD_PACKAGES_DB_USERNAME ?? '',
+      password: process.env.CROWD_PACKAGES_DB_PASSWORD ?? '',
+    })
+    qx = pgpQx(conn)
+    await cleanupFixtures()
+
+    // Package with two advisories (latest_version 2.0.0 drives resolution below).
+    const withRow = await qx.selectOne(
+      `INSERT INTO packages (purl, ecosystem, name, latest_version, ingestion_source, status)
+       VALUES ($(purl), 'npm', 'with-advisories-fixture', '2.0.0', $(tag), 'active')
+       RETURNING id`,
+      { purl: withAdvisoriesPurl, tag: FIXTURE_TAG },
+    )
+    const withPackageId = withRow.id as string
+
+    // Package that exists but has no advisories at all.
+    await qx.result(
+      `INSERT INTO packages (purl, ecosystem, name, latest_version, ingestion_source, status)
+       VALUES ($(purl), 'npm', 'no-advisories-fixture', '1.0.0', $(tag), 'active')`,
+      { purl: noAdvisoriesPurl, tag: FIXTURE_TAG },
+    )
+
+    // Critical advisory, fixed at 3.0.0 → latest 2.0.0 is still affected → 'open'.
+    const openAdvisory = await qx.selectOne(
+      `INSERT INTO advisories (osv_id, severity, cvss) VALUES ($(osv), 'CRITICAL', 9.1) RETURNING id`,
+      { osv: OSV_OPEN },
+    )
+    // High advisory, fixed at 1.5.0 → latest 2.0.0 has the fix → 'patched'.
+    const patchedAdvisory = await qx.selectOne(
+      `INSERT INTO advisories (osv_id, severity, cvss) VALUES ($(osv), 'HIGH', 7.5) RETURNING id`,
+      { osv: OSV_PATCHED },
+    )
+
+    for (const [advisoryId, fixedVersion] of [
+      [openAdvisory.id, '3.0.0'],
+      [patchedAdvisory.id, '1.5.0'],
+    ] as const) {
+      const ap = await qx.selectOne(
+        `INSERT INTO advisory_packages (advisory_id, package_id, ecosystem, package_name)
+         VALUES ($(advisoryId), $(packageId), 'npm', 'with-advisories-fixture') RETURNING id`,
+        { advisoryId, packageId: withPackageId },
+      )
+      await qx.result(
+        `INSERT INTO advisory_affected_ranges (advisory_package_id, introduced_version, fixed_version)
+         VALUES ($(apId), '1.0.0', $(fixed))`,
+        { apId: ap.id, fixed: fixedVersion },
+      )
+    }
+  }, 30_000)
+
+  afterAll(async () => {
+    if (qx) await cleanupFixtures()
+  })
+
+  it('returns no rows for a purl that does not resolve to a package', async () => {
+    const rows = await getAdvisoriesByPurls(qx, [missingPurl])
+    expect(rows).toHaveLength(0)
+  })
+
+  it('returns a single null-osvId sentinel row for a found package with no advisories', async () => {
+    const rows = await getAdvisoriesByPurls(qx, [noAdvisoriesPurl])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].purl).toBe(noAdvisoriesPurl)
+    expect(rows[0].osvId).toBeNull()
+  })
+
+  it('returns one row per advisory with resolution derived from the latest version', async () => {
+    const rows = await getAdvisoriesByPurls(qx, [withAdvisoriesPurl])
+    const byOsv = new Map(rows.map((r) => [r.osvId, r]))
+    expect(rows).toHaveLength(2)
+    expect(byOsv.get(OSV_OPEN)?.resolution).toBe('open')
+    expect(byOsv.get(OSV_OPEN)?.severity).toBe('critical')
+    expect(byOsv.get(OSV_OPEN)?.isCritical).toBe(true)
+    expect(byOsv.get(OSV_PATCHED)?.resolution).toBe('patched')
+    expect(byOsv.get(OSV_PATCHED)?.severity).toBe('high')
+  })
+
+  it('batches many purls, omitting the misses and keeping found-but-empty packages', async () => {
+    const rows = await getAdvisoriesByPurls(qx, [missingPurl, noAdvisoriesPurl, withAdvisoriesPurl])
+    const purls = new Set(rows.map((r) => r.purl))
+    expect(purls.has(missingPurl)).toBe(false)
+    expect(purls.has(noAdvisoriesPurl)).toBe(true)
+    expect(purls.has(withAdvisoriesPurl)).toBe(true)
+  })
+})

--- a/services/libs/data-access-layer/src/osspckgs/sqlFragments.ts
+++ b/services/libs/data-access-layer/src/osspckgs/sqlFragments.ts
@@ -40,3 +40,24 @@ export const DOWNLOADS_LAST_30D_SUBQUERY = `(
         ORDER BY d.end_date DESC
         LIMIT 1
       )`
+
+// Resolution of an advisory against a package's latest version: 'patched' once every
+// affected range is fixed/passed, 'open' otherwise, NULL when unknowable (no latest
+// version, or no affected ranges recorded). Aggregate expression — must be used under a
+// GROUP BY, and expects `packages p` and `advisory_affected_ranges ar` in scope.
+// TODO: text comparison is lexicographic, not semver — '1.9.0' >= '1.10.0' is TRUE here.
+// Replace with a proper semver comparison function when one is available in the DB.
+export const ADVISORY_RESOLUTION_EXPR = `CASE
+          WHEN p.latest_version IS NULL THEN NULL
+          WHEN COUNT(ar.id) = 0 THEN NULL
+          WHEN BOOL_AND(
+            CASE
+              WHEN ar.fixed_version IS NULL AND ar.last_affected IS NULL THEN FALSE
+              WHEN ar.fixed_version IS NOT NULL AND p.latest_version >= ar.fixed_version THEN TRUE
+              WHEN ar.fixed_version IS NOT NULL THEN FALSE
+              WHEN ar.last_affected IS NOT NULL AND p.latest_version > ar.last_affected THEN TRUE
+              ELSE FALSE
+            END
+          ) THEN 'patched'
+          ELSE 'open'
+        END`


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
<!-- Example: Adds batch processing for member enrichment to reduce API calls -->

Adds the **Advisories** endpoints to the `akrites-external` public API, following the
same shape and conventions as the existing Packages endpoints. Akrites needs a stable,
externally-facing view of a package's security advisories (keyed by purl), split out of
package detail per the draft contract — both for single lookups and bulk resolution.

New read-only endpoints under `/v1/akrites-external/advisories` (Auth0 M2M, rate-limited):
- `GET /detail?purl=…` — advisories for one package (`404` if the package doesn't exist;
  `200` with an empty list if it exists but has none)
- `POST /detail:batch` — advisories for up to 100 purls in one request

Each advisory exposes `osvId`, `severity`, `resolution` (open/patched), and `isCritical`,
mapped from CDP's internal advisory model to the Akrites contract shape.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->

- **New `advisories` sub-router** (`akrites-external/index.ts`): rate-limited, mounted
  under `/v1/akrites-external/advisories`.
  - Gated on `READ_PACKAGES` only (not `READ_STEWARDSHIPS` like the packages sub-router) —
    advisories are package security data and need no stewardship read. The contract's
    dedicated `read:advisories` scope isn't issued by Auth0 yet; reusing `READ_PACKAGES`
    with a `TODO` until it is. Scope-naming (`read:advisories` vs `cdp:advisories:read`)
    is an open question flagged for product.
- **Single endpoint** (`getAkritesExternalAdvisoryDetail.ts`): `404` only when the package
  itself is absent; a found package with no advisories returns `200` + `[]`.
- **Batch endpoint** (`getAkritesExternalAdvisoryDetailBatch.ts`): normalizes purls *after*
  Zod parsing to echo back each caller's original `requestedPurl`; returns a
  `{ found, advisories }` entry per requested purl rather than dropping misses.
- **New DAL query `getAdvisoriesByPurls`** (`osspckgs/api.ts`): one batched query across all
  purls. A found package with zero advisories still emits one sentinel row (null `osvId`),
  so the caller can distinguish "package not found" (no row) from "found, no advisories".
- **Advisory resolution computed in TypeScript, not SQL** (`advisoryResolution.ts`): the
  external endpoint derives `open`/`patched`/`null` from the affected ranges in application
  code, matching the codebase's established rule (`deriveCriticalFlag.ts`) that
  version-range logic must live in TS, not SQL. This fixes three correctness defects the
  lexicographic SQL expression had:
  - **numeric version comparison** (`1.9.0 < 1.10.0`) instead of text comparison, which had
    reported still-vulnerable packages as `patched`;
  - honors the `introduced` lower bound (a version predating the range is no longer `open`);
  - excludes deps.dev raw-only ranges (unknowable, not "unfixed") so they don't drag an
    otherwise-patched advisory to `open`; OSV all-null MAL ranges are kept and resolve to `open`.
  - The interim comparator is dependency-free and covers clean dotted-numeric versions;
    anything it can't parse resolves to `null` (**unknown**, never a guessed verdict).
    `TODO(consolidate)` to unify with the canonical `packages_worker/src/osv/versionCompare.ts`
    (npm + Maven) once it moves into a shared lib. **The internal `getAdvisoriesByPackageId`
    endpoint still uses the lexicographic SQL and is intentionally left unchanged in this PR.**
- **Severity `medium → moderate` crosswalk** (`akritesExternalAdvisoryDetail.ts`): the DB
  normalizes the middle band to `MEDIUM` while the contract enum uses `moderate`; the mapper
  crosswalks explicitly so no advisory silently loses its severity. Unrecognized values map
  to `null` rather than violating the published enum.
- **Extracted `ADVISORY_RESOLUTION_EXPR`** (`sqlFragments.ts`): the resolution CASE was
  pulled out of `getAdvisoriesByPackageId` into a shared fragment (same pattern as
  `BEST_REPO_LINK_JOIN`); the internal endpoint still references it.
- **OpenAPI** (`akrites-external/openapi.yaml`): `Advisory` / `AdvisoryDetail` /
  `AdvisoryDetailBulkEntry` schemas, the two advisory paths, and the Advisories tag.
- **Tests**: unit tests for the advisory mapper (`akritesExternalAdvisoryDetail.test.ts`)
  and the pure resolver (`advisoryResolution.test.ts`, covering the numeric-comparison,
  introduced-bound, raw-only, and MAL cases), plus an integration test for the batched DAL
  query (`getAdvisoriesByPurls.integration.test.ts`).


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1335](https://linuxfoundation.atlassian.net/browse/CM-1335)

[CM-1335]: https://linuxfoundation.atlassian.net/browse/CM-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ