### PR TITLE
fix: add pagination and remove mapping (CM-1322)

### DIFF
--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -86,13 +86,10 @@ components:
 
     HealthBand:
       type: string
-      enum: [critical, low, medium, high]
+      enum: [excellent, healthy, fair, concerning, critical]
       description: >
-        UNCONFIRMED CROSSWALK — the internal health scale is
-        excellent/healthy/fair/concerning/critical (good→bad); there is no
-        agreed mapping to this critical/low/medium/high scale yet. See
-        HEALTH_BAND_CROSSWALK in akritesExternalPackageDetail.ts. Confirm
-        with Akrites/product before relying on exact band values.
+        Health band on the internal scale (best→worst), returned verbatim —
+        no external crosswalk.
 
     PackageDetail:
       type: object
@@ -192,12 +189,11 @@ components:
           properties:
             lifecycle:
               type: string
-              enum: [active, inactive, deprecated, abandoned, null]
+              enum: [active, stable, declining, abandoned, archived, null]
               nullable: true
               description: >
-                UNCONFIRMED CROSSWALK from the internal
-                active/stable/declining/abandoned/archived scale — see
-                LIFECYCLE_CROSSWALK in akritesExternalPackageDetail.ts.
+                Lifecycle stage on the internal scale, returned verbatim — no
+                external crosswalk. Null when unknown or unrecognized.
             maintainerBusFactor:
               type: integer
               nullable: true
@@ -372,13 +368,12 @@ components:
 
     OverallConfidenceBand:
       type: string
-      enum: [HIGH, MEDIUM, LOW, NONE]
+      enum: [PRIMARY, SECONDARY, FALLBACK, NONE]
       description: >
-        Aggregate confidence, derived from the highest-scoring contact.
-        UNCONFIRMED CROSSWALK: the internal aggregate band is
-        PRIMARY/SECONDARY/FALLBACK/NONE; this HIGH/MEDIUM/LOW/NONE scale is a
-        4→4 tier rename (PRIMARY→HIGH, …) pending confirmation with Akrites —
-        see OVERALL_CONFIDENCE_CROSSWALK in akritesExternalContactDetail.ts.
+        Aggregate confidence, derived from the highest-scoring contact. Uses the
+        internal SecurityContact confidence scale, returned verbatim — same scale
+        as ContactConfidenceBand, no external crosswalk. NONE when there are no
+        contacts.
 
     SecurityContact:
       type: object
@@ -646,15 +641,31 @@ paths:
                   maxItems: 100
                   items:
                     type: string
+                page:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                pageSize:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 20
       responses:
         '200':
-          description: Results in the same order as the request.
+          description: One page of results, in request order.
           content:
             application/json:
               schema:
                 type: object
-                required: [results]
+                required: [page, pageSize, total, results]
                 properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
+                    description: Total number of requested purls, across all pages.
                   results:
                     type: array
                     items:
@@ -747,15 +758,31 @@ paths:
                   maxItems: 100
                   items:
                     type: string
+                page:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                pageSize:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 20
       responses:
         '200':
-          description: Results in the same order as the request.
+          description: One page of results, in request order.
           content:
             application/json:
               schema:
                 type: object
-                required: [results]
+                required: [page, pageSize, total, results]
                 properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
+                    description: Total number of requested purls, across all pages.
                   results:
                     type: array
                     items:
@@ -851,15 +878,31 @@ paths:
                   maxItems: 100
                   items:
                     type: string
+                page:
+                  type: integer
+                  minimum: 1
+                  default: 1
+                pageSize:
+                  type: integer
+                  minimum: 1
+                  maximum: 100
+                  default: 20
       responses:
         '200':
-          description: Results in the same order as the request.
+          description: One page of results, in request order.
           content:
             application/json:
               schema:
                 type: object
-                required: [results]
+                required: [page, pageSize, total, results]
                 properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
+                    description: Total number of requested purls, across all pages.
                   results:
                     type: array
                     items:

--- a/backend/src/api/public/v1/packages/akritesExternalContactDetail.test.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalContactDetail.test.ts
@@ -57,12 +57,12 @@ describe('toAkritesExternalContactDetail', () => {
     ])
   })
 
-  it('derives overallConfidenceBand from the highest-scoring contact and crosswalks it', () => {
-    // max score 0.94 -> PRIMARY -> HIGH (not SECONDARY/MEDIUM from the other contact).
-    expect(toAkritesExternalContactDetail(baseRow()).overallConfidenceBand).toBe('HIGH')
+  it('derives overallConfidenceBand from the highest-scoring contact, returned verbatim', () => {
+    // max score 0.94 -> PRIMARY (not SECONDARY from the other, lower-scoring contact).
+    expect(toAkritesExternalContactDetail(baseRow()).overallConfidenceBand).toBe('PRIMARY')
   })
 
-  it('crosswalks each internal band to the contract scale', () => {
+  it('returns the aggregate band on the internal scale (no crosswalk)', () => {
     const band = (confidence: string, score: number) =>
       toAkritesExternalContactDetail(
         baseRow({
@@ -77,8 +77,8 @@ describe('toAkritesExternalContactDetail', () => {
           ],
         }),
       ).overallConfidenceBand
-    expect(band('SECONDARY', 0.6)).toBe('MEDIUM')
-    expect(band('FALLBACK', 0.4)).toBe('LOW')
+    expect(band('SECONDARY', 0.6)).toBe('SECONDARY')
+    expect(band('FALLBACK', 0.4)).toBe('FALLBACK')
   })
 
   it('returns NONE band and an empty array when there are no contacts', () => {

--- a/backend/src/api/public/v1/packages/akritesExternalContactDetail.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalContactDetail.ts
@@ -4,10 +4,11 @@ import {
   securityContactConfidenceBand,
 } from '@crowd/data-access-layer'
 
-// Per-contact band mirrors the internal SecurityContactConfidence enum verbatim.
+// Both the per-contact band and the aggregate band mirror the internal
+// SecurityContactConfidence enum verbatim (PRIMARY/SECONDARY/FALLBACK/NONE) —
+// no external crosswalk (confirmed with product).
 export type AkritesExternalContactConfidenceBand = SecurityContactConfidence
-// Aggregate band is a DIFFERENT scale in the contract (HIGH/MEDIUM/LOW/NONE).
-export type AkritesExternalOverallConfidenceBand = 'HIGH' | 'MEDIUM' | 'LOW' | 'NONE'
+export type AkritesExternalOverallConfidenceBand = SecurityContactConfidence
 
 export interface AkritesExternalSecurityContact {
   channel: string
@@ -42,21 +43,6 @@ export interface ContactDetailBulkEntry {
   contact: AkritesExternalContactDetail | null
 }
 
-// UNCONFIRMED CROSSWALK — the internal aggregate band is PRIMARY/SECONDARY/FALLBACK/NONE
-// (securityContactConfidenceBand), but the Akrites contract's overallConfidenceBand uses
-// HIGH/MEDIUM/LOW/NONE. This is a clean 4→4 tier rename, but the contract flags it as an
-// open question (there is no existing function producing the HIGH/… scale). Confirm with
-// Akrites/product; if they'd rather reuse PRIMARY/SECONDARY/FALLBACK/NONE, drop this table.
-const OVERALL_CONFIDENCE_CROSSWALK: Record<
-  SecurityContactConfidence,
-  AkritesExternalOverallConfidenceBand
-> = {
-  PRIMARY: 'HIGH',
-  SECONDARY: 'MEDIUM',
-  FALLBACK: 'LOW',
-  NONE: 'NONE',
-}
-
 export function toAkritesExternalContactDetail(
   row: AkritesExternalContactDetailRow,
 ): AkritesExternalContactDetail {
@@ -69,12 +55,10 @@ export function toAkritesExternalContactDetail(
   }))
 
   // Aggregate band derives from the highest-scoring contact (same rule as the internal
-  // packageConfidence), then crosswalked to the contract's scale. NONE when there are none.
-  const overallConfidenceBand =
+  // packageConfidence), returned verbatim. NONE when there are no contacts.
+  const overallConfidenceBand: AkritesExternalOverallConfidenceBand =
     contacts.length > 0
-      ? OVERALL_CONFIDENCE_CROSSWALK[
-          securityContactConfidenceBand(Math.max(...contacts.map((c) => c.confidenceScore)))
-        ]
+      ? securityContactConfidenceBand(Math.max(...contacts.map((c) => c.confidenceScore)))
       : 'NONE'
 
   return {

--- a/backend/src/api/public/v1/packages/akritesExternalPackageDetail.test.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalPackageDetail.test.ts
@@ -48,19 +48,19 @@ describe('toAkritesExternalPackageDetail', () => {
   it('maps a well-formed row to the akrites-external shape', () => {
     const result = toAkritesExternalPackageDetail(baseRow())
     expect(result.purl).toBe('pkg:npm/lodash')
-    expect(result.health.band).toBe('high')
+    expect(result.health.band).toBe('healthy')
     expect(result.riskSignals.lifecycle).toBe('active')
     expect(result.impact.score).toBe(50)
   })
 
   it('falls back to computeHealthBand(scorecardScore) for an unrecognized (non-null) healthLabel', () => {
-    // scorecardScore 7.5 -> computeHealthBand() returns 'healthy' -> crosswalk 'high'.
-    // A naive `?? computeHealthBand(...)` (bug fixed in code review) would have
-    // trusted 'not-a-real-label' as-is and returned 'critical' instead.
+    // scorecardScore 7.5 -> computeHealthBand() returns 'healthy'. A naive
+    // `?? computeHealthBand(...)` (bug fixed in code review) would have trusted
+    // 'not-a-real-label' as-is and returned it verbatim instead.
     const result = toAkritesExternalPackageDetail(
       baseRow({ healthLabel: 'not-a-real-label', scorecardScore: 7.5 }),
     )
-    expect(result.health.band).toBe('high')
+    expect(result.health.band).toBe('healthy')
   })
 
   it('falls back to computeHealthBand(scorecardScore) when healthLabel is null', () => {
@@ -68,12 +68,12 @@ describe('toAkritesExternalPackageDetail', () => {
     expect(result.health.band).toBe('critical')
   })
 
-  it('maps every known internal health label through the crosswalk', () => {
+  it('returns every known internal health label verbatim', () => {
     expect(toAkritesExternalPackageDetail(baseRow({ healthLabel: 'excellent' })).health.band).toBe(
-      'high',
+      'excellent',
     )
     expect(toAkritesExternalPackageDetail(baseRow({ healthLabel: 'concerning' })).health.band).toBe(
-      'low',
+      'concerning',
     )
     expect(toAkritesExternalPackageDetail(baseRow({ healthLabel: 'critical' })).health.band).toBe(
       'critical',
@@ -85,13 +85,13 @@ describe('toAkritesExternalPackageDetail', () => {
     expect(result.riskSignals.lifecycle).toBeNull()
   })
 
-  it('maps lifecycle labels not present verbatim in the external enum (stable, archived)', () => {
+  it('returns internal lifecycle labels verbatim (stable, archived)', () => {
     expect(
       toAkritesExternalPackageDetail(baseRow({ lifecycleLabel: 'stable' })).riskSignals.lifecycle,
-    ).toBe('active')
+    ).toBe('stable')
     expect(
       toAkritesExternalPackageDetail(baseRow({ lifecycleLabel: 'archived' })).riskSignals.lifecycle,
-    ).toBe('deprecated')
+    ).toBe('archived')
   })
 
   it('normalizes raw timestamptz strings (not Date objects) to ISO 8601', () => {

--- a/backend/src/api/public/v1/packages/akritesExternalPackageDetail.ts
+++ b/backend/src/api/public/v1/packages/akritesExternalPackageDetail.ts
@@ -9,8 +9,11 @@ import { HEALTH_BAND_SET, LIFECYCLE_VALUES, type Lifecycle } from './types'
 
 const LIFECYCLE_SET = new Set<string>(LIFECYCLE_VALUES)
 
-export type AkritesExternalHealthBand = 'critical' | 'low' | 'medium' | 'high'
-export type AkritesExternalLifecycle = 'active' | 'inactive' | 'deprecated' | 'abandoned' | null
+// The API returns the internal bands verbatim — no external crosswalk (confirmed
+// with product): health excellent/healthy/fair/concerning/critical, lifecycle
+// active/stable/declining/abandoned/archived.
+export type AkritesExternalHealthBand = HealthBand
+export type AkritesExternalLifecycle = Lifecycle | null
 
 export interface AkritesExternalPackageDetail {
   purl: string
@@ -70,48 +73,20 @@ export interface PackageDetailBulkEntry {
   package: AkritesExternalPackageDetail | null
 }
 
-// UNCONFIRMED CROSSWALK — see the HealthBand schema note in the akrites-external
-// OpenAPI contract: the internal excellent/healthy/fair/concerning/critical scale
-// (good→bad) has no agreed mapping to Akrites' critical/low/medium/high scale yet.
-// This mirrors the "fair -> medium" guess from the original Akrites draft spec
-// (not encoded in this repo's openapi.yaml). Confirm the real crosswalk with
-// Akrites/product before this ships, then update this table only.
-const HEALTH_BAND_CROSSWALK: Record<HealthBand, AkritesExternalHealthBand> = {
-  excellent: 'high',
-  healthy: 'high',
-  fair: 'medium',
-  concerning: 'low',
-  critical: 'critical',
-}
-
 function toAkritesHealthBand(
   healthLabel: string | null,
   scorecardScore: number | null,
 ): AkritesExternalHealthBand {
   // Same validity guard as getPackage.ts: an unrecognized (not just null) stored
   // label falls back to computeHealthBand() instead of silently miscategorizing.
-  const label: HealthBand =
-    healthLabel != null && HEALTH_BAND_SET.has(healthLabel)
-      ? (healthLabel as HealthBand)
-      : computeHealthBand(scorecardScore)
-  return HEALTH_BAND_CROSSWALK[label]
-}
-
-// UNCONFIRMED CROSSWALK — same caveat as HEALTH_BAND_CROSSWALK above: the internal
-// lifecycle scale (active/stable/declining/abandoned/archived) doesn't line up
-// one-to-one with Akrites' (active/inactive/deprecated/abandoned/null). Confirm
-// with Akrites/product before this ships.
-const LIFECYCLE_CROSSWALK: Record<Lifecycle, AkritesExternalLifecycle> = {
-  active: 'active',
-  stable: 'active',
-  declining: 'inactive',
-  abandoned: 'abandoned',
-  archived: 'deprecated',
+  return healthLabel != null && HEALTH_BAND_SET.has(healthLabel)
+    ? (healthLabel as HealthBand)
+    : computeHealthBand(scorecardScore)
 }
 
 function toAkritesLifecycle(lifecycleLabel: string | null): AkritesExternalLifecycle {
   if (lifecycleLabel === null || !LIFECYCLE_SET.has(lifecycleLabel)) return null
-  return LIFECYCLE_CROSSWALK[lifecycleLabel as Lifecycle]
+  return lifecycleLabel as Lifecycle
 }
 
 // Timestamptz columns arrive as the raw Postgres string (OID 1184 parser returns

--- a/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetailBatch.ts
+++ b/backend/src/api/public/v1/packages/getAkritesExternalAdvisoryDetailBatch.ts
@@ -10,18 +10,17 @@ import {
   type AdvisoryDetailBulkEntry,
   toAkritesExternalAdvisoryDetail,
 } from './akritesExternalAdvisoryDetail'
-import { normalizePurl, purlsBodySchema } from './purl'
+import { paginatePurls, paginatedPurlsBodySchema } from './purl'
 
-const bodySchema = purlsBodySchema()
+const bodySchema = paginatedPurlsBodySchema()
 
 export async function getAkritesExternalAdvisoryDetailBatch(
   req: Request,
   res: Response,
 ): Promise<void> {
-  const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
-  // Normalize after parsing (not in the schema) so rawPurls keeps the client's
-  // original form — echoed back as requestedPurl so callers can self-correlate.
-  const normalizedPurls = rawPurls.map(normalizePurl)
+  const { page, pageSize, total, pagedPurls, normalizedPurls } = paginatePurls(
+    validateOrThrow(bodySchema, req.body),
+  )
 
   const qx = await getPackagesQx()
   const rows = await getAdvisoriesByPurls(qx, normalizedPurls)
@@ -35,7 +34,7 @@ export async function getAkritesExternalAdvisoryDetailBatch(
     else byPurl.set(row.purl, [row])
   }
 
-  const results: AdvisoryDetailBulkEntry[] = rawPurls.map((requestedPurl, i) => {
+  const results: AdvisoryDetailBulkEntry[] = pagedPurls.map((requestedPurl, i) => {
     const purlRows = byPurl.get(normalizedPurls[i])
     return {
       requestedPurl,
@@ -44,5 +43,5 @@ export async function getAkritesExternalAdvisoryDetailBatch(
     }
   })
 
-  ok(res, { results })
+  ok(res, { page, pageSize, total, results })
 }

--- a/backend/src/api/public/v1/packages/getAkritesExternalContactDetailBatch.ts
+++ b/backend/src/api/public/v1/packages/getAkritesExternalContactDetailBatch.ts
@@ -13,25 +13,24 @@ import {
   type ContactDetailBulkEntry,
   toAkritesExternalContactDetail,
 } from './akritesExternalContactDetail'
-import { normalizePurl, purlsBodySchema } from './purl'
+import { paginatePurls, paginatedPurlsBodySchema } from './purl'
 
-const bodySchema = purlsBodySchema()
+const bodySchema = paginatedPurlsBodySchema()
 
 export async function getAkritesExternalContactDetailBatch(
   req: Request,
   res: Response,
 ): Promise<void> {
-  const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
-  // Normalize after parsing (not in the schema) so rawPurls keeps the client's
-  // original form — echoed back as requestedPurl so callers can self-correlate.
-  const normalizedPurls = rawPurls.map(normalizePurl)
+  const { page, pageSize, total, pagedPurls, normalizedPurls } = paginatePurls(
+    validateOrThrow(bodySchema, req.body),
+  )
 
   const qx = await getPackagesQx()
   const rows = await getContactDetailsByPurls(qx, normalizedPurls)
 
   const byPurl = new Map<string, AkritesExternalContactDetailRow>(rows.map((r) => [r.purl, r]))
 
-  const results: ContactDetailBulkEntry[] = rawPurls.map((requestedPurl, i) => {
+  const results: ContactDetailBulkEntry[] = pagedPurls.map((requestedPurl, i) => {
     const row = byPurl.get(normalizedPurls[i])
     return {
       requestedPurl,
@@ -40,5 +39,5 @@ export async function getAkritesExternalContactDetailBatch(
     }
   })
 
-  ok(res, { results })
+  ok(res, { page, pageSize, total, results })
 }

--- a/backend/src/api/public/v1/packages/getAkritesExternalPackageDetailBatch.ts
+++ b/backend/src/api/public/v1/packages/getAkritesExternalPackageDetailBatch.ts
@@ -13,25 +13,24 @@ import {
   type PackageDetailBulkEntry,
   toAkritesExternalPackageDetail,
 } from './akritesExternalPackageDetail'
-import { normalizePurl, purlsBodySchema } from './purl'
+import { paginatePurls, paginatedPurlsBodySchema } from './purl'
 
-const bodySchema = purlsBodySchema()
+const bodySchema = paginatedPurlsBodySchema()
 
 export async function getAkritesExternalPackageDetailBatch(
   req: Request,
   res: Response,
 ): Promise<void> {
-  const { purls: rawPurls } = validateOrThrow(bodySchema, req.body)
-  // Normalize after parsing (not in the schema) so rawPurls keeps the client's
-  // original form — echoed back as requestedPurl so callers can self-correlate.
-  const normalizedPurls = rawPurls.map(normalizePurl)
+  const { page, pageSize, total, pagedPurls, normalizedPurls } = paginatePurls(
+    validateOrThrow(bodySchema, req.body),
+  )
 
   const qx = await getPackagesQx()
   const rows = await getPackageDetailsByPurls(qx, normalizedPurls)
 
   const byPurl = new Map<string, AkritesExternalPackageDetailRow>(rows.map((r) => [r.purl, r]))
 
-  const results: PackageDetailBulkEntry[] = rawPurls.map((requestedPurl, i) => {
+  const results: PackageDetailBulkEntry[] = pagedPurls.map((requestedPurl, i) => {
     const row = byPurl.get(normalizedPurls[i])
     return {
       requestedPurl,
@@ -40,5 +39,5 @@ export async function getAkritesExternalPackageDetailBatch(
     }
   })
 
-  ok(res, { results })
+  ok(res, { page, pageSize, total, results })
 }

--- a/backend/src/api/public/v1/packages/purl.ts
+++ b/backend/src/api/public/v1/packages/purl.ts
@@ -58,3 +58,45 @@ export function purlsBodySchema(max: number = MAX_PURLS_PER_BATCH) {
     purls: z.array(purlArrayItemSchema).min(1).max(max, `Maximum ${max} purls per request`),
   })
 }
+
+export const DEFAULT_BATCH_PAGE_SIZE = 20
+
+// Batch endpoints resolve the exact purls the client sends, then return one page of
+// results (request order). page/pageSize mirror the GET /packages list contract;
+// pageSize caps at the batch max so a single page can still cover a full request.
+export function paginatedPurlsBodySchema(max: number = MAX_PURLS_PER_BATCH) {
+  return purlsBodySchema(max).extend({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(max).default(DEFAULT_BATCH_PAGE_SIZE),
+  })
+}
+
+export interface PaginatedPurls {
+  page: number
+  pageSize: number
+  total: number
+  // The client's original (un-normalized) purls for the requested page — echoed
+  // back as requestedPurl so callers can self-correlate.
+  pagedPurls: string[]
+  // normalizedPurls[i] corresponds to pagedPurls[i]; used for the DB lookup.
+  normalizedPurls: string[]
+}
+
+// Slice the requested page out of a parsed paginatedPurlsBodySchema body and normalize
+// only that page's purls, so a single page never resolves the whole batch.
+export function paginatePurls(body: {
+  purls: string[]
+  page: number
+  pageSize: number
+}): PaginatedPurls {
+  const { purls, page, pageSize } = body
+  const start = (page - 1) * pageSize
+  const pagedPurls = purls.slice(start, start + pageSize)
+  return {
+    page,
+    pageSize,
+    total: purls.length,
+    pagedPurls,
+    normalizedPurls: pagedPurls.map(normalizePurl),
+  }
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Applies the review feedback on the external Akrites APIs (packages, advisories,
security contacts) before we freeze their response contracts. Two changes:

1. **Pagination** on the three bulk `detail:batch` endpoints (requested by Francis).
2. **Enums returned verbatim** — we no longer remap internal health / lifecycle /
   confidence bands to a separate external scale (confirmed with product). Keeping
   one scale avoids a crosswalk that had no agreed mapping and keeps the API
   consistent with what we store.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- **Pagination on `POST /akrites-external/{packages,advisories,contacts}/detail:batch`.**
  Request accepts optional `page` (default 1) and `pageSize` (default 20, max 100);
  response is now a `{ page, pageSize, total, results }` envelope (`total` = number
  of requested purls), mirroring the `GET /packages` list contract.
- **The page is sliced *before* the DB query**, so a single page only resolves its
  own purls instead of the whole batch — no wasted lookups.
- **Shared pagination logic** extracted into `paginatePurls()` + `paginatedPurlsBodySchema()`
  in `purl.ts` so the three handlers don't duplicate the slice/normalize logic; the
  schema composes from the existing `purlsBodySchema` (single source of truth for the
  `purls` validation rules).
- **Enum pass-through** — removed the three crosswalk tables:
  - `health.band` → `excellent | healthy | fair | concerning | critical`
  - `riskSignals.lifecycle` → `active | stable | declining | abandoned | archived | null`
  - `overallConfidenceBand` → `PRIMARY | SECONDARY | FALLBACK | NONE` (now the same
    scale as the per-contact `confidenceBand`)
- **Behavior preserved on the health band:** an unknown/`null` stored label still
  falls back to `computeHealthBand(scorecardScore)` rather than being returned as-is;
  unknown/`null` lifecycle still returns `null`.
- **OpenAPI** (`akrites-external/openapi.yaml`) updated: the three enum definitions,
  plus `page`/`pageSize` on the batch request bodies and the paginated response envelope.
- **Tests** updated to assert the verbatim enum values.

### Intentionally out of scope
- The advisory `SEVERITY_CROSSWALK` is left as-is — it wasn't part of the enum
  discussion and normalizes a genuinely different (severity) scale.
- `purlsBodySchema` is left untouched (still used by the internal `batchGetStewardship`).
- No changes to the Blast Radius API (stays under epic CM-1320) or the auth work.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1332](https://linuxfoundation.atlassian.net/browse/CM-1322)

[CM-1332]: https://linuxfoundation.atlassian.net/browse/CM-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ