### PR TITLE
fix: add maintainers.yml and maintainers.yaml to KNOWN_PATHS (CM-1342)

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -56,6 +56,8 @@ class MaintainerService(BaseService):
         "maintainers",
         "maintainers.md",
         "maintainer.md",
+        "maintainers.yml",
+        "maintainers.yaml",
         "codeowners",
         "codeowners.md",
         "contributors",


### PR DESCRIPTION
## Summary

- `MAINTAINERS.yml` / `MAINTAINERS.yaml` were not in `KNOWN_PATHS`, so the extraction logic applied YAML section filtering — keeping only top-level keys whose **name** contains a governance keyword
- For repos like Zephyr (398 area entries, each with a `maintainers:` list), only the `"MAINTAINERS file"` meta-section matched, yielding 3 maintainers instead of the full set (~997)
- Fix: add both extensions to `KNOWN_PATHS` so the full file is sent to AI via chunked analysis, bypassing section filtering

Reported via: https://github.com/linuxfoundation/insights/issues/2012

## Test

Ran extraction against a local clone of `zephyrproject-rtos/zephyr`:
- Before: 3 maintainers found
- After: 997 maintainers found

🤖 Generated with [Claude Code](https://claude.com/claude-code)