### PR TITLE
fix: include community collections in collectionsSlugs (IN-1195)

### DIFF
--- a/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/insights_projects_populated_copy.pipe
@@ -1,12 +1,18 @@
 NODE insights_projects_populated_copy_collections_slugs
 DESCRIPTION >
-    Returns collection slugs per project
+    Returns collection slugs per project, for both curated (ssoUserId IS NULL) and
+    community (ssoUserId IS NOT NULL) collections. Community collections were previously
+    excluded here, which left their slugs out of collectionsSlugs and caused
+    collection_insights_aggregate to report 0 contributors / no health for them (IN-1195).
+    Downstream leaderboard/insightsProjects_filtered pipes only apply the collectionsSlugs
+    filter when an explicit collectionSlug param is passed, so including community slugs does
+    not change any un-scoped listing.
 
 SQL >
     SELECT cip.insightsProjectId, groupArray(c.slug) AS "collectionsSlugs"
     FROM collectionsInsightsProjects cip FINAL
     JOIN collections c FINAL ON c.id = cip.collectionId
-    WHERE isNull (c.deletedAt) AND isNull (c.ssoUserId) AND isNull (cip.deletedAt)
+    WHERE isNull (c.deletedAt) AND isNull (cip.deletedAt)
     GROUP BY cip.insightsProjectId
 
 NODE insights_projects_populated_copy_segment_id_mapping


### PR DESCRIPTION
## Problem

Community (non-LF) collection detail pages show **Contributors: 0** and **Avg. Health: —** even when the collection has projects (e.g. `agentic-ai-momentum-watchlist` shows 88 projects but 0 contributors). Reported from a review of the Collections feature.

Root cause is in the Tinybird layer, not the frontend. The `collection_insights_aggregate` pipe (which powers the header metrics) resolves collection membership via `insights_projects_populated_ds.collectionsSlugs`. That array is built in `insights_projects_populated_copy.pipe`, whose `collectionsSlugs` node filtered with `AND isNull(c.ssoUserId)` — `ssoUserId` is set for community/user-created collections and null only for curated (LF) ones. So **every community collection was excluded from `collectionsSlugs`**, and the aggregate pipe matched 0 projects for them → `uniqueContributorCount: 0`, `avgHealthScore: nan`. The Postgres-derived project count still worked, which is why the count showed but the other two metrics didn't.

Verified against prod Tinybird:
- `cloud-native-computing-foundation-(cncf)` (curated) → 127 / 306251 / 72 ✅
- `agentic-ai-momentum-watchlist` (community) → 0 / 0 / nan ❌
- `arrayJoin(collectionsSlugs)` contains **no** community slugs (only curated).

## Fix

Drop the `AND isNull(c.ssoUserId)` filter from the `collectionsSlugs` node so community collection memberships are populated alongside curated ones.

## Blast radius

Other consumers of `collectionsSlugs` (`collection_insights_aggregate`, `segments_filtered_by_collection`, `leaderboards_*`, `insightsProjects_filtered`) only apply a `collectionsSlugs` filter **when an explicit `collectionSlug` param is passed** — so no un-scoped listing changes. The only new capability is that passing a community `collectionSlug` now returns results, which is the intended behavior.

`insights_projects_populated_copy` is a `COPY` pipe on a `*/15 * * * *` schedule, so the 43 existing community collections will backfill correct metrics on the next run after deploy — no manual backfill needed.

## Validation

- `tb check` passes
- `tb fmt` applied
- No schema change; datasource `collectionsSlugs` column unchanged (only more rows populated)

## Related

Frontend collection-widget wiring (Contributors/Popularity/Development tabs) is tracked separately in insights PR #2013 (IN-1191). This PR is the upstream data half and is independent of it.

https://claude.ai/code/session_014Fc86j8FLeWFAs3fDCQs38
