### PR TITLE
fix: collection dev-velocity scope + repo contributor count inflation (IN-1195)

### DIFF
--- a/services/libs/tinybird/pipes/issues_average_resolve_velocity.pipe
+++ b/services/libs/tinybird/pipes/issues_average_resolve_velocity.pipe
@@ -4,8 +4,11 @@ DESCRIPTION >
     - Only includes issues that have been closed (`isNotNull(closedAt)`) to ensure accurate velocity calculations.
     - Queries `issues_analyzed` directly for optimal performance using sorting key on `segmentId, channel, openedAt`.
     - Primary use case: displaying average issue resolution time metrics in development health dashboards.
+    - The pipe scopes data either to a single project (via `segments_filtered`) or to every project in a
+    collection (via `segments_filtered_by_collection`). Exactly one of `project`/`collectionSlug` must be given.
     - Parameters:
-    - `project`: Required string for project slug (e.g., 'k8s', 'tensorflow') - inherited from `segments_filtered`
+    - `project`: Project slug (e.g., 'k8s', 'tensorflow') - inherited from `segments_filtered`. Required unless `collectionSlug` is given.
+    - `collectionSlug`: Collection slug (e.g., 'cncf') - inherited from `segments_filtered_by_collection`. Required unless `project` is given.
     - `repos`: Optional array of repository URLs for filtering (e.g., ['https://github.com/kubernetes/kubernetes'])
     - `startDate`: Optional DateTime filter for issues opened after timestamp (e.g., '2024-01-01 00:00:00')
     - `endDate`: Optional DateTime filter for issues opened before timestamp (e.g., '2024-12-31 23:59:59')
@@ -17,7 +20,10 @@ SQL >
     SELECT round(avg(closedInSeconds)) AS "averageIssueResolveVelocitySeconds"
     FROM issues_analyzed
     WHERE
-        segmentId = (SELECT segmentId FROM segments_filtered) AND isNotNull(closedAt)
+        {% if defined(collectionSlug) %}
+            segmentId IN (SELECT segmentId FROM segments_filtered_by_collection)
+        {% else %} segmentId = (SELECT segmentId FROM segments_filtered)
+        {% end %} AND isNotNull(closedAt)
         {% if defined(repos) %}
             AND channel
             IN {{ Array(repos, 'String', description="Filter activity repo list", required=False) }}

--- a/services/libs/tinybird/pipes/pull_requests_average_resolve_velocity.pipe
+++ b/services/libs/tinybird/pipes/pull_requests_average_resolve_velocity.pipe
@@ -5,8 +5,11 @@ DESCRIPTION >
     - Excludes Gerrit platform as it uses a different workflow model.
     - Queries `pull_requests_analyzed` directly for optimal performance using sorting key on `segmentId, channel, openedAt`.
     - Primary use case: displaying average PR resolution time metrics in development health dashboards.
+    - The pipe scopes data either to a single project (via `segments_filtered`) or to every project in a
+    collection (via `segments_filtered_by_collection`). Exactly one of `project`/`collectionSlug` must be given.
     - Parameters:
-    - `project`: Required string for project slug (e.g., 'k8s', 'tensorflow') - inherited from `segments_filtered`
+    - `project`: Project slug (e.g., 'k8s', 'tensorflow') - inherited from `segments_filtered`. Required unless `collectionSlug` is given.
+    - `collectionSlug`: Collection slug (e.g., 'cncf') - inherited from `segments_filtered_by_collection`. Required unless `project` is given.
     - `repos`: Optional array of repository URLs for filtering (e.g., ['https://github.com/kubernetes/kubernetes'])
     - `startDate`: Optional DateTime filter for PRs opened after timestamp (e.g., '2024-01-01 00:00:00')
     - `endDate`: Optional DateTime filter for PRs opened before timestamp (e.g., '2024-12-31 23:59:59')
@@ -18,10 +21,10 @@ SQL >
     SELECT round(avg(resolvedInSeconds)) AS "averagePullRequestResolveVelocitySeconds"
     FROM pull_requests_analyzed
     WHERE
-        segmentId = (SELECT segmentId FROM segments_filtered)
-        AND isNotNull(resolvedAt)
-        AND resolvedInSeconds > 0
-        AND platform != 'gerrit'
+        {% if defined(collectionSlug) %}
+            segmentId IN (SELECT segmentId FROM segments_filtered_by_collection)
+        {% else %} segmentId = (SELECT segmentId FROM segments_filtered)
+        {% end %} AND isNotNull(resolvedAt) AND resolvedInSeconds > 0 AND platform != 'gerrit'
         {% if defined(repos) %}
             AND channel
             IN {{ Array(repos, 'String', description="Filter activity repo list", required=False) }}

--- a/services/libs/tinybird/pipes/repositories_populated_copy.pipe
+++ b/services/libs/tinybird/pipes/repositories_populated_copy.pipe
@@ -9,7 +9,11 @@ SQL >
 
 NODE repositories_populated_copy_contributor_org_counts
 DESCRIPTION >
-    Calculate contributor and organization counts per repository (channel)
+    Calculate contributor and organization counts per repository (channel).
+    Excludes 'star' and 'fork' activity: stargazers/forkers are engagement, not contributors,
+    and counting them inflated contributorCount massively for popular repos (e.g. OpenClaw showed
+    483K where the true contributor count is ~46K - 404K of those were stargazers). This mirrors
+    the "contributions only" semantics the widget pipes use via onlyContributions/activityTypes_filtered.
 
 SQL >
     SELECT
@@ -17,6 +21,7 @@ SQL >
         uniq(CASE WHEN memberId != '' THEN memberId ELSE NULL END) AS contributorCount,
         uniq(CASE WHEN organizationId != '' THEN organizationId ELSE NULL END) AS organizationCount
     FROM activityRelations_deduplicated_cleaned_bucket_union
+    WHERE type NOT IN ('star', 'fork')
     GROUP BY channel
 
 NODE repositories_populated_copy_first_commit


### PR DESCRIPTION
## Problem

Two data-quality bugs surfaced during Collections v2 (IN-1191) prod QA of the LF Foundation collection in-depth tabs.

### 1. Development tab — "Avg. velocity: 0 seconds" on every collection
`issues_average_resolve_velocity.pipe` and `pull_requests_average_resolve_velocity.pipe` scoped only to a single project (`segmentId = (SELECT segmentId FROM segments_filtered)`). `segments_filtered` requires a `project` param, so a **collection-scoped** call (with `collectionSlug`) matched no segment and returned `null`. The frontend rendered that null as a literal **"Avg. velocity: 0 seconds"**.

### 2. Projects table — Contributors column inflated by stargazers
`repositories_populated_copy.pipe` computed repo-level `contributorCount` as `uniq(memberId)` over **all** activity in `activityRelations_deduplicated_cleaned_bucket_union` — with no contribution-type filter. That counts **stargazers and forkers as contributors**. For OpenClaw this produced **483,139** where the true contributor count is **~46,031** (404,619 of the counted members were stargazers, 86,360 forkers). This value flows through `project_insights_copy_ds` → `project_repo_insights` → the collection projects-table Contributors column.

## Fix

1. Add the `collectionSlug` branch to both velocity pipes — `segmentId IN (SELECT segmentId FROM segments_filtered_by_collection)` — mirroring the exact pattern already used by `activities_filtered.pipe` and the other collection-scoped widget pipes. Project-scope behavior is unchanged.
2. Exclude `type IN ('star', 'fork')` when counting repo contributors, matching the "contributions only" semantics the widget pipes use via `onlyContributions`/`activityTypes_filtered`.

## Verification (against prod Tinybird)

| Metric | Before | After |
|---|---|---|
| CNCF collection avg issue-resolve velocity | `null` → UI "0 seconds" | **8,744,956 s** (~101 days) |
| OpenClaw repo `contributorCount` | 483,139 | **46,031** |

`tb check` passes on all three pipes; `tb fmt` applied.

## Blast radius / note for reviewers

- The velocity change is additive (a new `collectionSlug` branch); project-scoped callers are unaffected.
- **The `contributorCount` change affects repo-level contributor counts platform-wide**, not just collections — it can only *reduce* an inflated count (removes star/fork engagement). `repositories_populated_copy` is a COPY pipe on a schedule, so counts recompute on the next run after deploy. Flagging in case the current (inflated) definition was relied upon anywhere; the corrected definition (excluding stars/forks) matches how contributors are counted elsewhere.

## Related

- Frontend companion (renders null velocity as "—" instead of "0 seconds", + other Collections v2 QA fixes): insights PR #2013 branch `feat/collections-widget`.
- Prior community-metrics fix (merged): #4360.
- Out of scope here (separate data investigation): `copy-of-agentic-ai-momentum-watchlist` has 0 rows in `collectionsInsightsProjects` (CDC/collection-copy membership gap, not a pipe-logic bug).

https://claude.ai/code/session_014Fc86j8FLeWFAs3fDCQs38
