### PR TITLE
fix: keep contacts from succeeded sources when an extractor fails [CM-1341]

### DIFF
--- a/services/apps/packages_worker/src/security-contacts/ingestSingle.ts
+++ b/services/apps/packages_worker/src/security-contacts/ingestSingle.ts
@@ -94,8 +94,10 @@ export async function ingestSecurityContactsForPurl(
   const baseDeps = buildBaseDeps(config)
   try {
     const result = await processRepo(target, baseDeps, cdpQx)
-    if (result.status === 'ok') {
-      await writeContacts(qx, result.repoId, result.contacts, result.policies)
+    if (result.status === 'ok' || result.status === 'partial') {
+      await writeContacts(qx, result.repoId, result.contacts, result.policies, {
+        merge: result.status === 'partial',
+      })
     } else {
       await markRepoAttempted(qx, result.repoId)
     }

--- a/services/apps/packages_worker/src/security-contacts/processBatch.ts
+++ b/services/apps/packages_worker/src/security-contacts/processBatch.ts
@@ -135,13 +135,16 @@ export async function processRepo(
 
   const results = await Promise.allSettled(EXTRACTORS.map((extract) => extract(target, deps)))
 
-  // Write only when every extractor succeeded, so a failed one can't wipe contacts it didn't see.
-  const failed = results.find((r) => r.status === 'rejected') as PromiseRejectedResult | undefined
-  if (failed) {
+  let failedCount = 0
+  results.forEach((r, i) => {
+    if (r.status !== 'rejected') return
+    failedCount++
     log.warn(
-      { repoId: target.repoId, errMsg: failed.reason?.message },
-      'Extractor failed — preserving existing data',
+      { repoId: target.repoId, extractor: EXTRACTORS[i].name, errMsg: r.reason?.message },
+      'Extractor failed — keeping contacts from remaining sources',
     )
+  })
+  if (failedCount === results.length) {
     return { repoId: target.repoId, status: 'extractor-failed' }
   }
 
@@ -177,7 +180,12 @@ export async function processRepo(
   }
 
   const scored = reconcile(contacts)
-  return { repoId: target.repoId, status: 'ok', contacts: scored, policies }
+  return {
+    repoId: target.repoId,
+    status: failedCount > 0 ? 'partial' : 'ok',
+    contacts: scored,
+    policies,
+  }
 }
 
 export async function processBatch(
@@ -228,10 +236,12 @@ export async function processBatch(
 
     const extractionDurationMs = Date.now() - extractionStartedAt
     const ok = outcomes.filter((o) => o.status === 'ok').length
+    const partial = outcomes.filter((o) => o.status === 'partial').length
     log.info(
       {
         ok,
-        failed: outcomes.length - ok,
+        partial,
+        failed: outcomes.length - ok - partial,
         durationMs: extractionDurationMs,
         reposPerSec: Number((outcomes.length / (extractionDurationMs / 1000)).toFixed(1)),
       },

--- a/services/apps/packages_worker/src/security-contacts/types.ts
+++ b/services/apps/packages_worker/src/security-contacts/types.ts
@@ -81,4 +81,10 @@ export type Extractor = (target: RepoTarget, deps: ExtractorDeps) => Promise<Ext
 
 export type ProcessRepoResult =
   | { repoId: string; status: 'ok'; contacts: ScoredContact[]; policies: Partial<RepoPolicies> }
+  | {
+      repoId: string
+      status: 'partial'
+      contacts: ScoredContact[]
+      policies: Partial<RepoPolicies>
+    }
   | { repoId: string; status: 'extractor-failed' }

--- a/services/apps/packages_worker/src/security-contacts/writeContacts.ts
+++ b/services/apps/packages_worker/src/security-contacts/writeContacts.ts
@@ -57,17 +57,23 @@ export async function markRepoAttempted(qx: QueryExecutor, repoId: string): Prom
 //
 // Soft-delete: mark every active row stale, then upsert this pass's contacts, reviving whatever
 // was rediscovered. Readers of this table must filter on deleted_at IS NULL.
+//
+// merge: skip the soft-delete when this pass ran with a failed extractor — a failed source
+// can't wipe contacts it didn't see; stale rows are cleaned on the next fully-successful pass.
 export async function writeContacts(
   qx: QueryExecutor,
   repoId: string,
   contacts: ScoredContact[],
   policies: Partial<RepoPolicies>,
+  opts: { merge?: boolean } = {},
 ): Promise<void> {
   await qx.tx(async (tx) => {
-    await tx.result(
-      'UPDATE security_contacts SET deleted_at = NOW(), updated_at = NOW() WHERE repo_id = $(repoId) AND deleted_at IS NULL',
-      { repoId },
-    )
+    if (!opts.merge) {
+      await tx.result(
+        'UPDATE security_contacts SET deleted_at = NOW(), updated_at = NOW() WHERE repo_id = $(repoId) AND deleted_at IS NULL',
+        { repoId },
+      )
+    }
 
     if (contacts.length > 0) {
       await tx.result(
@@ -114,12 +120,12 @@ export async function markReposAttempted(qx: QueryExecutor, repoIds: string[]): 
   )
 }
 
-type OkResult = Extract<ProcessRepoResult, { status: 'ok' }>
+type PersistableResult = Extract<ProcessRepoResult, { status: 'ok' | 'partial' }>
 
 // Bounds blast radius: a bad row only forces a re-extract of its chunk next sweep, not the whole batch.
 const WRITE_CHUNK_SIZE = 100
 
-function prepareBulkPolicyUpdate(chunk: OkResult[]): string {
+function prepareBulkPolicyUpdate(chunk: PersistableResult[]): string {
   const rows = chunk.map(
     (_, i) =>
       `($(id${i})::bigint, $(securityPolicyUrl${i}), $(vulnerabilityReportingUrl${i}), $(pvrResolved${i})::boolean, $(bugBountyUrl${i}), $(securityTxtUrl${i}), $(pvrEnabled${i})::boolean)`,
@@ -156,15 +162,20 @@ function prepareBulkPolicyUpdate(chunk: OkResult[]): string {
   )
 }
 
-async function writeContactsChunk(qx: QueryExecutor, chunk: OkResult[]): Promise<void> {
+async function writeContactsChunk(qx: QueryExecutor, chunk: PersistableResult[]): Promise<void> {
   if (chunk.length === 0) return
-  const repoIds = chunk.map((r) => r.repoId)
+
+  // Partial repos get a merge-only write: their failed extractor couldn't re-see existing
+  // contacts, so soft-deleting would wipe data the pass never evaluated.
+  const fullRefreshIds = chunk.filter((r) => r.status === 'ok').map((r) => r.repoId)
 
   await qx.tx(async (tx) => {
-    await tx.result(
-      'UPDATE security_contacts SET deleted_at = NOW(), updated_at = NOW() WHERE repo_id = ANY($(repoIds)::bigint[]) AND deleted_at IS NULL',
-      { repoIds },
-    )
+    if (fullRefreshIds.length > 0) {
+      await tx.result(
+        'UPDATE security_contacts SET deleted_at = NOW(), updated_at = NOW() WHERE repo_id = ANY($(repoIds)::bigint[]) AND deleted_at IS NULL',
+        { repoIds: fullRefreshIds },
+      )
+    }
 
     const rows = chunk.flatMap((r) => r.contacts.map((c) => toContactRow(r.repoId, c)))
     if (rows.length > 0) {
@@ -184,7 +195,9 @@ export async function writeContactsBatch(
   const attemptedOnlyIds = outcomes
     .filter((o) => o.status === 'extractor-failed')
     .map((o) => o.repoId)
-  const ok = outcomes.filter((o): o is OkResult => o.status === 'ok')
+  const ok = outcomes.filter(
+    (o): o is PersistableResult => o.status === 'ok' || o.status === 'partial',
+  )
 
   let firstError: Error | undefined
   for (let i = 0; i < ok.length; i += WRITE_CHUNK_SIZE) {


### PR DESCRIPTION
This pull request improves the reliability of security contact extraction by introducing a new `'partial'` status for repositories where some extractors fail but others succeed. The changes ensure that existing contact data is only updated (not deleted) when extraction is partial, preventing accidental data loss. Logging and batch processing are also updated to reflect this new status and handle partial results safely.

**Handling partial extraction results:**

* Added a `'partial'` status to `ProcessRepoResult` and updated return logic in `processRepo` to use it when some, but not all, extractors fail. [[1]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90L138-R147) [[2]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90L180-R188) [[3]](diffhunk://#diff-08c95ac72ec31c2dfce764a0067743456fb54cc9333120c449ed7efd01a8de41R84-R89)
* Updated `ingestSecurityContactsForPurl` to call `writeContacts` with a `merge` option when the result is `'partial'`, ensuring existing contacts are not deleted. [[1]](diffhunk://#diff-2b5df6e874143d8ba632cd4596d13b1d65c5eea6b417cae64b9a8de49955abb3L97-R100) [[2]](diffhunk://#diff-6c39a576a3d7756b80164d60a85a974fdfc930e090e8f6319661dae5c55cedd6R60-R76)

**Safe database updates:**

* Modified `writeContacts` and `writeContactsChunk` to skip soft-deleting contacts for partial results, so only new/updated contacts are merged and no data is lost if an extractor fails. [[1]](diffhunk://#diff-6c39a576a3d7756b80164d60a85a974fdfc930e090e8f6319661dae5c55cedd6R60-R76) [[2]](diffhunk://#diff-6c39a576a3d7756b80164d60a85a974fdfc930e090e8f6319661dae5c55cedd6L159-R178)

**Batch processing and logging improvements:**

* Updated batch processing and logging to track and report the number of partial results, and to ensure only fully successful or partial results are written. [[1]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90R239-R244) [[2]](diffhunk://#diff-6c39a576a3d7756b80164d60a85a974fdfc930e090e8f6319661dae5c55cedd6L117-R128) [[3]](diffhunk://#diff-6c39a576a3d7756b80164d60a85a974fdfc930e090e8f6319661dae5c55cedd6L187-R200)

These changes make the security contact extraction process more robust to partial failures and reduce the risk of losing valid contact data.