### PR TITLE
feat: resolve rubygems owner handles via github contributor verification [CM-1341]

### DIFF
--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/index.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/index.ts
@@ -29,9 +29,8 @@ const FETCHERS: Record<string, EcosystemFetcher> = {
 export const extractManifest: Extractor = async (target, deps) => {
   const contacts: RawContact[] = []
   const policies: Partial<RepoPolicies> = {}
-  const handleCandidates: RawContact[] = []
+  const candidatesByHandle = new Map<string, RawContact>()
   const seenPurls = new Set<string>()
-  const seenCandidates = new Set<string>()
 
   for (const pkg of target.packages) {
     if (seenPurls.has(pkg.purl)) continue
@@ -48,9 +47,12 @@ export const extractManifest: Extractor = async (target, deps) => {
       contacts.push(...result.contacts)
       for (const candidate of result.handleCandidates ?? []) {
         const key = candidate.value.toLowerCase()
-        if (seenCandidates.has(key)) continue
-        seenCandidates.add(key)
-        handleCandidates.push(candidate)
+        const existing = candidatesByHandle.get(key)
+        if (existing) {
+          existing.provenance.push(...candidate.provenance)
+        } else {
+          candidatesByHandle.set(key, { ...candidate, provenance: [...candidate.provenance] })
+        }
       }
       for (const [key, value] of Object.entries(result.policies)) {
         if (!(policies as Record<string, unknown>)[key] && value != null) {
@@ -63,5 +65,5 @@ export const extractManifest: Extractor = async (target, deps) => {
     }
   }
 
-  return { contacts, policies, handleCandidates }
+  return { contacts, policies, handleCandidates: [...candidatesByHandle.values()] }
 }

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/index.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/index.ts
@@ -29,7 +29,9 @@ const FETCHERS: Record<string, EcosystemFetcher> = {
 export const extractManifest: Extractor = async (target, deps) => {
   const contacts: RawContact[] = []
   const policies: Partial<RepoPolicies> = {}
+  const handleCandidates: RawContact[] = []
   const seenPurls = new Set<string>()
+  const seenCandidates = new Set<string>()
 
   for (const pkg of target.packages) {
     if (seenPurls.has(pkg.purl)) continue
@@ -44,6 +46,12 @@ export const extractManifest: Extractor = async (target, deps) => {
     try {
       const result = await fetcher(parsed, deps.fetchTimeoutMs, deps.userAgent)
       contacts.push(...result.contacts)
+      for (const candidate of result.handleCandidates ?? []) {
+        const key = candidate.value.toLowerCase()
+        if (seenCandidates.has(key)) continue
+        seenCandidates.add(key)
+        handleCandidates.push(candidate)
+      }
       for (const [key, value] of Object.entries(result.policies)) {
         if (!(policies as Record<string, unknown>)[key] && value != null) {
           ;(policies as Record<string, unknown>)[key] = value
@@ -55,5 +63,5 @@ export const extractManifest: Extractor = async (target, deps) => {
     }
   }
 
-  return { contacts, policies }
+  return { contacts, policies, handleCandidates }
 }

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/rubygems.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/rubygems.ts
@@ -67,6 +67,35 @@ export function mapRubygemsOwners(
   return contacts
 }
 
+// RubyGems accounts are independent of GitHub, so a handle matching a GitHub login is only a
+// guess — emitted as candidates that must pass repo-contributor corroboration before use.
+export function mapRubygemsOwnerHandles(
+  owners: unknown,
+  sourceUrl: string,
+  fetchedAt: string,
+): RawContact[] {
+  if (!Array.isArray(owners)) return []
+
+  const candidates: RawContact[] = []
+  const seen = new Set<string>()
+  for (const owner of owners) {
+    const o = (owner ?? {}) as Record<string, unknown>
+    if (typeof o.email === 'string' && isEmail(o.email)) continue
+    if (typeof o.handle !== 'string' || o.handle.length === 0) continue
+    const key = o.handle.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    candidates.push({
+      channel: 'github-handle',
+      value: o.handle,
+      role: 'maintainer',
+      tier: 'B',
+      provenance: [{ source: SOURCE, sourceTier: 'B', path: sourceUrl, fetchedAt }],
+    })
+  }
+  return candidates
+}
+
 export async function fetchRubygems(
   parsed: ParsedPurl,
   timeoutMs: number,
@@ -91,5 +120,9 @@ export async function fetchRubygems(
     ...mapRubygemsOwners(ownersResult.json, ownersUrl, fetchedAt),
   ]
 
-  return { contacts, policies: {} }
+  return {
+    contacts,
+    policies: {},
+    handleCandidates: mapRubygemsOwnerHandles(ownersResult.json, ownersUrl, fetchedAt),
+  }
 }

--- a/services/apps/packages_worker/src/security-contacts/processBatch.ts
+++ b/services/apps/packages_worker/src/security-contacts/processBatch.ts
@@ -26,6 +26,7 @@ import {
   RepoPolicies,
   RepoTarget,
 } from './types'
+import { verifyHandleCandidates } from './verifyHandleCandidates'
 import { writeContactsBatch } from './writeContacts'
 
 const log = getServiceChildLogger('security-contacts')
@@ -150,9 +151,11 @@ export async function processRepo(
 
   let contacts: RawContact[] = []
   const policies: Partial<RepoPolicies> = {}
+  const handleCandidates: RawContact[] = []
   for (const r of results) {
     if (r.status !== 'fulfilled') continue
     contacts.push(...r.value.contacts)
+    handleCandidates.push(...(r.value.handleCandidates ?? []))
     for (const [key, value] of Object.entries(r.value.policies)) {
       if (!(policies as Record<string, unknown>)[key] && value != null) {
         ;(policies as Record<string, unknown>)[key] = value
@@ -164,6 +167,8 @@ export async function processRepo(
   if (policies.pvrEnabled === false) {
     contacts = contacts.filter((c) => c.channel !== 'github-pvr')
   }
+
+  contacts.push(...(await verifyHandleCandidates(target, deps, handleCandidates)))
 
   contacts.push(...deriveGithubHandlesFromNoreplyEmails(contacts))
 

--- a/services/apps/packages_worker/src/security-contacts/types.ts
+++ b/services/apps/packages_worker/src/security-contacts/types.ts
@@ -46,6 +46,9 @@ export interface RepoPolicies {
 export interface ExtractorResult {
   contacts: RawContact[]
   policies: Partial<RepoPolicies>
+  /** Registry usernames that only *might* be GitHub logins — never written without
+   *  corroboration (see verifyHandleCandidates.ts). */
+  handleCandidates?: RawContact[]
 }
 
 export interface RepoPackage {

--- a/services/apps/packages_worker/src/security-contacts/verifyHandleCandidates.ts
+++ b/services/apps/packages_worker/src/security-contacts/verifyHandleCandidates.ts
@@ -1,0 +1,69 @@
+import { getServiceChildLogger } from '@crowd/logging'
+
+import { parseGithubUrl } from '../enricher/fetchLightRepo'
+
+import { ExtractorDeps, RawContact, RepoTarget } from './types'
+
+const log = getServiceChildLogger('security-contacts')
+
+interface ContributorEntry {
+  login?: unknown
+}
+
+/**
+ * Corroborates registry usernames that are only *guessed* to be GitHub logins (e.g. RubyGems
+ * owners). A candidate is confirmed only when the same login owns the repo or appears in its
+ * top-100 contributors — existence of a github.com/<handle> account alone is not enough, since
+ * an unrelated person or bot can hold that name.
+ */
+export async function verifyHandleCandidates(
+  target: RepoTarget,
+  deps: Pick<ExtractorDeps, 'githubGet'>,
+  candidates: RawContact[],
+): Promise<RawContact[]> {
+  if (candidates.length === 0) return []
+
+  let owner: string
+  let name: string
+  try {
+    ;({ owner, name } = parseGithubUrl(target.url))
+  } catch {
+    return []
+  }
+
+  const path = `/repos/${owner}/${name}/contributors?per_page=100`
+  const corroborated = new Set<string>([owner.toLowerCase()])
+  try {
+    const { text } = await deps.githubGet(path)
+    if (text) {
+      const entries = JSON.parse(text) as ContributorEntry[]
+      if (Array.isArray(entries)) {
+        for (const e of entries) {
+          if (typeof e.login === 'string') corroborated.add(e.login.toLowerCase())
+        }
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { repoId: target.repoId, errMsg: (err as Error).message },
+      'Contributor lookup failed — dropping handle candidates',
+    )
+    return []
+  }
+
+  const fetchedAt = new Date().toISOString()
+  return candidates
+    .filter((c) => corroborated.has(c.value.toLowerCase()))
+    .map((c) => ({
+      ...c,
+      provenance: [
+        ...c.provenance,
+        {
+          source: 'github-contributors',
+          sourceTier: c.tier,
+          path: `https://api.github.com${path}`,
+          fetchedAt,
+        },
+      ],
+    }))
+}

--- a/services/apps/packages_worker/src/security-contacts/verifyHandleCandidates.ts
+++ b/services/apps/packages_worker/src/security-contacts/verifyHandleCandidates.ts
@@ -32,14 +32,14 @@ export async function verifyHandleCandidates(
   }
 
   const path = `/repos/${owner}/${name}/contributors?per_page=100`
-  const corroborated = new Set<string>([owner.toLowerCase()])
+  const contributors = new Set<string>()
   try {
     const { text } = await deps.githubGet(path)
     if (text) {
       const entries = JSON.parse(text) as ContributorEntry[]
       if (Array.isArray(entries)) {
         for (const e of entries) {
-          if (typeof e.login === 'string') corroborated.add(e.login.toLowerCase())
+          if (typeof e.login === 'string') contributors.add(e.login.toLowerCase())
         }
       }
     }
@@ -52,18 +52,25 @@ export async function verifyHandleCandidates(
   }
 
   const fetchedAt = new Date().toISOString()
-  return candidates
-    .filter((c) => corroborated.has(c.value.toLowerCase()))
-    .map((c) => ({
+  const confirmed: RawContact[] = []
+  for (const c of candidates) {
+    const handle = c.value.toLowerCase()
+    const viaContributors = contributors.has(handle)
+    if (!viaContributors && handle !== owner.toLowerCase()) continue
+    confirmed.push({
       ...c,
       provenance: [
         ...c.provenance,
-        {
-          source: 'github-contributors',
-          sourceTier: c.tier,
-          path: `https://api.github.com${path}`,
-          fetchedAt,
-        },
+        viaContributors
+          ? {
+              source: 'github-contributors',
+              sourceTier: c.tier,
+              path: `https://api.github.com${path}`,
+              fetchedAt,
+            }
+          : { source: 'github-repo-owner', sourceTier: c.tier, path: target.url, fetchedAt },
       ],
-    }))
+    })
+  }
+  return confirmed
 }


### PR DESCRIPTION
This pull request enhances the security contacts extraction process by introducing a mechanism to identify and verify registry usernames that might correspond to GitHub handles, but require corroboration before being accepted as valid contacts. The changes mainly add support for handling such "handle candidates" (especially for RubyGems), collecting them during extraction, and confirming their association with a repository via contributor checks before inclusion.

**New candidate handle extraction and verification:**

* Added a new function `mapRubygemsOwnerHandles` in `rubygems.ts` to extract possible GitHub handles from RubyGems owners, marking them as candidates that require further verification.
* Updated the RubyGems fetcher (`fetchRubygems`) to return both direct contacts and these handle candidates.
* Updated the extractor interface and result type (`ExtractorResult` in `types.ts`) to include an optional `handleCandidates` field.
* Modified the main manifest extraction logic (`extractManifest` in `index.ts`) to collect and deduplicate handle candidates from all fetchers. [[1]](diffhunk://#diff-2282dea20f7d818451e6f201b91e30263e6315d45d7ea4373c9b3de89f6faf3aR32-R34) [[2]](diffhunk://#diff-2282dea20f7d818451e6f201b91e30263e6315d45d7ea4373c9b3de89f6faf3aR49-R54) [[3]](diffhunk://#diff-2282dea20f7d818451e6f201b91e30263e6315d45d7ea4373c9b3de89f6faf3aL58-R66)

**Handle candidate verification and integration:**

* Introduced a new module, `verifyHandleCandidates.ts`, which verifies candidate handles by checking if they are the repo owner or a top-100 contributor, only accepting corroborated handles as contacts.
* Updated `processBatch.ts` to collect all handle candidates from extractors, verify them using the new function, and only then add them to the final contacts list. [[1]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90R29) [[2]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90R154-R158) [[3]](diffhunk://#diff-45b96b785c4634710dd9989fd1b7fb746ed60143a4cbce9d909140a75da89b90R171-R172)

These changes improve the accuracy and reliability of GitHub handle extraction from package registries, reducing the risk of false positives.