### PR TITLE
feat: resolve nuget owner handles via github contributor verification [CM-1341]

### DIFF
--- a/services/apps/packages_worker/src/nuget/client.ts
+++ b/services/apps/packages_worker/src/nuget/client.ts
@@ -26,7 +26,7 @@ interface ResolvedEndpoints {
 
 let cachedEndpoints: ResolvedEndpoints | null = null
 
-async function resolveEndpoints(): Promise<ResolvedEndpoints> {
+export async function resolveEndpoints(): Promise<ResolvedEndpoints> {
   if (cachedEndpoints) return cachedEndpoints
 
   const resp = await axios.get<ServiceIndex>(SERVICE_INDEX_URL, {

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/handles.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/handles.ts
@@ -1,0 +1,28 @@
+import { ProvenanceEntry, RawContact } from '../../types'
+
+// Registry usernames are only *guessed* to be GitHub logins — callers emit them as candidates
+// that must pass verifyHandleCandidates corroboration before becoming contacts.
+export function toHandleCandidates(
+  handles: unknown[],
+  source: string,
+  sourceUrl: string,
+  fetchedAt: string,
+): RawContact[] {
+  const prov = (): ProvenanceEntry[] => [{ source, sourceTier: 'B', path: sourceUrl, fetchedAt }]
+  const candidates: RawContact[] = []
+  const seen = new Set<string>()
+  for (const handle of handles) {
+    if (typeof handle !== 'string' || handle.length === 0) continue
+    const key = handle.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    candidates.push({
+      channel: 'github-handle',
+      value: handle,
+      role: 'maintainer',
+      tier: 'B',
+      provenance: prov(),
+    })
+  }
+  return candidates
+}

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
@@ -3,10 +3,14 @@ import { XMLParser } from 'fast-xml-parser'
 import { ExtractorResult, ProvenanceEntry, RawContact } from '../../types'
 import { extractEmails, fetchJson, fetchText, registryHeaders } from '../http'
 
+import { toHandleCandidates } from './handles'
 import { ParsedPurl } from './purl'
 
 const SOURCE = 'nuget-nuspec'
+const SEARCH_SOURCE = 'nuget-search'
 const BASE = 'https://api.nuget.org/v3-flatcontainer'
+// Owner usernames are only exposed by the search service, not the flatcontainer API.
+const SEARCH_BASE = 'https://azuresearch-usnc.nuget.org/query'
 const parser = new XMLParser({ ignoreAttributes: true })
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -45,6 +49,22 @@ export function mapNuspec(xml: string, sourceUrl: string, fetchedAt: string): Ra
   return contacts
 }
 
+// NuGet.org accounts are independent of GitHub, so an owner username matching a GitHub login is
+// only a guess — emitted as candidates that must pass repo-contributor corroboration before use.
+export function mapNugetOwnerHandles(
+  doc: unknown,
+  packageId: string,
+  sourceUrl: string,
+  fetchedAt: string,
+): RawContact[] {
+  const data = (doc as any)?.data
+  if (!Array.isArray(data) || data.length === 0) return []
+  const entry = data[0] as Record<string, unknown>
+  if (typeof entry.id !== 'string' || entry.id.toLowerCase() !== packageId.toLowerCase()) return []
+  if (!Array.isArray(entry.owners)) return []
+  return toHandleCandidates(entry.owners, SEARCH_SOURCE, sourceUrl, fetchedAt)
+}
+
 async function latestStableVersion(
   id: string,
   timeoutMs: number,
@@ -67,11 +87,23 @@ export async function fetchNuget(
   userAgent: string,
 ): Promise<ExtractorResult> {
   const id = parsed.name.toLowerCase()
-  const version = await latestStableVersion(id, timeoutMs, userAgent)
-  if (!version) return { contacts: [], policies: {} }
+  const searchUrl = `${SEARCH_BASE}?q=packageid:${encodeURIComponent(id)}&prerelease=true&semVerLevel=2.0.0`
+  const fetchedAt = new Date().toISOString()
+
+  const [version, searchResult] = await Promise.all([
+    latestStableVersion(id, timeoutMs, userAgent),
+    fetchJson(searchUrl, timeoutMs, registryHeaders(userAgent)).catch(() => ({
+      status: 0,
+      json: null,
+    })),
+  ])
+
+  const handleCandidates = mapNugetOwnerHandles(searchResult.json, id, searchUrl, fetchedAt)
+
+  if (!version) return { contacts: [], policies: {}, handleCandidates }
 
   const url = `${BASE}/${id}/${version}/${id}.nuspec`
   const { text } = await fetchText(url, timeoutMs, registryHeaders(userAgent))
-  if (!text) return { contacts: [], policies: {} }
-  return { contacts: mapNuspec(text, url, new Date().toISOString()), policies: {} }
+  if (!text) return { contacts: [], policies: {}, handleCandidates }
+  return { contacts: mapNuspec(text, url, fetchedAt), policies: {}, handleCandidates }
 }

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from 'fast-xml-parser'
 
+import { resolveEndpoints } from '../../../nuget/client'
 import { ExtractorResult, ProvenanceEntry, RawContact } from '../../types'
 import { extractEmails, fetchJson, fetchText, registryHeaders } from '../http'
 
@@ -9,8 +10,6 @@ import { ParsedPurl } from './purl'
 const SOURCE = 'nuget-nuspec'
 const SEARCH_SOURCE = 'nuget-search'
 const BASE = 'https://api.nuget.org/v3-flatcontainer'
-// Owner usernames are only exposed by the search service, not the flatcontainer API.
-const SEARCH_BASE = 'https://azuresearch-usnc.nuget.org/query'
 const parser = new XMLParser({ ignoreAttributes: true })
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -69,6 +68,24 @@ export function mapNugetOwnerHandles(
   return toHandleCandidates(entry.owners, SEARCH_SOURCE, sourceUrl, fetchedAt)
 }
 
+// Owner usernames are only exposed by the search service, not the flatcontainer API; the
+// search host is resolved from the V3 service index (it is regional and can rotate).
+async function fetchOwnerCandidates(
+  id: string,
+  timeoutMs: number,
+  userAgent: string,
+  fetchedAt: string,
+): Promise<RawContact[]> {
+  try {
+    const { searchBaseUrl } = await resolveEndpoints()
+    const searchUrl = `${searchBaseUrl}?q=packageid:${encodeURIComponent(id)}&prerelease=true&semVerLevel=2.0.0`
+    const { json } = await fetchJson(searchUrl, timeoutMs, registryHeaders(userAgent))
+    return mapNugetOwnerHandles(json, id, searchUrl, fetchedAt)
+  } catch {
+    return []
+  }
+}
+
 async function latestStableVersion(
   id: string,
   timeoutMs: number,
@@ -91,18 +108,12 @@ export async function fetchNuget(
   userAgent: string,
 ): Promise<ExtractorResult> {
   const id = parsed.name.toLowerCase()
-  const searchUrl = `${SEARCH_BASE}?q=packageid:${encodeURIComponent(id)}&prerelease=true&semVerLevel=2.0.0`
   const fetchedAt = new Date().toISOString()
 
-  const [version, searchResult] = await Promise.all([
+  const [version, handleCandidates] = await Promise.all([
     latestStableVersion(id, timeoutMs, userAgent),
-    fetchJson(searchUrl, timeoutMs, registryHeaders(userAgent)).catch(() => ({
-      status: 0,
-      json: null,
-    })),
+    fetchOwnerCandidates(id, timeoutMs, userAgent, fetchedAt),
   ])
-
-  const handleCandidates = mapNugetOwnerHandles(searchResult.json, id, searchUrl, fetchedAt)
 
   if (!version) return { contacts: [], policies: {}, handleCandidates }
 

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/nuget.ts
@@ -58,10 +58,14 @@ export function mapNugetOwnerHandles(
   fetchedAt: string,
 ): RawContact[] {
   const data = (doc as any)?.data
-  if (!Array.isArray(data) || data.length === 0) return []
-  const entry = data[0] as Record<string, unknown>
-  if (typeof entry.id !== 'string' || entry.id.toLowerCase() !== packageId.toLowerCase()) return []
-  if (!Array.isArray(entry.owners)) return []
+  if (!Array.isArray(data)) return []
+  // The exact package is not guaranteed to be the first result — scan for the id match,
+  // same as fetchSearch in src/nuget/client.ts.
+  const lowerId = packageId.toLowerCase()
+  const entry = data.find((e) => typeof e?.id === 'string' && e.id.toLowerCase() === lowerId) as
+    | Record<string, unknown>
+    | undefined
+  if (!entry || !Array.isArray(entry.owners)) return []
   return toHandleCandidates(entry.owners, SEARCH_SOURCE, sourceUrl, fetchedAt)
 }
 

--- a/services/apps/packages_worker/src/security-contacts/extractors/registry/rubygems.ts
+++ b/services/apps/packages_worker/src/security-contacts/extractors/registry/rubygems.ts
@@ -1,6 +1,7 @@
 import { ExtractorResult, ProvenanceEntry, RawContact } from '../../types'
 import { extractEmails, fetchJson, isEmail, registryHeaders } from '../http'
 
+import { toHandleCandidates } from './handles'
 import { ParsedPurl } from './purl'
 
 const SOURCE = 'rubygems'
@@ -76,24 +77,11 @@ export function mapRubygemsOwnerHandles(
 ): RawContact[] {
   if (!Array.isArray(owners)) return []
 
-  const candidates: RawContact[] = []
-  const seen = new Set<string>()
-  for (const owner of owners) {
-    const o = (owner ?? {}) as Record<string, unknown>
-    if (typeof o.email === 'string' && isEmail(o.email)) continue
-    if (typeof o.handle !== 'string' || o.handle.length === 0) continue
-    const key = o.handle.toLowerCase()
-    if (seen.has(key)) continue
-    seen.add(key)
-    candidates.push({
-      channel: 'github-handle',
-      value: o.handle,
-      role: 'maintainer',
-      tier: 'B',
-      provenance: [{ source: SOURCE, sourceTier: 'B', path: sourceUrl, fetchedAt }],
-    })
-  }
-  return candidates
+  const handles = owners
+    .map((owner) => (owner ?? {}) as Record<string, unknown>)
+    .filter((o) => !(typeof o.email === 'string' && isEmail(o.email)))
+    .map((o) => o.handle)
+  return toHandleCandidates(handles, SOURCE, sourceUrl, fetchedAt)
 }
 
 export async function fetchRubygems(


### PR DESCRIPTION
This pull request refactors and enhances the extraction of candidate GitHub handles from package registries (NuGet and RubyGems) to improve maintainability and consistency. It introduces a shared utility for generating handle candidates, updates the NuGet extractor to emit owner handles, and simplifies the RubyGems extractor logic.

**Handle extraction improvements:**

* Added a new utility function `toHandleCandidates` in `handles.ts` to generate deduplicated, provenance-rich candidate GitHub handles for maintainers. This function is now used by both NuGet and RubyGems extractors to standardize candidate handle generation.

**NuGet extractor enhancements:**

* Updated `nuget.ts` to fetch and emit candidate owner handles from the NuGet search API, using the new `toHandleCandidates` utility. The extractor now returns these candidates in the `handleCandidates` field, improving downstream corroboration of maintainers. [[1]](diffhunk://#diff-ebce08c6b3baa51e4ea6d668e44b6818ca4bd00e040623aeef9ed170653d5c9cR6-R13) [[2]](diffhunk://#diff-ebce08c6b3baa51e4ea6d668e44b6818ca4bd00e040623aeef9ed170653d5c9cR52-R67) [[3]](diffhunk://#diff-ebce08c6b3baa51e4ea6d668e44b6818ca4bd00e040623aeef9ed170653d5c9cL70-R108)

**RubyGems extractor simplification:**

* Refactored `mapRubygemsOwnerHandles` in `rubygems.ts` to use the shared `toHandleCandidates` function, reducing code duplication and improving clarity. [[1]](diffhunk://#diff-efef48659e1da55fa35036a4a01031599d3bf3312e7f568871a0f488766d4a73R4) [[2]](diffhunk://#diff-efef48659e1da55fa35036a4a01031599d3bf3312e7f568871a0f488766d4a73L79-R84)