### PR TITLE
feat: add organization search to global search pipe (IN-1206)

### DIFF
--- a/services/libs/tinybird/pipes/organizations_filtered.pipe
+++ b/services/libs/tinybird/pipes/organizations_filtered.pipe
@@ -1,0 +1,31 @@
+DESCRIPTION >
+    Provides filters for organizations
+
+NODE organizations_filtered_0
+SQL >
+    %
+    SELECT
+        organizations_populated_slug.id AS id,
+        organizations_populated_slug.displayName AS displayName,
+        organizations_populated_slug.logo AS logo,
+        organizations_populated_slug.slug AS slug,
+        organizations_populated_slug.contributionCount AS contributionCount
+    FROM organizations_populated_slug
+    where
+        1 = 1
+        {% if defined(slug) %}
+            AND organizations_populated_slug.slug
+            = {{ String(slug, description="Filter organization by slug", required=False) }}
+        {% end %}
+        {% if defined(search) %}
+            AND organizations_populated_slug.displayName
+            ilike '%'
+            || {{
+                String(
+                    search,
+                    description="Search organization open ended wildcard using displayName",
+                    required=False,
+                )
+            }}
+            || '%'
+        {% end %}

--- a/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
+++ b/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
@@ -1,14 +1,14 @@
 DESCRIPTION >
-    - `search_collections_projects_repos.pipe` serves the unified search widget for collections, projects, and repositories.
-    - Performs search across three entity types using shared `search` parameter and returns up to configurable results per type.
-    - Combines results from `collections_filtered`, `insightsProjects_filtered`, and `activityRepositories_filtered` pipes.
+    - `search_collections_projects_repos.pipe` serves the unified search widget for collections, projects, repositories, and organizations.
+    - Performs search across four entity types using shared `search` parameter and returns up to configurable results per type.
+    - Combines results from `collections_filtered`, `insightsProjects_filtered`, `activityRepositories_filtered`, and `organizations_filtered` pipes.
     - Filters out inactive projects (with 0 organizations and 0 contributors) to ensure relevant search results.
-    - Orders results by relevance: collections by project count, projects by contributor count, repositories alphabetically.
+    - Orders results by relevance: collections by project count, projects by contributor count, repositories alphabetically, organizations by contribution count.
     - Primary use case: powering global search functionality and autocomplete dropdowns across the platform.
     - Parameters:
     - `search`: Required string for searching across all entity types (inherited by filtered pipes)
     - `limit`: Optional integer for result limit per entity type, defaults to 10
-    - Response: `type` ('collection'|'project'|'repository'), `id` (projectId only), `slug`, `logo`, `projectSlug`, `name`
+    - Response: `type` ('collection'|'project'|'repository'|'organization'), `id` (projectId only), `slug`, `logo`, `projectSlug`, `name`
 
 NODE merge_results_from_collections_projects_repos_filtered
 SQL >
@@ -52,4 +52,16 @@ SQL >
         '' as status
     from activityRepositories_filtered
     order by activityRepositories_filtered.repo asc
+    limit {{ Integer(limit, 10, description="Limit number of records for each type", required=False) }}
+    union all
+    select
+        'organization' as type,
+        organizations_filtered.id,
+        organizations_filtered.slug,
+        organizations_filtered.logo,
+        null as "projectSlug",
+        organizations_filtered.displayName as name,
+        '' as status
+    from organizations_filtered
+    order by organizations_filtered.contributionCount desc
     limit {{ Integer(limit, 10, description="Limit number of records for each type", required=False) }}


### PR DESCRIPTION
## What

Adds **organizations** as a 4th result type to the global search Tinybird pipe, so the LFX Insights search bar can return organizations alongside projects, repositories, and collections. Backs insights ticket **IN-1206**.

- **New** `services/libs/tinybird/pipes/organizations_filtered.pipe` — a `*_filtered`-family sub-pipe over the existing `organizations_populated_slug` datasource, with an optional `search` (ILIKE on `displayName`) and `slug` filter. Mirrors `collections_filtered.pipe`.
- **Edit** `services/libs/tinybird/pipes/search_collections_projects_repos.pipe` — adds a 4th `UNION ALL` branch selecting `type='organization'` (id, slug, logo, displayName→name), ordered by `contributionCount desc`. DESCRIPTION updated.