### PR TITLE
feat: filter org search to code contributors only (IN-1206)

### DIFF
--- a/services/libs/tinybird/pipes/organizations_filtered.pipe
+++ b/services/libs/tinybird/pipes/organizations_filtered.pipe
@@ -1,5 +1,19 @@
 DESCRIPTION >
-    Provides filters for organizations
+    Provides filters for organizations.
+    Only returns organizations that have at least one code contribution (commits, PRs, code
+    reviews), matching what the organization page dashboard actually renders. Organizations
+    with only non-code activity — or that were deleted in CDP but are still stale in Tinybird —
+    are excluded so search never links to an empty org dashboard.
+
+NODE organizations_code_contributors
+DESCRIPTION >
+    Distinct organizations that have at least one code contribution activity, sourced from the
+    precomputed org-page timeseries (already filtered to isCodeContribution activity types).
+
+SQL >
+    SELECT DISTINCT organizationId
+    FROM org_page_activities_timeseries_copy_ds
+    WHERE organizationId != ''
 
 NODE organizations_filtered_0
 SQL >
@@ -11,6 +25,8 @@ SQL >
         organizations_populated_slug.slug AS slug,
         organizations_populated_slug.contributionCount AS contributionCount
     FROM organizations_populated_slug
+    INNER JOIN organizations_code_contributors
+        ON organizations_populated_slug.id = organizations_code_contributors.organizationId
     where
         1 = 1
         {% if defined(slug) %}

--- a/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
+++ b/services/libs/tinybird/pipes/search_collections_projects_repos.pipe
@@ -3,6 +3,7 @@ DESCRIPTION >
     - Performs search across four entity types using shared `search` parameter and returns up to configurable results per type.
     - Combines results from `collections_filtered`, `insightsProjects_filtered`, `activityRepositories_filtered`, and `organizations_filtered` pipes.
     - Filters out inactive projects (with 0 organizations and 0 contributors) to ensure relevant search results.
+    - Filters out organizations with no code contributions (via `organizations_filtered`) so search never links to an empty org dashboard.
     - Orders results by relevance: collections by project count, projects by contributor count, repositories alphabetically, organizations by contribution count.
     - Primary use case: powering global search functionality and autocomplete dropdowns across the platform.
     - Parameters:


### PR DESCRIPTION
## What

Filters the global search **organization** results down to orgs that actually have code contributions, so search never links to an empty organization dashboard. Follow-up to #4368, backs insights ticket **IN-1206**.

## Why

The org results in global search come from `organizations_populated_slug`, ordered by `contributionCount`. That `contributionCount` is `countState(activityId)` — it counts **all** activities, not just code contributions. Meanwhile the organization page dashboard only renders activity where `(type, platform)` matches an `activityTypes` row with `isCodeContribution = true`.

Verified against prod Tinybird:

- **519,349** orgs were searchable (all have `contributionCount > 0`, so a naive `contributionCount = 0` filter is a no-op).
- Only **198,694** of them have any code contributions.
- So ~62% of searchable orgs had activity but **zero code contributions** → they linked to an empty dashboard. Examples with huge activity but no code contributions: *Eventual Inc* (2.2M), *Groups.io Inc* (610K), *Databricks* (257K).

Orgs deleted in CDP also linger as stale rows in Tinybird — this filter drops those too, since they have no code-contribution activity.

## How

`organizations_filtered.pipe` now `INNER JOIN`s against the distinct set of org IDs in `org_page_activities_timeseries_copy_ds` — the precomputed datasource that is already scoped to `isCodeContribution` activity types (10-year window), i.e. the exact definition the org page uses. Only orgs that would render something on the dashboard survive.

`organizations_filtered` is consumed **only** by `search_collections_projects_repos.pipe`, so org pages, leaderboards, and the shared `organizations_populated_slug` datasource are unaffected.

## Result (validated on prod)

- Searchable orgs: **519,349 → 198,583**.
- Stale high-activity, no-code orgs (Eventual Inc, Groups.io, Databricks) no longer appear.
- Real orgs preserved (Google, Kubernetes, etc.).

## Deploy order

⚠️ This Tinybird pipe change must be **deployed to prod before** it takes effect for the Insights search bar (which already consumes the pipe via #4368 / IN-1206).

## Test plan

- [x] Confirmed `contributionCount = 0` filter is a no-op (0 rows) — wrong approach.
- [x] Confirmed `org_page_activities_timeseries_copy_ds` join removes non-code orgs (Eventual Inc et al.) and preserves code-contributing orgs (Google, Kubernetes).
- [x] Confirmed row-count drop (519k → 199k) matches the count of code-contributing orgs.
