### PR TITLE
fix: add security insights yaml to known maintainers paths

### DIFF
--- a/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
+++ b/services/apps/git_integration/src/crowdgit/services/maintainer/maintainer_service.py
@@ -72,6 +72,8 @@ class MaintainerService(BaseService):
         ".github/contributors.md",
         ".github/codeowners",
         "security-insights.md",
+        "security-insights.yml",
+        "security-insights.yaml",
         "readme.md",
     }
 


### PR DESCRIPTION
This pull request makes a minor update to the `MaintainerService` class by expanding the set of recognized security insights files. Now, both `security-insights.yml` and `security-insights.yaml` are included alongside the previously supported `security-insights.md`.

* Added support for `security-insights.yml` and `security-insights.yaml` files in the set of recognized security insights files in `MaintainerService` (`maintainer_service.py`).