### PR TITLE
perf: optimize enrichable members selection query

### DIFF
--- a/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
@@ -189,6 +189,7 @@ export async function fetchMembersForEnrichment(
          ) AS identities,
          c."activityCount"
     FROM candidates c
+         INNER JOIN members ON members.id = c.id
          INNER JOIN "memberIdentities" mi
            ON mi."memberId" = c.id
           AND mi."deletedAt" IS NULL

--- a/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
@@ -137,7 +137,7 @@ export async function fetchMembersForEnrichment(
           SELECT 1 FROM "memberEnrichmentCache" mec
           WHERE mec."memberId" = members.id
           AND mec.source = '${input.source}'
-          AND EXTRACT(EPOCH FROM (now() - mec."updatedAt")) < ${input.cacheObsoleteAfterSeconds})
+          AND mec."updatedAt" > now() - make_interval(secs => ${input.cacheObsoleteAfterSeconds}))
       )`,
       )
     }
@@ -145,19 +145,40 @@ export async function fetchMembersForEnrichment(
     enrichableBySqlConditions.push(`(${input.enrichableBySql})`)
   })
 
-  let enrichableBySqlJoined = ''
+  const enrichableBySqlJoined =
+    enrichableBySqlConditions.length > 0 ? `(${enrichableBySqlConditions.join(' OR ')})` : 'TRUE'
 
-  if (enrichableBySqlConditions.length > 0) {
-    enrichableBySqlJoined = `(${enrichableBySqlConditions.join(' OR ')}) `
-  }
-
+  // Pick top-N by activity first, then load identities for those rows only.
   return db.connection().query(
     `
+    WITH candidates AS (
+      SELECT
+           members.id,
+           members."displayName",
+           members.attributes->'location'->>'default' AS location,
+           members.attributes->'websiteUrl'->>'default' AS website,
+           coalesce("membersGlobalActivityCount".total_count, 0) AS "activityCount"
+      FROM "membersGlobalActivityCount"
+           INNER JOIN members ON members.id = "membersGlobalActivityCount"."memberId"
+      WHERE members."deletedAt" IS NULL
+        AND coalesce((members.attributes ->'isBot'->>'default')::boolean, false) = false
+        AND coalesce((members.attributes ->'isOrganization'->>'default')::boolean, false) = false
+        AND EXISTS (
+          SELECT 1
+          FROM "memberIdentities" mi
+          WHERE mi."memberId" = members.id
+            AND mi."deletedAt" IS NULL
+            AND ${enrichableBySqlJoined}
+        )
+        AND (${cacheAgeInnerQueryItems.join(' OR ')})
+      ORDER BY "membersGlobalActivityCount".total_count DESC
+      LIMIT $1
+    )
     SELECT
-         members."id",
-         members."displayName",
-         members.attributes->'location'->>'default' AS location,
-         members.attributes->'websiteUrl'->>'default' AS website,
+         c.id,
+         c."displayName",
+         c.location,
+         c.website,
          JSON_AGG(
            JSON_BUILD_OBJECT(
              'platform', mi.platform,
@@ -166,19 +187,17 @@ export async function fetchMembersForEnrichment(
              'verified', mi.verified
            )
          ) AS identities,
-         MAX(coalesce("membersGlobalActivityCount".total_count, 0)) AS "activityCount"
-    FROM members
-         INNER JOIN "memberIdentities" mi ON mi."memberId" = members.id and mi."deletedAt" is null
-         LEFT JOIN "membersGlobalActivityCount" ON "membersGlobalActivityCount"."memberId" = members.id
-    WHERE
-      ${enrichableBySqlJoined}
-      AND coalesce((members.attributes ->'isBot'->>'default')::boolean, false) = false 
-      AND coalesce((members.attributes ->'isOrganization'->>'default')::boolean, false) = false
-      AND members."deletedAt" IS NULL
-      AND (${cacheAgeInnerQueryItems.join(' OR ')})
-    GROUP BY members.id
-    ORDER BY "activityCount" DESC
-    LIMIT $1;
+         c."activityCount"
+    FROM candidates c
+         INNER JOIN "memberIdentities" mi
+           ON mi."memberId" = c.id
+          AND mi."deletedAt" IS NULL
+         CROSS JOIN LATERAL (
+           SELECT c."activityCount" AS total_count
+         ) AS "membersGlobalActivityCount"
+    WHERE ${enrichableBySqlJoined}
+    GROUP BY c.id, c."displayName", c.location, c.website, c."activityCount"
+    ORDER BY c."activityCount" DESC;
     `,
     [limit],
   )


### PR DESCRIPTION
## Summary
`fetchMembersForEnrichment` was selecting enrichable members by scanning a huge identity join, aggregating, then sorting — so `LIMIT 500` only applied at the end and the query regularly ran for tens of minutes.

## Changes
- Rewrite the query to walk `membersGlobalActivityCount` high → low, apply the same enrichability / cache / bot filters, take `LIMIT` first, then `json_agg` identities for those candidates only
- Keep the same result shape and enrichable identity filtering used by the enrichment worker
- Express cache freshness as `updatedAt > now() - make_interval(...)` (same meaning as the old epoch check)