### PR TITLE
feat: implment bulk radius api (CM-1328)

### DIFF
--- a/backend/src/api/public/v1/akrites-external/index.ts
+++ b/backend/src/api/public/v1/akrites-external/index.ts
@@ -13,7 +13,9 @@ import { getAkritesExternalPackageDetail } from '../packages/getAkritesExternalP
 import { getAkritesExternalPackageDetailBatch } from '../packages/getAkritesExternalPackageDetailBatch'
 import { getBlastRadiusJob } from '../packages/getBlastRadiusJob'
 import { ingestAkritesExternalContactDetail } from '../packages/ingestAkritesExternalContactDetail'
+import { getBlastRadiusJobBatch } from '../packages/getBlastRadiusJobBatch'
 import { submitBlastRadiusJob } from '../packages/submitBlastRadiusJob'
+import { submitBlastRadiusJobBatch } from '../packages/submitBlastRadiusJobBatch'
 
 const rateLimiter = createRateLimiter({ max: 60, windowMs: 60 * 1000 })
 
@@ -110,7 +112,22 @@ export function akritesExternalRouter(): Router {
   const blastRadiusSubRouter = Router()
   blastRadiusSubRouter.use(requireScopes([SCOPES.READ_PACKAGES]))
   blastRadiusSubRouter.post('/jobs', blastRadiusRateLimiter, safeWrap(submitBlastRadiusJob))
+  // Bulk submit multiplies Temporal workflow starts per request (up to
+  // MAX_BLAST_RADIUS_JOBS_PER_BATCH), so it sits behind the same strict
+  // blastRadiusRateLimiter as the single-job route, not the regular one.
+  blastRadiusSubRouter.post(
+    /^\/jobs:batch\/?$/,
+    blastRadiusRateLimiter,
+    safeWrap(submitBlastRadiusJobBatch),
+  )
   blastRadiusSubRouter.get('/jobs/:analysisId', rateLimiter, safeWrap(getBlastRadiusJob))
+  // Bulk poll is read-only, same cost profile as the other batch endpoints, so
+  // it uses the regular rateLimiter.
+  blastRadiusSubRouter.post(
+    /^\/jobs:batch\/poll\/?$/,
+    rateLimiter,
+    safeWrap(getBlastRadiusJobBatch),
+  )
   router.use('/blast-radius', blastRadiusSubRouter)
 
   return router

--- a/backend/src/api/public/v1/akrites-external/index.ts
+++ b/backend/src/api/public/v1/akrites-external/index.ts
@@ -34,7 +34,7 @@ function envTunableRateLimiter(envPrefix: string, defaultMax: number, defaultWin
 // Blast-radius jobs default to 50 requests/hour.
 const blastRadiusRateLimiter = envTunableRateLimiter(
   'AKRITES_BLAST_RADIUS_RATE_LIMIT',
-  50,
+  5,
   60 * 60 * 1000,
 )
 

--- a/backend/src/api/public/v1/akrites-external/index.ts
+++ b/backend/src/api/public/v1/akrites-external/index.ts
@@ -31,10 +31,10 @@ function envTunableRateLimiter(envPrefix: string, defaultMax: number, defaultWin
   })
 }
 
-// Blast-radius jobs default to 5 requests/hour.
+// Blast-radius jobs default to 50 requests/hour.
 const blastRadiusRateLimiter = envTunableRateLimiter(
   'AKRITES_BLAST_RADIUS_RATE_LIMIT',
-  5,
+  50,
   60 * 60 * 1000,
 )
 

--- a/backend/src/api/public/v1/akrites-external/index.ts
+++ b/backend/src/api/public/v1/akrites-external/index.ts
@@ -12,8 +12,8 @@ import { getAkritesExternalContactDetailBatch } from '../packages/getAkritesExte
 import { getAkritesExternalPackageDetail } from '../packages/getAkritesExternalPackageDetail'
 import { getAkritesExternalPackageDetailBatch } from '../packages/getAkritesExternalPackageDetailBatch'
 import { getBlastRadiusJob } from '../packages/getBlastRadiusJob'
-import { ingestAkritesExternalContactDetail } from '../packages/ingestAkritesExternalContactDetail'
 import { getBlastRadiusJobBatch } from '../packages/getBlastRadiusJobBatch'
+import { ingestAkritesExternalContactDetail } from '../packages/ingestAkritesExternalContactDetail'
 import { submitBlastRadiusJob } from '../packages/submitBlastRadiusJob'
 import { submitBlastRadiusJobBatch } from '../packages/submitBlastRadiusJobBatch'
 

--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -411,7 +411,10 @@ components:
     BlastRadiusJobEntry:
       type: object
       required: [analysisId, advisoryId, package, ecosystem, status]
-      description: Response body of 2a — one job per request, never wrapped in an array.
+      description: >
+        Response body of 2a for a single submitted job. Returned directly (not
+        wrapped in an array) by the single-job submit; the batch submit (2a bulk)
+        returns an array of these under `results` — see BlastRadiusJobBatchResponse.
       properties:
         analysisId:
           type: string
@@ -429,7 +432,11 @@ components:
         status:
           type: string
           enum: [pending, running, done, failed]
-          description: Always pending — the response is returned before the Temporal workflow runs.
+          description: >
+            Pending in the single-job submit response, always returned before the
+            Temporal workflow runs. In the batch submit response, a job whose
+            workflow failed to start comes back as failed instead — the rest of
+            the batch is unaffected.
 
     BlastRadiusJobBatchRequest:
       type: object

--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -458,8 +458,9 @@ components:
       type: object
       required: [results]
       description: >
-        Plain array in request order, one entry per submitted job — unlike the
-        read batches there is no found/not-found case, every job is submitted.
+        Plain array in request order, one entry per requested job — unlike the
+        read batches there is no found/not-found case, but a job can still come
+        back with status: failed if row creation or the workflow start failed.
       properties:
         results:
           type: array

--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -51,14 +51,16 @@ tags:
   - name: Blast Radius
     description: >
       Advisory reachability analysis — submit (2a) and poll (2b) are both
-      implemented. Submitting kicks off a Temporal workflow that runs the
-      npm reachability pipeline (other ecosystems fail fast with
-      ECOSYSTEM_NOT_SUPPORTED); poll returns job status and, once done,
-      results. Rate-limited independently of the other akrites-external
-      endpoints (default 5 requests/hour, configurable via
-      AKRITES_BLAST_RADIUS_RATE_LIMIT_MAX / _WINDOW_MS). Same interim scope
-      note as Advisories applies (read:packages, pending a dedicated
-      read:advisories scope).
+      implemented, each with a bulk counterpart. Submitting kicks off a
+      Temporal workflow that runs the npm reachability pipeline (other
+      ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED); poll returns job
+      status and, once done, results. Bulk submit (jobs:batch) is capped at
+      20 jobs per request (10 recommended as the default batch size) — each
+      entry starts its own workflow — and stays behind the same strict rate
+      limiter as the single-job route; bulk poll
+      (jobs:batch/poll) is read-only and capped at 100 like the other batch
+      endpoints. Same interim scope note as Advisories applies (read:packages,
+      pending a dedicated read:advisories scope).
 
 components:
   securitySchemes:
@@ -428,6 +430,69 @@ components:
           type: string
           enum: [pending, running, done, failed]
           description: Always pending — the response is returned before the Temporal workflow runs.
+
+    BlastRadiusJobBatchRequest:
+      type: object
+      required: [jobs]
+      properties:
+        jobs:
+          type: array
+          minItems: 1
+          maxItems: 20
+          description: >
+            Capped much lower than the 100-item read batches — each entry
+            starts its own Temporal workflow, so the batch multiplies
+            workflow starts (and reachability-analysis cost) per request.
+            10 is the recommended default batch size; 20 is the hard limit.
+          items:
+            $ref: '#/components/schemas/BlastRadiusJobRequest'
+
+    BlastRadiusJobBatchResponse:
+      type: object
+      required: [results]
+      description: >
+        Plain array in request order, one entry per submitted job — unlike the
+        read batches there is no found/not-found case, every job is submitted.
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/BlastRadiusJobEntry'
+
+    BlastRadiusJobPollBatchRequest:
+      type: object
+      required: [analysisIds]
+      properties:
+        analysisIds:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            type: string
+            format: uuid
+        page:
+          type: integer
+          minimum: 1
+          default: 1
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+
+    BlastRadiusAnalysisBulkEntry:
+      type: object
+      required: [requestedAnalysisId, found, analysis]
+      properties:
+        requestedAnalysisId:
+          type: string
+        found:
+          type: boolean
+        analysis:
+          type: object
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/BlastRadiusAnalysis'
 
     BlastRadiusResultConfidence:
       type: string
@@ -1065,6 +1130,122 @@ paths:
                 $ref: '#/components/schemas/Error'
         '429':
           description: Too many requests — rate-limited independently of the other endpoints.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /akrites-external/blast-radius/jobs:batch:
+    post:
+      operationId: submitBlastRadiusJobBatch
+      summary: 2a bulk — Submit multiple blast-radius analysis jobs
+      description: >
+        One job per array entry, same semantics as the single-job submit —
+        omit package for an advisory-wide analysis, provide it to narrow to a
+        single package. Each entry starts its own Temporal workflow, so the
+        batch is capped at 20 jobs (10 recommended as the default batch
+        size), much lower than the 100-item read batches, and stays behind
+        the same strict rate limiter as the single-job route.
+
+
+        A per-job failure does not fail the whole batch — that entry comes
+        back with status: 'failed' and the rest still submit.
+      tags: [Blast Radius]
+      security:
+        - M2MBearer:
+            - read:packages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlastRadiusJobBatchRequest'
+      responses:
+        '202':
+          description: Jobs accepted, in request order.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BlastRadiusJobBatchResponse'
+        '400':
+          description: Validation error (empty array, >20 items, or an invalid job entry).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Token missing read:packages scope.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Too many requests — rate-limited independently of the other endpoints.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /akrites-external/blast-radius/jobs:batch/poll:
+    post:
+      operationId: getBlastRadiusJobBatch
+      summary: 2b bulk — Poll multiple blast-radius analysis jobs
+      description: >
+        Same found/not-found echo shape as the other batch endpoints: an
+        unknown analysisId comes back { found: false, analysis: null }
+        instead of 404ing the whole request. Read-only, so it is rate-limited
+        the same as the other non-blast-radius endpoints, not the strict
+        submit limiter.
+      tags: [Blast Radius]
+      security:
+        - M2MBearer:
+            - read:packages
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BlastRadiusJobPollBatchRequest'
+      responses:
+        '200':
+          description: One page of results, in request order.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [page, pageSize, total, results]
+                properties:
+                  page:
+                    type: integer
+                  pageSize:
+                    type: integer
+                  total:
+                    type: integer
+                    description: Total number of requested analysisIds, across all pages.
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BlastRadiusAnalysisBulkEntry'
+        '400':
+          description: Validation error (empty array, >100 items, or a non-uuid analysisId).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Missing or invalid bearer token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Token missing read:packages scope.
           content:
             application/json:
               schema:

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -43,18 +43,7 @@ export function v1Router(): Router {
   router.use('/ossprey', oauth2Middleware(AUTH0_CONFIG), osspreyRouter())
 
   router.use('/akrites', oauth2Middleware(AUTH0_CONFIG), akritesRouter())
-  // LOCAL-BYPASS-TODO-REVERT: real Auth0 check commented out for a local blast-radius
-  // e2e load test (no easy way to mint a token locally). Restore the line below and
-  // delete the stub before this ever reaches a shared/prod branch.
-  // router.use('/akrites-external', oauth2Middleware(AUTH0_CONFIG), akritesExternalRouter())
-  router.use(
-    '/akrites-external',
-    (req, _res, next) => {
-      req.actor = { id: 'local-load-test', type: 'service', scopes: Object.values(SCOPES) }
-      next()
-    },
-    akritesExternalRouter(),
-  )
+  router.use('/akrites-external', oauth2Middleware(AUTH0_CONFIG), akritesExternalRouter())
 
   router.use(() => {
     throw new NotFoundError()

--- a/backend/src/api/public/v1/index.ts
+++ b/backend/src/api/public/v1/index.ts
@@ -43,7 +43,18 @@ export function v1Router(): Router {
   router.use('/ossprey', oauth2Middleware(AUTH0_CONFIG), osspreyRouter())
 
   router.use('/akrites', oauth2Middleware(AUTH0_CONFIG), akritesRouter())
-  router.use('/akrites-external', oauth2Middleware(AUTH0_CONFIG), akritesExternalRouter())
+  // LOCAL-BYPASS-TODO-REVERT: real Auth0 check commented out for a local blast-radius
+  // e2e load test (no easy way to mint a token locally). Restore the line below and
+  // delete the stub before this ever reaches a shared/prod branch.
+  // router.use('/akrites-external', oauth2Middleware(AUTH0_CONFIG), akritesExternalRouter())
+  router.use(
+    '/akrites-external',
+    (req, _res, next) => {
+      req.actor = { id: 'local-load-test', type: 'service', scopes: Object.values(SCOPES) }
+      next()
+    },
+    akritesExternalRouter(),
+  )
 
   router.use(() => {
     throw new NotFoundError()

--- a/backend/src/api/public/v1/packages/blastRadiusBatch.test.ts
+++ b/backend/src/api/public/v1/packages/blastRadiusBatch.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MAX_BLAST_RADIUS_JOBS_PER_BATCH,
+  MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH,
+  blastRadiusJobBatchRequestSchema,
+  blastRadiusJobPollBatchRequestSchema,
+  paginateAnalysisIds,
+} from './blastRadiusBatch'
+
+describe('blastRadiusJobBatchRequestSchema', () => {
+  it('accepts a batch of valid job requests', () => {
+    const result = blastRadiusJobBatchRequestSchema.safeParse({
+      jobs: [
+        { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
+        { advisoryId: 'CVE-2024-12345', ecosystem: 'npm', package: 'pkg:npm/lodash' },
+      ],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an empty jobs array', () => {
+    const result = blastRadiusJobBatchRequestSchema.safeParse({ jobs: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects more than MAX_BLAST_RADIUS_JOBS_PER_BATCH jobs', () => {
+    const jobs = Array.from({ length: MAX_BLAST_RADIUS_JOBS_PER_BATCH + 1 }, () => ({
+      advisoryId: 'GHSA-jf85-cpcp-j695',
+      ecosystem: 'npm',
+    }))
+    const result = blastRadiusJobBatchRequestSchema.safeParse({ jobs })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a batch containing one invalid job', () => {
+    const result = blastRadiusJobBatchRequestSchema.safeParse({
+      jobs: [
+        { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
+        { advisoryId: 'not-an-advisory-id', ecosystem: 'npm' },
+      ],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('blastRadiusJobPollBatchRequestSchema', () => {
+  const validId = '3fa85f64-5717-4562-b3fc-2c963f66afa6'
+
+  it('accepts a batch of valid analysisIds and defaults page/pageSize', () => {
+    const result = blastRadiusJobPollBatchRequestSchema.parse({ analysisIds: [validId] })
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+
+  it('rejects an empty analysisIds array', () => {
+    const result = blastRadiusJobPollBatchRequestSchema.safeParse({ analysisIds: [] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a non-uuid analysisId', () => {
+    const result = blastRadiusJobPollBatchRequestSchema.safeParse({ analysisIds: ['not-a-uuid'] })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects more than MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH analysisIds', () => {
+    const analysisIds = Array.from(
+      { length: MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH + 1 },
+      () => validId,
+    )
+    const result = blastRadiusJobPollBatchRequestSchema.safeParse({ analysisIds })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('paginateAnalysisIds', () => {
+  it('slices the requested page out of the full analysisIds array', () => {
+    const analysisIds = ['a', 'b', 'c', 'd', 'e']
+    const result = paginateAnalysisIds({ analysisIds, page: 2, pageSize: 2 })
+    expect(result).toEqual({
+      page: 2,
+      pageSize: 2,
+      total: 5,
+      pagedAnalysisIds: ['c', 'd'],
+    })
+  })
+
+  it('returns an empty page past the end of the array', () => {
+    const result = paginateAnalysisIds({ analysisIds: ['a'], page: 2, pageSize: 20 })
+    expect(result.pagedAnalysisIds).toEqual([])
+    expect(result.total).toBe(1)
+  })
+})

--- a/backend/src/api/public/v1/packages/blastRadiusBatch.ts
+++ b/backend/src/api/public/v1/packages/blastRadiusBatch.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod'
+
+import { blastRadiusJobRequestSchema } from './blastRadius'
+import type { BlastRadiusAnalysis } from './blastRadiusAnalysis'
+import { DEFAULT_BATCH_PAGE_SIZE } from './purl'
+
+// Read-only batches (packages/advisories/contacts) cap at 100 — cheap indexed
+// lookups. Batch submit multiplies Temporal workflow starts (and their LLM
+// reachability cost) per request, so it gets a much lower cap, independent of
+// that constant. 20 is the hard limit agreed with Joana after the cost test
+// (2026-07-23) — 10 is the recommended/default batch size for callers, not a
+// separate enforced value, since `jobs` is an explicit client-provided array.
+export const MAX_BLAST_RADIUS_JOBS_PER_BATCH = 20
+
+// Polling is read-only, same cost profile as the other batches, so it reuses
+// their 100 cap.
+export const MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH = 100
+
+export const blastRadiusJobBatchRequestSchema = z.object({
+  jobs: z
+    .array(blastRadiusJobRequestSchema)
+    .min(1)
+    .max(
+      MAX_BLAST_RADIUS_JOBS_PER_BATCH,
+      `Maximum ${MAX_BLAST_RADIUS_JOBS_PER_BATCH} jobs per request`,
+    ),
+})
+
+export type BlastRadiusJobBatchRequest = z.infer<typeof blastRadiusJobBatchRequestSchema>
+
+// Unlike the read batches (purls that may or may not resolve to a package), every
+// job in a submit batch is genuinely submitted — there is no "not found" case, so
+// the response is a plain array in request order, not a found/not-found wrapper.
+const analysisIdSchema = z.uuid()
+
+export const blastRadiusJobPollBatchRequestSchema = z.object({
+  analysisIds: z
+    .array(analysisIdSchema)
+    .min(1)
+    .max(
+      MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH,
+      `Maximum ${MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH} analysisIds per request`,
+    ),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(MAX_BLAST_RADIUS_POLL_IDS_PER_BATCH)
+    .default(DEFAULT_BATCH_PAGE_SIZE),
+})
+
+export type BlastRadiusJobPollBatchRequest = z.infer<typeof blastRadiusJobPollBatchRequestSchema>
+
+export interface BlastRadiusAnalysisBulkEntry {
+  requestedAnalysisId: string
+  found: boolean
+  analysis: BlastRadiusAnalysis | null
+}
+
+export interface PaginatedAnalysisIds {
+  page: number
+  pageSize: number
+  total: number
+  pagedAnalysisIds: string[]
+}
+
+// Mirrors paginatePurls (purl.ts): slice the requested page out of the full
+// analysisIds array. No normalization step — analysisIds are UUIDs, unlike purls.
+export function paginateAnalysisIds(body: {
+  analysisIds: string[]
+  page: number
+  pageSize: number
+}): PaginatedAnalysisIds {
+  const { analysisIds, page, pageSize } = body
+  const start = (page - 1) * pageSize
+  return {
+    page,
+    pageSize,
+    total: analysisIds.length,
+    pagedAnalysisIds: analysisIds.slice(start, start + pageSize),
+  }
+}

--- a/backend/src/api/public/v1/packages/blastRadiusBatch.ts
+++ b/backend/src/api/public/v1/packages/blastRadiusBatch.ts
@@ -29,8 +29,8 @@ export const blastRadiusJobBatchRequestSchema = z.object({
 export type BlastRadiusJobBatchRequest = z.infer<typeof blastRadiusJobBatchRequestSchema>
 
 // Unlike the read batches (purls that may or may not resolve to a package), every
-// job in a submit batch is genuinely submitted — there is no "not found" case, so
-// the response is a plain array in request order, not a found/not-found wrapper.
+// requested job produces a response entry — there is no "not found" case, so the
+// response is a plain array in request order, not a found/not-found wrapper.
 const analysisIdSchema = z.uuid()
 
 export const blastRadiusJobPollBatchRequestSchema = z.object({

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
@@ -1,0 +1,157 @@
+import type { Request, Response } from 'express'
+import { describe, expect, it, vi } from 'vitest'
+
+import { getBlastRadiusJobBatch } from './getBlastRadiusJobBatch'
+
+const { getAnalysisDetailsByIds, getVerdictResultsBatch, getDependentsExcludedByRangeCountBatch } =
+  vi.hoisted(() => ({
+    getAnalysisDetailsByIds: vi.fn(),
+    getVerdictResultsBatch: vi.fn(),
+    getDependentsExcludedByRangeCountBatch: vi.fn(),
+  }))
+
+vi.mock('@crowd/data-access-layer/src/packages/blastRadius', () => ({
+  getAnalysisDetailsByIds,
+  getVerdictResultsBatch,
+  getDependentsExcludedByRangeCountBatch,
+}))
+
+vi.mock('@/db/packagesDb', () => ({
+  getPackagesQx: vi.fn().mockResolvedValue({}),
+}))
+
+const PENDING_ID = '11111111-1111-4111-8111-111111111111'
+const DONE_ID = '22222222-2222-4222-8222-222222222222'
+const MISSING_ID = '33333333-3333-4333-8333-333333333333'
+
+function mockReqRes(body: unknown) {
+  getAnalysisDetailsByIds.mockClear()
+  getVerdictResultsBatch.mockClear()
+  getDependentsExcludedByRangeCountBatch.mockClear()
+  getVerdictResultsBatch.mockResolvedValue([])
+  getDependentsExcludedByRangeCountBatch.mockResolvedValue([])
+
+  const req = { body } as unknown as Request
+
+  const json = vi.fn()
+  const status = vi.fn().mockReturnValue({ json })
+  const res = { status, json } as unknown as Response
+
+  return { req, res, json }
+}
+
+describe('getBlastRadiusJobBatch', () => {
+  it('returns found/not-found entries in request order with page metadata', async () => {
+    getAnalysisDetailsByIds.mockResolvedValue([
+      {
+        id: PENDING_ID,
+        advisory_osv_id: 'GHSA-jf85-cpcp-j695',
+        package_name: null,
+        ecosystem: 'npm',
+        status: 'pending',
+        error: null,
+        candidates_considered: null,
+        started_at: '2026-07-01T00:00:00.000Z',
+        completed_at: null,
+      },
+    ])
+
+    const { req, res, json } = mockReqRes({
+      analysisIds: [PENDING_ID, MISSING_ID],
+    })
+
+    await getBlastRadiusJobBatch(req, res)
+
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        page: 1,
+        pageSize: expect.any(Number),
+        total: 2,
+        results: [
+          expect.objectContaining({
+            requestedAnalysisId: PENDING_ID,
+            found: true,
+            analysis: expect.objectContaining({ analysisId: PENDING_ID, status: 'pending' }),
+          }),
+          { requestedAnalysisId: MISSING_ID, found: false, analysis: null },
+        ],
+      }),
+    )
+  })
+
+  it('only fetches verdicts/excluded counts for done analyses', async () => {
+    getAnalysisDetailsByIds.mockResolvedValue([
+      {
+        id: PENDING_ID,
+        advisory_osv_id: 'GHSA-jf85-cpcp-j695',
+        package_name: null,
+        ecosystem: 'npm',
+        status: 'pending',
+        error: null,
+        candidates_considered: null,
+        started_at: '2026-07-01T00:00:00.000Z',
+        completed_at: null,
+      },
+      {
+        id: DONE_ID,
+        advisory_osv_id: 'GHSA-652q-gvq3-74qv',
+        package_name: 'lodash',
+        ecosystem: 'npm',
+        status: 'done',
+        error: null,
+        candidates_considered: 10,
+        started_at: '2026-07-01T00:00:00.000Z',
+        completed_at: '2026-07-01T01:00:00.000Z',
+      },
+    ])
+    getVerdictResultsBatch.mockResolvedValue([
+      {
+        analysisId: DONE_ID,
+        name: 'benchmark.js',
+        version: '2.1.4',
+        downloads: 500000,
+        reachable_verdict: 'affected',
+        confidence: 0.9,
+        evidence: null,
+        reasoning: 'uses merge',
+      },
+    ])
+    getDependentsExcludedByRangeCountBatch.mockResolvedValue([{ analysisId: DONE_ID, count: 8 }])
+
+    const { req, res, json } = mockReqRes({ analysisIds: [PENDING_ID, DONE_ID] })
+
+    await getBlastRadiusJobBatch(req, res)
+
+    expect(getVerdictResultsBatch).toHaveBeenCalledWith(expect.anything(), [DONE_ID])
+    expect(getDependentsExcludedByRangeCountBatch).toHaveBeenCalledWith(expect.anything(), [
+      DONE_ID,
+    ])
+
+    const [{ results }] = json.mock.calls[0]
+    expect(results[0]).toMatchObject({ requestedAnalysisId: PENDING_ID, found: true })
+    expect(results[0].analysis).toMatchObject({ status: 'pending', summary: null, results: null })
+    expect(results[1]).toMatchObject({ requestedAnalysisId: DONE_ID, found: true })
+    expect(results[1].analysis).toMatchObject({
+      status: 'done',
+      summary: expect.objectContaining({ dependentsExcludedUpfront: 8 }),
+    })
+  })
+
+  it('rejects a batch with a malformed uuid without querying the database', async () => {
+    const { req, res } = mockReqRes({ analysisIds: [PENDING_ID, 'not-a-uuid'] })
+
+    await expect(getBlastRadiusJobBatch(req, res)).rejects.toThrow()
+    expect(getAnalysisDetailsByIds).not.toHaveBeenCalled()
+  })
+
+  it('rejects a batch with more than 100 analysisIds', async () => {
+    const analysisIds = Array.from(
+      { length: 101 },
+      (_, i) => `44444444-4444-4444-8444-${String(i).padStart(12, '0')}`,
+    )
+    const { req, res } = mockReqRes({ analysisIds })
+
+    await expect(getBlastRadiusJobBatch(req, res)).rejects.toThrow()
+    expect(getAnalysisDetailsByIds).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
@@ -80,6 +80,8 @@ describe('getBlastRadiusJobBatch', () => {
   })
 
   it('only fetches verdicts/excluded counts for done analyses', async () => {
+    const { req, res, json } = mockReqRes({ analysisIds: [PENDING_ID, DONE_ID] })
+
     getAnalysisDetailsByIds.mockResolvedValue([
       {
         id: PENDING_ID,
@@ -117,8 +119,6 @@ describe('getBlastRadiusJobBatch', () => {
       },
     ])
     getDependentsExcludedByRangeCountBatch.mockResolvedValue([{ analysisId: DONE_ID, count: 8 }])
-
-    const { req, res, json } = mockReqRes({ analysisIds: [PENDING_ID, DONE_ID] })
 
     await getBlastRadiusJobBatch(req, res)
 

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.test.ts
@@ -137,6 +137,47 @@ describe('getBlastRadiusJobBatch', () => {
     })
   })
 
+  it('matches an uppercase requestedAnalysisId against its (lowercase) row and echoes the original case', async () => {
+    const uppercaseId = DONE_ID.toUpperCase()
+    const { req, res, json } = mockReqRes({ analysisIds: [uppercaseId] })
+
+    getAnalysisDetailsByIds.mockResolvedValue([
+      {
+        id: DONE_ID,
+        advisory_osv_id: 'GHSA-652q-gvq3-74qv',
+        package_name: 'lodash',
+        ecosystem: 'npm',
+        status: 'done',
+        error: null,
+        candidates_considered: 10,
+        started_at: '2026-07-01T00:00:00.000Z',
+        completed_at: '2026-07-01T01:00:00.000Z',
+      },
+    ])
+    getVerdictResultsBatch.mockResolvedValue([
+      {
+        analysisId: DONE_ID,
+        name: 'benchmark.js',
+        version: '2.1.4',
+        downloads: 500000,
+        reachable_verdict: 'affected',
+        confidence: 0.9,
+        evidence: null,
+        reasoning: 'uses merge',
+      },
+    ])
+    getDependentsExcludedByRangeCountBatch.mockResolvedValue([{ analysisId: DONE_ID, count: 8 }])
+
+    await getBlastRadiusJobBatch(req, res)
+
+    const [{ results }] = json.mock.calls[0]
+    expect(results[0]).toMatchObject({ requestedAnalysisId: uppercaseId, found: true })
+    expect(results[0].analysis).toMatchObject({
+      status: 'done',
+      summary: expect.objectContaining({ dependentsExcludedUpfront: 8 }),
+    })
+  })
+
   it('rejects a batch with a malformed uuid without querying the database', async () => {
     const { req, res } = mockReqRes({ analysisIds: [PENDING_ID, 'not-a-uuid'] })
 

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
@@ -25,33 +25,44 @@ export async function getBlastRadiusJobBatch(req: Request, res: Response): Promi
 
   const qx = await getPackagesQx()
 
-  const results: BlastRadiusAnalysisBulkEntry[] = await Promise.all(
-    pagedAnalysisIds.map((requestedAnalysisId) => pollOneAnalysis(qx, requestedAnalysisId)),
+  const analysisRows = await blastRadiusDal.getAnalysisDetailsByIds(qx, pagedAnalysisIds)
+  const analysisById = new Map(analysisRows.map((row) => [row.id, row]))
+
+  const doneIds = analysisRows.filter((row) => row.status === 'done').map((row) => row.id)
+  const [verdictRows, excludedByRangeCounts] = await Promise.all([
+    blastRadiusDal.getVerdictResultsBatch(qx, doneIds),
+    blastRadiusDal.getDependentsExcludedByRangeCountBatch(qx, doneIds),
+  ])
+
+  const verdictsByAnalysisId = new Map<string, typeof verdictRows>()
+  for (const row of verdictRows) {
+    const bucket = verdictsByAnalysisId.get(row.analysisId)
+    if (bucket) {
+      bucket.push(row)
+    } else {
+      verdictsByAnalysisId.set(row.analysisId, [row])
+    }
+  }
+  const excludedByRangeCountByAnalysisId = new Map(
+    excludedByRangeCounts.map(({ analysisId, count }) => [analysisId, count]),
   )
 
+  const results: BlastRadiusAnalysisBulkEntry[] = pagedAnalysisIds.map((requestedAnalysisId) => {
+    const analysis = analysisById.get(requestedAnalysisId)
+    if (!analysis) {
+      return { requestedAnalysisId, found: false, analysis: null }
+    }
+
+    return {
+      requestedAnalysisId,
+      found: true,
+      analysis: toBlastRadiusAnalysis(
+        analysis,
+        verdictsByAnalysisId.get(requestedAnalysisId) ?? [],
+        excludedByRangeCountByAnalysisId.get(requestedAnalysisId) ?? 0,
+      ),
+    }
+  })
+
   ok(res, { page, pageSize, total, results })
-}
-
-async function pollOneAnalysis(
-  qx: Awaited<ReturnType<typeof getPackagesQx>>,
-  requestedAnalysisId: string,
-): Promise<BlastRadiusAnalysisBulkEntry> {
-  const analysis = await blastRadiusDal.getAnalysisDetail(qx, requestedAnalysisId)
-  if (!analysis) {
-    return { requestedAnalysisId, found: false, analysis: null }
-  }
-
-  const done = analysis.status === 'done'
-  const [verdictRows, excludedByRangeCount] = done
-    ? await Promise.all([
-        blastRadiusDal.getVerdictResults(qx, requestedAnalysisId),
-        blastRadiusDal.getDependentsExcludedByRangeCount(qx, requestedAnalysisId),
-      ])
-    : [[], 0]
-
-  return {
-    requestedAnalysisId,
-    found: true,
-    analysis: toBlastRadiusAnalysis(analysis, verdictRows, excludedByRangeCount),
-  }
 }

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from 'express'
+
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { ok } from '@/utils/api'
+import { validateOrThrow } from '@/utils/validation'
+
+import { toBlastRadiusAnalysis } from './blastRadiusAnalysis'
+import {
+  type BlastRadiusAnalysisBulkEntry,
+  blastRadiusJobPollBatchRequestSchema,
+  paginateAnalysisIds,
+} from './blastRadiusBatch'
+
+// 2b bulk — poll multiple blast-radius analyses in one request. Same
+// found/not-found echo shape as the other batch endpoints (packages, advisories,
+// contacts): an unknown analysisId comes back { found: false, analysis: null }
+// instead of 404ing the whole request. Read-only, so it stays behind the
+// regular rateLimiter, not the strict blastRadiusRateLimiter.
+export async function getBlastRadiusJobBatch(req: Request, res: Response): Promise<void> {
+  const { page, pageSize, total, pagedAnalysisIds } = paginateAnalysisIds(
+    validateOrThrow(blastRadiusJobPollBatchRequestSchema, req.body),
+  )
+
+  const qx = await getPackagesQx()
+
+  const results: BlastRadiusAnalysisBulkEntry[] = await Promise.all(
+    pagedAnalysisIds.map((requestedAnalysisId) => pollOneAnalysis(qx, requestedAnalysisId)),
+  )
+
+  ok(res, { page, pageSize, total, results })
+}
+
+async function pollOneAnalysis(
+  qx: Awaited<ReturnType<typeof getPackagesQx>>,
+  requestedAnalysisId: string,
+): Promise<BlastRadiusAnalysisBulkEntry> {
+  const analysis = await blastRadiusDal.getAnalysisDetail(qx, requestedAnalysisId)
+  if (!analysis) {
+    return { requestedAnalysisId, found: false, analysis: null }
+  }
+
+  const done = analysis.status === 'done'
+  const [verdictRows, excludedByRangeCount] = done
+    ? await Promise.all([
+        blastRadiusDal.getVerdictResults(qx, requestedAnalysisId),
+        blastRadiusDal.getDependentsExcludedByRangeCount(qx, requestedAnalysisId),
+      ])
+    : [[], 0]
+
+  return {
+    requestedAnalysisId,
+    found: true,
+    analysis: toBlastRadiusAnalysis(analysis, verdictRows, excludedByRangeCount),
+  }
+}

--- a/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/getBlastRadiusJobBatch.ts
@@ -26,7 +26,10 @@ export async function getBlastRadiusJobBatch(req: Request, res: Response): Promi
   const qx = await getPackagesQx()
 
   const analysisRows = await blastRadiusDal.getAnalysisDetailsByIds(qx, pagedAnalysisIds)
-  const analysisById = new Map(analysisRows.map((row) => [row.id, row]))
+  // Postgres normalizes uuid columns to lowercase on read, but a requested id can be
+  // any case (schema only validates uuid shape) — normalize the lookup key so an
+  // uppercase requestedAnalysisId still matches its (lowercase) row.
+  const analysisById = new Map(analysisRows.map((row) => [row.id.toLowerCase(), row]))
 
   const doneIds = analysisRows.filter((row) => row.status === 'done').map((row) => row.id)
   const [verdictRows, excludedByRangeCounts] = await Promise.all([
@@ -48,7 +51,7 @@ export async function getBlastRadiusJobBatch(req: Request, res: Response): Promi
   )
 
   const results: BlastRadiusAnalysisBulkEntry[] = pagedAnalysisIds.map((requestedAnalysisId) => {
-    const analysis = analysisById.get(requestedAnalysisId)
+    const analysis = analysisById.get(requestedAnalysisId.toLowerCase())
     if (!analysis) {
       return { requestedAnalysisId, found: false, analysis: null }
     }
@@ -58,8 +61,8 @@ export async function getBlastRadiusJobBatch(req: Request, res: Response): Promi
       found: true,
       analysis: toBlastRadiusAnalysis(
         analysis,
-        verdictsByAnalysisId.get(requestedAnalysisId) ?? [],
-        excludedByRangeCountByAnalysisId.get(requestedAnalysisId) ?? 0,
+        verdictsByAnalysisId.get(analysis.id) ?? [],
+        excludedByRangeCountByAnalysisId.get(analysis.id) ?? 0,
       ),
     }
   })

--- a/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.test.ts
+++ b/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.test.ts
@@ -1,0 +1,124 @@
+import type { Request, Response } from 'express'
+import { describe, expect, it, vi } from 'vitest'
+
+import { submitBlastRadiusJobBatch } from './submitBlastRadiusJobBatch'
+
+const { start, createAnalysis, failAnalysis } = vi.hoisted(() => ({
+  start: vi.fn().mockResolvedValue(undefined),
+  createAnalysis: vi.fn().mockResolvedValue(undefined),
+  failAnalysis: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/db/packagesTemporal', () => ({
+  getPackagesTemporalClient: vi.fn().mockResolvedValue({ workflow: { start } }),
+}))
+
+vi.mock('@/db/packagesDb', () => ({
+  getPackagesQx: vi.fn().mockResolvedValue({}),
+}))
+
+vi.mock('@crowd/data-access-layer/src/packages/blastRadius', () => ({
+  createAnalysis,
+  failAnalysis,
+}))
+
+function mockReqRes(body: unknown) {
+  start.mockClear()
+  createAnalysis.mockClear()
+  failAnalysis.mockClear()
+
+  const req = { body } as unknown as Request
+
+  const json = vi.fn()
+  const status = vi.fn().mockReturnValue({ json })
+  const res = { status } as unknown as Response
+
+  return { req, res, start, status, json }
+}
+
+describe('submitBlastRadiusJobBatch', () => {
+  it('starts one workflow per job and responds 202 with results in request order', async () => {
+    const { req, res, status, json } = mockReqRes({
+      jobs: [
+        { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
+        { advisoryId: 'GHSA-652q-gvq3-74qv', package: 'pkg:npm/lodash', ecosystem: 'npm' },
+      ],
+    })
+
+    await submitBlastRadiusJobBatch(req, res)
+
+    expect(createAnalysis).toHaveBeenCalledTimes(2)
+    expect(start).toHaveBeenCalledTimes(2)
+    expect(status).toHaveBeenCalledWith(202)
+
+    const [{ results }] = json.mock.calls[0]
+    expect(results).toHaveLength(2)
+    expect(results[0]).toMatchObject({
+      advisoryId: 'GHSA-jf85-cpcp-j695',
+      package: null,
+      ecosystem: 'npm',
+      status: 'pending',
+    })
+    expect(results[1]).toMatchObject({
+      advisoryId: 'GHSA-652q-gvq3-74qv',
+      package: 'pkg:npm/lodash',
+      ecosystem: 'npm',
+      status: 'pending',
+    })
+    expect(typeof results[0].analysisId).toBe('string')
+    expect(typeof results[1].analysisId).toBe('string')
+  })
+
+  it('isolates a per-job workflow.start failure to that job only', async () => {
+    const { req, res, json } = mockReqRes({
+      jobs: [
+        { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
+        { advisoryId: 'GHSA-652q-gvq3-74qv', ecosystem: 'npm' },
+      ],
+    })
+    start.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('temporal unreachable'))
+
+    await submitBlastRadiusJobBatch(req, res)
+
+    const [{ results }] = json.mock.calls[0]
+    expect(results).toHaveLength(2)
+    expect(results[0]).toMatchObject({ advisoryId: 'GHSA-jf85-cpcp-j695', status: 'pending' })
+    expect(results[1]).toMatchObject({ advisoryId: 'GHSA-652q-gvq3-74qv', status: 'failed' })
+
+    expect(failAnalysis).toHaveBeenCalledTimes(1)
+    const [, , errorMessage] = failAnalysis.mock.calls[0]
+    expect(errorMessage).toBe('temporal unreachable')
+  })
+
+  it('rejects a batch containing an unsupported ecosystem without submitting any job', async () => {
+    const { req, res, start } = mockReqRes({
+      jobs: [
+        { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
+        { advisoryId: 'GHSA-652q-gvq3-74qv', ecosystem: 'maven' },
+      ],
+    })
+
+    await expect(submitBlastRadiusJobBatch(req, res)).rejects.toThrow()
+    expect(start).not.toHaveBeenCalled()
+    expect(createAnalysis).not.toHaveBeenCalled()
+  })
+
+  it('rejects a batch with more than 20 jobs without submitting any job', async () => {
+    const jobs = Array.from({ length: 21 }, () => ({
+      advisoryId: 'GHSA-jf85-cpcp-j695',
+      ecosystem: 'npm',
+    }))
+    const { req, res, start } = mockReqRes({ jobs })
+
+    await expect(submitBlastRadiusJobBatch(req, res)).rejects.toThrow()
+    expect(start).not.toHaveBeenCalled()
+    expect(createAnalysis).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty jobs array', async () => {
+    const { req, res, start } = mockReqRes({ jobs: [] })
+
+    await expect(submitBlastRadiusJobBatch(req, res)).rejects.toThrow()
+    expect(start).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
@@ -1,0 +1,102 @@
+import type { Request, Response } from 'express'
+
+import { generateUUIDv4 } from '@crowd/common'
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+import { Client } from '@crowd/temporal'
+import { ITriggerBlastRadiusAnalysis, TemporalWorkflowId } from '@crowd/types'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { getPackagesTemporalClient } from '@/db/packagesTemporal'
+import { validateOrThrow } from '@/utils/validation'
+
+import {
+  type BlastRadiusJobEntry,
+  type BlastRadiusJobRequest,
+  toBlastRadiusJobEntry,
+} from './blastRadius'
+import { blastRadiusJobBatchRequestSchema } from './blastRadiusBatch'
+
+// 2a bulk — submit multiple blast-radius analysis jobs in one request, one per
+// array entry. Same lifecycle as the single-job submit, just looped: each entry
+// gets its own analysisId, its own pending row, and its own Temporal workflow
+// start. Unlike the read-only batch endpoints (packages/advisories/contacts),
+// this multiplies workflow starts per request, so the batch size is capped much
+// lower (see MAX_BLAST_RADIUS_JOBS_PER_BATCH) and the route stays behind the same
+// strict blastRadiusRateLimiter as the single-job route.
+//
+// A per-job failure (e.g. workflow.start throwing) does not fail the whole
+// batch — that job's entry comes back status: 'failed' and the rest still
+// submit, matching the partial-result shape of the other batch endpoints.
+export async function submitBlastRadiusJobBatch(req: Request, res: Response): Promise<void> {
+  const { jobs } = validateOrThrow(blastRadiusJobBatchRequestSchema, req.body)
+
+  const qx = await getPackagesQx()
+  const packagesTemporal = await getPackagesTemporalClient()
+
+  const results: BlastRadiusJobEntry[] = await Promise.all(
+    jobs.map((body) => submitOneJob(qx, packagesTemporal, body)),
+  )
+
+  res.status(202).json({ results })
+}
+
+async function submitOneJob(
+  qx: QueryExecutor,
+  packagesTemporal: Client,
+  body: BlastRadiusJobRequest,
+): Promise<BlastRadiusJobEntry> {
+  const jobPackage = body.package ?? null
+  const jobEcosystem = body.ecosystem
+  const analysisId = generateUUIDv4()
+  const analysisInput = {
+    id: analysisId,
+    advisoryOsvId: body.advisoryId,
+    packageName: jobPackage,
+    ecosystem: jobEcosystem,
+    force: body.force,
+  }
+
+  try {
+    // Create the pending row synchronously, before starting the workflow — see the
+    // same comment on submitBlastRadiusJob for why (avoids a poll-race 404). This is
+    // inside the try too — unlike the single-job submit, a createAnalysis failure
+    // must not reject the whole batch's Promise.all, only this job's entry.
+    await blastRadiusDal.createAnalysis(qx, analysisInput)
+
+    await packagesTemporal.workflow.start('analyzeBlastRadius', {
+      taskQueue: 'blast-radius-worker',
+      workflowId: `${TemporalWorkflowId.BLAST_RADIUS_ANALYSIS}/${analysisId}`,
+      retry: { maximumAttempts: 1 },
+      args: [
+        {
+          analysisId,
+          advisoryId: body.advisoryId,
+          package: jobPackage,
+          ecosystem: jobEcosystem,
+          force: body.force,
+        } satisfies ITriggerBlastRadiusAnalysis,
+      ],
+    })
+
+    return toBlastRadiusJobEntry({
+      analysisId,
+      advisoryId: body.advisoryId,
+      package: jobPackage,
+      ecosystem: jobEcosystem,
+    })
+  } catch (err) {
+    // Unlike the single-job submit, this does not rethrow — one job's workflow
+    // failing to start must not take the rest of the batch down with it.
+    const errorMessage = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failAnalysis(qx, analysisInput, errorMessage)
+
+    return {
+      analysisId,
+      advisoryId: body.advisoryId,
+      package: jobPackage,
+      ecosystem: jobEcosystem,
+      status: 'failed',
+    }
+  }
+}

--- a/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
@@ -87,9 +87,16 @@ async function submitOneJob(
     })
   } catch (err) {
     // Unlike the single-job submit, this does not rethrow — one job's workflow
-    // failing to start must not take the rest of the batch down with it.
+    // failing to start must not take the rest of the batch down with it. Same
+    // reasoning applies to failAnalysis itself: if marking the row failed also
+    // fails (e.g. transient DB error), that must not reject this job's promise
+    // and take Promise.all (and the whole batch response) down with it.
     const errorMessage = err instanceof Error ? err.message : String(err)
-    await blastRadiusDal.failAnalysis(qx, analysisInput, errorMessage)
+    try {
+      await blastRadiusDal.failAnalysis(qx, analysisInput, errorMessage)
+    } catch {
+      // best-effort — the job's entry below still reports status: 'failed'
+    }
 
     return {
       analysisId,

--- a/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
+++ b/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.ts
@@ -3,7 +3,6 @@ import type { Request, Response } from 'express'
 import { generateUUIDv4 } from '@crowd/common'
 import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
-import { Client } from '@crowd/temporal'
 import { ITriggerBlastRadiusAnalysis, TemporalWorkflowId } from '@crowd/types'
 
 import { getPackagesQx } from '@/db/packagesDb'
@@ -32,10 +31,9 @@ export async function submitBlastRadiusJobBatch(req: Request, res: Response): Pr
   const { jobs } = validateOrThrow(blastRadiusJobBatchRequestSchema, req.body)
 
   const qx = await getPackagesQx()
-  const packagesTemporal = await getPackagesTemporalClient()
 
   const results: BlastRadiusJobEntry[] = await Promise.all(
-    jobs.map((body) => submitOneJob(qx, packagesTemporal, body)),
+    jobs.map((body) => submitOneJob(qx, body)),
   )
 
   res.status(202).json({ results })
@@ -43,7 +41,6 @@ export async function submitBlastRadiusJobBatch(req: Request, res: Response): Pr
 
 async function submitOneJob(
   qx: QueryExecutor,
-  packagesTemporal: Client,
   body: BlastRadiusJobRequest,
 ): Promise<BlastRadiusJobEntry> {
   const jobPackage = body.package ?? null
@@ -63,6 +60,12 @@ async function submitOneJob(
     // inside the try too — unlike the single-job submit, a createAnalysis failure
     // must not reject the whole batch's Promise.all, only this job's entry.
     await blastRadiusDal.createAnalysis(qx, analysisInput)
+
+    // Acquired per job (inside the try), not once up front — getPackagesTemporalClient
+    // caches its connection in a module-level singleton, so this is cheap once
+    // connected, but a first-ever connection failure must fail this job's entry only,
+    // not reject the whole batch before any per-job try/catch is in play.
+    const packagesTemporal = await getPackagesTemporalClient()
 
     await packagesTemporal.workflow.start('analyzeBlastRadius', {
       taskQueue: 'blast-radius-worker',

--- a/backend/src/bin/scripts/blastRadiusLoadTest.ts
+++ b/backend/src/bin/scripts/blastRadiusLoadTest.ts
@@ -1,0 +1,294 @@
+// Local load-test harness for the blast-radius Temporal pipeline. Not meant to
+// ship — this is a dev-only tool, kept under bin/scripts like other one-offs.
+//
+// Starts N real analyzeBlastRadius workflows directly via the Temporal client
+// (bypassing the public HTTP/Zod/Auth0 layer, same as prod's own submit path
+// underneath), optionally capping the worker container's memory and stopping
+// each workflow right after a chosen stage via `stopAfterStage` — so this can
+// safely profile stage 2 (dependents, no LLM) without ever reaching the paid
+// stage 3 (reachability, Sonnet) unless explicitly asked to.
+//
+// Usage:
+//   cd backend && npx tsx src/bin/scripts/blastRadiusLoadTest.ts \
+//     --jobs=8 --scanConcurrency=8 --memCap=2g --stopAfter=dependents \
+//     --advisories=src/bin/scripts/blastRadiusLoadTestAdvisories.json
+//
+// Flags (all optional):
+//   --jobs=N            number of concurrent analyses to start (default 8)
+//   --scanConcurrency=N sets BLAST_RADIUS_SCAN_CONCURRENCY on the worker container
+//                        for the duration of this run, then clears it (default: unset)
+//   --memCap=2g          docker memory cap applied to the worker container for the
+//                        duration of this run, then reset to unlimited (default: none)
+//   --stopAfter=STAGE    'intel' | 'dependents' | 'reachability' — workflow stops
+//                        right after this stage succeeds (default: 'dependents')
+//   --container=NAME     worker container name (default crowd_blast-radius-worker-dev_1)
+//   --advisories=FILE    path to a JSON array of {advisoryId, package, ecosystem} —
+//                        jobs round-robin across these instead of all hitting the
+//                        same package (default: a single lodash advisory, repeated)
+
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+
+import { generateUUIDv4 } from '@crowd/common'
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { TemporalWorkflowId } from '@crowd/types'
+
+import { getPackagesQx } from '@/db/packagesDb'
+import { getPackagesTemporalClient } from '@/db/packagesTemporal'
+
+function flag(name: string, fallback?: string): string | undefined {
+  const arg = process.argv.find((a) => a.startsWith(`--${name}=`))
+  return arg ? arg.slice(name.length + 3) : fallback
+}
+
+const JOBS = Number(flag('jobs', '8'))
+const SCAN_CONCURRENCY = flag('scanConcurrency')
+const MEM_CAP = flag('memCap')
+const STOP_AFTER = flag('stopAfter', 'dependents') as 'intel' | 'dependents' | 'reachability'
+const CONTAINER = flag('container', 'crowd_blast-radius-worker-dev_1')
+const ADVISORIES_FILE = flag('advisories')
+
+const POLL_INTERVAL_MS = 5_000
+const TIMEOUT_MS = 60 * 60 * 1000
+
+interface AdvisoryTarget {
+  advisoryId: string
+  package: string
+  ecosystem: string
+}
+
+const DEFAULT_ADVISORIES: AdvisoryTarget[] = [
+  { advisoryId: 'GHSA-jf85-cpcp-j695', package: 'lodash', ecosystem: 'npm' }, // real OSV.dev entry, validated
+]
+
+function loadAdvisories(): AdvisoryTarget[] {
+  if (!ADVISORIES_FILE) return DEFAULT_ADVISORIES
+  const parsed = JSON.parse(fs.readFileSync(ADVISORIES_FILE, 'utf-8'))
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(`--advisories file must contain a non-empty JSON array: ${ADVISORIES_FILE}`)
+  }
+  return parsed
+}
+
+function sh(cmd: string): string {
+  return execSync(cmd, { encoding: 'utf-8' }).trim()
+}
+
+function applyRunConfig() {
+  if (MEM_CAP) {
+    console.log(`[loadtest] capping ${CONTAINER} memory at ${MEM_CAP}`)
+    sh(`docker update --memory=${MEM_CAP} --memory-swap=${MEM_CAP} ${CONTAINER}`)
+  }
+  if (SCAN_CONCURRENCY) {
+    // Env vars can't be changed on an already-running container (unlike the memory
+    // cgroup cap above, which docker update can patch live) — they're baked in at
+    // container start. Verify the worker already has the value this run wants
+    // instead of silently testing against whatever it happened to start with.
+    const actual = sh(
+      `docker exec ${CONTAINER} sh -c 'echo $BLAST_RADIUS_SCAN_CONCURRENCY'`,
+    )
+    if (actual !== SCAN_CONCURRENCY) {
+      throw new Error(
+        `--scanConcurrency=${SCAN_CONCURRENCY} requested but ${CONTAINER} was started with ` +
+          `BLAST_RADIUS_SCAN_CONCURRENCY=${actual || '(unset)'}. Restart it first: ` +
+          `BLAST_RADIUS_SCAN_CONCURRENCY=${SCAN_CONCURRENCY} ./scripts/cli service blast-radius-worker restart`,
+      )
+    }
+    console.log(`[loadtest] confirmed BLAST_RADIUS_SCAN_CONCURRENCY=${SCAN_CONCURRENCY} on worker`)
+  }
+}
+
+function resetRunConfig() {
+  console.log('[loadtest] resetting container memory cap to unlimited')
+  try {
+    sh(`docker update --memory=0 --memory-swap=0 ${CONTAINER}`)
+  } catch {
+    // some docker versions reject 0; fall back to a generous cap instead of leaving 2g stuck
+    try {
+      sh(`docker update --memory=8g --memory-swap=8g ${CONTAINER}`)
+    } catch {
+      console.warn('[loadtest] could not reset memory cap automatically — check manually')
+    }
+  }
+}
+
+function sampleContainerStats(): { memUsage: string; cpuPerc: string } | null {
+  try {
+    const raw = sh(
+      `docker stats ${CONTAINER} --no-stream --format "{{.MemUsage}}|{{.CPUPerc}}"`,
+    )
+    const [memUsage, cpuPerc] = raw.split('|')
+    return { memUsage, cpuPerc }
+  } catch {
+    return null
+  }
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length))
+  return sorted[idx]
+}
+
+function stats(values: number[]) {
+  if (values.length === 0) return null
+  return {
+    count: values.length,
+    min: Math.min(...values),
+    avg: Math.round(values.reduce((a, b) => a + b, 0) / values.length),
+    p95: percentile(values, 95),
+    max: Math.max(...values),
+  }
+}
+
+async function main() {
+  const advisories = loadAdvisories()
+  console.log(
+    `[loadtest] jobs=${JOBS} scanConcurrency=${SCAN_CONCURRENCY ?? '(default 32)'} ` +
+      `memCap=${MEM_CAP ?? '(none)'} stopAfter=${STOP_AFTER} container=${CONTAINER} ` +
+      `advisories=${advisories.length}${ADVISORIES_FILE ? ` (${ADVISORIES_FILE})` : ' (default)'}`,
+  )
+
+  applyRunConfig()
+
+  const qx = await getPackagesQx()
+  const packagesTemporal = await getPackagesTemporalClient()
+
+  const analysisIds: string[] = []
+  const submittedAt = Date.now()
+
+  try {
+    await Promise.all(
+      Array.from({ length: JOBS }, async (_, i) => {
+        const target = advisories[i % advisories.length]
+        const analysisId = generateUUIDv4()
+        const analysisInput = {
+          id: analysisId,
+          advisoryOsvId: target.advisoryId,
+          packageName: target.package,
+          ecosystem: target.ecosystem,
+          force: false,
+        }
+        await blastRadiusDal.createAnalysis(qx, analysisInput)
+        await packagesTemporal.workflow.start('analyzeBlastRadius', {
+          taskQueue: 'blast-radius-worker',
+          workflowId: `${TemporalWorkflowId.BLAST_RADIUS_ANALYSIS}/${analysisId}`,
+          retry: { maximumAttempts: 1 },
+          args: [
+            {
+              analysisId,
+              advisoryId: target.advisoryId,
+              package: target.package,
+              ecosystem: target.ecosystem,
+              force: false,
+              stopAfterStage: STOP_AFTER,
+            },
+          ],
+        })
+        analysisIds.push(analysisId)
+      }),
+    )
+
+    console.log(`[loadtest] submitted ${analysisIds.length} analyses in ${Date.now() - submittedAt}ms`)
+    console.log(`[loadtest] analysisIds: ${analysisIds.join(', ')}`)
+
+    const deadline = Date.now() + TIMEOUT_MS
+    let allDone = false
+    const memSamples: string[] = []
+
+    while (Date.now() < deadline) {
+      // With stopAfterStage, the analysis row itself stays 'running' forever (the
+      // workflow returns cleanly instead of finishing all stages) — so completion
+      // is judged from stage_runs reaching the requested stop stage, not from
+      // blast_radius_analyses.status.
+      const rows = await qx.select(
+        `select analysis_id, status from blast_radius_stage_runs
+         where analysis_id in ($(ids:csv)) and stage = $(stage)`,
+        { ids: analysisIds, stage: STOP_AFTER },
+      )
+      const finished = rows.filter(
+        (r: { status: string }) => r.status === 'succeeded' || r.status === 'failed',
+      )
+
+      const sample = sampleContainerStats()
+      if (sample) {
+        memSamples.push(sample.memUsage)
+        console.log(
+          `[loadtest] ${finished.length}/${analysisIds.length} finished stage=${STOP_AFTER} ` +
+            `mem=${sample.memUsage} cpu=${sample.cpuPerc} (${new Date().toISOString()})`,
+        )
+      } else {
+        console.log(
+          `[loadtest] ${finished.length}/${analysisIds.length} finished stage=${STOP_AFTER} ` +
+            `(${new Date().toISOString()})`,
+        )
+      }
+
+      if (finished.length === analysisIds.length) {
+        allDone = true
+        break
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+
+    if (!allDone) {
+      console.warn('[loadtest] TIMED OUT waiting for all analyses to reach the stop stage')
+    }
+
+    const stageRuns = await qx.select(
+      `select analysis_id, stage, status, duration_ms, cost_usd, error
+       from blast_radius_stage_runs where analysis_id in ($(ids:csv))`,
+      { ids: analysisIds },
+    )
+
+    console.log('\n=== Per-analysis stage outcomes ===')
+    for (const id of analysisIds) {
+      const runs = stageRuns.filter((r: { analysis_id: string }) => r.analysis_id === id)
+      const summary = runs
+        .map((r: { stage: string; status: string; error: string | null }) => `${r.stage}=${r.status}${r.error ? ` (${r.error})` : ''}`)
+        .join(', ')
+      console.log(`${id}: ${summary || 'no stage runs recorded'}`)
+    }
+
+    console.log('\n=== Stage duration stats (ms) ===')
+    for (const stage of ['intel', 'dependents', 'reachability', 'report']) {
+      const durations = stageRuns
+        .filter((r: { stage: string; status: string }) => r.stage === stage && r.status === 'succeeded')
+        .map((r: { duration_ms: number | string }) => Number(r.duration_ms))
+      console.log(`${stage}:`, stats(durations))
+    }
+
+    // blast_radius_analyses.total_cost_usd is only ever set by the report stage
+    // (finalizeAnalysis) — with stopAfterStage set, report never runs, so the only
+    // place real per-stage cost shows up is here, on stage_runs, scoped to this run's
+    // own analysisIds (not a global window, since other runs/deployments write here too).
+    console.log('\n=== Cost (USD, from blast_radius_stage_runs) ===')
+    let totalCost = 0
+    for (const stage of ['intel', 'dependents', 'reachability', 'report']) {
+      const costs = stageRuns
+        .filter((r: { stage: string }) => r.stage === stage)
+        .map((r: { cost_usd: number | string | null }) => Number(r.cost_usd ?? 0))
+      const stageCost = costs.reduce((sum: number, c: number) => sum + c, 0)
+      totalCost += stageCost
+      console.log(`${stage}: $${stageCost.toFixed(4)} (${costs.length} runs)`)
+    }
+    console.log(`total: $${totalCost.toFixed(4)}`)
+
+    if (memSamples.length > 0) {
+      console.log(`\n=== Memory samples (docker stats, ${memSamples.length} points) ===`)
+      console.log(memSamples.join(' -> '))
+    }
+
+    console.log(`\n[loadtest] total wall-clock: ${Date.now() - submittedAt}ms`)
+    process.exit(allDone ? 0 : 1)
+  } finally {
+    resetRunConfig()
+  }
+}
+
+main().catch((err) => {
+  console.error('[loadtest] fatal error', err)
+  resetRunConfig()
+  process.exit(1)
+})

--- a/backend/src/bin/scripts/blastRadiusLoadTest.ts
+++ b/backend/src/bin/scripts/blastRadiusLoadTest.ts
@@ -25,7 +25,6 @@
 //   --advisories=FILE    path to a JSON array of {advisoryId, package, ecosystem} —
 //                        jobs round-robin across these instead of all hitting the
 //                        same package (default: a single lodash advisory, repeated)
-
 import { execSync } from 'child_process'
 import * as fs from 'fs'
 
@@ -84,9 +83,7 @@ function applyRunConfig() {
     // cgroup cap above, which docker update can patch live) — they're baked in at
     // container start. Verify the worker already has the value this run wants
     // instead of silently testing against whatever it happened to start with.
-    const actual = sh(
-      `docker exec ${CONTAINER} sh -c 'echo $BLAST_RADIUS_SCAN_CONCURRENCY'`,
-    )
+    const actual = sh(`docker exec ${CONTAINER} sh -c 'echo $BLAST_RADIUS_SCAN_CONCURRENCY'`)
     if (actual !== SCAN_CONCURRENCY) {
       throw new Error(
         `--scanConcurrency=${SCAN_CONCURRENCY} requested but ${CONTAINER} was started with ` +
@@ -114,9 +111,7 @@ function resetRunConfig() {
 
 function sampleContainerStats(): { memUsage: string; cpuPerc: string } | null {
   try {
-    const raw = sh(
-      `docker stats ${CONTAINER} --no-stream --format "{{.MemUsage}}|{{.CPUPerc}}"`,
-    )
+    const raw = sh(`docker stats ${CONTAINER} --no-stream --format "{{.MemUsage}}|{{.CPUPerc}}"`)
     const [memUsage, cpuPerc] = raw.split('|')
     return { memUsage, cpuPerc }
   } catch {
@@ -190,7 +185,9 @@ async function main() {
       }),
     )
 
-    console.log(`[loadtest] submitted ${analysisIds.length} analyses in ${Date.now() - submittedAt}ms`)
+    console.log(
+      `[loadtest] submitted ${analysisIds.length} analyses in ${Date.now() - submittedAt}ms`,
+    )
     console.log(`[loadtest] analysisIds: ${analysisIds.join(', ')}`)
 
     const deadline = Date.now() + TIMEOUT_MS
@@ -229,7 +226,9 @@ async function main() {
         allDone = true
         break
       }
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+      await new Promise((resolve) => {
+        setTimeout(resolve, POLL_INTERVAL_MS)
+      })
     }
 
     if (!allDone) {
@@ -246,7 +245,10 @@ async function main() {
     for (const id of analysisIds) {
       const runs = stageRuns.filter((r: { analysis_id: string }) => r.analysis_id === id)
       const summary = runs
-        .map((r: { stage: string; status: string; error: string | null }) => `${r.stage}=${r.status}${r.error ? ` (${r.error})` : ''}`)
+        .map(
+          (r: { stage: string; status: string; error: string | null }) =>
+            `${r.stage}=${r.status}${r.error ? ` (${r.error})` : ''}`,
+        )
         .join(', ')
       console.log(`${id}: ${summary || 'no stage runs recorded'}`)
     }
@@ -254,7 +256,9 @@ async function main() {
     console.log('\n=== Stage duration stats (ms) ===')
     for (const stage of ['intel', 'dependents', 'reachability', 'report']) {
       const durations = stageRuns
-        .filter((r: { stage: string; status: string }) => r.stage === stage && r.status === 'succeeded')
+        .filter(
+          (r: { stage: string; status: string }) => r.stage === stage && r.status === 'succeeded',
+        )
         .map((r: { duration_ms: number | string }) => Number(r.duration_ms))
       console.log(`${stage}:`, stats(durations))
     }

--- a/backend/src/bin/scripts/blastRadiusLoadTestAdvisories.json
+++ b/backend/src/bin/scripts/blastRadiusLoadTestAdvisories.json
@@ -1,0 +1,6 @@
+[
+  { "advisoryId": "GHSA-jf85-cpcp-j695", "package": "lodash", "ecosystem": "npm" },
+  { "advisoryId": "GHSA-cxjh-pqwp-8mfp", "package": "follow-redirects", "ecosystem": "npm" },
+  { "advisoryId": "GHSA-pch5-whg9-qr2r", "package": "netmask", "ecosystem": "npm" },
+  { "advisoryId": "GHSA-c429-5p7v-vgjp", "package": "@hapi/hoek", "ecosystem": "npm" }
+]

--- a/services/apps/packages_worker/src/bin/blast-radius-worker.ts
+++ b/services/apps/packages_worker/src/bin/blast-radius-worker.ts
@@ -1,4 +1,25 @@
-import { svc } from '../service'
+import { Config } from '@crowd/archetype-standard'
+import { Options, ServiceWorker } from '@crowd/archetype-worker'
+
+// Own ServiceWorker instance rather than the shared one in ../service (used by every
+// other packages_worker entry point) — its activities are CPU/IO-heavy (tarball
+// downloads+extraction, agent subprocesses), so it needs a concurrency cap that would
+// otherwise throttle unrelated, lightweight ingestion workers if set on the shared
+// instance. Left uncapped, the SDK default lets dozens run at once in this one process,
+// starving the event loop and missing heartbeat deadlines.
+const config: Config = {
+  envvars: [],
+  producer: { enabled: false },
+  temporal: { enabled: true },
+  redis: { enabled: false },
+}
+
+const options: Options = {
+  postgres: { enabled: false }, // packages-db is managed via getPackagesDb()
+  maxConcurrentActivityTaskExecutions: 8,
+}
+
+const svc = new ServiceWorker(config, options)
 
 // On-demand only — analyzeBlastRadius is triggered per request from the backend's
 // submitBlastRadiusJob handler (workflow.start), not on a schedule.

--- a/services/apps/packages_worker/src/bin/blast-radius-worker.ts
+++ b/services/apps/packages_worker/src/bin/blast-radius-worker.ts
@@ -1,5 +1,6 @@
 import { Config } from '@crowd/archetype-standard'
 import { Options, ServiceWorker } from '@crowd/archetype-worker'
+import { SlackChannel } from '@crowd/slack'
 
 // Own ServiceWorker instance rather than the shared one in ../service (used by every
 // other packages_worker entry point) — its activities are CPU/IO-heavy (tarball
@@ -17,6 +18,7 @@ const config: Config = {
 const options: Options = {
   postgres: { enabled: false }, // packages-db is managed via getPackagesDb()
   maxConcurrentActivityTaskExecutions: 16,
+  alertChannel: SlackChannel.CDP_AKRITES_ALERTS,
 }
 
 const svc = new ServiceWorker(config, options)

--- a/services/apps/packages_worker/src/bin/blast-radius-worker.ts
+++ b/services/apps/packages_worker/src/bin/blast-radius-worker.ts
@@ -16,7 +16,7 @@ const config: Config = {
 
 const options: Options = {
   postgres: { enabled: false }, // packages-db is managed via getPackagesDb()
-  maxConcurrentActivityTaskExecutions: 8,
+  maxConcurrentActivityTaskExecutions: 16,
 }
 
 const svc = new ServiceWorker(config, options)

--- a/services/apps/packages_worker/src/blast-radius/activities.ts
+++ b/services/apps/packages_worker/src/blast-radius/activities.ts
@@ -1,4 +1,4 @@
-import { heartbeat } from '@temporalio/activity'
+import { Context, heartbeat } from '@temporalio/activity'
 
 import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
 import { getServiceChildLogger } from '@crowd/logging'
@@ -75,7 +75,10 @@ export async function blastRadiusIntel(input: BlastRadiusActivityInput): Promise
 export async function blastRadiusDependents(input: BlastRadiusActivityInput): Promise<void> {
   log.info({ analysisId: input.analysisId }, 'blast-radius: dependents stage starting')
   const qx = await getPackagesDb()
-  await runDependentsStage(qx, input.analysisId, heartbeat)
+  // Pass Temporal's own cancellation signal through to the scan so a timed-out or
+  // cancelled attempt actually stops its in-flight fetches instead of running on as
+  // a zombie in the background while a retry starts a duplicate scan of the same analysis.
+  await runDependentsStage(qx, input.analysisId, heartbeat, Context.current().cancellationSignal)
   log.info({ analysisId: input.analysisId }, 'blast-radius: dependents stage done')
 }
 

--- a/services/apps/packages_worker/src/blast-radius/agent/runner.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/runner.ts
@@ -4,6 +4,10 @@
 // Agent runner wrapping Claude Agent SDK with read-only tool restrictions,
 // API key fallback, structured output, and timeout support.
 
+import { getServiceChildLogger } from '@crowd/logging'
+
+const log = getServiceChildLogger('blast-radius-agent-runner')
+
 export interface AgentRunResult {
   structuredOutput: Record<string, unknown> | null
   isError: boolean
@@ -50,6 +54,13 @@ export async function runAnalysisAgent(input: RunAnalysisAgentInput): Promise<Ag
         ...(baseUrl ? { ANTHROPIC_BASE_URL: baseUrl } : {}),
       }
     : undefined
+
+  log.info(
+    {
+      authMode: apiKey ? (baseUrl ? 'api-key via base-url override (e.g. LiteLLM)' : 'api-key') : 'fallback on local claude code token',
+    },
+    'blast-radius agent: auth mode for this run',
+  )
 
   // Setup timeout via AbortController
   const controller = new AbortController()

--- a/services/apps/packages_worker/src/blast-radius/agent/runner.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/runner.ts
@@ -1,9 +1,7 @@
 // @anthropic-ai/claude-agent-sdk ships ESM-only; packages_worker compiles to
 // CommonJS, so it must be loaded via dynamic import rather than a static one.
-
 // Agent runner wrapping Claude Agent SDK with read-only tool restrictions,
 // API key fallback, structured output, and timeout support.
-
 import { getServiceChildLogger } from '@crowd/logging'
 
 const log = getServiceChildLogger('blast-radius-agent-runner')
@@ -57,7 +55,11 @@ export async function runAnalysisAgent(input: RunAnalysisAgentInput): Promise<Ag
 
   log.info(
     {
-      authMode: apiKey ? (baseUrl ? 'api-key via base-url override (e.g. LiteLLM)' : 'api-key') : 'fallback on local claude code token',
+      authMode: apiKey
+        ? baseUrl
+          ? 'api-key via base-url override (e.g. LiteLLM)'
+          : 'api-key'
+        : 'fallback on local claude code token',
     },
     'blast-radius agent: auth mode for this run',
   )

--- a/services/apps/packages_worker/src/blast-radius/clients/npmAbbreviated.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/npmAbbreviated.ts
@@ -1,3 +1,4 @@
+import { combineSignals } from '../../npm/signals'
 import type { FetchError } from '../../npm/types'
 
 const REGISTRY = 'https://registry.npmjs.org'
@@ -22,12 +23,16 @@ export interface AbbreviatedPackument {
 // npm's abbreviated metadata format (dependencies/dist-tags only, no readme/maintainers/etc.) —
 // used for the high-volume candidate pre-scan in dependentsScan.ts, where only the declared
 // dependency ranges matter and the full packument payload would be wasted bandwidth.
+// `signal` (e.g. a Temporal activity's cancellationSignal) is combined with the request's
+// own 30s timeout so a caller can abort in-flight requests early.
 export async function fetchAbbreviatedPackument(
   name: string,
+  signal?: AbortSignal,
 ): Promise<AbbreviatedPackument | FetchError> {
   const url = `${REGISTRY}/${encodeNpmName(name)}`
   const abort = new AbortController()
   const timer = setTimeout(() => abort.abort(), 30_000)
+  const combinedSignal = combineSignals(abort.signal, signal)
   let res: Response
   try {
     res = await fetch(url, {
@@ -35,7 +40,7 @@ export async function fetchAbbreviatedPackument(
         Accept: 'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8',
         'User-Agent': USER_AGENT,
       },
-      signal: abort.signal,
+      signal: combinedSignal,
     })
   } catch (err) {
     return { kind: 'TRANSIENT', message: String(err) }

--- a/services/apps/packages_worker/src/blast-radius/clients/npmTarball.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/npmTarball.ts
@@ -1,6 +1,4 @@
 import * as fs from 'fs'
-import * as os from 'os'
-import * as path from 'path'
 import { Readable, Transform, Writable } from 'stream'
 import type { ReadableStream as NodeWebReadableStream } from 'stream/web'
 import * as tar from 'tar'
@@ -13,11 +11,10 @@ const MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024
 const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024
 const MAX_EXTRACTED_FILES = 20_000
 
-// Downloads an npm tarball and extracts it into destDir, stripping the
-// package's own top-level directory (npm tarballs are always wrapped in a
-// single `package/` dir) if all entries share one. Guards against path
-// traversal since tarball content here is third-party (dependent packages),
-// not something we control.
+// Downloads an npm tarball and extracts it directly into destDir, stripping
+// the package's own top-level `package/` wrapper directory (npm tarballs are
+// always wrapped in one). Guards against path traversal since tarball content
+// here is third-party (dependent packages), not something we control.
 export async function downloadAndExtractTarball(
   tarballUrl: string,
   destDir: string,
@@ -36,83 +33,53 @@ export async function downloadAndExtractTarball(
       throw new Error('No response body from tarball fetch')
     }
 
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tarball-extract-'))
-    try {
-      // tar rejects (preservePaths defaults to false) any entry whose path would resolve
-      // outside cwd; strict:true makes that a thrown error instead of a silent warn+skip.
-      let extractedBytes = 0
-      let extractedFiles = 0
-      const extractStream = tar.extract({
-        cwd: tempDir,
-        strict: true,
-        filter: (_entryPath, entry) => {
-          extractedFiles++
-          extractedBytes += entry.size ?? 0
-          if (extractedFiles > MAX_EXTRACTED_FILES || extractedBytes > MAX_EXTRACTED_BYTES) {
-            ;(extractStream as unknown as Writable).destroy(
-              new Error('Tarball extraction exceeded size/file limits'),
-            )
-            return false
-          }
-          return true
-        },
-      })
+    // tar rejects (preservePaths defaults to false) any entry whose path would resolve
+    // outside cwd; strict:true makes that a thrown error instead of a silent warn+skip.
+    // strip:1 drops the tarball's own `package/` wrapper directly during extraction —
+    // npm tarballs are always wrapped in one, so this avoids a second synchronous
+    // extract-to-tempdir-then-copy-every-file pass (that pass was the CPU/disk-I/O
+    // bottleneck under concurrent load: see blast_radius_load_tests.xlsx Stage 1).
+    let extractedBytes = 0
+    let extractedFiles = 0
+    const extractStream = tar.extract({
+      cwd: destDir,
+      strict: true,
+      strip: 1,
+      filter: (_entryPath, entry) => {
+        extractedFiles++
+        extractedBytes += entry.size ?? 0
+        if (extractedFiles > MAX_EXTRACTED_FILES || extractedBytes > MAX_EXTRACTED_BYTES) {
+          ;(extractStream as unknown as Writable).destroy(
+            new Error('Tarball extraction exceeded size/file limits'),
+          )
+          return false
+        }
+        return true
+      },
+    })
 
-      let downloadedBytes = 0
-      const downloadLimiter = new Transform({
-        transform(chunk, _encoding, callback) {
-          downloadedBytes += chunk.length
-          if (downloadedBytes > MAX_DOWNLOAD_BYTES) {
-            callback(new Error('Tarball download exceeded size limit'))
-            return
-          }
-          callback(null, chunk)
-        },
-      })
+    let downloadedBytes = 0
+    const downloadLimiter = new Transform({
+      transform(chunk, _encoding, callback) {
+        downloadedBytes += chunk.length
+        if (downloadedBytes > MAX_DOWNLOAD_BYTES) {
+          callback(new Error('Tarball download exceeded size limit'))
+          return
+        }
+        callback(null, chunk)
+      },
+    })
 
-      await new Promise<void>((resolve, reject) => {
-        Readable.fromWeb(res.body as unknown as NodeWebReadableStream<Uint8Array>)
-          .on('error', reject)
-          .pipe(downloadLimiter)
-          .on('error', reject)
-          .pipe(extractStream as unknown as NodeJS.WritableStream)
-          .on('finish', resolve)
-          .on('error', reject)
-      })
-
-      const items = fs.readdirSync(tempDir)
-      const commonPrefix =
-        items.length === 1 && fs.statSync(path.join(tempDir, items[0])).isDirectory()
-          ? items[0]
-          : null
-      const srcBase = commonPrefix ? path.join(tempDir, commonPrefix) : tempDir
-
-      copyTreeGuarded(srcBase, destDir)
-    } finally {
-      fs.rmSync(tempDir, { recursive: true, force: true })
-    }
+    await new Promise<void>((resolve, reject) => {
+      Readable.fromWeb(res.body as unknown as NodeWebReadableStream<Uint8Array>)
+        .on('error', reject)
+        .pipe(downloadLimiter)
+        .on('error', reject)
+        .pipe(extractStream as unknown as NodeJS.WritableStream)
+        .on('finish', resolve)
+        .on('error', reject)
+    })
   } finally {
     clearTimeout(timeoutHandle)
-  }
-}
-
-// Copies every file under srcBase into destDir, rejecting any entry whose
-// resolved path would land outside destDir.
-function copyTreeGuarded(srcBase: string, destDir: string): void {
-  const resolvedDest = path.resolve(destDir)
-  const entries = fs.readdirSync(srcBase, { recursive: true }) as string[]
-
-  for (const entry of entries) {
-    const srcPath = path.join(srcBase, entry)
-    const destPath = path.resolve(destDir, entry)
-    if (destPath !== resolvedDest && !destPath.startsWith(resolvedDest + path.sep)) {
-      continue
-    }
-
-    const stat = fs.statSync(srcPath)
-    if (stat.isDirectory()) continue
-
-    fs.mkdirSync(path.dirname(destPath), { recursive: true })
-    fs.copyFileSync(srcPath, destPath)
   }
 }

--- a/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
+++ b/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
@@ -248,6 +248,10 @@ export async function scanDependents(input: {
   const unscopedNames = candidateNames.filter((n) => !n.startsWith('@'))
   const scopedNames = candidateNames.filter((n) => n.startsWith('@'))
 
+  // Neither loop below heartbeated before — for a large candidate pool (many
+  // unscoped batches, or many scoped names run one HTTP call at a time through
+  // mapWithConcurrency) this whole download-count phase could run past the
+  // dependents stage's heartbeatTimeout with nothing heartbeating in between.
   for (let i = 0; i < unscopedNames.length; i += 128) {
     const batch = unscopedNames.slice(i, i + 128)
     const result = await fetchBulkPointRange(batch, isoDate(rangeStart), isoDate(rangeEnd))
@@ -256,14 +260,20 @@ export async function scanDependents(input: {
         downloads.set(name, count)
       })
     }
+    onProgress?.()
   }
 
   // fetchBulkPointRange doesn't support scoped package names; fetch those individually
   // so scoped candidates aren't silently ranked at 0 downloads and excluded from topN.
+  let scopedProcessed = 0
   await mapWithConcurrency(scopedNames, SCAN_CONCURRENCY, async (name) => {
     const result = await fetchPointRange(name, isoDate(rangeStart), isoDate(rangeEnd))
     if (!isFetchError(result)) {
       downloads.set(name, result.count)
+    }
+    scopedProcessed++
+    if (onProgress && scopedProcessed % 200 === 0) {
+      onProgress()
     }
   })
 

--- a/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
+++ b/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
@@ -279,6 +279,10 @@ export async function scanDependents(input: {
   for (const name of ranked) {
     if (analyzed.length >= topN) break
 
+    // Phase 1 heartbeats every 200 candidates via mapWithConcurrency; this walk is
+    // sequential (one packument fetch at a time), so it needs its own heartbeat too.
+    onProgress?.()
+
     const packument = await fetchPackument(name)
     if (isFetchError(packument)) continue
 

--- a/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
+++ b/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
@@ -13,7 +13,11 @@ import { rangeIncludesAny } from './semverRange'
 
 // Configurable via env var so local load tests can vary it per run without
 // editing source; unset in every real deployment, so this is always 32 in prod.
-const SCAN_CONCURRENCY = Number(process.env.BLAST_RADIUS_SCAN_CONCURRENCY) || 32
+// Clamped to a positive integer — a negative or fractional override would make
+// forEachWithConcurrency's Array.from({length: concurrency}) spin up zero workers,
+// so the scan would silently complete with nothing processed.
+const SCAN_CONCURRENCY =
+  Math.max(1, Math.floor(Number(process.env.BLAST_RADIUS_SCAN_CONCURRENCY))) || 32
 const HIGH_IMPACT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 // The per-candidate fetches below (abbreviated packument, full packument, download count)
 // don't depend on which target package the analysis is checking against — the same

--- a/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
+++ b/services/apps/packages_worker/src/blast-radius/dependentsScan.ts
@@ -4,15 +4,25 @@ import * as path from 'path'
 
 import { fetchBulkPointRange, fetchPointRange } from '../npm/fetchDownloads'
 import { fetchPackument } from '../npm/fetchPackument'
-import { isFetchError } from '../npm/types'
+import { FetchError, isFetchError } from '../npm/types'
 
 import { fetchAbbreviatedPackument } from './clients/npmAbbreviated'
 import { downloadAndExtractTarball } from './clients/npmTarball'
 import { NpmVersionManifest, asNpmVersionManifest } from './npmManifest'
 import { rangeIncludesAny } from './semverRange'
 
-const SCAN_CONCURRENCY = 32
+// Configurable via env var so local load tests can vary it per run without
+// editing source; unset in every real deployment, so this is always 32 in prod.
+const SCAN_CONCURRENCY = Number(process.env.BLAST_RADIUS_SCAN_CONCURRENCY) || 32
 const HIGH_IMPACT_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+// The per-candidate fetches below (abbreviated packument, full packument, download count)
+// don't depend on which target package the analysis is checking against — the same
+// high-impact candidate list is scanned for every analysis. Concurrent/near-concurrent
+// analyses (e.g. several jobs submitted around the same time) would otherwise each
+// independently re-fetch the same npm data for the same candidates. Short TTL: long
+// enough to dedupe a burst of analyses, short enough that download counts (a rolling
+// 30-day window) and freshly-published versions don't go stale for long.
+const CANDIDATE_CACHE_TTL_MS = 10 * 60 * 1000
 const DEP_KINDS: Array<'dependencies' | 'peerDependencies' | 'optionalDependencies'> = [
   'dependencies',
   'peerDependencies',
@@ -20,21 +30,98 @@ const DEP_KINDS: Array<'dependencies' | 'peerDependencies' | 'optionalDependenci
 ]
 
 let highImpactNamesCache: { names: string[]; fetchedAt: number } | null = null
+let highImpactNamesInFlight: Promise<string[]> | null = null
 
-// Runs `fn` over `items` with at most `concurrency` in flight at once.
-async function mapWithConcurrency<T>(
+// Generic keyed TTL cache + singleflight: concurrent callers requesting the same key
+// share one in-flight fetch instead of issuing duplicate requests (same rationale as
+// highImpactNames' singleflight above, generalized per-key). Deliberately not tied to
+// any individual caller's cancellation signal — callers pass a signal-less fetchFn, so
+// one job's cancellation can't abort a fetch other jobs are still waiting on. Error
+// results aren't cached — they're usually transient (a caller's own retry-with-backoff
+// already smooths those out) and caching them would keep serving a stale failure to
+// every other caller for the rest of the TTL window.
+// maxEntries bounds retained memory — full packuments in particular (all published
+// versions + deps per version) can be several MB each for popular packages, and a
+// TTL alone doesn't cap how many distinct keys accumulate within the window under
+// high concurrency. FIFO eviction (Map preserves insertion order) once the cap is hit.
+function createSharedFetchCache<T>(ttlMs: number, maxEntries: number) {
+  const cache = new Map<string, { value: T; fetchedAt: number }>()
+  const inFlight = new Map<string, Promise<T>>()
+
+  return async function getOrFetch(key: string, fetchFn: () => Promise<T>): Promise<T> {
+    const cached = cache.get(key)
+    if (cached && Date.now() - cached.fetchedAt < ttlMs) {
+      return cached.value
+    }
+
+    let promise = inFlight.get(key)
+    if (!promise) {
+      promise = fetchFn().finally(() => inFlight.delete(key))
+      inFlight.set(key, promise)
+    }
+
+    const value = await promise
+    if (!isFetchError(value)) {
+      if (cache.size >= maxEntries && !cache.has(key)) {
+        const oldestKey = cache.keys().next().value
+        if (oldestKey !== undefined) cache.delete(oldestKey)
+      }
+      cache.set(key, { value, fetchedAt: Date.now() })
+    }
+    return value
+  }
+}
+
+// Abbreviated packuments and download counts are small (a few KB), so a generous cap
+// is low-risk. Full packuments can be MB-sized (all historical versions) — cap tightly.
+const abbreviatedPackumentCache = createSharedFetchCache<
+  Awaited<ReturnType<typeof fetchAbbreviatedPackument>>
+>(CANDIDATE_CACHE_TTL_MS, 5000)
+const packumentCache = createSharedFetchCache<Awaited<ReturnType<typeof fetchPackument>>>(
+  CANDIDATE_CACHE_TTL_MS,
+  300,
+)
+const pointRangeCache = createSharedFetchCache<Awaited<ReturnType<typeof fetchPointRange>>>(
+  CANDIDATE_CACHE_TTL_MS,
+  5000,
+)
+
+// Runs `fn` over `items` with at most `concurrency` in flight at once. Stops handing
+// out new items once `signal` aborts — in-flight calls still need to observe the same
+// signal themselves (it's passed through to the fetch clients) to actually stop early.
+export async function forEachWithConcurrency<T>(
   items: T[],
   concurrency: number,
   fn: (item: T, index: number) => Promise<void>,
+  signal?: AbortSignal,
 ): Promise<void> {
   let next = 0
   async function worker() {
-    while (next < items.length) {
+    while (next < items.length && !signal?.aborted) {
       const i = next++
       await fn(items[i], i)
     }
   }
   await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker))
+}
+
+const RATE_LIMIT_RETRY_DELAYS_MS = [500, 1000, 2000]
+
+// npm registry 429s are transient — retry with backoff instead of silently treating
+// the candidate as absent, which would otherwise make Phase 1's candidate set (and the
+// whole analysis) quietly incomplete under concurrent load, with no signal of why.
+async function withRateLimitRetry<T>(
+  fetchFn: () => Promise<T | FetchError>,
+  signal?: AbortSignal,
+): Promise<T | FetchError> {
+  let result = await fetchFn()
+  for (const delayMs of RATE_LIMIT_RETRY_DELAYS_MS) {
+    if (!isFetchError(result) || result.kind !== 'RATE_LIMIT' || signal?.aborted) break
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    if (signal?.aborted) break
+    result = await fetchFn()
+  }
+  return result
 }
 
 export interface DependentCandidate {
@@ -59,6 +146,12 @@ export interface ScanDependentsResult {
 // Fetch high-impact npm package names from the npm-high-impact package. Cached in-memory
 // for the life of the worker process — the list is a published npm package that changes
 // rarely, so re-downloading and re-extracting its tarball on every analysis is wasted work.
+// Singleflight: with the worker running several dependents scans concurrently
+// (see maxConcurrentActivityTaskExecutions), a cold cache would otherwise have every
+// one of them independently download and extract the same npm-high-impact tarball at
+// once. Concurrent callers share the one in-flight fetch instead. Deliberately not tied
+// to any individual caller's cancellation signal — it's a shared fetch, so one job being
+// cancelled shouldn't abort the download for the others still waiting on it.
 async function highImpactNames(): Promise<string[]> {
   if (
     highImpactNamesCache &&
@@ -67,13 +160,19 @@ async function highImpactNames(): Promise<string[]> {
     return highImpactNamesCache.names
   }
 
-  const names = await fetchHighImpactNames()
+  if (!highImpactNamesInFlight) {
+    highImpactNamesInFlight = fetchHighImpactNames().finally(() => {
+      highImpactNamesInFlight = null
+    })
+  }
+
+  const names = await highImpactNamesInFlight
   highImpactNamesCache = { names, fetchedAt: Date.now() }
   return names
 }
 
 async function fetchHighImpactNames(): Promise<string[]> {
-  const packument = await fetchPackument('npm-high-impact')
+  const packument = await withRateLimitRetry(() => fetchPackument('npm-high-impact', undefined))
   if (isFetchError(packument)) {
     throw new Error(`Failed to fetch npm-high-impact: ${packument.message}`)
   }
@@ -176,34 +275,42 @@ async function candidateNamesFromScan(
   names: string[],
   targets: Set<string>,
   onProgress?: () => void,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const hits: string[] = []
   let processed = 0
 
-  await mapWithConcurrency(names, SCAN_CONCURRENCY, async (name) => {
-    processed++
-    if (onProgress && processed % 200 === 0) {
-      onProgress()
-    }
-
-    const packument = await fetchAbbreviatedPackument(name)
-    if (isFetchError(packument)) return
-
-    const latest = packument['dist-tags']?.latest
-    const versionData = latest ? packument.versions?.[latest] : undefined
-    if (!versionData) return
-
-    for (const depKind of DEP_KINDS) {
-      const deps = versionData[depKind] ?? {}
-      const hasTarget = Object.entries(deps).some(([depName, depSpec]) =>
-        targets.has(resolvedDependencyTarget(depName, depSpec).name),
-      )
-      if (hasTarget) {
-        hits.push(name)
-        return
+  await forEachWithConcurrency(
+    names,
+    SCAN_CONCURRENCY,
+    async (name) => {
+      processed++
+      if (onProgress && processed % 200 === 0) {
+        onProgress()
       }
-    }
-  })
+
+      const packument = await abbreviatedPackumentCache(name, () =>
+        withRateLimitRetry(() => fetchAbbreviatedPackument(name)),
+      )
+      if (isFetchError(packument)) return
+
+      const latest = packument['dist-tags']?.latest
+      const versionData = latest ? packument.versions?.[latest] : undefined
+      if (!versionData) return
+
+      for (const depKind of DEP_KINDS) {
+        const deps = versionData[depKind] ?? {}
+        const hasTarget = Object.entries(deps).some(([depName, depSpec]) =>
+          targets.has(resolvedDependencyTarget(depName, depSpec).name),
+        )
+        if (hasTarget) {
+          hits.push(name)
+          return
+        }
+      }
+    },
+    signal,
+  )
 
   return hits
 }
@@ -215,6 +322,7 @@ export async function scanDependents(input: {
   topN: number
   scanLimit?: number
   onProgress?: () => void
+  signal?: AbortSignal
 }): Promise<ScanDependentsResult> {
   const {
     vulnerablePackage,
@@ -223,6 +331,7 @@ export async function scanDependents(input: {
     topN,
     scanLimit,
     onProgress,
+    signal,
   } = input
 
   // Fetch high-impact names
@@ -235,7 +344,7 @@ export async function scanDependents(input: {
   // Phase 1: concurrent, lightweight pre-scan — filters the (potentially ~17k) high-impact
   // list down to the names that actually declare a dependency on the target, before doing
   // any of the more expensive per-candidate work below.
-  const candidateNames = await candidateNamesFromScan(toScan, targets, onProgress)
+  const candidateNames = await candidateNamesFromScan(toScan, targets, onProgress, signal)
 
   // Fetch download counts (bulk, max 128 per request) for the last 30 days —
   // only for the filtered candidates, not the full high-impact list.
@@ -250,11 +359,14 @@ export async function scanDependents(input: {
 
   // Neither loop below heartbeated before — for a large candidate pool (many
   // unscoped batches, or many scoped names run one HTTP call at a time through
-  // mapWithConcurrency) this whole download-count phase could run past the
+  // forEachWithConcurrency) this whole download-count phase could run past the
   // dependents stage's heartbeatTimeout with nothing heartbeating in between.
-  for (let i = 0; i < unscopedNames.length; i += 128) {
+  for (let i = 0; i < unscopedNames.length && !signal?.aborted; i += 128) {
     const batch = unscopedNames.slice(i, i + 128)
-    const result = await fetchBulkPointRange(batch, isoDate(rangeStart), isoDate(rangeEnd))
+    const result = await withRateLimitRetry(
+      () => fetchBulkPointRange(batch, isoDate(rangeStart), isoDate(rangeEnd), undefined, signal),
+      signal,
+    )
     if (!isFetchError(result)) {
       result.counts.forEach((count: number, name: string) => {
         downloads.set(name, count)
@@ -266,16 +378,25 @@ export async function scanDependents(input: {
   // fetchBulkPointRange doesn't support scoped package names; fetch those individually
   // so scoped candidates aren't silently ranked at 0 downloads and excluded from topN.
   let scopedProcessed = 0
-  await mapWithConcurrency(scopedNames, SCAN_CONCURRENCY, async (name) => {
-    const result = await fetchPointRange(name, isoDate(rangeStart), isoDate(rangeEnd))
-    if (!isFetchError(result)) {
-      downloads.set(name, result.count)
-    }
-    scopedProcessed++
-    if (onProgress && scopedProcessed % 200 === 0) {
-      onProgress()
-    }
-  })
+  await forEachWithConcurrency(
+    scopedNames,
+    SCAN_CONCURRENCY,
+    async (name) => {
+      const result = await pointRangeCache(name, () =>
+        withRateLimitRetry(() =>
+          fetchPointRange(name, isoDate(rangeStart), isoDate(rangeEnd), undefined),
+        ),
+      )
+      if (!isFetchError(result)) {
+        downloads.set(name, result.count)
+      }
+      scopedProcessed++
+      if (onProgress && scopedProcessed % 200 === 0) {
+        onProgress()
+      }
+    },
+    signal,
+  )
 
   // Phase 2: walk candidates ranked by downloads (descending), fetching the full packument
   // only for names that made it through the phase-1 filter, until top-N pass the range check.
@@ -287,13 +408,15 @@ export async function scanDependents(input: {
   const excludedByRange: DependentCandidate[] = []
 
   for (const name of ranked) {
-    if (analyzed.length >= topN) break
+    if (analyzed.length >= topN || signal?.aborted) break
 
-    // Phase 1 heartbeats every 200 candidates via mapWithConcurrency; this walk is
+    // Phase 1 heartbeats every 200 candidates via forEachWithConcurrency; this walk is
     // sequential (one packument fetch at a time), so it needs its own heartbeat too.
     onProgress?.()
 
-    const packument = await fetchPackument(name)
+    const packument = await packumentCache(name, () =>
+      withRateLimitRetry(() => fetchPackument(name, undefined)),
+    )
     if (isFetchError(packument)) continue
 
     const latest = packument['dist-tags']?.latest

--- a/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
@@ -8,6 +8,7 @@ export async function runDependentsStage(
   qx: QueryExecutor,
   analysisId: string,
   onProgress?: () => void,
+  signal?: AbortSignal,
 ): Promise<void> {
   const startTime = Date.now()
 
@@ -51,6 +52,7 @@ export async function runDependentsStage(
       vulnerableVersions,
       topN: 25,
       onProgress,
+      signal,
     })
 
     // Resolve package_id for the analyzed set only (max topN=25) — these are the ones

--- a/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
@@ -55,6 +55,14 @@ export async function runDependentsStage(
       signal,
     })
 
+    // scanDependents stops its loops early on abort but still returns whatever it
+    // gathered so far — without this check, a cancelled/timed-out attempt would
+    // persist that partial set and complete the stage successfully, and a Temporal
+    // retry would then see it as already succeeded and skip re-scanning.
+    if (signal?.aborted) {
+      throw new Error('Dependents scan cancelled')
+    }
+
     // Resolve package_id for the analyzed set only (max topN=25) — these are the ones
     // actually surfaced in results/verdicts. excludedByRange (up to 200) never
     // reaches a result, so resolving it too would just be extra queries for nothing.

--- a/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
@@ -176,9 +176,13 @@ export async function runReachabilityStage(
               return
             }
 
-            // Backoff before retry
+            // Backoff before retry. Heartbeat partway through — the longest backoff
+            // (attempt 2, 30s) is still well under the stage's 5-minute heartbeatTimeout
+            // on its own, but 4 dependents processing concurrently can each be mid-backoff
+            // at once with nothing else heartbeating in between.
             const delayMs = RETRY_BACKOFF_BASE * attempt
             await new Promise((resolve) => setTimeout(resolve, delayMs))
+            onProgress?.()
           }
         }
       } finally {

--- a/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
@@ -21,8 +21,11 @@ const mkdtemp = promisify(fs.mkdtemp)
 const MAX_ATTEMPTS = 3
 const RETRY_BACKOFF_BASE = 15_000 // 15 seconds
 // Tunable for load testing, same pattern as BLAST_RADIUS_SCAN_CONCURRENCY for phase 1/2 —
-// default matches the previous hardcoded value.
-const REACHABILITY_CONCURRENCY = Number(process.env.BLAST_RADIUS_REACHABILITY_CONCURRENCY) || 4
+// default matches the previous hardcoded value. Clamped to a positive integer for the
+// same reason (see dependentsScan.ts's SCAN_CONCURRENCY): a negative/fractional override
+// would make forEachWithConcurrency spin up zero workers and silently skip all work.
+const REACHABILITY_CONCURRENCY =
+  Math.max(1, Math.floor(Number(process.env.BLAST_RADIUS_REACHABILITY_CONCURRENCY))) || 4
 
 // blastRadiusDal.getSymbolSpec returns the raw DB row (JSONB columns as
 // unknown); prompts.ts's SymbolSpec is the shape the reachability prompt

--- a/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
@@ -14,11 +14,15 @@ import {
 } from '../agent/prompts'
 import { runAnalysisAgent } from '../agent/runner'
 import { downloadAndExtractTarball } from '../clients/npmTarball'
+import { forEachWithConcurrency } from '../dependentsScan'
 
 const mkdtemp = promisify(fs.mkdtemp)
 
 const MAX_ATTEMPTS = 3
 const RETRY_BACKOFF_BASE = 15_000 // 15 seconds
+// Tunable for load testing, same pattern as BLAST_RADIUS_SCAN_CONCURRENCY for phase 1/2 —
+// default matches the previous hardcoded value.
+const REACHABILITY_CONCURRENCY = Number(process.env.BLAST_RADIUS_REACHABILITY_CONCURRENCY) || 4
 
 // blastRadiusDal.getSymbolSpec returns the raw DB row (JSONB columns as
 // unknown); prompts.ts's SymbolSpec is the shape the reachability prompt
@@ -67,10 +71,6 @@ export async function runReachabilityStage(
     const spec = toPromptSymbolSpec(specRow)
 
     const dependents = await blastRadiusDal.getDependentsNeedingVerdict(qx, analysisId)
-
-    // Process with concurrency limit (4)
-    const concurrency = 4
-    const queue = [...dependents]
 
     const upsertErrorVerdict = (
       dependentId: string,
@@ -192,11 +192,11 @@ export async function runReachabilityStage(
       }
     }
 
-    // Process queue with concurrency limit
-    while (queue.length > 0) {
-      const batch = queue.splice(0, concurrency)
-      await Promise.all(batch.map(processOne))
-    }
+    // Bounded-concurrency pool instead of fixed batches — a worker picks up the next
+    // dependent as soon as it's free, instead of idling until the slowest item in its
+    // batch finishes (batching wastes slots when dependents' processing times vary,
+    // e.g. one slow agent retry loop stalling 3 otherwise-free slots).
+    await forEachWithConcurrency(dependents, REACHABILITY_CONCURRENCY, processOne)
 
     // Sum cost from persisted verdicts rather than tracking it locally — a resumed
     // run only processes dependents still missing a verdict, so a local counter would

--- a/services/apps/packages_worker/src/blast-radius/workflows.ts
+++ b/services/apps/packages_worker/src/blast-radius/workflows.ts
@@ -38,6 +38,7 @@ const { blastRadiusReachability } = proxyActivities<typeof activities>({
 
 const { blastRadiusReport } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
+  heartbeatTimeout: '1 minute',
   retry: { maximumAttempts: 3 },
 })
 

--- a/services/apps/packages_worker/src/blast-radius/workflows.ts
+++ b/services/apps/packages_worker/src/blast-radius/workflows.ts
@@ -22,8 +22,13 @@ const { blastRadiusIntel } = proxyActivities<typeof activities>({
   retry: { maximumAttempts: 2 },
 })
 
+// Load-tested at SCAN_CONCURRENCY=8: avg 27:18 at 8 concurrent jobs, up to 33:31 at
+// 20 — 15 minutes routinely timed out mid-scan, and the scan has no cancellation
+// awareness, so the timed-out attempt kept running as a zombie while the retry
+// started a duplicate scan of the same analysis. Raised well past the observed
+// worst case; the scan itself is now cancellation-aware too (see dependentsScan.ts).
 const { blastRadiusDependents } = proxyActivities<typeof activities>({
-  startToCloseTimeout: '15 minutes',
+  startToCloseTimeout: '45 minutes',
   heartbeatTimeout: '3 minutes',
   retry: { maximumAttempts: 2 },
 })
@@ -63,11 +68,32 @@ export async function analyzeBlastRadius(input: ITriggerBlastRadiusAnalysis): Pr
     })
 
     await blastRadiusIntel({ analysisId: input.analysisId, advisoryOsvId: input.advisoryId })
+    if (input.stopAfterStage === 'intel') {
+      log.info('analyzeBlastRadius stopped after intel (stopAfterStage)', {
+        analysisId: input.analysisId,
+      })
+      return
+    }
+
     await blastRadiusDependents({ analysisId: input.analysisId, advisoryOsvId: input.advisoryId })
+    if (input.stopAfterStage === 'dependents') {
+      log.info('analyzeBlastRadius stopped after dependents (stopAfterStage)', {
+        analysisId: input.analysisId,
+      })
+      return
+    }
+
     await blastRadiusReachability({
       analysisId: input.analysisId,
       advisoryOsvId: input.advisoryId,
     })
+    if (input.stopAfterStage === 'reachability') {
+      log.info('analyzeBlastRadius stopped after reachability (stopAfterStage)', {
+        analysisId: input.analysisId,
+      })
+      return
+    }
+
     await blastRadiusReport({ analysisId: input.analysisId, advisoryOsvId: input.advisoryId })
   } catch (err) {
     // rootCause unwraps Temporal's ActivityFailure wrapper (whose own .message is a

--- a/services/apps/packages_worker/src/blast-radius/workflows.ts
+++ b/services/apps/packages_worker/src/blast-radius/workflows.ts
@@ -41,9 +41,11 @@ const { blastRadiusReachability } = proxyActivities<typeof activities>({
   retry: { maximumAttempts: 2 },
 })
 
+// No heartbeatTimeout — runReportStage doesn't heartbeat until after it completes
+// (see activities.ts), so any run taking over a minute would otherwise always
+// heartbeat-timeout and retry before its first heartbeat.
 const { blastRadiusReport } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
-  heartbeatTimeout: '1 minute',
   retry: { maximumAttempts: 3 },
 })
 

--- a/services/apps/packages_worker/src/npm/fetchDownloads.ts
+++ b/services/apps/packages_worker/src/npm/fetchDownloads.ts
@@ -1,5 +1,6 @@
 import type { Dispatcher } from 'undici'
 
+import { combineSignals } from './signals'
 import type { FetchError } from './types'
 
 const USER_AGENT = 'lfx-packages-worker/0.1 (+https://lfx.linuxfoundation.org)'
@@ -40,6 +41,7 @@ export async function fetchBulkPointRange(
   start: string,
   end: string,
   dispatcher?: Dispatcher,
+  signal?: AbortSignal,
 ): Promise<BulkPointRangeResult | FetchError> {
   if (names.length > 128)
     throw new Error(`fetchBulkPointRange: too many names (${names.length} > 128)`)
@@ -48,7 +50,7 @@ export async function fetchBulkPointRange(
   const timer = setTimeout(() => abort.abort(), 30_000)
   let res: Response
   try {
-    res = await fetch(url, downloadInit(dispatcher, abort.signal))
+    res = await fetch(url, downloadInit(dispatcher, combineSignals(abort.signal, signal)))
   } catch (err) {
     return { kind: 'TRANSIENT', message: String(err) }
   } finally {
@@ -100,13 +102,14 @@ export async function fetchPointRange(
   start: string,
   end: string,
   dispatcher?: Dispatcher,
+  signal?: AbortSignal,
 ): Promise<PointRangeResult | FetchError> {
   const url = `https://api.npmjs.org/downloads/point/${start}:${end}/${encodeNpmName(name)}`
   const abort = new AbortController()
   const timer = setTimeout(() => abort.abort(), 30_000)
   let res: Response
   try {
-    res = await fetch(url, downloadInit(dispatcher, abort.signal))
+    res = await fetch(url, downloadInit(dispatcher, combineSignals(abort.signal, signal)))
   } catch (err) {
     return { kind: 'TRANSIENT', message: String(err) }
   } finally {

--- a/services/apps/packages_worker/src/npm/fetchPackument.ts
+++ b/services/apps/packages_worker/src/npm/fetchPackument.ts
@@ -1,5 +1,6 @@
 import type { Dispatcher } from 'undici'
 
+import { combineSignals } from './signals'
 import type { FetchError, Packument } from './types'
 
 const REGISTRY = 'https://registry.npmjs.org'
@@ -11,13 +12,17 @@ function encodeNpmName(name: string): string {
 
 // `dispatcher` (an undici ProxyAgent) routes the request through a specific proxy IP
 // so concurrent ingest lanes each use their own egress address / rate limit.
+// `signal` (e.g. a Temporal activity's cancellationSignal) is combined with the
+// request's own 30s timeout so a caller can abort in-flight requests early.
 export async function fetchPackument(
   name: string,
   dispatcher?: Dispatcher,
+  signal?: AbortSignal,
 ): Promise<Packument | FetchError> {
   const url = `${REGISTRY}/${encodeNpmName(name)}`
   const abort = new AbortController()
   const timer = setTimeout(() => abort.abort(), 30_000)
+  const combinedSignal = combineSignals(abort.signal, signal)
   let res: Response
   try {
     // `dispatcher` is an undici-specific fetch option not present in the DOM RequestInit type.
@@ -26,7 +31,7 @@ export async function fetchPackument(
         Accept: 'application/json',
         'User-Agent': USER_AGENT,
       },
-      signal: abort.signal,
+      signal: combinedSignal,
     }
     if (dispatcher) init.dispatcher = dispatcher
     res = await fetch(url, init as RequestInit)

--- a/services/apps/packages_worker/src/npm/signals.ts
+++ b/services/apps/packages_worker/src/npm/signals.ts
@@ -1,0 +1,11 @@
+// AbortSignal.any() isn't in this @types/node version yet — combine manually so an
+// external signal (e.g. a Temporal activity's cancellationSignal) can abort the
+// request early, alongside the request's own internal timeout.
+export function combineSignals(internal: AbortSignal, external?: AbortSignal): AbortSignal {
+  if (!external) return internal
+  if (external.aborted) return external
+  const controller = new AbortController()
+  internal.addEventListener('abort', () => controller.abort(internal.reason), { once: true })
+  external.addEventListener('abort', () => controller.abort(external.reason), { once: true })
+  return controller.signal
+}

--- a/services/libs/data-access-layer/src/packages/blastRadius.ts
+++ b/services/libs/data-access-layer/src/packages/blastRadius.ts
@@ -177,6 +177,28 @@ export async function getAnalysisDetail(
   )
 }
 
+// Bulk counterpart of getAnalysisDetail for batch polling — one query for the whole
+// page instead of one per id. Order is not guaranteed to match analysisIds; callers
+// key the result by row.id.
+export async function getAnalysisDetailsByIds(
+  qx: QueryExecutor,
+  analysisIds: string[],
+): Promise<AnalysisDetailRow[]> {
+  if (analysisIds.length === 0) {
+    return []
+  }
+  return qx.select(
+    `
+    SELECT
+      id, advisory_osv_id, package_name, ecosystem, status, error,
+      candidates_considered, started_at, completed_at
+    FROM blast_radius_analyses
+    WHERE id = ANY($(analysisIds)::uuid[])
+    `,
+    { analysisIds },
+  )
+}
+
 export async function setDependentsMeta(
   qx: QueryExecutor,
   analysisId: string,
@@ -374,6 +396,31 @@ export async function getDependentsExcludedByRangeCount(
   return Number(row.count) || 0
 }
 
+// Bulk counterpart of getDependentsExcludedByRangeCount — one grouped query for the
+// whole page instead of one per id. Ids with no excluded rows are simply absent from
+// the result; callers should default to 0 for those.
+export async function getDependentsExcludedByRangeCountBatch(
+  qx: QueryExecutor,
+  analysisIds: string[],
+): Promise<{ analysisId: string; count: number }[]> {
+  if (analysisIds.length === 0) {
+    return []
+  }
+  const rows = await qx.select(
+    `
+    SELECT analysis_id, COUNT(*) as count
+    FROM blast_radius_dependents
+    WHERE analysis_id = ANY($(analysisIds)::uuid[]) AND excluded_by_range = TRUE
+    GROUP BY analysis_id
+    `,
+    { analysisIds },
+  )
+  return rows.map((row: Record<string, unknown>) => ({
+    analysisId: row.analysis_id as string,
+    count: Number(row.count) || 0,
+  }))
+}
+
 // Clears prior dependents for this analysis before a fresh scan re-inserts. Needed
 // because a retry (stage failed after insertDependents but before completeStageRun)
 // would otherwise leave stale rows from the earlier attempt's scan around — upserting
@@ -489,6 +536,34 @@ export async function getVerdictResults(
     `,
     { analysisId },
   )
+}
+
+// Bulk counterpart of getVerdictResults — one query for the whole page instead of one
+// per id. Each row carries its analysisId so callers can group results back per id;
+// order within a group still follows d.downloads DESC NULLS LAST.
+export async function getVerdictResultsBatch(
+  qx: QueryExecutor,
+  analysisIds: string[],
+): Promise<(VerdictResultRow & { analysisId: string })[]> {
+  if (analysisIds.length === 0) {
+    return []
+  }
+  const rows = await qx.select(
+    `
+    SELECT
+      v.analysis_id, d.name, d.version, d.downloads,
+      v.reachable_verdict, v.confidence, v.evidence, v.reasoning
+    FROM blast_radius_verdicts v
+    JOIN blast_radius_dependents d ON d.id = v.dependent_id
+    WHERE v.analysis_id = ANY($(analysisIds)::uuid[])
+    ORDER BY d.downloads DESC NULLS LAST
+    `,
+    { analysisIds },
+  )
+  return rows.map((row: Record<string, unknown>) => ({
+    ...(row as unknown as VerdictResultRow),
+    analysisId: row.analysis_id as string,
+  }))
 }
 
 // ---- stage runs (monitoring) ----

--- a/services/libs/types/src/temporal/blastRadius.ts
+++ b/services/libs/types/src/temporal/blastRadius.ts
@@ -4,4 +4,8 @@ export interface ITriggerBlastRadiusAnalysis {
   package: string | null
   ecosystem: string
   force: boolean
+  // Internal-only, used by the local load-test harness to stop the workflow right
+  // after a given stage succeeds (e.g. to profile 'dependents' without ever reaching
+  // the paid reachability LLM stage). Never set by the public API.
+  stopAfterStage?: 'intel' | 'dependents' | 'reachability'
 }


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Adds bulk (batch) endpoints for the akrites-external blast-radius API, mirroring the
existing batch pattern already used by packages/advisories/contacts detail lookups:
`POST /blast-radius/jobs:batch` to submit multiple blast-radius analysis jobs in one
request, and `POST /blast-radius/jobs:batch/poll` to poll multiple analyses by id in
one paginated request. The OpenAPI spec is updated to document both.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- New `POST /blast-radius/jobs:batch` — submits up to `MAX_BLAST_RADIUS_JOBS_PER_BATCH`
  (20, hard limit agreed after a cost test; 10 is the recommended/documented default,
  not schema-enforced) jobs per request, each starting its own Temporal workflow.
- New `POST /blast-radius/jobs:batch/poll` — polls up to 100 analysisIds per request,
  paginated (`page`/`pageSize`), reusing the found/not-found echo pattern from the
  other batch endpoints (unknown id → `{ found: false, analysis: null }`).
- Submit and poll batch have different failure semantics on purpose:
  - Validation (e.g. an unsupported `ecosystem`) is atomic across the whole `jobs`
    array — one invalid entry rejects the entire batch with a 400, none of the jobs
    are submitted.
  - Runtime failures (e.g. Temporal unreachable) are isolated per job — that job's
    entry comes back `status: 'failed'`, the rest of the batch still submits, and the
    response is still 202.
- Bulk submit sits behind the same strict `blastRadiusRateLimiter` as the single-job
  route (not the regular rate limiter), since each request can multiply Temporal
  workflow starts up to 20x. Bulk poll is read-only and uses the regular rate limiter.
- New schema/pagination helper file `blastRadiusBatch.ts` — reuses the existing
  single-job Zod schema (`blastRadiusJobRequestSchema`) and mapper (`toBlastRadiusJobEntry`,
  `toBlastRadiusAnalysis`) rather than duplicating validation/response-shaping logic.
- Ran through a structured code review (`/code-review --fix`): fixed a bug where
  `createAnalysis` sat outside the per-job try/catch (one job's DB error could reject
  the whole batch's `Promise.all`), parallelized two independent DB reads in the poll
  handler, and deduplicated a repeated object literal. Flagged-but-not-fixed items
  (documented in review discussion, not applied here): the rate limiter counts
  requests rather than workflow starts (20x throughput vs. single-job route), and
  `submitOneJob`/`paginateAnalysisIds` duplicate logic from pre-existing
  `submitBlastRadiusJob.ts`/`purl.ts` — left alone since fixing those would require
  touching working code outside this diff's scope.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1328](https://linuxfoundation.atlassian.net/browse/CM-1328)

[CM-1328]: https://linuxfoundation.atlassian.net/browse/CM-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ