### PR TITLE
fix(tinybird): quarantine on organizations — IN-1209

### DIFF
--- a/services/libs/integrations/src/integrations/github/processData.ts
+++ b/services/libs/integrations/src/integrations/github/processData.ts
@@ -189,8 +189,8 @@ const parseMember = (memberData: GithubPrepareMemberOutput): IMemberData => {
 
       if (orgs && company.length > 0) {
         const organizationPayload = {
-          displayName: orgs.name,
-          names: [orgs.name],
+          displayName: orgs.name || '',
+          names: [orgs.name || ''],
           identities: [
             {
               platform: PlatformType.GITHUB,


### PR DESCRIPTION
## Summary

Fixes quarantine on `organizations` datasource.

**Root cause:** Null value not allowed on column displayName (strict type checking)
**Offending columns:** displayName
**Fix:** Add null guard / empty string fallback for displayName before Tinybird ingest.

**Related:** IN-1209
**Quarantined rows:** 907

> Auto-generated by tinybird-quarantine-autofix skill. Human review required before merge.