### PR TITLE
fix: skip merged-away members in llm merges

### DIFF
--- a/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
@@ -73,7 +73,17 @@ export async function mergeMembersWithLLM(
     return
   }
 
+  const mergedAwayMemberIds = new Set<string>()
+
   for (const suggestion of suggestions) {
+    if (mergedAwayMemberIds.has(suggestion[0]) || mergedAwayMemberIds.has(suggestion[1])) {
+      console.log(
+        `Skipping suggestion because a member was already merged away in this run: ${suggestion}`,
+      )
+      await removeMemberMergeSuggestion(suggestion)
+      continue
+    }
+
     const members = await getMembersForLLMConsumption(suggestion)
 
     if (members.length !== 2) {
@@ -107,6 +117,7 @@ export async function mergeMembersWithLLM(
         `LLM verdict says these two members are the same. Merging members: ${suggestion[0]} and ${suggestion[1]}!`,
       )
       await mergeMembers(suggestion[0], suggestion[1])
+      mergedAwayMemberIds.add(suggestion[1])
     } else {
       console.log(
         `LLM doesn't think these members are the same. Removing from suggestions and adding to no merge: ${suggestion[0]} and ${suggestion[1]}!`,

--- a/services/libs/data-access-layer/src/member_merge/index.ts
+++ b/services/libs/data-access-layer/src/member_merge/index.ts
@@ -41,7 +41,9 @@ export async function insertMemberNoMerge(
   await qx.result(
     `
       INSERT INTO "memberNoMerge" ("memberId", "noMergeId", "createdAt", "updatedAt")
-      VALUES ($(memberId), $(noMergeId), NOW(), NOW())
+      SELECT $(memberId), $(noMergeId), NOW(), NOW()
+      WHERE EXISTS (SELECT 1 FROM members WHERE id = $(memberId))
+        AND EXISTS (SELECT 1 FROM members WHERE id = $(noMergeId))
       ON CONFLICT ("memberId", "noMergeId") DO NOTHING
     `,
     { memberId, noMergeId },


### PR DESCRIPTION
## Summary
`mergeMembersWithLLM` was failing roughly every 2 hours when a batch contained overlapping member IDs: after merging pair A–B, async `finishMemberMerging` hard-deleted B, then a later pair like C–B hit `memberNoMerge` FK (`memberNoMerge_noMergeId_fkey`) and killed the run.

## Changes
- Track secondaries merged in the current run and skip (then remove) later suggestions that still reference them before fetching member data for the LLM
- Guard `insertMemberNoMerge` with `EXISTS` checks so no-merge rows are only inserted when both member IDs still exist