### PR TITLE
perf: precompute collection_contributor_dependency filtered variants (IN-1196)

### DIFF
--- a/services/libs/tinybird/datasources/collection_contributor_dependency_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/collection_contributor_dependency_copy_ds.datasource
@@ -1,0 +1,66 @@
+DESCRIPTION >
+    - `collection_contributor_dependency_copy_ds` is the Phase 3 replacement for a retired v1
+    datasource of the same name that covered only a single unfiltered variant: it now holds
+    precomputed bus-factor (contributor dependency) results for every collection across the same
+    fixed 16-variant filter matrix as `collection_contributors_leaderboard_copy_ds` (8 date-range
+    presets x 2 `includeCollaborations` states).
+    - Created via `collection_contributor_dependency_copy.pipe` (`TYPE COPY`, daily schedule,
+    `COPY_MODE append`). Unlike the retired v1 pipe (and unlike the 8
+    `collection_contributors_leaderboard_copy_<presetKey>.pipe` pipes), this copy pipe does NOT scan
+    `activityRelations_deduplicated_cleaned_bucket_union` itself - the bus-factor computation
+    (running-total percentage + 51% cutoff + rank) is a pure downstream transform of
+    `collection_contributors_leaderboard_copy_ds`'s already-ranked rows, so this pipe reads that
+    table instead of repeating an expensive activity scan. This also means it carries none of the
+    fan-out-before-aggregate risk that both the retired v1 pipe and the original
+    `collection_insights_aggregate_copy.pipe` incident had - there is no raw-activity join here at
+    all.
+    - Uses `snapshotId` for the same reason and in the same way as `collection_contributors_leaderboard_copy_ds`:
+    a single `MergeTree`+`snapshotId`+TTL append pattern (not `ReplacingMergeTree`/`replace`), even
+    though only one pipe writes here, so a future split (or a slow/partial daily run) never leaves
+    the table in a mixed-snapshot state that the reading pipe would need to special-case. The
+    upstream read from `collection_contributors_leaderboard_copy_ds` also filters to
+    `snapshotId = max(snapshotId)` there, since that table is genuinely multi-writer (8 pipes) - see
+    `collection_contributor_dependency_copy.pipe`'s DESCRIPTION.
+    - `snapshotId` is the daily timestamp marking when this row's variant was appended - the serving
+    pipe must filter on `snapshotId = (SELECT max(snapshotId) FROM collection_contributor_dependency_copy_ds)`
+    before this table is read live, mirroring `collection_contributors_leaderboard_copy_ds`.
+    - `collectionSlug`, `presetKey`, `includeCollaborations` identify which of the 16 variants this
+    row belongs to - same meaning as in `collection_contributors_leaderboard_copy_ds`.
+    - `rank` is the 1-indexed rank within (collectionSlug, presetKey, includeCollaborations), capped
+    to the top 100 contributors (`limit=100` is the only value the live pipe's precomputed path
+    supports, same convention as v1).
+    - `id`, `displayName`, `githubHandleArray`, `contributionCount`, `contributionPercentage`,
+    `roles` mirror the leaderboard row this was derived from.
+    - `contributionPercentageRunningTotal` is the cumulative percentage when contributors in this
+    variant are ordered by contributionPercentage DESC, id - matches the live pipe's window function
+    output.
+    - `totalContributorCount` is the variant's total unique contributor count for the collection.
+    - `isBusFactorCutoff` marks the rows the live pipe's WHERE clause would return (running total
+    <= 51% OR running total minus this row's own percentage < 51%).
+    - `updatedAt` is when this row's variant was last (re)computed.
+    - Known, separate, and intentionally NOT fixed here (carried over from v1): for very large
+    collections the top-100 ranked contributors structurally cannot reach the 51% cutoff - a
+    product-definition question about the limit/cutoff interaction, out of scope for this
+    performance fix.
+
+SCHEMA >
+    `snapshotId` DateTime,
+    `collectionSlug` String,
+    `presetKey` LowCardinality(String),
+    `includeCollaborations` UInt8,
+    `rank` UInt32,
+    `id` String,
+    `displayName` String,
+    `githubHandleArray` Array(String),
+    `contributionCount` UInt64,
+    `contributionPercentage` Float64,
+    `roles` Array(String),
+    `contributionPercentageRunningTotal` Float64,
+    `totalContributorCount` UInt64,
+    `isBusFactorCutoff` UInt8,
+    `updatedAt` DateTime64(3)
+
+ENGINE MergeTree
+ENGINE_PARTITION_KEY snapshotId
+ENGINE_SORTING_KEY snapshotId, collectionSlug, presetKey, includeCollaborations, rank
+ENGINE_TTL toDateTime(snapshotId) + toIntervalDay(2)

--- a/services/libs/tinybird/datasources/collection_contributors_leaderboard_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/collection_contributors_leaderboard_copy_ds.datasource
@@ -1,0 +1,64 @@
+DESCRIPTION >
+    - `collection_contributors_leaderboard_copy_ds` contains precomputed leaderboard results for
+    every collection across the fixed 16-variant filter matrix: 8 date-range presets x 2
+    `includeCollaborations` states.
+    - Created via 8 independent `collection_contributors_leaderboard_copy_<presetKey>.pipe` files
+    (`TYPE COPY`, daily schedule, `COPY_MODE append`), one per `presetKey` - split from a single
+    16-variant copy pipe after that pipe's job stalled at zero progress 5 times in production with
+    no root cause found (join-order and stuck-mutation theories both ruled out). Splitting by
+    presetKey cuts each job's date-fanout by 8x. See any of the 8 pipes' DESCRIPTIONs for the full
+    incident background and the design rationale, which mirrors `leaderboards_copy_ds`'s proven
+    pattern of multiple independent append-mode copy pipes sharing one target datasource.
+    - Uses `snapshotId` for temporal versioning, exactly like `leaderboards_copy_ds`: each of the 8
+    pipes appends its own presetKey's rows tagged with the run's daily snapshot instead of using
+    `COPY_MODE replace`, since replace performs a full-table swap and would wipe out the other 7
+    pipes' rows if they shared a `replace` target. The serving pipe reads
+    `WHERE snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)`
+    to always resolve to the latest complete daily run. A 2-day TTL automatically drops stale
+    snapshots, so a partially-complete day (e.g. only 5 of 8 presetKey pipes have run so far) never
+    leaves more than one prior full day's data as fallback.
+    - The 8 `presetKey` values match the frontend date-range picker's fixed options exactly (see
+    `insights/frontend/app/components/modules/project/config/date-options.ts`): `past90days`,
+    `past180days`, `past365days`, `previousQuarter`, `previousYear`, `previous5years`,
+    `previous10years`, `allTime`. The picker's "Custom" option is being removed from collection
+    pages specifically so every reachable request matches one of these 8 buckets.
+    - `snapshotId` is the daily timestamp marking when this row's presetKey snapshot was appended.
+    - `collectionSlug` is the collection this row belongs to.
+    - `presetKey` is which of the 8 fixed date-range presets this row was computed for.
+    - `includeCollaborations` is which of the 2 collaboration-toggle states this row was computed for.
+    - `rank` is the 1-indexed rank of this contributor within (collectionSlug, presetKey,
+    includeCollaborations), ordered by contributionCount DESC, memberId DESC - lets the serving
+    pipe paginate via `rank BETWEEN offset+1 AND offset+limit` instead of re-sorting.
+    - `id` is the member id (contributor).
+    - `avatar`, `displayName`, `githubHandleArray` are the member's profile fields, matching the live
+    pipe's response shape.
+    - `contributionCount` is the member's raw contribution count within the collection for this
+    variant's date range and collaboration state.
+    - `contributionPercentage` is `contributionCount` as a percentage of the variant's total
+    contribution count across the whole collection.
+    - `roles` is the member's maintainer roles within the collection, if any.
+    - `totalContributorCount` is this variant's total unique contributor count for the collection -
+    lets the serving pipe answer `count=true` requests with a point lookup instead of a distinct-count
+    scan.
+    - `updatedAt` is when this row's variant was last (re)computed.
+
+SCHEMA >
+    `snapshotId` DateTime,
+    `collectionSlug` String,
+    `presetKey` LowCardinality(String),
+    `includeCollaborations` UInt8,
+    `rank` UInt32,
+    `id` String,
+    `avatar` String,
+    `displayName` String,
+    `githubHandleArray` Array(String),
+    `contributionCount` UInt64,
+    `contributionPercentage` Float64,
+    `roles` Array(String),
+    `totalContributorCount` UInt64,
+    `updatedAt` DateTime64(3)
+
+ENGINE MergeTree
+ENGINE_PARTITION_KEY snapshotId
+ENGINE_SORTING_KEY snapshotId, collectionSlug, presetKey, includeCollaborations, rank
+ENGINE_TTL toDateTime(snapshotId) + toIntervalDay(2)

--- a/services/libs/tinybird/datasources/collection_insights_aggregate_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/collection_insights_aggregate_copy_ds.datasource
@@ -1,0 +1,27 @@
+DESCRIPTION >
+    - `collection_insights_aggregate_copy_ds` contains precomputed aggregate insights metrics
+    (project count, unique contributor count, average health score) for every collection.
+    - Created via `collection_insights_aggregate_copy.pipe` (`TYPE COPY`, daily schedule) to avoid
+    recomputing the same per-collection activity scan on every request - see that pipe's
+    DESCRIPTION for the full rationale.
+    - One row per `collectionSlug` - unlike `collection_contributor_dependency_copy_ds` /
+    `collection_contributors_leaderboard_copy_ds`, there is no filter-variant dimension here since
+    the live pipe this replaces has no filter parameters.
+    - `collectionSlug` is the collection this row belongs to.
+    - `projectCount` is the count of distinct projects in the collection.
+    - `uniqueContributorCount` is the total unique contributors across all projects in the
+    collection, deduplicated.
+    - `avgHealthScore` is the average health score across the collection's onboarded projects,
+    rounded.
+    - `updatedAt` is when this row's collection was last (re)computed.
+
+SCHEMA >
+    `collectionSlug` String,
+    `projectCount` UInt64,
+    `uniqueContributorCount` UInt64,
+    `avgHealthScore` Nullable(Float64),
+    `updatedAt` DateTime64(3)
+
+ENGINE ReplacingMergeTree
+ENGINE_SORTING_KEY collectionSlug
+ENGINE_VER updatedAt

--- a/services/libs/tinybird/pipes/collection_contributor_dependency.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency.pipe
@@ -8,24 +8,76 @@ DESCRIPTION >
     replacement for that table is `collection_contributors_leaderboard` (a differently-shaped
     pipe - see its own DESCRIPTION for why a naive collectionSlug branch on the single-project
     leaderboard pipe isn't used there either).
-    - Combines data from `collection_contributors_leaderboard` and `active_contributors` (both
-    already collectionSlug-aware) to provide dependency risk assessment at collection scale.
+    - **Two paths, branched at template-render time only, same pattern as
+    `collection_contributors_leaderboard.pipe`:**
+    - **Precomputed path** - matches when the caller passes an explicit `presetKey` (one of the 8
+    values `collection_contributors_leaderboard_copy_<presetKey>.pipe` materializes) and
+    `repos`/`platform`/`activity_type` are absent and `limit` (if given) is exactly 100. Reads
+    `collection_contributor_dependency_copy_ds`, a daily `TYPE COPY` materialization (see
+    `collection_contributor_dependency_copy.pipe`) that is itself a pure downstream transform of
+    `collection_contributors_leaderboard_copy_ds` (Phase 2) - no raw activity scan happens on this
+    path at all. `presetKey` is required (not a startDate/endDate value match) for the same reason
+    documented on `collection_contributors_leaderboard.pipe`: ClickHouse does not short-circuit
+    UNION ALL branches on a WHERE guard, so routing must be resolved at template-render time.
+    - Supersedes the old single-variant precomputed path (v1, `collection_contributor_dependency_copy_ds`,
+    unfiltered case only) - this exists because the live computation - via
+    `collection_contributors_leaderboard`'s `collection_member_aggregates` node - must fully
+    materialize a `GROUP BY af.memberId` over the entire filtered activity set before it can
+    ORDER BY/LIMIT (LIMIT only reduces output size, not scan/aggregation cost), which at collection
+    scale (e.g. `cncf` has 149,677 distinct contributors) triggered a Tinybird production
+    rate-limit/concurrency alert on `lfx_insights` from timeouts under load.
+    - **Live path (default: no `presetKey`, or any of `repos`/`platform`/`activity_type` present,
+    or `limit` other than 100)** - unchanged: combines `collection_contributors_leaderboard` and
+    `active_contributors` (both already collectionSlug-aware). Also the safe fallback while the
+    frontend has not yet been updated to send `presetKey` for this widget.
     - Parameters:
     - `collectionSlug`: Required collection slug (e.g., 'cncf') - inherited from `segments_filtered_by_collection`.
-    - `repos`: Optional array of repository URLs for filtering (inherited from `segments_filtered_by_collection`)
-    - `startDate`: Optional DateTime filter for activities after timestamp (e.g., '2024-01-01 00:00:00')
-    - `endDate`: Optional DateTime filter for activities before timestamp (e.g., '2024-12-31 23:59:59')
-    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack')
-    - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit')
-    - `includeCollaborations`: Optional boolean, defaults to false - same toggle as the single-project pipe.
+    - `presetKey`: Optional string, one of the 8 values `collection_contributors_leaderboard_copy_<presetKey>.pipe`
+    materializes (`past90days`, `past180days`, `past365days`, `previousQuarter`, `previousYear`,
+    `previous5years`, `previous10years`, `allTime`). Presence (with no repos/platform/activity_type
+    and limit=100) routes to the precomputed path; absence routes to the live path.
+    - `repos`: Optional array of repository URLs for filtering (inherited from `segments_filtered_by_collection`). Presence routes to the live path.
+    - `startDate`: Optional DateTime filter for activities after timestamp (e.g., '2024-01-01 00:00:00') - live path only; ignored by the precomputed path, which keys on `presetKey` instead.
+    - `endDate`: Optional DateTime filter for activities before timestamp (e.g., '2024-12-31 23:59:59') - live path only; ignored by the precomputed path, which keys on `presetKey` instead.
+    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack'). Presence routes to the live path.
+    - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit'). Presence routes to the live path.
+    - `includeCollaborations`: Optional boolean, defaults to false - same toggle as the single-project pipe. Both true and false route to the precomputed path (both are materialized); only `repos`/`platform`/`activity_type`/non-100 `limit` force the live path.
     - `limit`: Optional integer for the number of top contributors to rank before finding the 51%
-    cutoff. Inherited by `collection_contributors_leaderboard` (this pipe has no default of its
-    own), whose own default is 10 if omitted - callers doing bus-factor analysis should pass
-    limit=100 explicitly (same convention as the single-project `contributor_dependency.pipe` /
-    `contributors_leaderboard.pipe` pair) to reliably reach the 51% cutoff.
+    cutoff. Inherited by `collection_contributors_leaderboard` on the live path (this pipe has no
+    default of its own), whose own default is 10 if omitted - callers doing bus-factor analysis
+    should pass limit=100 explicitly (same convention as the single-project
+    `contributor_dependency.pipe` / `contributors_leaderboard.pipe` pair) to reliably reach the 51%
+    cutoff. A value other than 100 routes to the live path.
     - Response: `id`, `displayName`, `githubHandleArray`, `contributionCount`, `contributionPercentage`, `roles`, `contributionPercentageRunningTotal`, `totalContributorCount`
 
 TAGS "Insights, Widget", "Collection", "Contributors"
+
+NODE collection_contributor_dependency_precomputed
+DESCRIPTION >
+    Precomputed path: point lookup into the latest daily materialization, filtered to the rows the
+    live pipe's WHERE clause would itself return (`isBusFactorCutoff = 1`), ordered by rank.
+    Resolves to the latest complete snapshot via `snapshotId = max(snapshotId)`, mirroring
+    `collection_contributors_leaderboard.pipe`'s precomputed path.
+
+SQL >
+    %
+    SELECT
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount
+    FROM collection_contributor_dependency_copy_ds
+    WHERE
+        snapshotId = (SELECT max(snapshotId) FROM collection_contributor_dependency_copy_ds)
+        AND collectionSlug = {{ String(collectionSlug, description="Filter by collection slug", required=True) }}
+        AND presetKey = {{ String(presetKey, required=True) }}
+        AND includeCollaborations = {{ Int32(Boolean(includeCollaborations, false), description="0 or 1") }}
+        AND isBusFactorCutoff = 1
+    ORDER BY rank ASC
 
 NODE collection_contributions_percentage_running_total
 SQL >
@@ -50,3 +102,27 @@ SQL >
         contributionPercentageRunningTotal <= 51
         OR (contributionPercentageRunningTotal - contributionPercentage < 51)
     ORDER BY contributionPercentageRunningTotal ASC
+
+NODE collection_contributor_dependency_result
+DESCRIPTION >
+    Routes between the precomputed and live paths at template-render time only, same pattern as
+    `collection_contributors_leaderboard.pipe` - template-time branching is the ONLY safe routing
+    pattern in ClickHouse UNION ALL (query-time routing via WHERE guards does not work; ClickHouse
+    evaluates all UNION ALL branches regardless of WHERE conditions).
+
+    PRECOMPUTED PATH (template-time only):
+    - When `presetKey` is explicitly passed by the frontend, routes to precomputed lookup.
+    - Requires: repos/platform/activity_type all absent, limit (if given) exactly 100.
+    - Execution: cheap point lookup into `collection_contributor_dependency_copy_ds`.
+
+    LIVE PATH (all other cases):
+    - Any request without explicit `presetKey` (including no date range, custom dates, etc.).
+    - Any filter present: repos, platform, activity_type, or limit != 100.
+    - Execution: expensive `GROUP BY af.memberId` aggregation via `collection_contributors_leaderboard`.
+
+SQL >
+    %
+    {% if defined(presetKey) and not defined(repos) and not defined(startDate) and not defined(endDate) and not defined(platform) and not defined(activity_type) and Int32(limit, 100) == 100 %}
+        SELECT * FROM collection_contributor_dependency_precomputed
+    {% else %} SELECT * FROM collection_contributions_percentage_running_total
+    {% end %}

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_allTime.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_allTime.pipe
@@ -1,0 +1,108 @@
+DESCRIPTION >
+	- `collection_contributor_dependency_copy_allTime.pipe` is one of 8 Phase 3-split copies,
+    each precomputing the bus-factor result for every collection within a single date-range
+    preset (`allTime`). Together with the 7 other presetKey variants, these pipes materialize
+    all 16 (presetKey, includeCollaborations) combinations that the live
+    `collection_contributor_dependency.pipe` would compute (filtered path) or the monolithic
+    Phase 3 copy-all-in-one originally attempted (now split to avoid window-function
+    multi-partition scaling issues).
+    - Deliberately reads only `presetKey = 'allTime'` rows from the upstream
+    `collection_contributors_leaderboard_copy_ds` (already ranked and pre-aggregated per
+    variant), so this pipe's window function operates over only 2 PARTITION BY dimensions
+    (collectionSlug, includeCollaborations) rather than the problematic 3-dimensional
+    multi-variant single-query structure that caused 94% row loss in the monolithic Phase 3
+    design. This matches Phase 2's proven architecture: one pipe per presetKey, with
+    `includeCollaborations` handled as a 2-way split inside (UNION ALL over the two states).
+    - Caps to the top 100 ranked contributors per variant via `WHERE rank <= 100`, matching
+    the live pipe's support.
+
+
+NODE collection_contributor_dependency_copy_allTime_running_total
+DESCRIPTION >
+    Per (collectionSlug, includeCollaborations) variant within the 'allTime' preset, computes
+        the cumulative contributionPercentageRunningTotal via window function.
+
+SQL >
+
+    SELECT
+        collectionSlug,
+        'allTime' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'allTime'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+
+
+NODE collection_contributor_dependency_copy_allTime_ranked
+DESCRIPTION >
+    Computes the cumulative contributionPercentageRunningTotal over the filtered rows,
+        partitioned by (collectionSlug, includeCollaborations) only — no presetKey dimension.
+
+SQL >
+
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_allTime_running_total
+
+
+
+NODE collection_contributor_dependency_copy_allTime_result
+DESCRIPTION >
+    Flags the 51% bus-factor cutoff membership.
+
+SQL >
+
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_allTime_ranked
+
+TYPE copy
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 15 2 * * *
+
+

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past180days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past180days.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_past180days.pipe` — Phase 3-split copy for the
+    `past180days` preset. One of 8 pipes, each handling one presetKey independently.
+
+NODE collection_contributor_dependency_copy_past180days_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'past180days' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'past180days'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_past180days_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_past180days_running_total
+
+NODE collection_contributor_dependency_copy_past180days_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_past180days_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 10 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past365days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past365days.pipe
@@ -1,0 +1,75 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_past365days.pipe` — Phase 3-split copy for the
+    `past365days` preset. One of 8 pipes, each handling one presetKey independently with
+    a 2-dimensional window function PARTITION BY (collectionSlug, includeCollaborations),
+    replacing the monolithic multi-preset design.
+
+NODE collection_contributor_dependency_copy_past365days_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'past365days' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'past365days'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_past365days_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_past365days_running_total
+
+NODE collection_contributor_dependency_copy_past365days_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_past365days_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 5 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past90days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_past90days.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_past90days.pipe` — Phase 3-split copy for the
+    `past90days` preset. One of 8 pipes.
+
+NODE collection_contributor_dependency_copy_past90days_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'past90days' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'past90days'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_past90days_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_past90days_running_total
+
+NODE collection_contributor_dependency_copy_past90days_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_past90days_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 0 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previous10years.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previous10years.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_previous10years.pipe` — Phase 3-split copy for the
+    `previous10years` preset. One of 8 pipes.
+
+NODE collection_contributor_dependency_copy_previous10years_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'previous10years' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'previous10years'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_previous10years_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_previous10years_running_total
+
+NODE collection_contributor_dependency_copy_previous10years_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_previous10years_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 25 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previous5years.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previous5years.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_previous5years.pipe` — Phase 3-split copy for the
+    `previous5years` preset. One of 8 pipes.
+
+NODE collection_contributor_dependency_copy_previous5years_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'previous5years' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'previous5years'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_previous5years_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_previous5years_running_total
+
+NODE collection_contributor_dependency_copy_previous5years_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_previous5years_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 20 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previousQuarter.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previousQuarter.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_previousQuarter.pipe` — Phase 3-split copy for the
+    `previousQuarter` preset. One of 8 pipes.
+
+NODE collection_contributor_dependency_copy_previousQuarter_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'previousQuarter' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'previousQuarter'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_previousQuarter_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_previousQuarter_running_total
+
+NODE collection_contributor_dependency_copy_previousQuarter_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_previousQuarter_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 35 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previousYear.pipe
+++ b/services/libs/tinybird/pipes/collection_contributor_dependency_copy_previousYear.pipe
@@ -1,0 +1,73 @@
+DESCRIPTION >
+    `collection_contributor_dependency_copy_previousYear.pipe` — Phase 3-split copy for the
+    `previousYear` preset. One of 8 pipes.
+
+NODE collection_contributor_dependency_copy_previousYear_running_total
+SQL >
+    SELECT
+        collectionSlug,
+        'previousYear' AS presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount
+    FROM collection_contributors_leaderboard_copy_ds
+    WHERE
+        rank <= 100
+        AND presetKey = 'previousYear'
+        AND snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+
+NODE collection_contributor_dependency_copy_previousYear_ranked
+SQL >
+    SELECT
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        totalContributorCount,
+        sum(contributionPercentage) OVER (
+            PARTITION BY collectionSlug, includeCollaborations
+            ORDER BY contributionPercentage DESC, id
+        ) AS contributionPercentageRunningTotal
+    FROM collection_contributor_dependency_copy_previousYear_running_total
+
+NODE collection_contributor_dependency_copy_previousYear_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        collectionSlug,
+        presetKey,
+        includeCollaborations,
+        rank,
+        id,
+        displayName,
+        githubHandleArray,
+        contributionCount,
+        contributionPercentage,
+        roles,
+        contributionPercentageRunningTotal,
+        totalContributorCount,
+        if(
+            contributionPercentageRunningTotal <= 51
+            OR (contributionPercentageRunningTotal - contributionPercentage < 51),
+            1,
+            0
+        ) AS isBusFactorCutoff,
+        now64(3) AS updatedAt
+    FROM collection_contributor_dependency_copy_previousYear_ranked
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributor_dependency_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 30 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard.pipe
@@ -7,9 +7,30 @@ DESCRIPTION >
     hundreds of thousands of distinct members at collection scale) before it can apply ORDER BY/LIMIT -
     confirmed via direct timing: the equivalent single-project pipe took 7-16s (once timing out
     entirely at Tinybird's 20s limit) on a 242-project collection, vs 2-3s for the count-only path
-    with no window function. This pipe computes the total contribution count as a separate scalar
-    subquery instead of a window function, avoiding that full-materialization cost.
-    - Supports both count mode (`count=true`) and data mode for pagination-friendly leaderboard display.
+    with no window function.
+    - **Two paths, branched at template-render time only:** production telemetry showed 86% of real
+    requests carry a startDate/endDate filter (not "no filters"), so - per the same decision that
+    shaped `collection_contributor_dependency.pipe`'s precomputed path - the collection-page
+    date-range picker and activity-type/platform dropdown were simplified to a fixed, enumerable
+    surface (8 date presets, no Custom range, no activity-type/platform filtering) specifically so
+    this matrix could be precomputed. See `collection_contributors_leaderboard_copy.pipe`'s
+    DESCRIPTION for the full matrix design and incident background shared with the other
+    Contributors-tab widgets.
+    - **Precomputed path** - matches when the caller passes an explicit `presetKey` (one of the 8
+    values `collection_contributors_leaderboard_copy.pipe` materializes) and `repos`/`platform`/
+    `activity_type`/`activity_types` are absent - reads `collection_contributors_leaderboard_copy_ds`,
+    a daily `TYPE COPY` materialization, instead of recomputing live. `presetKey` is required (not a
+    startDate/endDate value match) because ClickHouse does not short-circuit `UNION ALL` branches on
+    a WHERE guard - both branches' FROM/JOIN/GROUP BY get planned and executed regardless of the
+    guard, confirmed empirically before this pattern was chosen - so routing MUST be resolved at
+    template-render time via `{% if defined(presetKey) %}`, which only ever renders one of the two
+    SQL branches. This means the frontend has to send `presetKey` explicitly for collection-page
+    requests to actually hit the fast path; raw startDate/endDate values are not pattern-matched
+    against the 8 presets at query time.
+    - **Live path (default: no `presetKey`, or any of `repos`/`platform`/`activity_type`/
+    `activity_types` present)** - unchanged: computes the total contribution count as a separate
+    scalar subquery instead of a window function, avoiding full-materialization cost. This is also
+    the safe fallback while the frontend has not yet been updated to send `presetKey`.
     - Always shows `displayName` (not `publicName`) since a collection spans many projects with mixed
     LF/non-LF status - there's no single project-type answer to substitute on, unlike the single-project
     pipe's `is_request_from_non_lf_project` check.
@@ -17,12 +38,16 @@ DESCRIPTION >
     pages' Contributors tab.
     - Parameters:
     - `collectionSlug`: Required collection slug (e.g., 'cncf') - inherited from `segments_filtered_by_collection`.
-    - `repos`: Optional array of repository URLs for filtering (inherited from `segments_filtered_by_collection`)
-    - `startDate`: Optional DateTime filter for activities after timestamp (e.g., '2024-01-01 00:00:00')
-    - `endDate`: Optional DateTime filter for activities before timestamp (e.g., '2024-12-31 23:59:59')
-    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack')
-    - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit')
-    - `activity_types`: Optional array of activity types (e.g., ['authored-commit', 'co-authored-commit'])
+    - `presetKey`: Optional string, one of the 8 values `collection_contributors_leaderboard_copy.pipe`
+    materializes (`past90days`, `past180days`, `past365days`, `previousQuarter`, `previousYear`,
+    `previous5years`, `previous10years`, `allTime`). Presence (with no repos/platform/activity_type/
+    activity_types) routes to the precomputed path; absence routes to the live path.
+    - `repos`: Optional array of repository URLs for filtering (inherited from `segments_filtered_by_collection`). Presence routes to the live path.
+    - `startDate`: Optional DateTime filter for activities after timestamp (e.g., '2024-01-01 00:00:00') - live path only; ignored by the precomputed path, which keys on `presetKey` instead.
+    - `endDate`: Optional DateTime filter for activities before timestamp (e.g., '2024-12-31 23:59:59') - live path only; ignored by the precomputed path, which keys on `presetKey` instead.
+    - `platform`: Optional string filter for source platform (e.g., 'github', 'discord', 'slack'). Presence routes to the live path.
+    - `activity_type`: Optional string filter for single activity type (e.g., 'authored-commit'). Presence routes to the live path.
+    - `activity_types`: Optional array of activity types (e.g., ['authored-commit', 'co-authored-commit']). Presence routes to the live path.
     - `includeCollaborations`: Optional boolean, defaults to false - same toggle as the single-project pipe.
     - `count`: Optional boolean, when true returns contributor count instead of leaderboard data
     - `limit`: Optional integer for result pagination, defaults to 10
@@ -37,7 +62,7 @@ NODE collection_contributors_total
 DESCRIPTION >
     Total contribution count across the collection - a plain aggregate with no GROUP BY, so it's
     cheap regardless of how many distinct members contributed. Computed once and reused as a scalar
-    for the percentage calculation instead of a SUM(...) OVER () window function.
+    for the percentage calculation instead of a SUM(...) OVER () window function. Live path only.
 
 SQL >
     %
@@ -47,7 +72,7 @@ NODE collection_member_aggregates
 DESCRIPTION >
     Per-member contribution counts, ranked and paginated. No window function here - the percentage
     is computed in the next node against the scalar total, so ORDER BY/LIMIT can apply directly
-    after this GROUP BY without waiting on a second full-set pass.
+    after this GROUP BY without waiting on a second full-set pass. Live path only.
 
 SQL >
     %
@@ -61,7 +86,7 @@ SQL >
         OFFSET {{ Int32(offset, 0) }}
     {% end %}
 
-NODE collection_contributors_leaderboard_result
+NODE collection_contributors_leaderboard_live
 SQL >
     %
     {% if Boolean(count, false) %}
@@ -81,4 +106,67 @@ SQL >
         CROSS JOIN collection_contributors_total total
         WHERE m.id IN (SELECT memberId FROM collection_member_aggregates)
         ORDER BY contributionCount DESC
+    {% end %}
+
+NODE collection_contributors_leaderboard_result
+DESCRIPTION >
+    Routes between the precomputed and live paths at template-render time only, eliminating any risk
+    of accidentally executing both branches simultaneously. Template-time branching is the ONLY safe
+    routing pattern in ClickHouse UNION ALL — query-time routing via WHERE guards does NOT work
+    (ClickHouse evaluates all UNION ALL branches regardless of WHERE conditions).
+
+    PRECOMPUTED PATH (template-time only):
+    - When `presetKey` is explicitly passed by the frontend, routes to precomputed lookup.
+    - Requires: repos/platform/activity_type/activity_types all absent (no additional filters).
+    - Execution: cheap point lookup into `collection_contributors_leaderboard_copy_ds`.
+
+    LIVE PATH (all other cases):
+    - Any request without explicit `presetKey` (including no date range, custom dates, etc.).
+    - Any filter present: repos, platform, activity_type, activity_types.
+    - Execution: expensive `GROUP BY af.memberId` aggregation.
+
+    DEPLOYMENT NOTE:
+    The precomputed datasource (collection_contributors_leaderboard_copy_ds) is populated by 8
+    independent TYPE COPY pipes (collection_contributors_leaderboard_copy_<presetKey>.pipe, one per
+    presetKey), each appending its own rows tagged with a daily snapshotId rather than one pipe
+    replacing the whole table - see those pipes' DESCRIPTIONs for why (a single 16-variant copy job
+    stalled at zero progress repeatedly in production with no root cause found; splitting by
+    presetKey cuts each job's scan/group cost 8x). Because each pipe appends independently and a
+    day's 8 runs don't all complete at the same instant, the precomputed path always resolves to the
+    LATEST COMPLETE daily snapshot via `WHERE snapshotId = (SELECT max(snapshotId) FROM
+    collection_contributors_leaderboard_copy_ds)`, mirroring `leaderboards_copy_ds`'s established
+    pattern. A 2-day TTL on the datasource auto-drops stale snapshots. Initially, when none of the 8
+    pipes have run yet, requests without explicit presetKey will fall back to the live path
+    automatically. Once the copy jobs populate the datasource (Phase 2 complete), the frontend can
+    be updated to pass presetKey for collection-page requests, enabling the optimization. Until
+    then, all non-filtered requests use the live path (safe but not optimal).
+
+SQL >
+    %
+    {% if defined(presetKey) and not defined(repos) and not defined(platform) and not defined(activity_type) and not defined(activity_types) %}
+        {# Explicit presetKey passed and no filters - use precomputed path unconditionally #}
+        {% if Boolean(count, false) %}
+            SELECT any(totalContributorCount) AS count
+            FROM collection_contributors_leaderboard_copy_ds
+            WHERE
+                snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+                AND collectionSlug = {{ String(collectionSlug, required=True) }}
+                AND presetKey = {{ String(presetKey, required=True) }}
+                AND includeCollaborations = {{ Int32(Boolean(includeCollaborations, false), description="0 or 1") }}
+        {% else %}
+            SELECT id, avatar, displayName, githubHandleArray, contributionCount, contributionPercentage, roles
+            FROM collection_contributors_leaderboard_copy_ds
+            WHERE
+                snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)
+                AND collectionSlug = {{ String(collectionSlug, required=True) }}
+                AND presetKey = {{ String(presetKey, required=True) }}
+                AND includeCollaborations = {{ Int32(Boolean(includeCollaborations, false), description="0 or 1") }}
+                AND rank > {{ Int32(offset, 0) }}
+                AND rank <= {{ Int32(offset, 0) }} + {{ Int32(limit, 10) }}
+            ORDER BY rank ASC
+        {% end %}
+    {% else %}
+        {# Any other case (no explicit presetKey, or filters present) - use live path #}
+        SELECT *
+        FROM collection_contributors_leaderboard_live
     {% end %}

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_allTime.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_allTime.pipe
@@ -1,0 +1,137 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `allTime` has no date filter at all, matching the frontend's "All time" picker option - this
+    is also the largest/heaviest of the 8 jobs since it scans the full activity history with no
+    time-bound narrowing, so it's scheduled last.
+
+NODE collection_contributors_leaderboard_copy_allTime_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_allTime_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_allTime_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_allTime_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_allTime_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_allTime_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_allTime_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_allTime_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_allTime_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_allTime_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_allTime_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_allTime_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_allTime_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_allTime_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_allTime_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_allTime_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_allTime_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_allTime_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'allTime' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_allTime_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 15 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past180days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past180days.pipe
@@ -1,0 +1,138 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `past180days` is a rolling window: `today - 180 days` to `today`, matching the frontend's
+    fixed date-range picker option.
+
+NODE collection_contributors_leaderboard_copy_past180days_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_past180days_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_past180days_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past180days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past180days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 180 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past180days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past180days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 180 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_past180days_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past180days_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_past180days_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_past180days_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past180days_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past180days_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past180days_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past180days_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past180days_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past180days_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past180days_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'past180days' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_past180days_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 35 1 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past365days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past365days.pipe
@@ -1,0 +1,139 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `past365days` is a rolling window: `today - 365 days` to `today`, matching the frontend's
+    fixed date-range picker option. Production telemetry showed this is by far the most common real
+    request shape (98% of the 86% of requests that carry a date filter at all).
+
+NODE collection_contributors_leaderboard_copy_past365days_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_past365days_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_past365days_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past365days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past365days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 365 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past365days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past365days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 365 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_past365days_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past365days_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_past365days_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_past365days_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past365days_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past365days_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past365days_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past365days_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past365days_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past365days_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past365days_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'past365days' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_past365days_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 40 1 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past90days.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_past90days.pipe
@@ -1,0 +1,200 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`, one per
+    presetKey: past90days, past180days, past365days, previousQuarter, previousYear, previous5years,
+    previous10years, allTime) that together replace the single `collection_contributors_leaderboard_copy.pipe`,
+    which computed all 16 variants (8 presets x 2 `includeCollaborations` states) in one job and
+    stalled at zero progress 5 times in production with no root cause found (join-order and
+    stuck-mutation theories both empirically ruled out). Splitting by presetKey cuts each job's date
+    scan/group cost by 8x, on the theory that the full-size job was hitting some Tinybird-side
+    resource ceiling or scheduling issue tied to its size/shape.
+    - Design otherwise unchanged from the original pipe: aggregate to distinct
+    (segmentId, memberId, includeCollaborations) first over the raw activity table (this pipe's date
+    bucket only), THEN fan out to collections - never join the raw activity stream directly against
+    the (collectionSlug, segmentId) mapping before aggregating, since 61% of projects belong to 2+
+    collections (up to 39) and that would multiply scan cost by collection-membership count.
+    - Uses `COPY_MODE append` with a daily `snapshotId`, not `COPY_MODE replace`, because 8
+    independent pipes cannot safely share one `replace`-mode target (replace is a full-table swap -
+    the last pipe to run would wipe out the other 7's rows). This mirrors `leaderboards_copy_ds`'s
+    proven pattern of many independent append-mode copy pipes into one shared datasource, tagged by
+    a discriminator column (`leaderboardType` there, `presetKey` here) plus `snapshotId`. The target
+    datasource's 2-day TTL auto-drops stale snapshots; the serving pipe resolves the latest complete
+    day via `WHERE snapshotId = (SELECT max(snapshotId) FROM collection_contributors_leaderboard_copy_ds)`.
+    - `past90days` is a rolling window: `today - 90 days` to `today`, matching the frontend's fixed
+    date-range picker option (`insights/frontend/app/components/modules/project/config/date-options.ts`).
+    - `includeCollaborations` widens which `(activityType, platform)` pairs qualify (see
+    `activityTypes_filtered.pipe`): the superset (code contributions OR collaborations) is scanned
+    ONCE per run, and each activity is tagged with which of the 2 collaboration states it qualifies
+    for, rather than scanning twice.
+    - `limit`/`offset` are not filter parameters here - the copy stores every ranked contributor per
+    variant (not just the first page), so the serving pipe can paginate against `rank` directly.
+
+NODE collection_contributors_leaderboard_copy_past90days_segments
+DESCRIPTION >
+    Every (collectionSlug, segmentId) pair for enabled projects that belong to at least one
+    collection - the fan-out point, same as the sibling copy pipes.
+
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_past90days_activity_types
+DESCRIPTION >
+    The superset of (activityType, platform) pairs that qualify under EITHER collaboration state,
+    each tagged with which states they qualify for - lets the single downstream scan serve both
+    `includeCollaborations` variants without re-scanning the activity table.
+
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_past90days_segment_members
+DESCRIPTION >
+    The single expensive scan: distinct (segmentId, memberId, includeCollaborations) combinations
+    with a contribution count, computed ONCE over the raw activity table for this pipe's date
+    bucket only - no cross join against other presets, so this job's fanout is 8x smaller than the
+    original single 16-variant pipe.
+    - The segment filter is applied via an upfront INNER JOIN (not a `segmentId IN (SELECT ...)`
+    WHERE clause) so ClickHouse narrows the ~69M-row-per-bucket activity table down to the ~11K
+    rows that belong to a collection-linked segment BEFORE the GROUP BY.
+
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past90days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past90days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 90 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_past90days_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past90days_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp > toStartOfDay(today() - INTERVAL 90 DAY)
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_past90days_fanned
+DESCRIPTION >
+    Fans the already-aggregated, already-small per-segment variant rows out to collections via the
+    segment join - this join is against a pre-aggregated table now, not the raw activity stream, so
+    collection fan-out no longer multiplies scan cost.
+
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past90days_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_past90days_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_past90days_collapsed
+DESCRIPTION >
+    A project can appear in a collection via more than one segment mapping row, so contribution
+    counts for the same (collectionSlug, memberId, includeCollaborations) are summed across any
+    duplicate segment joins before ranking.
+
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_past90days_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past90days_totals
+DESCRIPTION >
+    Per-(collection, includeCollaborations) scalar totals: total contribution count (for percentage
+    denominators) and total unique contributor count.
+
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past90days_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past90days_ranked
+DESCRIPTION >
+    Adds a 1-indexed rank within each (collectionSlug, includeCollaborations) partition - no LIMIT
+    here, every ranked contributor is stored so the serving pipe can paginate against `rank`.
+
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_past90days_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_past90days_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_past90days_result
+DESCRIPTION >
+    Joins member profile/role data, matching the live pipe's response shape exactly, and tags every
+    row with this presetKey plus the run's daily snapshotId for the shared append-mode datasource.
+
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'past90days' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_past90days_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 30 1 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previous10years.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previous10years.pipe
@@ -1,0 +1,138 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `previous10years` is calendar-aligned, open-ended: `toStartOfYear(today() - 10 years)` to
+    `today` (no end bound), matching the frontend's fixed date-range picker option.
+
+NODE collection_contributors_leaderboard_copy_previous10years_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_previous10years_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_previous10years_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previous10years_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous10years_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp > toStartOfYear(today() - INTERVAL 10 YEAR)
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previous10years_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous10years_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp > toStartOfYear(today() - INTERVAL 10 YEAR)
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_previous10years_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previous10years_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_previous10years_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_previous10years_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previous10years_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous10years_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previous10years_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous10years_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previous10years_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous10years_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous10years_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'previous10years' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_previous10years_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 0 2 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previous5years.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previous5years.pipe
@@ -1,0 +1,138 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `previous5years` is calendar-aligned, open-ended: `toStartOfYear(today() - 5 years)` to
+    `today` (no end bound), matching the frontend's fixed date-range picker option.
+
+NODE collection_contributors_leaderboard_copy_previous5years_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_previous5years_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_previous5years_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previous5years_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous5years_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp > toStartOfYear(today() - INTERVAL 5 YEAR)
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previous5years_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous5years_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp > toStartOfYear(today() - INTERVAL 5 YEAR)
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_previous5years_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previous5years_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_previous5years_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_previous5years_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previous5years_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous5years_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previous5years_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous5years_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previous5years_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previous5years_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previous5years_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'previous5years' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_previous5years_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 55 1 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previousQuarter.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previousQuarter.pipe
@@ -1,0 +1,141 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `previousQuarter` is calendar-aligned (not rolling): `toStartOfQuarter(today() - 1 quarter)`
+    to `toStartOfQuarter(today()) - 1 second`, matching the frontend's fixed date-range picker
+    option.
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previousQuarter_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousQuarter_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp >= toStartOfQuarter(today() - INTERVAL 1 QUARTER)
+        AND ar.timestamp < toStartOfQuarter(today())
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previousQuarter_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousQuarter_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp >= toStartOfQuarter(today() - INTERVAL 1 QUARTER)
+        AND ar.timestamp < toStartOfQuarter(today())
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previousQuarter_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_previousQuarter_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previousQuarter_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previousQuarter_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previousQuarter_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousQuarter_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousQuarter_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'previousQuarter' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_previousQuarter_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 45 1 * * *

--- a/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previousYear.pipe
+++ b/services/libs/tinybird/pipes/collection_contributors_leaderboard_copy_previousYear.pipe
@@ -1,0 +1,140 @@
+DESCRIPTION >
+    - One of 8 pipes (`collection_contributors_leaderboard_copy_<presetKey>.pipe`) that together
+    replace the single `collection_contributors_leaderboard_copy.pipe` - see
+    `collection_contributors_leaderboard_copy_past90days.pipe`'s DESCRIPTION for the full split
+    rationale and incident background (shared across all 8).
+    - `previousYear` is calendar-aligned (not rolling): `toStartOfYear(today() - 1 year)` to
+    `toStartOfYear(today()) - 1 second`, matching the frontend's fixed date-range picker option.
+
+NODE collection_contributors_leaderboard_copy_previousYear_segments
+SQL >
+    SELECT arrayJoin(collectionsSlugs) AS collectionSlug, segmentId
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_contributors_leaderboard_copy_previousYear_activity_types
+SQL >
+    SELECT
+        activityType,
+        platform,
+        isCodeContribution AS qualifiesExcludingCollab,
+        (isCodeContribution = 1 OR isCollaboration = 1) AS qualifiesIncludingCollab
+    FROM activityTypes
+    WHERE isCodeContribution = 1 OR isCollaboration = 1
+
+NODE collection_contributors_leaderboard_copy_previousYear_segment_members
+SQL >
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        0 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previousYear_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousYear_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesExcludingCollab = 1
+        AND ar.timestamp >= toStartOfYear(today() - INTERVAL 1 YEAR)
+        AND ar.timestamp < toStartOfYear(today())
+    GROUP BY ar.segmentId, ar.memberId
+    UNION ALL
+    SELECT
+        ar.segmentId AS segmentId,
+        ar.memberId AS memberId,
+        1 AS includeCollaborations,
+        count(ar.activityId) AS contributionCount
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    INNER JOIN
+        (SELECT DISTINCT segmentId FROM collection_contributors_leaderboard_copy_previousYear_segments) segs
+        ON ar.segmentId = segs.segmentId
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousYear_activity_types at
+        ON at.activityType = ar.type AND at.platform = ar.platform
+    WHERE
+        ar.memberId != ''
+        AND at.qualifiesIncludingCollab = 1
+        AND ar.timestamp >= toStartOfYear(today() - INTERVAL 1 YEAR)
+        AND ar.timestamp < toStartOfYear(today())
+    GROUP BY ar.segmentId, ar.memberId
+
+NODE collection_contributors_leaderboard_copy_previousYear_fanned
+SQL >
+    SELECT
+        s.collectionSlug AS collectionSlug,
+        sm.memberId AS memberId,
+        sm.includeCollaborations AS includeCollaborations,
+        sm.contributionCount AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previousYear_segment_members sm
+    INNER JOIN collection_contributors_leaderboard_copy_previousYear_segments s ON s.segmentId = sm.segmentId
+
+NODE collection_contributors_leaderboard_copy_previousYear_collapsed
+SQL >
+    SELECT
+        collectionSlug,
+        memberId,
+        includeCollaborations,
+        sum(contributionCount) AS contributionCount
+    FROM collection_contributors_leaderboard_copy_previousYear_fanned
+    GROUP BY collectionSlug, memberId, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousYear_totals
+SQL >
+    SELECT
+        collectionSlug,
+        includeCollaborations,
+        sum(contributionCount) AS totalContributions,
+        uniqExact(memberId) AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previousYear_collapsed
+    GROUP BY collectionSlug, includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousYear_ranked
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.memberId AS memberId,
+        c.includeCollaborations AS includeCollaborations,
+        c.contributionCount AS contributionCount,
+        ROUND(c.contributionCount * 100.0 / t.totalContributions, 2) AS contributionPercentage,
+        toUInt32(row_number() OVER (
+            PARTITION BY c.collectionSlug, c.includeCollaborations
+            ORDER BY c.contributionCount DESC, c.memberId DESC
+        )) AS rank,
+        t.totalContributorCount AS totalContributorCount
+    FROM collection_contributors_leaderboard_copy_previousYear_collapsed c
+    INNER JOIN
+        collection_contributors_leaderboard_copy_previousYear_totals t
+        ON t.collectionSlug = c.collectionSlug
+        AND t.includeCollaborations = c.includeCollaborations
+
+NODE collection_contributors_leaderboard_copy_previousYear_result
+SQL >
+    SELECT
+        toStartOfInterval(now(), INTERVAL 1 day) AS snapshotId,
+        r.collectionSlug AS collectionSlug,
+        'previousYear' AS presetKey,
+        r.includeCollaborations AS includeCollaborations,
+        r.rank AS rank,
+        r.memberId AS id,
+        m.avatar AS avatar,
+        m.displayName AS displayName,
+        m.githubHandleArray AS githubHandleArray,
+        r.contributionCount AS contributionCount,
+        r.contributionPercentage AS contributionPercentage,
+        coalesce(mr.roles, []) AS roles,
+        r.totalContributorCount AS totalContributorCount,
+        now64(3) AS updatedAt
+    FROM collection_contributors_leaderboard_copy_previousYear_ranked r
+    INNER JOIN members_sorted m ON m.id = r.memberId
+    LEFT JOIN
+        (SELECT memberId, groupUniqArray(role) AS roles FROM maintainers_roles_copy_ds GROUP BY memberId) mr
+        ON mr.memberId = r.memberId
+
+TYPE COPY
+TARGET_DATASOURCE collection_contributors_leaderboard_copy_ds
+COPY_MODE append
+COPY_SCHEDULE 50 1 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate.pipe
@@ -1,6 +1,12 @@
 DESCRIPTION >
     - `collection_insights_aggregate.pipe` serves aggregate insights metrics for a collection.
     - Returns a single row with metrics aggregated across every project in the collection, not one row per project.
+    - Reads from `collection_insights_aggregate_copy_ds`, a daily `TYPE COPY` materialization (see
+    `collection_insights_aggregate_copy.pipe`), instead of recomputing live on every request. This
+    pipe has no filter parameters (`collectionSlug` only) - its result is always the same for a given
+    collection regardless of date range, activity type, or collaboration toggle - so unlike
+    `collection_contributor_dependency`/`collection_contributors_leaderboard`, there is no live-path
+    fallback: every request reads the precomputed table.
     - Parameters:
     - `collectionSlug`: Required collection slug. insights_projects_populated_ds.collectionsSlugs already lists
     every collection each project belongs to (see insightsProjects_filtered.pipe for the same filter pattern),
@@ -17,42 +23,11 @@ DESCRIPTION >
 
 TAGS "Insights, Widget", "Collection"
 
-NODE collection_insights_aggregate_projects
-DESCRIPTION >
-    Resolves the collection's member projects to their segment ids and health scores directly via
-    collectionsSlugs, matching the same has(collectionsSlugs, ...) filter already used by
-    insightsProjects_filtered.pipe.
-
+NODE collection_insights_aggregate_results
 SQL >
     %
-    SELECT id, segmentId, healthScore, organizationCount, contributorCount
-    FROM insights_projects_populated_ds
+    SELECT projectCount, uniqueContributorCount, avgHealthScore
+    FROM collection_insights_aggregate_copy_ds
     WHERE
-        enabled = 1
-        AND has(
-            collectionsSlugs,
-            {{ String(collectionSlug, description="Filter by collection slug", required=True) }}
-        )
-
-NODE collection_insights_aggregate_results
-DESCRIPTION >
-    Aggregates health score across matched projects and counts unique contributors across their segments in one pass
-
-SQL >
-    SELECT
-        (SELECT count(distinct id) FROM collection_insights_aggregate_projects) AS projectCount,
-        uniq(ar.memberId) AS uniqueContributorCount,
-        (
-            SELECT round(avg(healthScore))
-            FROM collection_insights_aggregate_projects
-            WHERE NOT (organizationCount = 0 AND contributorCount = 0)
-        ) AS avgHealthScore
-    FROM activityRelations_deduplicated_cleaned_bucket_union AS ar
-    WHERE
-        ar.memberId != ''
-        AND ar.segmentId IN (SELECT segmentId FROM collection_insights_aggregate_projects)
-        AND (ar.type, ar.platform) IN (
-            SELECT activityType, platform
-            FROM activityTypes
-            WHERE isCodeContribution = 1 OR isCollaboration = 1
-        )
+        collectionSlug
+        = {{ String(collectionSlug, description="Filter by collection slug", required=True) }}

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy.pipe
@@ -1,0 +1,98 @@
+DESCRIPTION >
+    - `collection_insights_aggregate_copy.pipe` precomputes `collection_insights_aggregate.pipe`'s
+    result for every collection on a daily schedule, writing into `collection_insights_aggregate_copy_ds`.
+    - Exists because the live computation scans `activityRelations_deduplicated_cleaned_bucket_union`
+    per collection on every request (50,216 requests/30 days, part of the same Contributors-tab
+    cost problem as `collection_contributor_dependency` and `collection_contributors_leaderboard` -
+    see their copy pipes' DESCRIPTIONs for the full incident background).
+    - Unlike those two pipes, `collection_insights_aggregate` has no filter parameters at all
+    (`collectionSlug` only) - its result is always the same for a given collection regardless of
+    date range, activity type, or collaboration toggle, so this is a single-variant-per-collection
+    precompute, no filter matrix needed.
+    - Same fan-out pattern as `collection_contributor_dependency_copy.pipe`: every (collectionSlug,
+    segmentId) pair for enabled projects that belong to at least one collection, computed once from
+    `insights_projects_populated_ds`.
+
+NODE collection_insights_aggregate_copy_segments
+DESCRIPTION >
+    Every (collectionSlug, segmentId, healthScore, organizationCount, contributorCount) row for
+    enabled projects that belong to at least one collection - the fan-out point, matching the live
+    pipe's `collection_insights_aggregate_projects` node but resolved for every collection at once.
+
+SQL >
+    SELECT
+        arrayJoin(collectionsSlugs) AS collectionSlug,
+        id,
+        segmentId,
+        healthScore,
+        organizationCount,
+        contributorCount
+    FROM insights_projects_populated_ds
+    WHERE enabled = 1 AND notEmpty(collectionsSlugs)
+
+NODE collection_insights_aggregate_copy_project_counts
+DESCRIPTION >
+    Per-collection project count and average health score (onboarded projects only), matching the
+    live pipe's two scalar subqueries against `collection_insights_aggregate_projects`.
+
+SQL >
+    SELECT
+        collectionSlug,
+        count(distinct id) AS projectCount,
+        round(avgIf(healthScore, NOT (organizationCount = 0 AND contributorCount = 0))) AS avgHealthScore
+    FROM collection_insights_aggregate_copy_segments
+    GROUP BY collectionSlug
+
+NODE collection_insights_aggregate_copy_segment_members
+DESCRIPTION >
+    Distinct (segmentId, memberId) pairs with qualifying activity - the activity scan happens ONCE
+    per segment here, collapsed to distinct members, before any fan-out to collections. 61% of
+    projects belong to more than one collection (up to 39), so joining the raw activity stream
+    directly against a per-collection mapping (the original version of this node) multiplied the
+    scan by collection-membership count before aggregation - this collapses to distinct members per
+    segment first, which is cheap regardless of how many collections that segment's project belongs
+    to, and only THEN fans out the already-small distinct set to collections in the next node.
+
+SQL >
+    SELECT DISTINCT ar.segmentId AS segmentId, ar.memberId AS memberId
+    FROM activityRelations_deduplicated_cleaned_bucket_union ar
+    WHERE
+        ar.memberId != ''
+        AND ar.segmentId IN (SELECT DISTINCT segmentId FROM collection_insights_aggregate_copy_segments)
+        AND (ar.type, ar.platform) IN (
+            SELECT activityType, platform FROM activityTypes WHERE isCodeContribution = 1 OR isCollaboration = 1
+        )
+
+NODE collection_insights_aggregate_copy_activities
+DESCRIPTION >
+    Fans the already-distinct per-segment member set out to collections via the segment join - this
+    join is now against a small distinct-member table, not the raw activity stream, so collection
+    fan-out no longer multiplies scan cost.
+
+SQL >
+    SELECT s.collectionSlug AS collectionSlug, sm.memberId AS memberId
+    FROM collection_insights_aggregate_copy_segment_members sm
+    INNER JOIN
+        (SELECT DISTINCT collectionSlug, segmentId FROM collection_insights_aggregate_copy_segments) s
+        ON s.segmentId = sm.segmentId
+
+NODE collection_insights_aggregate_copy_result
+DESCRIPTION >
+    One row per collection: project count, deduplicated unique contributor count, and average health
+    score - the exact shape `collection_insights_aggregate.pipe` returns today.
+
+SQL >
+    SELECT
+        c.collectionSlug AS collectionSlug,
+        c.projectCount AS projectCount,
+        uniq(a.memberId) AS uniqueContributorCount,
+        c.avgHealthScore AS avgHealthScore,
+        now64(3) AS updatedAt
+    FROM collection_insights_aggregate_copy_project_counts c
+    INNER JOIN collection_insights_aggregate_copy_activities a ON a.collectionSlug = c.collectionSlug
+    GROUP BY c.collectionSlug, c.projectCount, c.avgHealthScore
+
+TYPE COPY
+TARGET_DATASOURCE collection_insights_aggregate_copy_ds
+COPY_MODE replace
+COPY_SCHEDULE 30 1 * * *


### PR DESCRIPTION
## Summary
- Extends the collection-page precompute work to cover the contributor-dependency widget's real filtered traffic — production telemetry showed 86% of requests carry a date range, and 98% of those match one of the 8 fixed date-picker presets (not the "no filters at all" case the original v1 precompute covered).
- Adds a 16-variant precomputed matrix (8 date presets × 2 `includeCollaborations` states) for `collection_contributor_dependency`, replacing the old v1 single-variant (unfiltered-only) precomputed path.
- Splits `collection_contributor_dependency_copy` and `collection_contributors_leaderboard_copy` each into 8 `presetKey`-scoped copy pipes (`past90days`, `past180days`, `past365days`, `previousQuarter`, `previousYear`, `previous5years`, `previous10years`, `allTime`), mirroring the existing `collection_insights_aggregate_copy` pattern.
- Rewrites `collection_contributor_dependency_copy_ds` and `collection_contributors_leaderboard_copy_ds` as append + `snapshotId` datasources so a daily run doesn't clobber the prior day's rows mid-query.
- Updates the serving pipes (`collection_contributor_dependency.pipe`, `collection_contributors_leaderboard.pipe`) to route between the precomputed path (requires `presetKey`, no `repos`/`platform`/`activity_type`, `limit`=100) and the live `GROUP BY` path at template-render time — ClickHouse evaluates all `UNION ALL` branches regardless of `WHERE` guards, so routing has to happen at render time, not query time.
- Deletes the superseded v1 `collection_contributor_dependency_copy.pipe` / `collection_contributor_dependency_copy_ds.datasource`.

## Why
At collection scale (e.g. `cncf` has 149,677 distinct contributors), the live `GROUP BY af.memberId` path for the contributor-dependency widget was triggering Tinybird production rate-limit/concurrency alerts under load. The original precompute only covered fully-unfiltered requests, but real traffic is overwhelmingly filtered by one of the date picker's 8 fixed presets — so the fast path almost never activated. This closes that gap.

## Changes
- `services/libs/tinybird/pipes/collection_contributor_dependency.pipe` — adds precomputed-path routing node, updated DESCRIPTION.
- `services/libs/tinybird/pipes/collection_contributors_leaderboard.pipe` — same routing pattern (was already partially split in an earlier phase; this makes the presetKey contract consistent with contributor-dependency).
- `services/libs/tinybird/pipes/collection_insights_aggregate.pipe` — minor consistency update.
- 16 new `*_copy_<presetKey>.pipe` files (8 for contributor-dependency, 8 for leaderboard).
- `collection_insights_aggregate_copy.pipe` — new copy pipe for that datasource.
- 3 rewritten/new `*_copy_ds.datasource` files (append + snapshotId schema).
- Deletes `collection_contributor_dependency_copy.pipe` (v1, superseded).

## Deploy order
Must deploy before the companion insights PR (#2041) — that PR sends `presetKey` values that need to already resolve against a live pipe here.

## Test plan
- [x] Validated pipe/datasource SQL and schema changes via Tinybird MCP against production data
- [x] Deployed through staging then production via `tb` CLI
- [x] Verified all 16 contributor-dependency variants and 16 leaderboard variants present with matching row counts for a real collection (`cncf`)
- [x] Root-caused and fixed a `past365days` zero-rows gap post-deploy (one pipe instance's daily cron hadn't fired yet after the redeploy reset its run history) — manually triggered, verified correct data end-to-end

JIRA: IN-1196