### PR TITLE
fix: cascade delete affiliation overrides when member is deleted

### DIFF
--- a/backend/src/database/migrations/V1785226126__cascade_delete_memberOrganizationAffiliationOverrides_on_member.sql
+++ b/backend/src/database/migrations/V1785226126__cascade_delete_memberOrganizationAffiliationOverrides_on_member.sql
@@ -1,0 +1,8 @@
+alter table "memberOrganizationAffiliationOverrides"
+  drop constraint if exists "memberOrganizationAffiliationOverrides_memberId_fkey";
+
+alter table "memberOrganizationAffiliationOverrides"
+  add constraint "memberOrganizationAffiliationOverrides_memberId_fkey"
+  foreign key ("memberId")
+  references members (id)
+  on delete cascade;


### PR DESCRIPTION
## Summary
`finishMemberMerging` can get stuck on `deleteMember` when `memberOrganizationAffiliationOverrides` rows still reference the secondary member. That FK was `ON DELETE NO ACTION`, while other member children (e.g. `memberOrganizations`) already cascade — so a race that recreates overrides on the secondary after merge sync blocks member deletion forever.

## Changes
- Recreate `memberOrganizationAffiliationOverrides_memberId_fkey` with `ON DELETE CASCADE`, so deleting a member removes its affiliation overrides and `deleteMember` can complete reliably.