### PR TITLE
fix: heartbeat and cancellation for rubygems

### DIFF
--- a/services/apps/packages_worker/src/config.ts
+++ b/services/apps/packages_worker/src/config.ts
@@ -98,7 +98,7 @@ export function getNuGetConfig() {
 
 export function getRubyGemsConfig() {
   return {
-    batchSize: parseInt(process.env.RUBYGEMS_FETCHER_BATCH_SIZE ?? '10000', 10),
+    batchSize: parseInt(process.env.RUBYGEMS_FETCHER_BATCH_SIZE ?? '15000', 10),
     concurrency: parseInt(process.env.RUBYGEMS_FETCHER_CONCURRENCY ?? '8', 10),
   }
 }

--- a/services/apps/packages_worker/src/rubygems/activities.ts
+++ b/services/apps/packages_worker/src/rubygems/activities.ts
@@ -11,20 +11,37 @@ import { BatchResult } from './types'
 
 const log = getServiceChildLogger('rubygems-activity')
 
-function checkpoint(): void {
+function assertNotCancelled(): void {
   if (cancellationSignal().aborted) {
     throw new Error('RubyGems batch cancelled — superseded by a newer activity attempt')
   }
-  heartbeat()
+}
+
+// Fixed-cadence heartbeat: a concurrency group can outlast the 2-minute heartbeatTimeout
+// (Retry-After sleeps, slow persistence), so heartbeating can't rely on group boundaries.
+function startHeartbeat(): () => void {
+  const timer = setInterval(() => {
+    try {
+      heartbeat()
+    } catch (err) {
+      log.warn({ errMsg: (err as Error).message }, 'Heartbeat failed')
+    }
+  }, 30_000)
+  return () => clearInterval(timer)
 }
 
 export async function processRubyGemsCoreBatch(): Promise<BatchResult> {
   const config = getRubyGemsConfig()
   const qx = await getPackagesDb()
   const today = new Date().toISOString().split('T')[0]
-  const result = await processCoreBatch(qx, config, today, checkpoint)
-  log.info({ ...result }, 'RubyGems core batch complete')
-  return result
+  const stopHeartbeat = startHeartbeat()
+  try {
+    const result = await processCoreBatch(qx, config, today, assertNotCancelled)
+    log.info({ ...result }, 'RubyGems core batch complete')
+    return result
+  } finally {
+    stopHeartbeat()
+  }
 }
 
 export async function processRubyGemsCriticalBatch(
@@ -32,7 +49,12 @@ export async function processRubyGemsCriticalBatch(
 ): Promise<BatchResult & { lastId: string | null }> {
   const config = getRubyGemsCriticalConfig()
   const qx = await getPackagesDb()
-  const result = await processCriticalBatch(qx, config, afterId, checkpoint)
-  log.info({ ...result }, 'RubyGems critical batch complete')
-  return result
+  const stopHeartbeat = startHeartbeat()
+  try {
+    const result = await processCriticalBatch(qx, config, afterId, assertNotCancelled)
+    log.info({ ...result }, 'RubyGems critical batch complete')
+    return result
+  } finally {
+    stopHeartbeat()
+  }
 }

--- a/services/apps/packages_worker/src/rubygems/activities.ts
+++ b/services/apps/packages_worker/src/rubygems/activities.ts
@@ -11,12 +11,6 @@ import { BatchResult } from './types'
 
 const log = getServiceChildLogger('rubygems-activity')
 
-function assertNotCancelled(): void {
-  if (cancellationSignal().aborted) {
-    throw new Error('RubyGems batch cancelled — superseded by a newer activity attempt')
-  }
-}
-
 // Fixed-cadence heartbeat: a concurrency group can outlast the 2-minute heartbeatTimeout
 // (Retry-After sleeps, slow persistence), so heartbeating can't rely on group boundaries.
 function startHeartbeat(): () => void {
@@ -36,7 +30,7 @@ export async function processRubyGemsCoreBatch(): Promise<BatchResult> {
   const today = new Date().toISOString().split('T')[0]
   const stopHeartbeat = startHeartbeat()
   try {
-    const result = await processCoreBatch(qx, config, today, assertNotCancelled)
+    const result = await processCoreBatch(qx, config, today, cancellationSignal())
     log.info({ ...result }, 'RubyGems core batch complete')
     return result
   } finally {
@@ -51,7 +45,7 @@ export async function processRubyGemsCriticalBatch(
   const qx = await getPackagesDb()
   const stopHeartbeat = startHeartbeat()
   try {
-    const result = await processCriticalBatch(qx, config, afterId, assertNotCancelled)
+    const result = await processCriticalBatch(qx, config, afterId, cancellationSignal())
     log.info({ ...result }, 'RubyGems critical batch complete')
     return result
   } finally {

--- a/services/apps/packages_worker/src/rubygems/activities.ts
+++ b/services/apps/packages_worker/src/rubygems/activities.ts
@@ -1,3 +1,5 @@
+import { cancellationSignal, heartbeat } from '@temporalio/activity'
+
 import { getServiceChildLogger } from '@crowd/logging'
 
 import { getRubyGemsConfig, getRubyGemsCriticalConfig } from '../config'
@@ -9,11 +11,18 @@ import { BatchResult } from './types'
 
 const log = getServiceChildLogger('rubygems-activity')
 
+function checkpoint(): void {
+  if (cancellationSignal().aborted) {
+    throw new Error('RubyGems batch cancelled — superseded by a newer activity attempt')
+  }
+  heartbeat()
+}
+
 export async function processRubyGemsCoreBatch(): Promise<BatchResult> {
   const config = getRubyGemsConfig()
   const qx = await getPackagesDb()
   const today = new Date().toISOString().split('T')[0]
-  const result = await processCoreBatch(qx, config, today)
+  const result = await processCoreBatch(qx, config, today, checkpoint)
   log.info({ ...result }, 'RubyGems core batch complete')
   return result
 }
@@ -23,7 +32,7 @@ export async function processRubyGemsCriticalBatch(
 ): Promise<BatchResult & { lastId: string | null }> {
   const config = getRubyGemsCriticalConfig()
   const qx = await getPackagesDb()
-  const result = await processCriticalBatch(qx, config, afterId)
+  const result = await processCriticalBatch(qx, config, afterId, checkpoint)
   log.info({ ...result }, 'RubyGems critical batch complete')
   return result
 }

--- a/services/apps/packages_worker/src/rubygems/client.ts
+++ b/services/apps/packages_worker/src/rubygems/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { acquireRubyGemsSlot, parseRetryAfterMs } from './rateLimiter'
+import { abortableSleep, acquireRubyGemsSlot, parseRetryAfterMs } from './rateLimiter'
 import {
   RubyGemsFetchResult,
   RubyGemsGemResponse,
@@ -10,13 +10,14 @@ import {
 
 const MAX_RATE_LIMIT_RETRIES = 5
 
-async function rubyGemsGet<T>(url: string): Promise<RubyGemsFetchResult<T>> {
+async function rubyGemsGet<T>(url: string, signal?: AbortSignal): Promise<RubyGemsFetchResult<T>> {
   for (let attempt = 0; ; attempt++) {
-    await acquireRubyGemsSlot()
+    await acquireRubyGemsSlot(signal)
     try {
-      const resp = await axios.get<T>(url, { timeout: 15000 })
+      const resp = await axios.get<T>(url, { timeout: 15000, signal })
       return resp.data
     } catch (err) {
+      signal?.throwIfAborted()
       if (axios.isAxiosError(err)) {
         const status = err.response?.status
         if (status === 404) return { kind: 'NOT_FOUND', status, message: err.message }
@@ -24,9 +25,7 @@ async function rubyGemsGet<T>(url: string): Promise<RubyGemsFetchResult<T>> {
           if (attempt >= MAX_RATE_LIMIT_RETRIES) {
             return { kind: 'RATE_LIMIT', status, message: err.message }
           }
-          await new Promise((r) =>
-            setTimeout(r, parseRetryAfterMs(err.response?.headers['retry-after'])),
-          )
+          await abortableSleep(parseRetryAfterMs(err.response?.headers['retry-after']), signal)
           continue
         }
       }
@@ -35,20 +34,32 @@ async function rubyGemsGet<T>(url: string): Promise<RubyGemsFetchResult<T>> {
   }
 }
 
-export function fetchGem(name: string): Promise<RubyGemsFetchResult<RubyGemsGemResponse>> {
+export function fetchGem(
+  name: string,
+  signal?: AbortSignal,
+): Promise<RubyGemsFetchResult<RubyGemsGemResponse>> {
   return rubyGemsGet<RubyGemsGemResponse>(
     `https://rubygems.org/api/v1/gems/${encodeURIComponent(name)}.json`,
+    signal,
   )
 }
 
-export function fetchVersions(name: string): Promise<RubyGemsFetchResult<RubyGemsVersionItem[]>> {
+export function fetchVersions(
+  name: string,
+  signal?: AbortSignal,
+): Promise<RubyGemsFetchResult<RubyGemsVersionItem[]>> {
   return rubyGemsGet<RubyGemsVersionItem[]>(
     `https://rubygems.org/api/v1/versions/${encodeURIComponent(name)}.json`,
+    signal,
   )
 }
 
-export function fetchOwners(name: string): Promise<RubyGemsFetchResult<RubyGemsOwner[]>> {
+export function fetchOwners(
+  name: string,
+  signal?: AbortSignal,
+): Promise<RubyGemsFetchResult<RubyGemsOwner[]>> {
   return rubyGemsGet<RubyGemsOwner[]>(
     `https://rubygems.org/api/v1/gems/${encodeURIComponent(name)}/owners.json`,
+    signal,
   )
 }

--- a/services/apps/packages_worker/src/rubygems/rateLimiter.ts
+++ b/services/apps/packages_worker/src/rubygems/rateLimiter.ts
@@ -3,12 +3,32 @@ const INTERVAL_MS = 1000 / MAX_RPS
 
 let nextSlot = 0
 
-export async function acquireRubyGemsSlot(): Promise<void> {
+export function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((r) => setTimeout(r, ms))
+  const sig = signal
+  return new Promise((resolve, reject) => {
+    if (sig.aborted) {
+      reject(sig.reason)
+      return
+    }
+    function onAbort() {
+      clearTimeout(timer)
+      reject(sig.reason)
+    }
+    const timer = setTimeout(() => {
+      sig.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    sig.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+export async function acquireRubyGemsSlot(signal?: AbortSignal): Promise<void> {
   const now = Date.now()
   const slot = Math.max(now, nextSlot)
   nextSlot = slot + INTERVAL_MS
   const wait = slot - now
-  if (wait > 0) await new Promise((r) => setTimeout(r, wait))
+  if (wait > 0) await abortableSleep(wait, signal)
 }
 
 export function parseRetryAfterMs(header: unknown): number {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -158,6 +158,7 @@ export async function processBatch(
   qx: QueryExecutor,
   config: RubyGemsCoreConfig,
   today: string,
+  checkpoint?: () => void,
 ): Promise<BatchResult> {
   const packages = await listRubyGemsPackagesToSync(qx, { limit: config.batchSize })
 
@@ -168,6 +169,7 @@ export async function processBatch(
   const counts = { processed: 0, skipped: 0, error: 0, unchanged: 0 }
 
   for (let batchStart = 0; batchStart < packages.length; batchStart += config.concurrency) {
+    checkpoint?.()
     const group = packages.slice(batchStart, batchStart + config.concurrency)
 
     await Promise.all(

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCoreLoop.ts
@@ -62,8 +62,9 @@ async function processPackage(
   qx: QueryExecutor,
   pkg: RubyGemsPackageToSync,
   today: string,
+  signal?: AbortSignal,
 ): Promise<PackageStatus> {
-  const gemResult = await fetchGem(pkg.name)
+  const gemResult = await fetchGem(pkg.name, signal)
 
   if (isRubyGemsFetchError(gemResult)) {
     if (gemResult.kind === 'NOT_FOUND') {
@@ -158,7 +159,7 @@ export async function processBatch(
   qx: QueryExecutor,
   config: RubyGemsCoreConfig,
   today: string,
-  checkpoint?: () => void,
+  signal?: AbortSignal,
 ): Promise<BatchResult> {
   const packages = await listRubyGemsPackagesToSync(qx, { limit: config.batchSize })
 
@@ -169,15 +170,16 @@ export async function processBatch(
   const counts = { processed: 0, skipped: 0, error: 0, unchanged: 0 }
 
   for (let batchStart = 0; batchStart < packages.length; batchStart += config.concurrency) {
-    checkpoint?.()
+    signal?.throwIfAborted()
     const group = packages.slice(batchStart, batchStart + config.concurrency)
 
     await Promise.all(
       group.map(async (pkg) => {
         try {
-          const status = await processPackage(qx, pkg, today)
+          const status = await processPackage(qx, pkg, today, signal)
           counts[status]++
         } catch (err) {
+          signal?.throwIfAborted()
           const message = err instanceof Error ? err.message : String(err)
           log.error({ purl: pkg.purl, error: message }, 'Unexpected error processing package')
           try {
@@ -189,6 +191,7 @@ export async function processBatch(
         }
       }),
     )
+    signal?.throwIfAborted()
 
     const done = batchStart + group.length
     if (done % 1000 === 0 || done === packages.length) {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCriticalLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCriticalLoop.ts
@@ -49,10 +49,11 @@ type PackageStatus = 'processed' | 'skipped' | 'error' | 'unchanged'
 async function processPackage(
   qx: QueryExecutor,
   pkg: RubyGemsCriticalPackageToSync,
+  signal?: AbortSignal,
 ): Promise<PackageStatus> {
   const [versionsResult, ownersResult] = await Promise.all([
-    fetchVersions(pkg.name),
-    fetchOwners(pkg.name),
+    fetchVersions(pkg.name, signal),
+    fetchOwners(pkg.name, signal),
   ])
 
   if (isRubyGemsFetchError(versionsResult)) {
@@ -147,7 +148,7 @@ export async function processBatch(
   qx: QueryExecutor,
   config: RubyGemsCriticalConfig,
   afterId: string,
-  checkpoint?: () => void,
+  signal?: AbortSignal,
 ): Promise<BatchResult & { lastId: string | null }> {
   const packages = await listRubyGemsCriticalPackagesToSync(qx, {
     limit: config.batchSize,
@@ -163,15 +164,16 @@ export async function processBatch(
   const counts = { processed: 0, skipped: 0, error: 0, unchanged: 0 }
 
   for (let batchStart = 0; batchStart < packages.length; batchStart += config.concurrency) {
-    checkpoint?.()
+    signal?.throwIfAborted()
     const group = packages.slice(batchStart, batchStart + config.concurrency)
 
     await Promise.all(
       group.map(async (pkg) => {
         try {
-          const status = await processPackage(qx, pkg)
+          const status = await processPackage(qx, pkg, signal)
           counts[status]++
         } catch (err) {
+          signal?.throwIfAborted()
           const message = err instanceof Error ? err.message : String(err)
           log.error(
             { purl: pkg.purl, error: message },
@@ -181,6 +183,7 @@ export async function processBatch(
         }
       }),
     )
+    signal?.throwIfAborted()
 
     const done = batchStart + group.length
     if (done % 1000 === 0 || done === packages.length) {

--- a/services/apps/packages_worker/src/rubygems/runRubyGemsCriticalLoop.ts
+++ b/services/apps/packages_worker/src/rubygems/runRubyGemsCriticalLoop.ts
@@ -147,6 +147,7 @@ export async function processBatch(
   qx: QueryExecutor,
   config: RubyGemsCriticalConfig,
   afterId: string,
+  checkpoint?: () => void,
 ): Promise<BatchResult & { lastId: string | null }> {
   const packages = await listRubyGemsCriticalPackagesToSync(qx, {
     limit: config.batchSize,
@@ -162,6 +163,7 @@ export async function processBatch(
   const counts = { processed: 0, skipped: 0, error: 0, unchanged: 0 }
 
   for (let batchStart = 0; batchStart < packages.length; batchStart += config.concurrency) {
+    checkpoint?.()
     const group = packages.slice(batchStart, batchStart + config.concurrency)
 
     await Promise.all(

--- a/services/apps/packages_worker/src/rubygems/workflows.ts
+++ b/services/apps/packages_worker/src/rubygems/workflows.ts
@@ -4,6 +4,7 @@ import type * as activities from './activities'
 
 const acts = proxyActivities<typeof activities>({
   startToCloseTimeout: '60 minutes',
+  heartbeatTimeout: '2 minutes',
   retry: { initialInterval: '30 seconds', backoffCoefficient: 2, maximumAttempts: 5 },
 })
 


### PR DESCRIPTION
This pull request introduces improvements to the RubyGems batch processing logic in the `packages_worker` service, focusing on better cancellation handling, increased batch size, and enhanced Temporal activity configuration. The most important changes are grouped below:

**Batch Processing and Cancellation Handling:**

* Added a `checkpoint` function to RubyGems activities that checks for cancellation and sends a heartbeat, ensuring the batch process can be cancelled promptly if superseded by a newer attempt (`activities.ts`, `runRubyGemsCoreLoop.ts`, `runRubyGemsCriticalLoop.ts`). [[1]](diffhunk://#diff-f4219ae458616723b6deb361ea3f3dbc59ce947751b4f9bf13d111b75950cfa8R1-R2) [[2]](diffhunk://#diff-f4219ae458616723b6deb361ea3f3dbc59ce947751b4f9bf13d111b75950cfa8R14-R25) [[3]](diffhunk://#diff-cd2e09f15e4cbe008d88c4649e70fab48168a26fec86a1354ed0894f547151a0R161) [[4]](diffhunk://#diff-cd2e09f15e4cbe008d88c4649e70fab48168a26fec86a1354ed0894f547151a0R172) [[5]](diffhunk://#diff-27bbf20256289bd3bd12f8afac7f86be7923e3cf2ffd6c5f05082dd379423e05R150) [[6]](diffhunk://#diff-27bbf20256289bd3bd12f8afac7f86be7923e3cf2ffd6c5f05082dd379423e05R166) [[7]](diffhunk://#diff-f4219ae458616723b6deb361ea3f3dbc59ce947751b4f9bf13d111b75950cfa8L26-R35)
* Updated `processCoreBatch` and `processCriticalBatch` to accept and invoke the new `checkpoint` function during batch loops, improving responsiveness to cancellation signals. [[1]](diffhunk://#diff-f4219ae458616723b6deb361ea3f3dbc59ce947751b4f9bf13d111b75950cfa8R14-R25) [[2]](diffhunk://#diff-f4219ae458616723b6deb361ea3f3dbc59ce947751b4f9bf13d111b75950cfa8L26-R35) [[3]](diffhunk://#diff-cd2e09f15e4cbe008d88c4649e70fab48168a26fec86a1354ed0894f547151a0R161) [[4]](diffhunk://#diff-cd2e09f15e4cbe008d88c4649e70fab48168a26fec86a1354ed0894f547151a0R172) [[5]](diffhunk://#diff-27bbf20256289bd3bd12f8afac7f86be7923e3cf2ffd6c5f05082dd379423e05R150) [[6]](diffhunk://#diff-27bbf20256289bd3bd12f8afac7f86be7923e3cf2ffd6c5f05082dd379423e05R166)

**Configuration Changes:**

* Increased the default `RUBYGEMS_FETCHER_BATCH_SIZE` from 10,000 to 15,000 to process more packages per batch by default (`config.ts`).
* Set a `heartbeatTimeout` of 2 minutes for Temporal activities to ensure regular heartbeats and timely detection of stalled or cancelled activities (`workflows.ts`).

These changes collectively make RubyGems batch processing more efficient and robust, especially in handling cancellations and scaling batch sizes.