### PR TITLE
fix: treat member identities as case-insensitive (CM-1349)

### DIFF
--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -54,7 +54,10 @@ export async function createMember(req: Request, res: Response): Promise<void> {
         identities.map((identity) => ({
           ...identity,
           memberId: dbMember.id,
-          value: identity.value.trim().toLowerCase(),
+          value:
+            identity.type === MemberIdentityType.EMAIL
+              ? identity.value.trim().toLowerCase()
+              : identity.value.trim(),
         })),
         true,
         true,

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -46,9 +46,9 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     throw new NotFoundError('Member not found')
   }
 
-  // The data-sink writes identity values as trimmed lowercase, so normalize here
-  // to keep idempotency checks reliable against existing rows.
-  const normalizedValue = data.value.trim().toLowerCase()
+  // Normalize emails to lowercase; keep username preferred casing from the caller.
+  const normalizedValue =
+    data.type === MemberIdentityType.EMAIL ? data.value.trim().toLowerCase() : data.value.trim()
 
   let result!: IMemberIdentity
   let alreadyExisted = false

--- a/backend/src/database/migrations/V1785255019__member_identities_case_insensitive_unique_indexes.sql
+++ b/backend/src/database/migrations/V1785255019__member_identities_case_insensitive_unique_indexes.sql
@@ -1,0 +1,15 @@
+-- Enforce uniqueness on lower(value) instead of the original value.
+-- `value` preserves the source's preferred casing; email values are stored in lowercase.
+-- docs/adr/0015-how-cdp-stores-member-identities.md
+
+create unique index concurrently if not exists "uix_memberIdentities_memberId_platform_type_lower_value"
+    on "memberIdentities" ("memberId", platform, type, lower(value))
+    where "deletedAt" is null;
+
+create unique index concurrently if not exists "uix_memberIdentities_platform_type_lower_value_verified"
+    on "memberIdentities" (platform, type, lower(value))
+    where verified = true
+      and "deletedAt" is null;
+
+drop index concurrently if exists "uix_memberIdentities_memberId_platform_value_type";
+drop index concurrently if exists "uix_memberIdentities_platform_value_type_verified";

--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -13,13 +13,18 @@ import {
   updateMemberIdentity,
 } from '@crowd/data-access-layer/src/members'
 import { LoggerBase } from '@crowd/logging'
-import { IMemberIdentity, NewMemberIdentity } from '@crowd/types'
+import { IMemberIdentity, MemberIdentityType, NewMemberIdentity } from '@crowd/types'
 
 import { IRepositoryOptions } from '@/database/repositories/IRepositoryOptions'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import { optionsQx } from '@/database/sequelizeQueryExecutor'
 
 import { IServiceOptions } from '../IServiceOptions'
+
+function normalizeIdentityValue(type: string, value: string): string {
+  const trimmed = value.trim()
+  return type === MemberIdentityType.EMAIL ? trimmed.toLowerCase() : trimmed
+}
 
 export default class MemberIdentityService extends LoggerBase {
   options: IServiceOptions
@@ -58,11 +63,16 @@ export default class MemberIdentityService extends LoggerBase {
 
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
+          const identityData = {
+            ...data,
+            value: normalizeIdentityValue(data.type, data.value),
+          }
+
           // Check if identity already exists
           const conflict = await findMemberIdentityConflict(qx, {
-            value: data.value,
-            platform: data.platform,
-            type: data.type,
+            value: identityData.value,
+            platform: identityData.platform,
+            type: identityData.type,
           })
 
           if (conflict) {
@@ -77,7 +87,7 @@ export default class MemberIdentityService extends LoggerBase {
           }
 
           // Create member identity
-          await insertMemberIdentities(qx, [{ ...data, memberId }])
+          await insertMemberIdentities(qx, [{ ...identityData, memberId }])
 
           await touchMemberUpdatedAt(qx, memberId)
 
@@ -131,7 +141,12 @@ export default class MemberIdentityService extends LoggerBase {
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
           // Check if any of the identities already exist
-          for (const identity of data) {
+          const normalizedData = data.map((identity) => ({
+            ...identity,
+            value: normalizeIdentityValue(identity.type, identity.value),
+          }))
+
+          for (const identity of normalizedData) {
             const conflict = await findMemberIdentityConflict(qx, {
               value: identity.value,
               platform: identity.platform,
@@ -153,7 +168,7 @@ export default class MemberIdentityService extends LoggerBase {
           // Create member identities
           await insertMemberIdentities(
             qx,
-            data.map((identity) => ({ ...identity, memberId })),
+            normalizedData.map((identity) => ({ ...identity, memberId })),
           )
 
           await touchMemberUpdatedAt(qx, memberId)
@@ -211,7 +226,10 @@ export default class MemberIdentityService extends LoggerBase {
             throw new Error404(this.options.language, 'errors.notFound.message')
           }
 
-          const value = data.value ?? currentIdentity.value
+          const value = normalizeIdentityValue(
+            data.type ?? currentIdentity.type,
+            data.value ?? currentIdentity.value,
+          )
           const platform = data.platform ?? currentIdentity.platform
           const type = data.type ?? currentIdentity.type
 
@@ -234,7 +252,10 @@ export default class MemberIdentityService extends LoggerBase {
           }
 
           // Update member identity with new data
-          await updateMemberIdentity(qx, memberId, id, data)
+          await updateMemberIdentity(qx, memberId, id, {
+            ...data,
+            ...(data.value !== undefined ? { value } : {}),
+          })
 
           await touchMemberUpdatedAt(qx, memberId)
 

--- a/backend/src/utils/err.ts
+++ b/backend/src/utils/err.ts
@@ -5,6 +5,8 @@ type ConflictFactory = (context?: Record<string, unknown>) => Error
 const DB_CONFLICT_MAP: Record<string, ConflictFactory> = {
   uix_memberIdentities_platform_value_type_verified: (context) =>
     new ConflictError('Identity already exists on another member', context),
+  uix_memberIdentities_platform_type_lower_value_verified: (context) =>
+    new ConflictError('Identity already exists on another member', context),
 }
 
 export function rethrowDbConflict(error: unknown, context?: Record<string, unknown>): never {

--- a/docs/adr/0015-how-cdp-stores-member-identities.md
+++ b/docs/adr/0015-how-cdp-stores-member-identities.md
@@ -1,0 +1,88 @@
+# ADR-0015: How CDP stores member identities
+
+**Date**: 2026-07-28
+**Status**: accepted
+**Deciders**: Yeganathan S
+**Related**: CM-1349
+
+## Context
+
+CDP treats member identities as case-insensitive when resolving people (`lower(value)` in lookups and many DAL queries), which matches how major platforms behave:
+
+- **GitHub / GitLab**: usernames are case-insensitive for uniqueness, but case-preserving for display (`WillsonHG` and `willsonhg` are the same account; APIs return preferred casing).
+- **Discord** (new usernames): forced lowercase.
+- **Email**: stored and compared lowercase in practice.
+
+Historically, `memberIdentities` uniqueness was defined on raw `value` (case-sensitive):
+
+- `uix_memberIdentities_memberId_platform_value_type`
+- `uix_memberIdentities_platform_value_type_verified`
+
+Lookups used `lower(value)`, but inserts often did not. Data-sink `mergeData` matched with exact `value ===`, so a self-serve lowercase `willsonhg` plus a later GitHub ingest of `WillsonHG` produced two rows for the same identity — often both verified on the same member. Prod had tens of thousands of GitHub case-variant groups.
+
+Ticket CM-1349 proposed soft-deleting / auto-verifying case variants at verification time. That treats a write-path bug as a product special case.
+
+## Decision
+
+**Mental model**
+
+| Kind | Store | Compare / unique on |
+| --- | --- | --- |
+| username | preferred casing from the source/integration | `lower(value)` |
+| email | always lowercase | `lower(value)` (same as stored) |
+
+Identity equality in CDP is `(platform, type, lower(value))`. The `value` column keeps what the source sent for usernames; we do not rewrite GitHub `login` casing on ingest.
+
+**Enforcement**
+
+1. **Write paths** match and upsert with case-insensitive equality (`isSameMemberIdentity` / `lower(value)`). Do not insert a second row that only differs by casing.
+2. **DB uniqueness** uses expression unique indexes on `lower(value)` (partial on `deletedAt is null`, and verified-only for the global verified owner index). See migration `V1785255019__member_identities_case_insensitive_unique_indexes.sql`.
+3. **Existing duplicates** are cleaned with a one-time script before the unique indexes can be applied: same-member case variants → keep one (prefer verified + `verifiedBy`, else most recent integration casing) and soft-delete the rest; cross-member unverified variants of a verified identity → soft-delete the unverified; both verified across members → merge / existing capitalization-merge workflows, not blind soft-delete.
+4. **Verification** does not need special “soft-delete case siblings” logic once the invariant holds — verifying finds the one row.
+
+## Alternatives Considered
+
+### Alternative 1: Soft-delete / auto-verify case variants at identity verification time (CM-1349 as written)
+
+- **Pros**: Fixes the user-visible self-serve pain quickly; no schema change.
+- **Cons**: Case variants keep being inserted by ingest/enrichment; verify path becomes a mop; duplicates still break uniqueness and analytics.
+- **Why not**: Papers over the root cause. If case variants should not exist, stop creating them and clean existing data.
+
+### Alternative 2: Always store usernames lowercase (like emails / Discord)
+
+- **Pros**: Simplest storage; uniqueness on `value` works without expression indexes.
+- **Cons**: Throws away GitHub/GitLab preferred casing; diverges from source payloads; confuses display and support (“CDP shows lowercase but GitHub shows mixed”).
+- **Why not**: We want GitHub-style case-preserving storage. Uniqueness belongs on `lower(value)`, not on mutating the stored handle.
+
+### Alternative 3: Keep case-sensitive unique indexes; only fix app-layer matching
+
+- **Pros**: No migration; no cleanup required to change indexes.
+- **Cons**: App bugs or races can still insert case variants; DB does not enforce the domain invariant.
+- **Why not**: At this scale, durable invariants need to live in the database, not only in callers.
+
+### Alternative 4: Update stored casing on every ingest when preferred casing differs
+
+- **Pros**: `value` always mirrors latest source casing.
+- **Cons**: Unsafe while same-member case-variant pairs still exist (updating both rows to the same `value` hits the old unique index). Extra write noise.
+- **Why not**: Deferred until after cleanup. Preventing duplicate inserts is enough for the durable fix; optional casing refresh can come later.
+
+## Consequences
+
+### Positive
+
+- One clear rule: same platform + type + lower(value) ⇒ same identity.
+- Lookups, writes, and uniqueness agree.
+- Self-serve / GitHub / enrichment stop creating `WillsonHG` + `willsonhg` pairs.
+- Preferred username casing from integrations is preserved.
+
+### Negative
+
+- Cleanup must run before the unique-index migration, or `create unique index` fails (and can leave an `INVALID` index).
+- Expression unique indexes are slightly less obvious than column-only uniques; callers must keep using `lower(value)` (or `isSameMemberIdentity`) consistently.
+- Conflict handlers need to recognize both old and new constraint names during rollout.
+
+### Risks
+
+- **Migration applied before cleanup** — mitigated by documenting order: write-path fix → cleanup script → unique-index migration.
+- **Cross-member verified case variants** — rare; require merge, not soft-delete. Existing `findAndMergeMembersWithSamePlatformIdentitiesDifferentCapitalization` covers part of this.
+- **Incomplete write-path coverage** — mitigated by DB unique indexes as the backstop once cleanup is done; shared `isSameMemberIdentity` for app equality.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0012](./0012-api-e2e-test-architecture.md)                | API e2e test architecture                                                                            | accepted | 2026-07-25 |
 | [ADR-0013](./0013-api-e2e-test-suite-design.md)                | API e2e test suite design                                                                            | accepted | 2026-07-24 |
 | [ADR-0014](./0014-collaboration-track-record-signal.md)        | Collaboration track record signal                                                                    | accepted | 2026-07-28 |
+| [ADR-0015](./0015-how-cdp-stores-member-identities.md)         | How CDP stores member identities                                                                     | accepted | 2026-07-28 |
 
 ## Why ADRs?
 

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -521,10 +521,16 @@ export default class ActivityService extends LoggerBase {
       const toEraseMemberIdentities = toErase.filter((e) =>
         member.identities.some((i) => {
           if (i.type === MemberIdentityType.EMAIL) {
-            return e.type === i.type && e.value === i.value
+            return (
+              e.type === i.type && e.value.trim().toLowerCase() === i.value.trim().toLowerCase()
+            )
           }
 
-          return e.type === i.type && e.value === i.value && e.platform === i.platform
+          return (
+            e.type === i.type &&
+            e.value.trim().toLowerCase() === i.value.trim().toLowerCase() &&
+            e.platform === i.platform
+          )
         }),
       )
 
@@ -550,7 +556,7 @@ export default class ActivityService extends LoggerBase {
             const maybeToErase = toEraseMemberIdentities.find(
               (e) =>
                 e.type === i.type &&
-                e.value === i.value &&
+                e.value.trim().toLowerCase() === i.value.trim().toLowerCase() &&
                 (e.type === MemberIdentityType.EMAIL || e.platform === i.platform),
             )
 
@@ -1761,7 +1767,8 @@ export default class ActivityService extends LoggerBase {
         error.constructor &&
         error.constructor.name === 'DatabaseError' &&
         error.constraint &&
-        error.constraint === 'uix_memberIdentities_platform_value_type_verified'
+        (error.constraint === 'uix_memberIdentities_platform_value_type_verified' ||
+          error.constraint === 'uix_memberIdentities_platform_type_lower_value_verified')
       ) {
         return true
       }
@@ -2004,7 +2011,10 @@ export default class ActivityService extends LoggerBase {
 
     for (const i1 of m1Identities) {
       for (const i2 of m2Identities) {
-        if (i1.type === i2.type && i1.value === i2.value) {
+        if (
+          i1.type === i2.type &&
+          i1.value.trim().toLowerCase() === i2.value.trim().toLowerCase()
+        ) {
           return true
         }
       }

--- a/services/apps/data_sink_worker/src/service/dataSink.service.ts
+++ b/services/apps/data_sink_worker/src/service/dataSink.service.ts
@@ -128,7 +128,10 @@ export default class DataSinkService extends LoggerBase {
     // allowing retries to grow without bound. Now we respect the retry limit so the row
     // eventually reaches ERROR state instead of cycling forever.
     if (
-      errorData.errorMessage.includes('uix_memberIdentities_platform_value_type_verified') &&
+      (errorData.errorMessage.includes('uix_memberIdentities_platform_value_type_verified') ||
+        errorData.errorMessage.includes(
+          'uix_memberIdentities_platform_type_lower_value_verified',
+        )) &&
       resultInfo.retries + 1 <= WORKER_SETTINGS().maxStreamRetries
     ) {
       const delaySeconds = Math.floor(Math.random() * (120 - 10 + 1) + 10) * 60

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -10,6 +10,7 @@ import {
   isDomainExcluded,
   isEmail,
   isObjectEmpty,
+  isSameMemberIdentity,
   singleOrDefault,
 } from '@crowd/common'
 import {
@@ -132,8 +133,8 @@ export default class MemberService extends LoggerBase {
     identities: IMemberIdentity[],
     attemptMerge = true,
   ): Promise<string | void> {
-    // Deduplicate by (platform, value, type) — prefer verified=true when the same
-    // identity appears with both flags. Prevents uix_memberIdentities_memberId_platform_value_type
+    // Deduplicate by (platform, type, lower(value)) — prefer verified=true when the same
+    // identity appears with both flags. Prevents per-member unique identity index
     // from firing when a payload contains the same identity twice with different verified values.
     const seen = new Map<string, IMemberIdentity>()
     for (const id of identities) {
@@ -150,7 +151,8 @@ export default class MemberService extends LoggerBase {
     } catch (err) {
       if (
         !err?.constraint ||
-        err.constraint !== 'uix_memberIdentities_platform_value_type_verified'
+        (err.constraint !== 'uix_memberIdentities_platform_value_type_verified' &&
+          err.constraint !== 'uix_memberIdentities_platform_type_lower_value_verified')
       ) {
         throw err
       }
@@ -233,32 +235,23 @@ export default class MemberService extends LoggerBase {
       const freshMap = await findIdentitiesForMembers(this.pgQx, [survivingId])
       const freshIdentities = freshMap.get(survivingId) ?? []
 
-      // Match on (platform, value, type) only — per-member unique index excludes verified.
+      // Match on (platform, type, lower(value)) only — per-member unique index excludes verified.
       // Inserting an identity that already exists with a different verified flag would hit
-      // uix_memberIdentities_memberId_platform_value_type.
+      // the per-member unique identity index.
       const toInsert = incomingIdentities.filter(
-        (incoming) =>
-          !freshIdentities.some(
-            (existing) =>
-              existing.platform === incoming.platform &&
-              existing.value.trim().toLowerCase() === incoming.value.trim().toLowerCase() &&
-              existing.type === incoming.type,
-          ),
+        (incoming) => !freshIdentities.some((existing) => isSameMemberIdentity(existing, incoming)),
       )
 
       // Promote verified=false → true for identities already on the surviving member
       // where the incoming payload asserts verified=true.
-      const toVerify = incomingIdentities.filter(
-        (incoming) =>
-          incoming.verified &&
-          freshIdentities.some(
-            (existing) =>
-              existing.platform === incoming.platform &&
-              existing.value.trim().toLowerCase() === incoming.value.trim().toLowerCase() &&
-              existing.type === incoming.type &&
-              !existing.verified,
-          ),
-      )
+      const toVerify = incomingIdentities
+        .filter((incoming) => incoming.verified)
+        .flatMap((incoming) => {
+          const existing = freshIdentities.find(
+            (e) => isSameMemberIdentity(e, incoming) && !e.verified,
+          )
+          return existing ? [{ ...incoming, value: existing.value }] : []
+        })
 
       if (toVerify.length > 0) {
         await this.memberRepo.updateIdentities(survivingId, toVerify)
@@ -324,11 +317,7 @@ export default class MemberService extends LoggerBase {
             (identity, idx) =>
               !!identity.value &&
               data.identities.findIndex(
-                (j) =>
-                  j.platform === identity.platform &&
-                  j.value === identity.value &&
-                  j.type === identity.type &&
-                  j.verified === identity.verified,
+                (j) => isSameMemberIdentity(j, identity) && j.verified === identity.verified,
               ) === idx,
           )
 
@@ -968,17 +957,17 @@ export default class MemberService extends LoggerBase {
 
     for (const identity of identities) {
       if (identity.type === MemberIdentityType.EMAIL) {
-        // check if email is valid and that the same email doesn't already exists in the array for the same platform
+        const lowerValue = identity.value.toLowerCase()
         if (
           isEmail(identity.value) &&
           toReturn.find(
             (i) =>
               i.type === MemberIdentityType.EMAIL &&
-              i.value === identity.value &&
+              i.value === lowerValue &&
               i.platform === identity.platform,
           ) === undefined
         ) {
-          toReturn.push({ ...identity, value: identity.value.toLowerCase() })
+          toReturn.push({ ...identity, value: lowerValue })
         }
       } else {
         toReturn.push(identity)
@@ -1011,16 +1000,12 @@ export default class MemberService extends LoggerBase {
       const newIdentities: IMemberIdentity[] = []
       const toUpdate: IMemberIdentity[] = []
       for (const identity of member.identities) {
-        const dbIdentity = dbIdentities.find(
-          (t) =>
-            t.platform === identity.platform &&
-            t.value === identity.value &&
-            t.type === identity.type,
-        )
+        const dbIdentity = dbIdentities.find((t) => isSameMemberIdentity(t, identity))
         if (!dbIdentity) {
           newIdentities.push(identity)
         } else if (dbIdentity.verified !== identity.verified) {
-          toUpdate.push(identity)
+          // Keep stored preferred casing; updateIdentities matches on exact value.
+          toUpdate.push({ ...identity, value: dbIdentity.value })
         }
       }
 

--- a/services/apps/members_enrichment_worker/src/workflows/lf-auth0/enrichMemberWithLFAuth0.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/lf-auth0/enrichMemberWithLFAuth0.ts
@@ -75,7 +75,7 @@ export async function enrichMemberWithLFAuth0(token: string, member: IMember): P
       identitiesToCheck.push({
         platform: PlatformType.LFID,
         type: MemberIdentityType.USERNAME,
-        value: enriched.username.toLowerCase(),
+        value: enriched.username,
         verified: true,
         verifiedBy: 'lf-auth0',
       })
@@ -98,7 +98,7 @@ export async function enrichMemberWithLFAuth0(token: string, member: IMember): P
         identitiesToCheck.push({
           type: MemberIdentityType.USERNAME,
           platform: PlatformType.GITHUB,
-          value: enrichmentGithub.profileData.nickname.toLowerCase(),
+          value: enrichmentGithub.profileData.nickname,
           verified: true,
           verifiedBy: 'lf-auth0',
         })
@@ -187,7 +187,7 @@ export async function enrichMemberWithLFAuth0(token: string, member: IMember): P
         identitiesToCheck.push({
           type: MemberIdentityType.USERNAME,
           platform: PlatformType.TWITTER,
-          value: profileData.twitter_username.toLowerCase(),
+          value: profileData.twitter_username,
           verified: false,
         })
       }
@@ -204,7 +204,10 @@ export async function enrichMemberWithLFAuth0(token: string, member: IMember): P
     const identitesToAdd = identitiesToCheck.filter(
       (i) =>
         !identitiesExistInOtherMembers.some(
-          (e) => e.type === i.type && e.platform === i.platform && e.value === i.value,
+          (e) =>
+            e.type === i.type &&
+            e.platform === i.platform &&
+            e.value.trim().toLowerCase() === i.value.trim().toLowerCase(),
         ),
     )
 

--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -114,7 +114,8 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
             if (
               (toBeSquashed[source].identities || []).some(
                 (i) =>
-                  i.value === discardedLinkedinIdentity.value &&
+                  i.value.trim().toLowerCase() ===
+                    discardedLinkedinIdentity.value.trim().toLowerCase() &&
                   i.platform === PlatformType.LINKEDIN,
               )
             ) {
@@ -155,7 +156,8 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
             if (
               (toBeSquashed[source].identities || []).some(
                 (i) =>
-                  i.value === discardedLinkedinIdentity.value &&
+                  i.value.trim().toLowerCase() ===
+                    discardedLinkedinIdentity.value.trim().toLowerCase() &&
                   i.platform === PlatformType.LINKEDIN,
               )
             ) {
@@ -178,21 +180,14 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
     for (const source of Object.keys(toBeSquashed)) {
       if (toBeSquashed[source].identities) {
         for (const identity of toBeSquashed[source].identities) {
-          // check if identity already exists, if not add it to squashedPayload
+          const sameIdentity = (i: { platform: string; type: string; value: string }) =>
+            i.platform === identity.platform &&
+            i.type === identity.type &&
+            i.value.trim().toLowerCase() === identity.value.trim().toLowerCase()
+
           if (
-            !squashedPayload.identities.find(
-              (i) =>
-                i.platform === identity.platform &&
-                i.type === identity.type &&
-                i.value === identity.value,
-            ) &&
-            // check in member data as well
-            !existingMemberData.identities.find(
-              (i) =>
-                i.platform === identity.platform &&
-                i.type === identity.type &&
-                i.value === identity.value,
-            )
+            !squashedPayload.identities.find(sameIdentity) &&
+            !existingMemberData.identities.find(sameIdentity)
           ) {
             squashedPayload.identities.push(identity)
           }

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -9,6 +9,17 @@ import {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+export function isSameMemberIdentity(
+  a: { platform: string; type: string; value: string },
+  b: { platform: string; type: string; value: string },
+): boolean {
+  return (
+    a.platform === b.platform &&
+    a.type === b.type &&
+    a.value.trim().toLowerCase() === b.value.trim().toLowerCase()
+  )
+}
+
 export async function setAttributesDefaultValues(
   attributes: Record<string, unknown>,
   priorities: string[],

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -15,6 +15,7 @@ import {
   getEarliestValidDate,
   getLongestDateRange,
   getMemberOrganizationSourceRank,
+  isSameMemberIdentity,
   mergeObjects,
   safeObjectMerge,
   sanitizeMemberOrganizationDateRange,
@@ -400,17 +401,12 @@ export class CommonMemberService extends LoggerBase {
             const identitiesToUpdate = []
             const identitiesToMove = []
             for (const identity of toMergeIdentities) {
-              const existing = originalIdentities.find(
-                (i) =>
-                  i.platform === identity.platform &&
-                  i.type === identity.type &&
-                  i.value === identity.value,
-              )
+              const existing = originalIdentities.find((i) => isSameMemberIdentity(i, identity))
 
               if (existing) {
                 // if it's not verified but it should be
                 if (!existing.verified && identity.verified) {
-                  identitiesToUpdate.push(identity)
+                  identitiesToUpdate.push({ ...identity, value: existing.value })
                 }
               } else {
                 identitiesToMove.push(identity)

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -406,7 +406,7 @@ export class CommonMemberService extends LoggerBase {
               if (existing) {
                 // if it's not verified but it should be
                 if (!existing.verified && identity.verified) {
-                  identitiesToUpdate.push({ ...identity, value: existing.value })
+                  identitiesToUpdate.push(identity)
                 }
               } else {
                 identitiesToMove.push(identity)

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -372,7 +372,7 @@ export async function updateVerifiedFlag(
       where
         "memberId" = $(memberId) and
         platform = $(platform) and
-        value = $(value) and
+        lower(value) = lower($(value)) and
         type = $(type) and
         "deletedAt" is null
     `,
@@ -387,10 +387,10 @@ export async function deleteMemberIdentities(
   return qx.result(
     `
       update "memberIdentities" set "deletedAt" = now()
-      where "memberId" = $(memberId) 
-        and platform = $(platform) 
-        and value = $(value) 
-        and type = $(type) 
+      where "memberId" = $(memberId)
+        and platform = $(platform)
+        and lower(value) = lower($(value))
+        and type = $(type)
         and "deletedAt" is null;
     `,
     p,

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -63,14 +63,14 @@ export async function findMemberIdentityConflict(
 ): Promise<{ id: string; memberId: string } | null> {
   return qx.selectOneOrNone(
     `
-      SELECT id, "memberId"
-      FROM "memberIdentities"
-      WHERE platform = $(platform)
-        AND type = $(type)
-        AND lower(value) = lower($(value))
-        AND "deletedAt" IS NULL
-        ${params.excludeMemberId ? 'AND "memberId" <> $(excludeMemberId)' : ''}
-      LIMIT 1;
+      select id, "memberId"
+      from "memberIdentities"
+      where platform = $(platform)
+        and type = $(type)
+        and lower(value) = lower($(value))
+        and "deletedAt" is null
+        ${params.excludeMemberId ? 'and "memberId" <> $(excludeMemberId)' : ''}
+      limit 1;
     `,
     params,
   )
@@ -106,12 +106,12 @@ export async function findMemberIdentitiesByValue(
 ): Promise<IMemberIdentity[]> {
   return qx.select(
     `
-        SELECT *
-        FROM "memberIdentities"
-        WHERE value = $(value) 
-          AND "memberId" = $(memberId)
-          AND "deletedAt" is null
-        ${filter.type ? 'AND type = $(type)' : ''}
+        select *
+        from "memberIdentities"
+        where lower(value) = lower($(value))
+          and "memberId" = $(memberId)
+          and "deletedAt" is null
+        ${filter.type ? 'and type = $(type)' : ''}
     `,
     { value, memberId, type: filter.type },
   )
@@ -222,13 +222,13 @@ export async function findMemberIdByVerifiedIdentity(
   type: MemberIdentityType,
 ): Promise<string | null> {
   const result = await qx.selectOneOrNone(
-    `SELECT "memberId" FROM "memberIdentities"
-     WHERE platform = $(platform)
-       AND value = $(value)
-       AND type = $(type)
-       AND verified = true
-       AND "deletedAt" IS NULL
-     LIMIT 1`,
+    `select "memberId" from "memberIdentities"
+     where platform = $(platform)
+       and lower(value) = lower($(value))
+       and type = $(type)
+       and verified = true
+       and "deletedAt" is null
+     limit 1`,
     { platform, value, type },
   )
   return result?.memberId ?? null


### PR DESCRIPTION
## Summary
- Stop creating case-variant member identities (e.g. `WillsonHG` vs `willsonhg`) by matching and writing with case-insensitive equality, while keeping preferred username casing from sources.
- Add unique indexes on `lower(value)` (migration must run after a follow-up cleanup of existing duplicates).
- Document the storage model in [ADR-0015](docs/adr/0015-how-cdp-stores-member-identities.md).

## Changes
- Data-sink, enrichment, merge, public API, and CDP UI write paths now treat `(platform, type, lower(value))` as the same identity; emails stay lowercase on write.
- Shared `isSameMemberIdentity` helper; DAL conflict/lookup queries use `lower(value)`.
- Migration replaces case-sensitive unique indexes with case-insensitive ones on `lower(value)`.
- Conflict handlers accept both old and new constraint names during rollout.

**Deploy note:** do not apply the migration until existing case-variant rows are cleaned up (separate PR/script). Scale down high-write workers (data-sink, enrichment, profiles) around cleanup + migrate, then scale back up.