### PR TITLE
fix: lowercase email-shaped identity values (CM-1349)

### DIFF
--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberCreateAction, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { getProperDisplayName } from '@crowd/common'
+import { getProperDisplayName, normalizeMemberIdentityValue } from '@crowd/common'
 import { createMember as insertMember, insertMemberIdentities } from '@crowd/data-access-layer'
 import { MemberIdentityType } from '@crowd/types'
 
@@ -54,10 +54,7 @@ export async function createMember(req: Request, res: Response): Promise<void> {
         identities.map((identity) => ({
           ...identity,
           memberId: dbMember.id,
-          value:
-            identity.type === MemberIdentityType.EMAIL
-              ? identity.value.trim().toLowerCase()
-              : identity.value.trim(),
+          value: normalizeMemberIdentityValue(identity.value),
         })),
         true,
         true,

--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberCreateAction, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { getProperDisplayName, normalizeMemberIdentityValue } from '@crowd/common'
+import { getProperDisplayName } from '@crowd/common'
 import { createMember as insertMember, insertMemberIdentities } from '@crowd/data-access-layer'
 import { MemberIdentityType } from '@crowd/types'
 
@@ -54,7 +54,6 @@ export async function createMember(req: Request, res: Response): Promise<void> {
         identities.map((identity) => ({
           ...identity,
           memberId: dbMember.id,
-          value: normalizeMemberIdentityValue(identity.value),
         })),
         true,
         true,

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { NotFoundError } from '@crowd/common'
+import { NotFoundError, normalizeMemberIdentityValue } from '@crowd/common'
 import {
   MemberField,
   findMemberById,
@@ -46,9 +46,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     throw new NotFoundError('Member not found')
   }
 
-  // Normalize emails to lowercase; keep username preferred casing from the caller.
-  const normalizedValue =
-    data.type === MemberIdentityType.EMAIL ? data.value.trim().toLowerCase() : data.value.trim()
+  const normalizedValue = normalizeMemberIdentityValue(data.value)
 
   let result!: IMemberIdentity
   let alreadyExisted = false

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { NotFoundError, normalizeMemberIdentityValue } from '@crowd/common'
+import { NotFoundError } from '@crowd/common'
 import {
   MemberField,
   findMemberById,
@@ -46,8 +46,6 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     throw new NotFoundError('Member not found')
   }
 
-  const normalizedValue = normalizeMemberIdentityValue(data.value)
-
   let result!: IMemberIdentity
   let alreadyExisted = false
 
@@ -57,7 +55,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
       captureOldState({})
 
       await qx.tx(async (tx) => {
-        const existing = await findMemberIdentitiesByValue(tx, memberId, normalizedValue, {
+        const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
           type: data.type,
         })
         const exactMatch = existing.find((i) => i.platform === data.platform)
@@ -73,7 +71,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
                 {
                   memberId,
                   platform: data.platform,
-                  value: normalizedValue,
+                  value: data.value,
                   type: data.type,
                   source: data.source,
                   verified: data.verified,
@@ -103,7 +101,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
             }
           }
         } catch (error) {
-          const ctx = { platform: data.platform, value: normalizedValue, type: data.type }
+          const ctx = { platform: data.platform, value: data.value, type: data.type }
           rethrowDbConflict(error, ctx)
         }
 

--- a/backend/src/database/repositories/memberRepository.ts
+++ b/backend/src/database/repositories/memberRepository.ts
@@ -14,6 +14,7 @@ import {
   Error409,
   RawQueryParser,
   groupBy,
+  normalizeMemberIdentityValue,
 } from '@crowd/common'
 import { BotDetectionService, CommonMemberService } from '@crowd/common_services'
 import {
@@ -1852,6 +1853,7 @@ class MemberRepository {
     const transaction = SequelizeRepository.getTransaction(options)
 
     const seq = SequelizeRepository.getSequelize(options)
+    const normalizedValue = normalizeMemberIdentityValue(value)
 
     const query = `
       insert into "memberIdentities"("memberId", platform, type, value, "tenantId", verified)
@@ -1863,7 +1865,7 @@ class MemberRepository {
       await seq.query(query, {
         replacements: {
           memberId,
-          value,
+          value: normalizedValue,
           type,
           platform,
           tenantId: DEFAULT_TENANT_ID,

--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -2,7 +2,7 @@
 import lodash from 'lodash'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { Error404, Error409 } from '@crowd/common'
+import { Error404, Error409, normalizeMemberIdentityValue } from '@crowd/common'
 import { findIdentitiesForMembers, insertMemberIdentities } from '@crowd/data-access-layer'
 import {
   deleteMemberIdentity,
@@ -13,18 +13,13 @@ import {
   updateMemberIdentity,
 } from '@crowd/data-access-layer/src/members'
 import { LoggerBase } from '@crowd/logging'
-import { IMemberIdentity, MemberIdentityType, NewMemberIdentity } from '@crowd/types'
+import { IMemberIdentity, NewMemberIdentity } from '@crowd/types'
 
 import { IRepositoryOptions } from '@/database/repositories/IRepositoryOptions'
 import SequelizeRepository from '@/database/repositories/sequelizeRepository'
 import { optionsQx } from '@/database/sequelizeQueryExecutor'
 
 import { IServiceOptions } from '../IServiceOptions'
-
-function normalizeIdentityValue(type: string, value: string): string {
-  const trimmed = value.trim()
-  return type === MemberIdentityType.EMAIL ? trimmed.toLowerCase() : trimmed
-}
 
 export default class MemberIdentityService extends LoggerBase {
   options: IServiceOptions
@@ -65,7 +60,7 @@ export default class MemberIdentityService extends LoggerBase {
 
           const identityData = {
             ...data,
-            value: normalizeIdentityValue(data.type, data.value),
+            value: normalizeMemberIdentityValue(data.value),
           }
 
           // Check if identity already exists
@@ -143,7 +138,7 @@ export default class MemberIdentityService extends LoggerBase {
           // Check if any of the identities already exist
           const normalizedData = data.map((identity) => ({
             ...identity,
-            value: normalizeIdentityValue(identity.type, identity.value),
+            value: normalizeMemberIdentityValue(identity.value),
           }))
 
           for (const identity of normalizedData) {
@@ -226,10 +221,7 @@ export default class MemberIdentityService extends LoggerBase {
             throw new Error404(this.options.language, 'errors.notFound.message')
           }
 
-          const value = normalizeIdentityValue(
-            data.type ?? currentIdentity.type,
-            data.value ?? currentIdentity.value,
-          )
+          const value = normalizeMemberIdentityValue(data.value ?? currentIdentity.value)
           const platform = data.platform ?? currentIdentity.platform
           const type = data.type ?? currentIdentity.type
 

--- a/backend/src/services/member/memberIdentityService.ts
+++ b/backend/src/services/member/memberIdentityService.ts
@@ -2,7 +2,7 @@
 import lodash from 'lodash'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { Error404, Error409, normalizeMemberIdentityValue } from '@crowd/common'
+import { Error404, Error409 } from '@crowd/common'
 import { findIdentitiesForMembers, insertMemberIdentities } from '@crowd/data-access-layer'
 import {
   deleteMemberIdentity,
@@ -58,16 +58,11 @@ export default class MemberIdentityService extends LoggerBase {
 
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
-          const identityData = {
-            ...data,
-            value: normalizeMemberIdentityValue(data.value),
-          }
-
           // Check if identity already exists
           const conflict = await findMemberIdentityConflict(qx, {
-            value: identityData.value,
-            platform: identityData.platform,
-            type: identityData.type,
+            value: data.value,
+            platform: data.platform,
+            type: data.type,
           })
 
           if (conflict) {
@@ -82,7 +77,7 @@ export default class MemberIdentityService extends LoggerBase {
           }
 
           // Create member identity
-          await insertMemberIdentities(qx, [{ ...identityData, memberId }])
+          await insertMemberIdentities(qx, [{ ...data, memberId }])
 
           await touchMemberUpdatedAt(qx, memberId)
 
@@ -136,12 +131,7 @@ export default class MemberIdentityService extends LoggerBase {
           const qx = SequelizeRepository.getQueryExecutor(repoOptions)
 
           // Check if any of the identities already exist
-          const normalizedData = data.map((identity) => ({
-            ...identity,
-            value: normalizeMemberIdentityValue(identity.value),
-          }))
-
-          for (const identity of normalizedData) {
+          for (const identity of data) {
             const conflict = await findMemberIdentityConflict(qx, {
               value: identity.value,
               platform: identity.platform,
@@ -163,7 +153,7 @@ export default class MemberIdentityService extends LoggerBase {
           // Create member identities
           await insertMemberIdentities(
             qx,
-            normalizedData.map((identity) => ({ ...identity, memberId })),
+            data.map((identity) => ({ ...identity, memberId })),
           )
 
           await touchMemberUpdatedAt(qx, memberId)
@@ -221,7 +211,7 @@ export default class MemberIdentityService extends LoggerBase {
             throw new Error404(this.options.language, 'errors.notFound.message')
           }
 
-          const value = normalizeMemberIdentityValue(data.value ?? currentIdentity.value)
+          const value = data.value ?? currentIdentity.value
           const platform = data.platform ?? currentIdentity.platform
           const type = data.type ?? currentIdentity.type
 

--- a/docs/adr/0015-how-cdp-stores-member-identities.md
+++ b/docs/adr/0015-how-cdp-stores-member-identities.md
@@ -3,86 +3,73 @@
 **Date**: 2026-07-28
 **Status**: accepted
 **Deciders**: Yeganathan S
-**Related**: CM-1349
 
 ## Context
 
-CDP treats member identities as case-insensitive when resolving people (`lower(value)` in lookups and many DAL queries), which matches how major platforms behave:
+Member identities in CDP come from many sources (integrations, enrichment, UI, public APIs). The same logical identity often arrives with different casing — for example GitHub’s `login` is case-preserving in the API but case-insensitive for account uniqueness.
 
-- **GitHub / GitLab**: usernames are case-insensitive for uniqueness, but case-preserving for display (`WillsonHG` and `willsonhg` are the same account; APIs return preferred casing).
-- **Discord** (new usernames): forced lowercase.
-- **Email**: stored and compared lowercase in practice.
+CDP already resolves people with case-insensitive lookups (`lower(value)`). Uniqueness and some write paths historically used raw `value`, so the same identity could be stored more than once under different casings. Lookups, merges, and verification then disagree about whether two rows are “the same.”
 
-Historically, `memberIdentities` uniqueness was defined on raw `value` (case-sensitive):
-
-- `uix_memberIdentities_memberId_platform_value_type`
-- `uix_memberIdentities_platform_value_type_verified`
-
-Lookups used `lower(value)`, but inserts often did not. Data-sink `mergeData` matched with exact `value ===`, so a self-serve lowercase `willsonhg` plus a later GitHub ingest of `WillsonHG` produced two rows for the same identity — often both verified on the same member. Prod had tens of thousands of GitHub case-variant groups.
-
-Ticket CM-1349 proposed soft-deleting / auto-verifying case variants at verification time. That treats a write-path bug as a product special case.
+We need a single, durable rule for what we store and what counts as the same identity — aligned with how the platforms we integrate with actually work.
 
 ## Decision
 
-**Mental model**
+Identity equality in CDP is `(platform, type, lower(value))`.
 
-| Kind     | Store                                        | Compare / unique on             |
-| -------- | -------------------------------------------- | ------------------------------- |
-| username | preferred casing from the source/integration | `lower(value)`                  |
-| email    | always lowercase                             | `lower(value)` (same as stored) |
+| Kind     | Store in `value`                             | Compare / unique on |
+| -------- | -------------------------------------------- | ------------------- |
+| username | preferred casing from the source/integration | `lower(value)`      |
+| email    | always lowercase                             | `lower(value)`      |
 
-Identity equality in CDP is `(platform, type, lower(value))`. Email vs username for storage casing is inferred from the value with `isValidEmail`, not from `type` (git often stores emails as `type=username`). Non-email usernames keep preferred casing from the source.
+Whether a value is stored as an email (lowercased) vs a username (preferred casing) is inferred from the string with `isValidEmail`, not only from `type` — some sources (notably git) store email addresses with `type = username`.
 
-**Enforcement**
+### Conventions
 
-1. **Write paths** match and upsert with case-insensitive equality (`isSameMemberIdentity` / `lower(value)`). Do not insert a second row that only differs by casing.
-2. **DB uniqueness** uses expression unique indexes on `lower(value)` (partial on `deletedAt is null`, and verified-only for the global verified owner index). See migration `V1785255019__member_identities_case_insensitive_unique_indexes.sql`.
-3. **Existing duplicates** are cleaned with a one-time script before the unique indexes can be applied: same-member case variants → keep one (prefer verified + `verifiedBy`, else most recent integration casing) and soft-delete the rest; cross-member unverified variants of a verified identity → soft-delete the unverified; both verified across members → merge / existing capitalization-merge workflows, not blind soft-delete.
-4. **Verification** does not need special “soft-delete case siblings” logic once the invariant holds — verifying finds the one row.
+1. **Do not invent casing** — for non-email usernames, persist what the source sent (after trim). Do not force lowercase on GitHub/GitLab-style handles.
+2. **Do not insert case variants** — if a row already exists for the same `(platform, type, lower(value))`, update or no-op; never insert a second row that only differs by casing.
+3. **App equality matches DB equality** — use `isSameMemberIdentity` (or equivalent `lower(value)` comparisons) on write and merge paths. `type` stays in the equality key even when a git `username` holds an email-shaped string.
+4. **DB enforces the invariant** — unique indexes on `lower(value)` (per member for all active identities; globally for verified identities). Schema detail: migration `V1785255019__member_identities_case_insensitive_unique_indexes.sql`.
 
 ## Alternatives Considered
 
-### Alternative 1: Soft-delete / auto-verify case variants at identity verification time (CM-1349 as written)
+### Alternative 1: Always store usernames lowercase
 
-- **Pros**: Fixes the user-visible self-serve pain quickly; no schema change.
-- **Cons**: Case variants keep being inserted by ingest/enrichment; verify path becomes a mop; duplicates still break uniqueness and analytics.
-- **Why not**: Papers over the root cause. If case variants should not exist, stop creating them and clean existing data.
+- **Pros**: Simplest storage; uniqueness can stay on raw `value`.
+- **Cons**: Discards preferred casing from GitHub/GitLab; CDP display and support diverge from the source platform.
+- **Why not**: We want GitHub-style case-preserving storage. Sameness belongs on `lower(value)`, not on rewriting the handle.
 
-### Alternative 2: Always store usernames lowercase (like emails / Discord)
+### Alternative 2: Case-sensitive storage and uniqueness (raw `value` only)
 
-- **Pros**: Simplest storage; uniqueness on `value` works without expression indexes.
-- **Cons**: Throws away GitHub/GitLab preferred casing; diverges from source payloads; confuses display and support (“CDP shows lowercase but GitHub shows mixed”).
-- **Why not**: We want GitHub-style case-preserving storage. Uniqueness belongs on `lower(value)`, not on mutating the stored handle.
+- **Pros**: Matches naive string equality; no expression indexes.
+- **Cons**: Conflicts with how platforms define accounts and with how CDP already looks identities up; duplicate rows for the same person identity are inevitable.
+- **Why not**: That mismatch is the problem this decision closes.
 
-### Alternative 3: Keep case-sensitive unique indexes; only fix app-layer matching
+### Alternative 3: Case-insensitive matching in application code only
 
-- **Pros**: No migration; no cleanup required to change indexes.
-- **Cons**: App bugs or races can still insert case variants; DB does not enforce the domain invariant.
-- **Why not**: At this scale, durable invariants need to live in the database, not only in callers.
+- **Pros**: No schema change.
+- **Cons**: Any missed caller or race can still insert case variants; the database does not protect the invariant.
+- **Why not**: At CDP scale, identity uniqueness must be enforced in the database as well as in callers.
 
-### Alternative 4: Update stored casing on every ingest when preferred casing differs
+### Alternative 4: Refresh stored casing on every ingest when the source casing differs
 
-- **Pros**: `value` always mirrors latest source casing.
-- **Cons**: Unsafe while same-member case-variant pairs still exist (updating both rows to the same `value` hits the old unique index). Extra write noise.
-- **Why not**: Deferred until after cleanup. Preventing duplicate inserts is enough for the durable fix; optional casing refresh can come later.
+- **Pros**: `value` always mirrors the latest source spelling.
+- **Cons**: Extra writes; needs a single surviving row per identity before it is safe.
+- **Why not**: Optional later enhancement. Preventing duplicate rows is the required invariant; updating preferred casing can be layered on afterward.
 
 ## Consequences
 
 ### Positive
 
-- One clear rule: same platform + type + lower(value) ⇒ same identity.
-- Lookups, writes, and uniqueness agree.
-- Self-serve / GitHub / enrichment stop creating `WillsonHG` + `willsonhg` pairs.
+- One rule for “same identity” across lookup, ingest, merge, and uniqueness.
 - Preferred username casing from integrations is preserved.
+- Emails are normalized consistently.
 
 ### Negative
 
-- Cleanup must run before the unique-index migration, or `create unique index` fails (and can leave an `INVALID` index).
-- Expression unique indexes are slightly less obvious than column-only uniques; callers must keep using `lower(value)` (or `isSameMemberIdentity`) consistently.
-- Conflict handlers need to recognize both old and new constraint names during rollout.
+- Callers must compare with `lower(value)` / `isSameMemberIdentity`, not exact string equality.
+- Unique indexes are expression-based (`lower(value)`), which is slightly less obvious than column-only uniques.
 
 ### Risks
 
-- **Migration applied before cleanup** — mitigated by documenting order: write-path fix → cleanup script → unique-index migration.
-- **Cross-member verified case variants** — rare; require merge, not soft-delete. Existing `findAndMergeMembersWithSamePlatformIdentitiesDifferentCapitalization` covers part of this.
-- **Incomplete write-path coverage** — mitigated by DB unique indexes as the backstop once cleanup is done; shared `isSameMemberIdentity` for app equality.
+- **Missed write path still using exact `value ===`** — mitigated by DB unique indexes on `lower(value)` and shared helpers.
+- **Two verified members sharing the same identity under `lower(value)`** — a data conflict requiring merge, not a second identity row.

--- a/docs/adr/0015-how-cdp-stores-member-identities.md
+++ b/docs/adr/0015-how-cdp-stores-member-identities.md
@@ -31,7 +31,7 @@ Ticket CM-1349 proposed soft-deleting / auto-verifying case variants at verifica
 | username | preferred casing from the source/integration | `lower(value)`                  |
 | email    | always lowercase                             | `lower(value)` (same as stored) |
 
-Identity equality in CDP is `(platform, type, lower(value))`. Email vs username for storage casing is inferred from the value with `isEmail`, not from `type` (git often stores emails as `type=username`). Non-email usernames keep preferred casing from the source.
+Identity equality in CDP is `(platform, type, lower(value))`. Email vs username for storage casing is inferred from the value with `isValidEmail`, not from `type` (git often stores emails as `type=username`). Non-email usernames keep preferred casing from the source.
 
 **Enforcement**
 

--- a/docs/adr/0015-how-cdp-stores-member-identities.md
+++ b/docs/adr/0015-how-cdp-stores-member-identities.md
@@ -6,70 +6,82 @@
 
 ## Context
 
-Member identities in CDP come from many sources (integrations, enrichment, UI, public APIs). The same logical identity often arrives with different casing — for example GitHub’s `login` is case-preserving in the API but case-insensitive for account uniqueness.
+CDP treats member identities as case-insensitive when resolving people (`lower(value)` in lookups and many DAL queries), which matches how major platforms behave:
 
-CDP already resolves people with case-insensitive lookups (`lower(value)`). Uniqueness and some write paths historically used raw `value`, so the same identity could be stored more than once under different casings. Lookups, merges, and verification then disagree about whether two rows are “the same.”
+- **GitHub / GitLab**: usernames are case-insensitive for uniqueness, but case-preserving for display (`WillsonHG` and `willsonhg` are the same account; APIs return preferred casing).
+- **Discord** (new usernames): forced lowercase.
+- **Email**: stored and compared lowercase in practice.
 
-We need a single, durable rule for what we store and what counts as the same identity — aligned with how the platforms we integrate with actually work.
+Historically, `memberIdentities` uniqueness was defined on raw `value` (case-sensitive):
+
+- `uix_memberIdentities_memberId_platform_value_type`
+- `uix_memberIdentities_platform_value_type_verified`
+
+Lookups used `lower(value)`, but inserts often did not. Data-sink `mergeData` matched with exact `value ===`, so a self-serve lowercase `willsonhg` plus a later GitHub ingest of `WillsonHG` produced two rows for the same identity — often both verified on the same member. Prod had tens of thousands of GitHub case-variant groups.
+
+Soft-deleting or auto-verifying case variants only at verification time would treat a write-path bug as a product special case.
 
 ## Decision
 
-Identity equality in CDP is `(platform, type, lower(value))`.
+**Mental model**
 
-| Kind     | Store in `value`                             | Compare / unique on |
-| -------- | -------------------------------------------- | ------------------- |
-| username | preferred casing from the source/integration | `lower(value)`      |
-| email    | always lowercase                             | `lower(value)`      |
+| Kind     | Store                            | Compare / unique on             |
+| -------- | -------------------------------- | ------------------------------- |
+| username | preferred casing from the source | `lower(value)`                  |
+| email    | always lowercase                 | `lower(value)` (same as stored) |
 
-Whether a value is stored as an email (lowercased) vs a username (preferred casing) is inferred from the string with `isValidEmail`, not only from `type` — some sources (notably git) store email addresses with `type = username`.
+Identity equality in CDP is `(platform, type, lower(value))`. Email vs username for storage casing is inferred from the value with `isValidEmail`, not from `type` (git often stores emails as `type=username`). Non-email usernames keep preferred casing from the source.
 
-### Conventions
+**Enforcement**
 
-1. **Do not invent casing** — for non-email usernames, persist what the source sent (after trim). Do not force lowercase on GitHub/GitLab-style handles.
-2. **Do not insert case variants** — if a row already exists for the same `(platform, type, lower(value))`, update or no-op; never insert a second row that only differs by casing.
-3. **App equality matches DB equality** — use `isSameMemberIdentity` (or equivalent `lower(value)` comparisons) on write and merge paths. `type` stays in the equality key even when a git `username` holds an email-shaped string.
-4. **DB enforces the invariant** — unique indexes on `lower(value)` (per member for all active identities; globally for verified identities). Schema detail: migration `V1785255019__member_identities_case_insensitive_unique_indexes.sql`.
+1. **Write paths** match and upsert with case-insensitive equality (`isSameMemberIdentity` / `lower(value)`). Do not insert a second row that only differs by casing.
+2. **DB uniqueness** uses expression unique indexes on `lower(value)` (partial on `deletedAt is null`, and verified-only for the global verified owner index). See migration `V1785255019__member_identities_case_insensitive_unique_indexes.sql`.
+3. **Existing duplicates** are cleaned with a one-time script before the unique indexes can be applied: same-member case variants → keep one (prefer verified + `verifiedBy`, else most recent integration casing) and soft-delete the rest; cross-member unverified variants of a verified identity → soft-delete the unverified; both verified across members → merge / existing capitalization-merge workflows, not blind soft-delete.
+4. **Verification** does not need special “soft-delete case siblings” logic once the invariant holds — verifying finds the one row.
 
 ## Alternatives Considered
 
-### Alternative 1: Always store usernames lowercase
+### Alternative 1: Soft-delete / auto-verify case variants at identity verification time
 
-- **Pros**: Simplest storage; uniqueness can stay on raw `value`.
-- **Cons**: Discards preferred casing from GitHub/GitLab; CDP display and support diverge from the source platform.
-- **Why not**: We want GitHub-style case-preserving storage. Sameness belongs on `lower(value)`, not on rewriting the handle.
+- **Pros**: Fixes the user-visible self-serve pain quickly; no schema change.
+- **Cons**: Case variants keep being inserted by ingest/enrichment; verify path becomes a mop; duplicates still break uniqueness and analytics.
+- **Why not**: Papers over the root cause. If case variants should not exist, stop creating them and clean existing data.
 
-### Alternative 2: Case-sensitive storage and uniqueness (raw `value` only)
+### Alternative 2: Always store usernames lowercase (like emails / Discord)
 
-- **Pros**: Matches naive string equality; no expression indexes.
-- **Cons**: Conflicts with how platforms define accounts and with how CDP already looks identities up; duplicate rows for the same person identity are inevitable.
-- **Why not**: That mismatch is the problem this decision closes.
+- **Pros**: Simplest storage; uniqueness on `value` works without expression indexes.
+- **Cons**: Throws away GitHub/GitLab preferred casing; diverges from source payloads; confuses display and support (“CDP shows lowercase but GitHub shows mixed”).
+- **Why not**: We want GitHub-style case-preserving storage. Uniqueness belongs on `lower(value)`, not on mutating the stored handle.
 
-### Alternative 3: Case-insensitive matching in application code only
+### Alternative 3: Keep case-sensitive unique indexes; only fix app-layer matching
 
-- **Pros**: No schema change.
-- **Cons**: Any missed caller or race can still insert case variants; the database does not protect the invariant.
-- **Why not**: At CDP scale, identity uniqueness must be enforced in the database as well as in callers.
+- **Pros**: No migration; no cleanup required to change indexes.
+- **Cons**: App bugs or races can still insert case variants; DB does not enforce the domain invariant.
+- **Why not**: At this scale, durable invariants need to live in the database, not only in callers.
 
-### Alternative 4: Refresh stored casing on every ingest when the source casing differs
+### Alternative 4: Update stored casing on every ingest when preferred casing differs
 
-- **Pros**: `value` always mirrors the latest source spelling.
-- **Cons**: Extra writes; needs a single surviving row per identity before it is safe.
-- **Why not**: Optional later enhancement. Preventing duplicate rows is the required invariant; updating preferred casing can be layered on afterward.
+- **Pros**: `value` always mirrors latest source casing.
+- **Cons**: Unsafe while same-member case-variant pairs still exist (updating both rows to the same `value` hits the old unique index). Extra write noise.
+- **Why not**: Deferred until after cleanup. Preventing duplicate inserts is enough for the durable fix; optional casing refresh can come later.
 
 ## Consequences
 
 ### Positive
 
-- One rule for “same identity” across lookup, ingest, merge, and uniqueness.
+- One clear rule: same platform + type + lower(value) ⇒ same identity.
+- Lookups, writes, and uniqueness agree.
+- Self-serve / GitHub / enrichment stop creating `WillsonHG` + `willsonhg` pairs.
 - Preferred username casing from integrations is preserved.
-- Emails are normalized consistently.
 
 ### Negative
 
-- Callers must compare with `lower(value)` / `isSameMemberIdentity`, not exact string equality.
-- Unique indexes are expression-based (`lower(value)`), which is slightly less obvious than column-only uniques.
+- Cleanup must run before the unique-index migration, or `create unique index` fails (and can leave an `INVALID` index).
+- Expression unique indexes are slightly less obvious than column-only uniques; callers must keep using `lower(value)` (or `isSameMemberIdentity`) consistently.
+- Conflict handlers need to recognize both old and new constraint names during rollout.
 
 ### Risks
 
-- **Missed write path still using exact `value ===`** — mitigated by DB unique indexes on `lower(value)` and shared helpers.
-- **Two verified members sharing the same identity under `lower(value)`** — a data conflict requiring merge, not a second identity row.
+- **Migration applied before cleanup** — mitigated by documenting order: write-path fix → cleanup script → unique-index migration.
+- **Cross-member verified case variants** — rare; require merge, not soft-delete. Existing `findAndMergeMembersWithSamePlatformIdentitiesDifferentCapitalization` covers part of this.
+- **Incomplete write-path coverage** — mitigated by DB unique indexes as the backstop once cleanup is done; shared `isSameMemberIdentity` for app equality.

--- a/docs/adr/0015-how-cdp-stores-member-identities.md
+++ b/docs/adr/0015-how-cdp-stores-member-identities.md
@@ -26,12 +26,12 @@ Ticket CM-1349 proposed soft-deleting / auto-verifying case variants at verifica
 
 **Mental model**
 
-| Kind | Store | Compare / unique on |
-| --- | --- | --- |
-| username | preferred casing from the source/integration | `lower(value)` |
-| email | always lowercase | `lower(value)` (same as stored) |
+| Kind     | Store                                        | Compare / unique on             |
+| -------- | -------------------------------------------- | ------------------------------- |
+| username | preferred casing from the source/integration | `lower(value)`                  |
+| email    | always lowercase                             | `lower(value)` (same as stored) |
 
-Identity equality in CDP is `(platform, type, lower(value))`. The `value` column keeps what the source sent for usernames; we do not rewrite GitHub `login` casing on ingest.
+Identity equality in CDP is `(platform, type, lower(value))`. Email vs username for storage casing is inferred from the value with `isEmail`, not from `type` (git often stores emails as `type=username`). Non-email usernames keep preferred casing from the source.
 
 **Enforcement**
 

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -11,6 +11,7 @@ import {
   generateUUIDv1,
   isDomainExcluded,
   isValidEmail,
+  normalizeMemberIdentityValue,
   parseGitHubNoreplyEmail,
   single,
   singleOrDefault,
@@ -287,7 +288,12 @@ export default class ActivityService extends LoggerBase {
       }
 
       let member = activity.member
-      const username = activity.username ? activity.username.trim() : undefined
+      const username = activity.username
+        ? normalizeMemberIdentityValue(activity.username)
+        : undefined
+      if (username) {
+        activity.username = username
+      }
       if (!member && username) {
         member = {
           identities: [
@@ -315,12 +321,15 @@ export default class ActivityService extends LoggerBase {
             i.value &&
             i.verified,
         )
-        if (platformIdentity && platformIdentity.value !== username) {
-          this.log.debug(
-            { platform, originalUsername: username, correctedUsername: platformIdentity.value },
-            'Overriding activity.username with member platform identity value',
-          )
-          activity.username = platformIdentity.value
+        if (platformIdentity) {
+          const correctedUsername = normalizeMemberIdentityValue(platformIdentity.value)
+          if (correctedUsername !== username) {
+            this.log.debug(
+              { platform, originalUsername: username, correctedUsername },
+              'Overriding activity.username with member platform identity value',
+            )
+            activity.username = correctedUsername
+          }
         }
       }
 
@@ -332,7 +341,7 @@ export default class ActivityService extends LoggerBase {
         )
 
         if (identities.length === 1) {
-          activity.username = identities[0].value
+          activity.username = normalizeMemberIdentityValue(identities[0].value)
         } else if (identities.length === 0) {
           // Fall back to same-platform email identity — handles old gerrit records where
           // only a type:email identity was stored (before the gerrit integration
@@ -341,11 +350,12 @@ export default class ActivityService extends LoggerBase {
             (i) => i.platform === platform && i.type === MemberIdentityType.EMAIL && i.value,
           )
           if (emailFallback && emailFallback.verified) {
-            activity.username = emailFallback.value
+            const emailUsername = normalizeMemberIdentityValue(emailFallback.value)
+            activity.username = emailUsername
             activity.member.identities.push({
               platform,
               type: MemberIdentityType.USERNAME,
-              value: emailFallback.value,
+              value: emailUsername,
               verified: true,
               source: emailFallback.source,
             })

--- a/services/apps/data_sink_worker/src/service/activity.service.ts
+++ b/services/apps/data_sink_worker/src/service/activity.service.ts
@@ -11,6 +11,7 @@ import {
   generateUUIDv1,
   isDomainExcluded,
   isValidEmail,
+  normalizeMemberIdentities,
   normalizeMemberIdentityValue,
   parseGitHubNoreplyEmail,
   single,
@@ -288,6 +289,10 @@ export default class ActivityService extends LoggerBase {
       }
 
       let member = activity.member
+      if (member?.identities) {
+        member.identities = normalizeMemberIdentities(member.identities)
+      }
+
       const username = activity.username
         ? normalizeMemberIdentityValue(activity.username)
         : undefined
@@ -321,41 +326,39 @@ export default class ActivityService extends LoggerBase {
             i.value &&
             i.verified,
         )
-        if (platformIdentity) {
-          const correctedUsername = normalizeMemberIdentityValue(platformIdentity.value)
-          if (correctedUsername !== username) {
-            this.log.debug(
-              { platform, originalUsername: username, correctedUsername },
-              'Overriding activity.username with member platform identity value',
-            )
-            activity.username = correctedUsername
-          }
+        if (platformIdentity && platformIdentity.value !== username) {
+          this.log.debug(
+            {
+              platform,
+              originalUsername: username,
+              correctedUsername: platformIdentity.value,
+            },
+            'Overriding activity.username with member platform identity value',
+          )
+          activity.username = platformIdentity.value
         }
       }
 
-      member.identities = member.identities.filter((i) => i.value)
-
-      if (!username) {
-        const identities = activity.member.identities.filter(
+      if (!activity.username) {
+        const identities = (member?.identities ?? []).filter(
           (i) => i.platform === platform && i.type === MemberIdentityType.USERNAME,
         )
 
         if (identities.length === 1) {
-          activity.username = normalizeMemberIdentityValue(identities[0].value)
+          activity.username = identities[0].value
         } else if (identities.length === 0) {
           // Fall back to same-platform email identity — handles old gerrit records where
           // only a type:email identity was stored (before the gerrit integration
           // gained the email-as-username fallback).
-          const emailFallback = activity.member.identities.find(
+          const emailFallback = (member?.identities ?? []).find(
             (i) => i.platform === platform && i.type === MemberIdentityType.EMAIL && i.value,
           )
           if (emailFallback && emailFallback.verified) {
-            const emailUsername = normalizeMemberIdentityValue(emailFallback.value)
-            activity.username = emailUsername
-            activity.member.identities.push({
+            activity.username = emailFallback.value
+            member.identities.push({
               platform,
               type: MemberIdentityType.USERNAME,
-              value: emailUsername,
+              value: emailFallback.value,
               verified: true,
               source: emailFallback.source,
             })
@@ -398,12 +401,15 @@ export default class ActivityService extends LoggerBase {
       }
 
       const objectMemberUsername = activity.objectMemberUsername
-        ? activity.objectMemberUsername.trim()
+        ? normalizeMemberIdentityValue(activity.objectMemberUsername)
         : undefined
+      if (objectMemberUsername) {
+        activity.objectMemberUsername = objectMemberUsername
+      }
       let objectMember = activity.objectMember
 
-      if (objectMember) {
-        objectMember.identities = objectMember.identities.filter((i) => i.value)
+      if (objectMember?.identities) {
+        objectMember.identities = normalizeMemberIdentities(objectMember.identities)
       }
 
       if (objectMember && !objectMemberUsername) {
@@ -451,6 +457,11 @@ export default class ActivityService extends LoggerBase {
             } as IMemberIdentity,
           ],
         }
+      }
+
+      activity.member = member
+      if (objectMember) {
+        activity.objectMember = objectMember
       }
 
       results.set(resultId, { success: true })

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -10,8 +10,7 @@ import {
   isDomainExcluded,
   isObjectEmpty,
   isSameMemberIdentity,
-  isValidEmail,
-  normalizeMemberIdentityValue,
+  normalizeMemberIdentities,
   singleOrDefault,
 } from '@crowd/common'
 import {
@@ -137,15 +136,7 @@ export default class MemberService extends LoggerBase {
     // Deduplicate by (platform, type, lower(value)) — prefer verified=true when the same
     // identity appears with both flags. Prevents per-member unique identity index
     // from firing when a payload contains the same identity twice with different verified values.
-    const seen = new Map<string, IMemberIdentity>()
-    for (const id of identities) {
-      const key = `${id.platform}:${id.type}:${id.value.trim().toLowerCase()}`
-      const existing = seen.get(key)
-      if (!existing || (!existing.verified && id.verified)) {
-        seen.set(key, id)
-      }
-    }
-    const deduped = Array.from(seen.values())
+    const deduped = normalizeMemberIdentities(identities)
 
     try {
       await this.memberRepo.insertIdentities(memberId, integrationId, deduped, true)
@@ -347,8 +338,9 @@ export default class MemberService extends LoggerBase {
             )
           }
 
-          // validate emails
-          data.identities = this.validateEmails(data.identities)
+          data.identities = normalizeMemberIdentities(data.identities, {
+            dropInvalidEmails: true,
+          })
 
           data.displayName = getProperDisplayName(data.displayName)
 
@@ -587,11 +579,9 @@ export default class MemberService extends LoggerBase {
             )
           }
 
-          // prevent empty identity handles
-          data.identities = data.identities.filter((i) => i.value)
-
-          // validate emails
-          data.identities = this.validateEmails(data.identities)
+          data.identities = normalizeMemberIdentities(data.identities, {
+            dropInvalidEmails: true,
+          })
 
           // make sure displayName is proper
           if (data.displayName) {
@@ -951,17 +941,6 @@ export default class MemberService extends LoggerBase {
       this.log.error(err, 'Error while processing a member update!')
       throw err
     }
-  }
-
-  private validateEmails(identities: IMemberIdentity[]): IMemberIdentity[] {
-    return identities
-      .map((identity) => ({
-        ...identity,
-        value: normalizeMemberIdentityValue(identity.value),
-      }))
-      .filter(
-        (identity) => identity.type !== MemberIdentityType.EMAIL || isValidEmail(identity.value),
-      )
   }
 
   private mergeData(

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -8,9 +8,9 @@ import {
   getEarliestValidDate,
   getProperDisplayName,
   isDomainExcluded,
-  isEmail,
   isObjectEmpty,
   isSameMemberIdentity,
+  isValidEmail,
   normalizeMemberIdentityValue,
   singleOrDefault,
 } from '@crowd/common'
@@ -954,24 +954,14 @@ export default class MemberService extends LoggerBase {
   }
 
   private validateEmails(identities: IMemberIdentity[]): IMemberIdentity[] {
-    const toReturn: IMemberIdentity[] = []
-
-    for (const identity of identities) {
-      const value = normalizeMemberIdentityValue(identity.value)
-      const normalized = { ...identity, value }
-
-      if (identity.type === MemberIdentityType.EMAIL && !isEmail(value)) {
-        continue
-      }
-
-      if (toReturn.some((i) => isSameMemberIdentity(i, normalized))) {
-        continue
-      }
-
-      toReturn.push(normalized)
-    }
-
-    return toReturn
+    return identities
+      .map((identity) => ({
+        ...identity,
+        value: normalizeMemberIdentityValue(identity.value),
+      }))
+      .filter(
+        (identity) => identity.type !== MemberIdentityType.EMAIL || isValidEmail(identity.value),
+      )
   }
 
   private mergeData(

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -11,6 +11,7 @@ import {
   isEmail,
   isObjectEmpty,
   isSameMemberIdentity,
+  normalizeMemberIdentityValue,
   singleOrDefault,
 } from '@crowd/common'
 import {
@@ -956,22 +957,18 @@ export default class MemberService extends LoggerBase {
     const toReturn: IMemberIdentity[] = []
 
     for (const identity of identities) {
-      if (identity.type === MemberIdentityType.EMAIL) {
-        const lowerValue = identity.value.toLowerCase()
-        if (
-          isEmail(identity.value) &&
-          toReturn.find(
-            (i) =>
-              i.type === MemberIdentityType.EMAIL &&
-              i.value === lowerValue &&
-              i.platform === identity.platform,
-          ) === undefined
-        ) {
-          toReturn.push({ ...identity, value: lowerValue })
-        }
-      } else {
-        toReturn.push(identity)
+      const value = normalizeMemberIdentityValue(identity.value)
+      const normalized = { ...identity, value }
+
+      if (identity.type === MemberIdentityType.EMAIL && !isEmail(value)) {
+        continue
       }
+
+      if (toReturn.some((i) => isSameMemberIdentity(i, normalized))) {
+        continue
+      }
+
+      toReturn.push(normalized)
     }
 
     return toReturn

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -7,6 +7,8 @@ import {
   OrganizationSource,
 } from '@crowd/types'
 
+import { isEmail } from './validations'
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export function isSameMemberIdentity(
@@ -18,6 +20,12 @@ export function isSameMemberIdentity(
     a.type === b.type &&
     a.value.trim().toLowerCase() === b.value.trim().toLowerCase()
   )
+}
+
+export function normalizeMemberIdentityValue(value: string): string {
+  const trimmed = value.trim()
+  const lower = trimmed.toLowerCase()
+  return isEmail(lower) ? lower : trimmed
 }
 
 export async function setAttributesDefaultValues(

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -7,7 +7,7 @@ import {
   OrganizationSource,
 } from '@crowd/types'
 
-import { isEmail } from './validations'
+import { isValidEmail } from './email'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -25,7 +25,7 @@ export function isSameMemberIdentity(
 export function normalizeMemberIdentityValue(value: string): string {
   const trimmed = value.trim()
   const lower = trimmed.toLowerCase()
-  return isEmail(lower) ? lower : trimmed
+  return isValidEmail(lower) ? lower : trimmed
 }
 
 export async function setAttributesDefaultValues(

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -2,6 +2,7 @@ import merge from 'lodash.merge'
 import ldSum from 'lodash.sum'
 
 import {
+  MemberIdentityType,
   MemberOrganizationDateInput,
   MemberOrganizationDateRange,
   OrganizationSource,
@@ -22,10 +23,45 @@ export function isSameMemberIdentity(
   )
 }
 
+/** Email-shaped → lowercase; otherwise trim and keep preferred casing. */
 export function normalizeMemberIdentityValue(value: string): string {
   const trimmed = value.trim()
   const lower = trimmed.toLowerCase()
   return isValidEmail(lower) ? lower : trimmed
+}
+
+/** Normalize values, drop empties, dedupe by (platform, type, lower(value)) preferring verified. */
+export function normalizeMemberIdentities<
+  T extends { platform: string; type: string; value: string; verified?: boolean },
+>(identities: T[], options: { dropInvalidEmails?: boolean } = {}): T[] {
+  const seen = new Map<string, T>()
+
+  for (const identity of identities) {
+    if (!identity.value?.trim()) {
+      continue
+    }
+
+    const normalized = {
+      ...identity,
+      value: normalizeMemberIdentityValue(identity.value),
+    }
+
+    if (
+      options.dropInvalidEmails &&
+      normalized.type === MemberIdentityType.EMAIL &&
+      !isValidEmail(normalized.value)
+    ) {
+      continue
+    }
+
+    const key = `${normalized.platform}:${normalized.type}:${normalized.value.toLowerCase()}`
+    const existing = seen.get(key)
+    if (!existing || (!existing.verified && normalized.verified)) {
+      seen.set(key, normalized)
+    }
+  }
+
+  return Array.from(seen.values())
 }
 
 export async function setAttributesDefaultValues(

--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -3,6 +3,7 @@ import max from 'lodash.max'
 import min from 'lodash.min'
 import moment from 'moment'
 
+import { normalizeMemberIdentityValue } from '@crowd/common'
 import {
   ActivityRelations,
   ActivityTimeseriesDatapoint,
@@ -448,6 +449,11 @@ export async function createOrUpdateRelations(
       continue
     }
 
+    data.username = normalizeMemberIdentityValue(data.username)
+    if (data.objectMemberUsername != null) {
+      data.objectMemberUsername = normalizeMemberIdentityValue(data.objectMemberUsername)
+    }
+
     if (data.platform === undefined || data.platform === null) {
       continue
     }
@@ -777,6 +783,13 @@ export async function updateActivityRelationsById(
   qe: QueryExecutor,
   data: IActivityRelationUpdateById,
 ): Promise<void> {
+  if (typeof data.username === 'string') {
+    data.username = normalizeMemberIdentityValue(data.username)
+  }
+  if (typeof data.objectMemberUsername === 'string') {
+    data.objectMemberUsername = normalizeMemberIdentityValue(data.objectMemberUsername)
+  }
+
   const fields: string[] = []
 
   for (const [key, value] of Object.entries(data)) {

--- a/services/libs/data-access-layer/src/activities/sql.ts
+++ b/services/libs/data-access-layer/src/activities/sql.ts
@@ -485,7 +485,7 @@ export async function createOrUpdateRelations(
                 `
           SELECT "memberId"
           FROM "memberIdentities"
-          WHERE value = $(value)
+          WHERE lower(value) = lower($(value))
             and platform = $(platform)
             and verified = true
             and "deletedAt" is null
@@ -594,7 +594,7 @@ export async function createOrUpdateRelations(
             `
         SELECT "memberId"
         FROM "memberIdentities"
-        WHERE value = $(value)
+        WHERE lower(value) = lower($(value))
           and platform = $(platform)
           and verified = true
           and "deletedAt" is null

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TENANT_ID, generateUUIDv1 } from '@crowd/common'
+import { DEFAULT_TENANT_ID, generateUUIDv1, normalizeMemberIdentityValue } from '@crowd/common'
 import {
   IMemberIdentity,
   MemberIdentityDbInsert,
@@ -142,6 +142,10 @@ export async function updateMemberIdentity(
 
   if (Object.keys(filtered).length === 0) return null
 
+  if (typeof filtered.value === 'string') {
+    filtered.value = normalizeMemberIdentityValue(filtered.value)
+  }
+
   const setClause = Object.keys(filtered).map((key) => `"${key}" = $(${key})`)
   setClause.push('"updatedAt" = now()')
 
@@ -275,6 +279,7 @@ export async function insertMemberIdentities(
       ...i,
       id: i.id || generateUUIDv1(),
       tenantId: DEFAULT_TENANT_ID,
+      value: normalizeMemberIdentityValue(i.value),
     })),
     failOnConflict ? undefined : 'DO NOTHING',
     returnRows,


### PR DESCRIPTION
## Summary
Make member identity casing durable: email-shaped values are always stored lowercase (even when `type` is `username`, e.g. git), usernames keep preferred casing, and equality/uniqueness stay on `(platform, type, lower(value))`.

## Changes
- Shared helpers in `@crowd/common`: `normalizeMemberIdentityValue` (`isValidEmail` shape check) and `normalizeMemberIdentities` (normalize + same-batch case-variant dedupe, prefer verified)
- Persist choke point: DAL `insertMemberIdentities` / `updateMemberIdentity` (plus the legacy `addAsUnverifiedIdentity` raw insert)
- Data-sink create/update use `normalizeMemberIdentities` (replaces the misleading `validateEmails` path)
- Activity prepare normalizes `username` and `objectMemberUsername` the same way; AR fallback lookups use `lower(value)`
- API / UI identity services rely on DAL normalize on write
- ADR-0015 updated to the durable storage/equality model (no ticket narrative)