### PR TITLE
feat: add rule for comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,4 @@ Millions of rows. Every query matters.
 - Define types properly — extend and reuse existing types. Don't sprinkle `any`.
 - Don't touch working code outside the scope of the current task.
 - Prefer doing less over introducing risk. Weigh trade-offs before acting.
+- Default to no comments. When one is warranted (non-obvious WHY), keep it to 2 lines max.


### PR DESCRIPTION
## Summary
Adds a code-quality rule to the root `CLAUDE.md` capping comment length, so
AI assistants (and contributors) writing comments in this codebase keep them
short instead of adding multi-line explanatory blocks.

## Changes
- Added a bullet to `CLAUDE.md`'s "Code quality" section: default to no
  comments, and when one is warranted (non-obvious WHY), keep it to 2 lines max.


## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [X] Chore / dependency update
- [ ] Documentation

