### PR TITLE
fix: privilege shared organization domain over username clashes (CM-1119)

### DIFF
--- a/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
@@ -20,6 +20,12 @@ class OrganizationSimilarityCalculator {
 
     let similarPrimaryIdentity: IOrganizationIdentity = null
 
+    // Orgs often have multiple accounts on the same platform (e.g. github.com/openai vs
+    // github.com/OpenAI-Discord). A shared verified primary-domain outweighs that clash.
+    if (this.hasSharedVerifiedPrimaryDomain(primaryOrganization, similarOrganization)) {
+      return this.HIGH_CONFIDENCE_SCORE
+    }
+
     if (this.hasClashingOrganizationIdentities(primaryOrganization, similarOrganization)) {
       return this.LOW_CONFIDENCE_SCORE
     }
@@ -115,6 +121,26 @@ class OrganizationSimilarityCalculator {
 
   static bumpConfidenceScore(confidenceScore: number, bump: number): number {
     return Math.min(1, confidenceScore + bump)
+  }
+
+  static hasSharedVerifiedPrimaryDomain(
+    organization: IOrganizationFullAggregatesOpensearch,
+    similarOrganization: IOrganizationFullAggregatesOpensearch,
+  ): boolean {
+    const primaryDomains = organization.identities
+      .filter((i) => i.verified && i.type === OrganizationIdentityType.PRIMARY_DOMAIN)
+      .map((i) => i.value.toLowerCase())
+
+    if (primaryDomains.length === 0) {
+      return false
+    }
+
+    return similarOrganization.identities.some(
+      (i) =>
+        i.verified &&
+        i.type === OrganizationIdentityType.PRIMARY_DOMAIN &&
+        primaryDomains.includes(i.value.toLowerCase()),
+    )
   }
 
   static hasClashingOrganizationIdentities(


### PR DESCRIPTION
## Summary

Organization merge suggestions were hard-failing at similarity `0.2` whenever two orgs had different verified usernames on the same platform (e.g. GitHub), even when they shared the same verified primary domain. That score never reaches the UI (`organizationToMerge` only keeps scores `> 0.75`), so legitimate duplicates like Tubi (`adRise` vs `Tubitv` on `tubitv.com`) stayed invisible.

Orgs commonly have multiple accounts on one platform, so a shared verified primary domain is a stronger signal than a username clash. This change scores those pairs at `0.9` and only applies the username-clash hard-fail when domains do not match.

## Changes

- In `OrganizationSimilarityCalculator.calculateSimilarity`, check for a shared verified `primary-domain` before the clash short-circuit and return `HIGH_CONFIDENCE_SCORE` (`0.9`) when present
- Add `hasSharedVerifiedPrimaryDomain` to compare verified primary-domain identity values case-insensitively
- Leave existing clash / displayName / fuzzy scoring paths unchanged when there is no shared verified primary domain