### PR TITLE
fix: restore public API conflict alert message layout

### DIFF
--- a/backend/src/api/public/alerts/identityConflict.ts
+++ b/backend/src/api/public/alerts/identityConflict.ts
@@ -23,19 +23,20 @@ function notifyIdentityConflict(
     .filter(Boolean)
     .join(':')
 
-  void notifyOnce(req, dedupeKey, 'Identity conflict', [
-    {
-      title: 'Identity',
-      text: `*Platform:* \`${identity.platform}\`\n*Type:* \`${identity.type}\`\n*Value:* \`${identity.value}\``,
-    },
-    ...(identity.memberId
-      ? [{ title: 'Member', text: `*Member ID:* \`${identity.memberId}\`` }]
-      : []),
-    { title: 'Conflict', text: `*Message:* ${message}` },
+  const context = {
+    platform: identity.platform,
+    value: identity.value,
+    type: identity.type,
+    ...(identity.memberId ? { memberId: identity.memberId } : {}),
+  }
+
+  void notifyOnce(req, dedupeKey, 'Public API Identity Conflict 409', [
     {
       title: 'Request',
-      text: `*Method:* \`${req.method}\`\n*URL:* \`${req.url}\``,
+      text: `*Method:* \`${req.method}\`\n*URL:* \`${req.originalUrl}\``,
     },
+    { title: 'Conflict', text: `*Message:* ${message}` },
+    { title: 'Context', text: `\`\`\`${JSON.stringify(context, null, 2)}\`\`\`` },
   ])
 }
 

--- a/backend/src/api/public/alerts/memberResolveConflict.ts
+++ b/backend/src/api/public/alerts/memberResolveConflict.ts
@@ -7,15 +7,15 @@ import { notifyOnce } from '@/api/public/alerts/notifyOnce'
 function notifyMemberResolveConflict(req: Request, memberIds: string[], message: string): void {
   const dedupeKey = `member-resolve:${[...memberIds].sort().join(':')}`
 
-  void notifyOnce(req, dedupeKey, 'Member resolve conflict', [
+  void notifyOnce(req, dedupeKey, 'Public API Member Resolve Conflict 409', [
     {
-      title: 'Members',
-      text: memberIds.map((id) => `• \`${id}\``).join('\n'),
+      title: 'Request',
+      text: `*Method:* \`${req.method}\`\n*URL:* \`${req.originalUrl}\``,
     },
     { title: 'Conflict', text: `*Message:* ${message}` },
     {
-      title: 'Request',
-      text: `*Method:* \`${req.method}\`\n*URL:* \`${req.url}\``,
+      title: 'Context',
+      text: `\`\`\`${JSON.stringify({ memberIds }, null, 2)}\`\`\``,
     },
   ])
 }


### PR DESCRIPTION
## Summary
Restore the previous Slack alert layout for public API conflict notifications so they are easier to scan in triage.

## Changes
- Identity conflict alerts use `Public API Identity Conflict 409` with Request / Conflict / Context sections
- Member resolve conflict alerts use `Public API Member Resolve Conflict 409` with the same section layout
- Request URLs use `req.originalUrl` so the full `/v1/...` path is shown