### PR TITLE
fix: require display name for shared organization domain matches (CM-1119)

### DIFF
--- a/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
@@ -20,10 +20,17 @@ class OrganizationSimilarityCalculator {
 
     let similarPrimaryIdentity: IOrganizationIdentity = null
 
-    // Orgs often have multiple accounts on the same platform (e.g. github.com/openai vs
-    // github.com/OpenAI-Discord). A shared verified primary-domain outweighs that clash.
-    if (this.hasSharedVerifiedPrimaryDomain(primaryOrganization, similarOrganization)) {
-      return this.HIGH_CONFIDENCE_SCORE
+    const sameDisplayName =
+      primaryOrganization.displayName?.toLowerCase() ===
+      similarOrganization.displayName?.toLowerCase()
+
+    // Orgs can have multiple usernames on one platform; don't let that clash
+    // veto a shared verified primary-domain and same displayName.
+    if (
+      sameDisplayName &&
+      this.hasSharedVerifiedPrimaryDomain(primaryOrganization, similarOrganization)
+    ) {
+      return 0.85
     }
 
     if (this.hasClashingOrganizationIdentities(primaryOrganization, similarOrganization)) {
@@ -48,7 +55,7 @@ class OrganizationSimilarityCalculator {
       }
 
       // check displayName match
-      if (similarOrganization.displayName === primaryOrganization.displayName) {
+      if (sameDisplayName) {
         return this.decideSimilarityUsingAdditionalChecks(primaryOrganization, similarOrganization)
       }
 

--- a/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
+++ b/services/apps/merge_suggestions_worker/src/organizationSimilarityCalculator.ts
@@ -21,10 +21,12 @@ class OrganizationSimilarityCalculator {
     let similarPrimaryIdentity: IOrganizationIdentity = null
 
     const sameDisplayName =
-      primaryOrganization.displayName?.toLowerCase() ===
-      similarOrganization.displayName?.toLowerCase()
+      Boolean(primaryOrganization.displayName) &&
+      Boolean(similarOrganization.displayName) &&
+      primaryOrganization.displayName.toLowerCase() ===
+        similarOrganization.displayName.toLowerCase()
 
-    // Orgs can have multiple usernames on one platform; don't let that clash
+    // Organizations can have multiple usernames on one platform; don't let that clash
     // veto a shared verified primary-domain and same displayName.
     if (
       sameDisplayName &&


### PR DESCRIPTION
## Summary

Follow-up to the CM-1119 org merge scoring change. Shared verified primary-domain alone was too broad: unrelated organizations can share a domain identity while having different display names, which would create false positive merge suggestions.

Requiring the same displayName (case-insensitive) as well keeps the intended cases — the same organization with multiple usernames on one platform — while dropping pairs that only agree on domain. Score is set to `0.85` (above the `> 0.75` merge-ready threshold, below hard `0.9`) so these still reach review without overstating confidence when usernames clash.

## Changes

- Gate the pre-clash override on **same displayName (CI) and** shared verified primary-domain, not domain alone
- Return `0.85` for that path instead of `HIGH_CONFIDENCE_SCORE` (`0.9`)
- Reuse the case-insensitive displayName check later in the verified-identity loop