### PR TITLE
fix: stagger collection-bucket copy pipe schedules (CM-XXXX)

### DIFF
--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_0_ds
 COPY_MODE replace
-COPY_SCHEDULE 2 1 * * *
+COPY_SCHEDULE 0 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_0_ds
 COPY_MODE replace
-COPY_SCHEDULE 0 1 * * *
+COPY_SCHEDULE 2 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_1_ds
 COPY_MODE replace
-COPY_SCHEDULE 7 1 * * *
+COPY_SCHEDULE 5 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_1_ds
 COPY_MODE replace
-COPY_SCHEDULE 5 1 * * *
+COPY_SCHEDULE 7 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_2_ds
 COPY_MODE replace
-COPY_SCHEDULE 12 1 * * *
+COPY_SCHEDULE 10 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_2_ds
 COPY_MODE replace
-COPY_SCHEDULE 10 1 * * *
+COPY_SCHEDULE 12 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_3_ds
 COPY_MODE replace
-COPY_SCHEDULE 15 1 * * *
+COPY_SCHEDULE 17 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_3_ds
 COPY_MODE replace
-COPY_SCHEDULE 17 1 * * *
+COPY_SCHEDULE 15 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_4_ds
 COPY_MODE replace
-COPY_SCHEDULE 20 1 * * *
+COPY_SCHEDULE 22 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_4_ds
 COPY_MODE replace
-COPY_SCHEDULE 22 1 * * *
+COPY_SCHEDULE 20 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_5_ds
 COPY_MODE replace
-COPY_SCHEDULE 27 1 * * *
+COPY_SCHEDULE 25 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_5_ds
 COPY_MODE replace
-COPY_SCHEDULE 25 1 * * *
+COPY_SCHEDULE 27 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_6_ds
 COPY_MODE replace
-COPY_SCHEDULE 32 1 * * *
+COPY_SCHEDULE 30 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_6_ds
 COPY_MODE replace
-COPY_SCHEDULE 30 1 * * *
+COPY_SCHEDULE 32 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_7_ds
 COPY_MODE replace
-COPY_SCHEDULE 35 1 * * *
+COPY_SCHEDULE 37 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_7_ds
 COPY_MODE replace
-COPY_SCHEDULE 37 1 * * *
+COPY_SCHEDULE 35 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_8_ds
 COPY_MODE replace
-COPY_SCHEDULE 40 1 * * *
+COPY_SCHEDULE 42 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_8_ds
 COPY_MODE replace
-COPY_SCHEDULE 42 1 * * *
+COPY_SCHEDULE 40 4 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_9_ds
 COPY_MODE replace
-COPY_SCHEDULE 45 1 * * *
+COPY_SCHEDULE 47 1 * * *

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
@@ -54,4 +54,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE activityRelations_collection_deduplicated_cleaned_bucket_9_ds
 COPY_MODE replace
-COPY_SCHEDULE 47 1 * * *
+COPY_SCHEDULE 45 4 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_0.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 5 2 * * *
+COPY_SCHEDULE 3 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_0.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 3 2 * * *
+COPY_SCHEDULE 5 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_1.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 10 2 * * *
+COPY_SCHEDULE 8 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_1.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 8 2 * * *
+COPY_SCHEDULE 10 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_2.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 13 2 * * *
+COPY_SCHEDULE 15 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_2.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 15 2 * * *
+COPY_SCHEDULE 13 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_3.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 18 2 * * *
+COPY_SCHEDULE 20 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_3.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 20 2 * * *
+COPY_SCHEDULE 18 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_4.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 25 2 * * *
+COPY_SCHEDULE 23 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_4.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 23 2 * * *
+COPY_SCHEDULE 25 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_5.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 28 2 * * *
+COPY_SCHEDULE 30 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_5.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 30 2 * * *
+COPY_SCHEDULE 28 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_6.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 35 2 * * *
+COPY_SCHEDULE 33 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_6.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 33 2 * * *
+COPY_SCHEDULE 35 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_7.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 40 2 * * *
+COPY_SCHEDULE 38 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_7.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 38 2 * * *
+COPY_SCHEDULE 40 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_8.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 43 2 * * *
+COPY_SCHEDULE 45 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_8.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 45 2 * * *
+COPY_SCHEDULE 43 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_9.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 50 2 * * *
+COPY_SCHEDULE 48 2 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_copy_pipe_9.pipe
@@ -32,4 +32,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_consolidated_ds
 COPY_MODE append
-COPY_SCHEDULE 48 2 * * *
+COPY_SCHEDULE 50 5 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
@@ -37,4 +37,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_projects_ds
 COPY_MODE replace
-COPY_SCHEDULE 3 3 * * *
+COPY_SCHEDULE 0 6 * * *

--- a/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
+++ b/services/libs/tinybird/pipes/collection_insights_aggregate_projects_copy_pipe.pipe
@@ -37,4 +37,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE collection_insights_aggregate_projects_ds
 COPY_MODE replace
-COPY_SCHEDULE 0 3 * * *
+COPY_SCHEDULE 3 3 * * *


### PR DESCRIPTION
## Summary
- Collection-bucketing's copy pipes were scheduled in the same 1–3 AM UTC hour block as the pre-existing `leaderboards_*` copy pipes, contending for the same account-level concurrent-copy-job quota (12) — this caused `leaderboards_members`, `leaderboards_commits`, `leaderboards_forks`, and `leaderboards_issue_response` to get stuck permanently `queued`, emptying the public contributors leaderboard (`insights.linuxfoundation.org/leaderboards/contributors`)
- **Revised approach (2nd commit)**: rather than staggering minutes within the shared hour block, this moves the whole collection-bucket block to a separate, previously near-empty hour span so it no longer competes with `leaderboards_*` for the quota at all:
  - `activityRelations_collection_bucket_clean_enrich_copy_pipe_0..9`: 1 AM → 4 AM
  - `collection_insights_aggregate_copy_pipe_0..9`: 2 AM → 5 AM
  - `collection_insights_aggregate_projects_copy_pipe`: 3 AM → 6 AM
- Verified zero minute-for-minute collisions across all `leaderboards_*` + collection-bucket pipes, and that the one pre-existing pipe in the 4–6 AM window (`contributions_with_local_time` at 4:44) doesn't collide with the new grid
- No `leaderboards_*` files touched

**Deploy note**: the first commit's minute-offset values for the 10 `clean_enrich_copy_pipe_*` pipes were already pushed to production before this correction landed. Deploying the current commit moves them again (1 AM → 4 AM). The four originally-stuck pipes were already manually retriggered to `ok` earlier as an immediate fix.

## Test plan
- [x] Verified with `.pipe` file diffs that no two pipes among the 26 in the 1–6 AM window share the same hour+minute after this change
- [x] Confirmed no docs/config reference the old schedule literals outside the `.pipe` files themselves
- [ ] After deploy, confirm `monitoring_copy_pipe_executions` shows all 26 pipes reaching `ok` (not `queued`) on the next scheduled run
- [ ] Confirm `leaderboards` endpoint (`leaderboardType=contributors`) continues returning data the day after deploy