### PR TITLE
feat: apply select enrichment attributes from a single source (CM-1355)

### DIFF
--- a/services/apps/members_enrichment_worker/src/types.ts
+++ b/services/apps/members_enrichment_worker/src/types.ts
@@ -117,6 +117,7 @@ export type IMemberEnrichmentAttributeSettings = {
 
 export interface IProcessMemberSourcesArgs {
   memberId: string
+  activityCount: number
   sources: MemberEnrichmentSource[]
 }
 

--- a/services/apps/members_enrichment_worker/src/utils/config.ts
+++ b/services/apps/members_enrichment_worker/src/utils/config.ts
@@ -1,2 +1,12 @@
+import { MemberAttributeName } from '@crowd/types'
+
 export const ALSO_USE_EMAIL_IDENTITIES_FOR_ENRICHMENT = false
 export const ENRICH_EMAIL_IDENTITIES = false
+
+/**
+ * Attributes safe to write from a single enrichment source.
+ */
+export const SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES: MemberAttributeName[] = [
+  MemberAttributeName.LOCATION,
+  MemberAttributeName.COUNTRY,
+]

--- a/services/apps/members_enrichment_worker/src/workflows/enrichMember.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/enrichMember.ts
@@ -86,8 +86,7 @@ export async function enrichMember(
 
   const changeInEnrichmentSourceData = sourceResults.some(Boolean)
 
-  if (changeInEnrichmentSourceData && input.activityCount > 100) {
-    // Member enrichment data has been updated, use squasher again!
+  if (changeInEnrichmentSourceData) {
     await executeChild(processMemberSources, {
       workflowId: 'member-enrichment/' + input.id + '/processMemberSources',
       cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
@@ -102,6 +101,7 @@ export async function enrichMember(
       args: [
         {
           memberId: input.id,
+          activityCount: input.activityCount ?? 0,
           sources,
         },
       ],

--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -36,9 +36,25 @@ const { squashMultipleValueAttributesWithLLM, squashWorkExperiencesWithLLM } = p
   },
 })
 
+function getEnrichmentAttributeValue(
+  attributes: IMemberEnrichmentDataNormalized['attributes'],
+  attributeName: string,
+): unknown {
+  const values = attributes?.[attributeName]
+  if (!values) {
+    return undefined
+  }
+
+  const enrichmentKey = Object.keys(values).find((key) => key.startsWith('enrichment-'))
+  return enrichmentKey ? values[enrichmentKey] : undefined
+}
+
 export async function processMemberSources(args: IProcessMemberSourcesArgs): Promise<boolean> {
   // without contributions since they take a lot of space
-  const toBeSquashed = {}
+  const toBeSquashed: Record<
+    string,
+    IMemberEnrichmentDataNormalized | IMemberEnrichmentDataNormalized[]
+  > = {}
 
   let hasContributions = false
 
@@ -47,10 +63,9 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
   for (const source of args.sources) {
     const cache = caches.find((c) => c.source === source)
     if (cache && cache.data) {
-      const normalized = (await normalizeEnrichmentData(
-        source,
-        cache.data,
-      )) as IMemberEnrichmentDataNormalized
+      const normalized = (await normalizeEnrichmentData(source, cache.data)) as
+        | IMemberEnrichmentDataNormalized
+        | IMemberEnrichmentDataNormalized[]
 
       if (Array.isArray(normalized)) {
         for (const n of normalized) {
@@ -65,17 +80,89 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
             delete n.reach
           }
         }
-      }
+      } else {
+        if (normalized.contributions) {
+          delete normalized.contributions
+        }
 
-      if (normalized.contributions) {
-        delete normalized.contributions
-      }
-
-      if (normalized.reach) {
-        delete normalized.reach
+        if (normalized.reach) {
+          delete normalized.reach
+        }
       }
 
       toBeSquashed[source] = normalized
+    }
+  }
+
+  let existingMemberData = null
+
+  const arraySources = Object.keys(toBeSquashed).filter((source) =>
+    Array.isArray(toBeSquashed[source]),
+  )
+
+  if (arraySources.length > 0) {
+    existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
+
+    const orderedArraySources = [
+      ...arraySources.filter((source) => source === MemberEnrichmentSource.CRUSTDATA),
+      ...arraySources.filter((source) => source === MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER),
+      ...arraySources.filter(
+        (source) =>
+          source !== MemberEnrichmentSource.CRUSTDATA &&
+          source !== MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER,
+      ),
+    ]
+
+    for (const source of orderedArraySources) {
+      const normalized = toBeSquashed[source]
+      if (!Array.isArray(normalized)) {
+        continue
+      }
+
+      const categorizationResult = await findWhichLinkedinProfileToUseAmongScraperResult(
+        args.memberId,
+        existingMemberData,
+        normalized,
+      )
+
+      if (categorizationResult.selected) {
+        toBeSquashed[source] = categorizationResult.selected
+      } else {
+        delete toBeSquashed[source]
+      }
+
+      // check if there are any discarded profiles
+      if (categorizationResult.discarded.length > 0) {
+        for (const discardedProfile of categorizationResult.discarded) {
+          const discardedLinkedinIdentity = discardedProfile.identities?.find(
+            (i) => i.platform === PlatformType.LINKEDIN,
+          )
+
+          // Skip if no LinkedIn identity found
+          if (!discardedLinkedinIdentity) {
+            continue
+          }
+
+          // remove the root source where the discarded linkedin profile is coming from
+          for (const otherSource of Object.keys(toBeSquashed)) {
+            const profile = toBeSquashed[otherSource]
+            if (Array.isArray(profile)) {
+              continue
+            }
+
+            if (
+              (profile.identities || []).some(
+                (i) =>
+                  i.value.trim().toLowerCase() ===
+                    discardedLinkedinIdentity.value.trim().toLowerCase() &&
+                  i.platform === PlatformType.LINKEDIN,
+              )
+            ) {
+              delete toBeSquashed[otherSource]
+            }
+          }
+        }
+      }
     }
   }
 
@@ -85,13 +172,13 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
   // are still useful for aggregate consumers, where coverage matters more than certainty.
   if (sourceKeys.length === 1) {
     const source = sourceKeys[0]
-    const normalized = toBeSquashed[source]
+    const normalized = toBeSquashed[source] as IMemberEnrichmentDataNormalized
 
-    if (!Array.isArray(normalized) && normalized.attributes) {
+    if (normalized.attributes) {
       const attributes = {}
 
       for (const attributeName of SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES) {
-        const value = normalized.attributes[attributeName]?.[`enrichment-${source}`]
+        const value = getEnrichmentAttributeValue(normalized.attributes, attributeName)
         if (value) {
           attributes[attributeName] = {
             enrichment: await cleanAttributeValue(value),
@@ -100,7 +187,10 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
       }
 
       if (Object.keys(attributes).length > 0) {
-        const existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
+        if (!existingMemberData) {
+          existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
+        }
+
         return updateMemberUsingSquashedPayload(
           args.memberId,
           existingMemberData,
@@ -118,94 +208,16 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
   }
 
   if (sourceKeys.length > 1 && args.activityCount > 100) {
-    const existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
-
-    let progaiLinkedinScraperProfileSelected: IMemberEnrichmentDataNormalized = null
-    let crustDataProfileSelected: IMemberEnrichmentDataNormalized = null
-
-    if (toBeSquashed[MemberEnrichmentSource.CRUSTDATA]) {
-      const categorizationResult = await findWhichLinkedinProfileToUseAmongScraperResult(
-        args.memberId,
-        existingMemberData,
-        toBeSquashed[MemberEnrichmentSource.CRUSTDATA],
-      )
-
-      crustDataProfileSelected = categorizationResult.selected
-
-      if (crustDataProfileSelected) {
-        toBeSquashed[MemberEnrichmentSource.CRUSTDATA] = crustDataProfileSelected
-      }
-
-      // check if there are any discarded profiles
-      if (categorizationResult.discarded.length > 0) {
-        for (const discardedProfile of categorizationResult.discarded) {
-          const discardedLinkedinIdentity = discardedProfile.identities.find(
-            (i) => i.platform === PlatformType.LINKEDIN,
-          )
-
-          // Skip if no LinkedIn identity found
-          if (!discardedLinkedinIdentity) {
-            continue
-          }
-
-          // remove the root source where the discarded linkedin profile is coming from
-          for (const source of Object.keys(toBeSquashed)) {
-            if (
-              (toBeSquashed[source].identities || []).some(
-                (i) =>
-                  i.value.trim().toLowerCase() ===
-                    discardedLinkedinIdentity.value.trim().toLowerCase() &&
-                  i.platform === PlatformType.LINKEDIN,
-              )
-            ) {
-              delete toBeSquashed[source]
-            }
-          }
-        }
-      }
+    if (!existingMemberData) {
+      existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
     }
 
-    if (toBeSquashed[MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER]) {
-      const categorizationResult = await findWhichLinkedinProfileToUseAmongScraperResult(
-        args.memberId,
-        existingMemberData,
-        toBeSquashed[MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER],
-      )
-
-      progaiLinkedinScraperProfileSelected = categorizationResult.selected
-
-      if (progaiLinkedinScraperProfileSelected) {
-        toBeSquashed[MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER] =
-          progaiLinkedinScraperProfileSelected
-      }
-
-      if (categorizationResult.discarded.length > 0) {
-        for (const discardedProfile of categorizationResult.discarded) {
-          const discardedLinkedinIdentity = discardedProfile.identities.find(
-            (i) => i.platform === PlatformType.LINKEDIN,
-          )
-
-          // Skip if no LinkedIn identity found
-          if (!discardedLinkedinIdentity) {
-            continue
-          }
-
-          // remove the root source where the discarded linkedin profile is coming from
-          for (const source of Object.keys(toBeSquashed)) {
-            if (
-              (toBeSquashed[source].identities || []).some(
-                (i) =>
-                  i.value.trim().toLowerCase() ===
-                    discardedLinkedinIdentity.value.trim().toLowerCase() &&
-                  i.platform === PlatformType.LINKEDIN,
-              )
-            ) {
-              delete toBeSquashed[source]
-            }
-          }
-        }
-      }
-    }
+    const crustDataProfileSelected = toBeSquashed[
+      MemberEnrichmentSource.CRUSTDATA
+    ] as IMemberEnrichmentDataNormalized
+    const progaiLinkedinScraperProfileSelected = toBeSquashed[
+      MemberEnrichmentSource.PROGAI_LINKEDIN_SCRAPER
+    ] as IMemberEnrichmentDataNormalized
 
     // start squashing the data
     const squashedPayload: IMemberEnrichmentDataNormalized = {
@@ -217,8 +229,9 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
 
     // 1) squash identities
     for (const source of Object.keys(toBeSquashed)) {
-      if (toBeSquashed[source].identities) {
-        for (const identity of toBeSquashed[source].identities) {
+      const profile = toBeSquashed[source] as IMemberEnrichmentDataNormalized
+      if (profile.identities) {
+        for (const identity of profile.identities) {
           const sameIdentity = (i: { platform: string; type: string; value: string }) =>
             i.platform === identity.platform &&
             i.type === identity.type &&
@@ -240,23 +253,21 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
 
     // 2) squash attributes
     for (const source of Object.keys(toBeSquashed)) {
-      if (toBeSquashed[source].attributes) {
-        for (const attribute of Object.keys(toBeSquashed[source].attributes)) {
-          if (toBeSquashed[source].attributes[attribute][`enrichment-${source}`]) {
+      const profile = toBeSquashed[source] as IMemberEnrichmentDataNormalized
+      if (profile.attributes) {
+        for (const attribute of Object.keys(profile.attributes)) {
+          const value = getEnrichmentAttributeValue(profile.attributes, attribute)
+          if (value) {
             if (attributeCountMap[attribute]) {
               attributeCountMap[attribute] = attributeCountMap[attribute] + 1
               delete attributesSquashed[attribute]
-              attributeValues[attribute].push(
-                toBeSquashed[source].attributes[attribute][`enrichment-${source}`],
-              )
+              attributeValues[attribute].push(value)
             } else {
               attributeCountMap[attribute] = 1
               attributesSquashed[attribute] = {
-                enrichment: toBeSquashed[source].attributes[attribute][`enrichment-${source}`],
+                enrichment: value,
               }
-              attributeValues[attribute] = [
-                toBeSquashed[source].attributes[attribute][`enrichment-${source}`],
-              ]
+              attributeValues[attribute] = [value]
             }
           }
         }
@@ -302,11 +313,9 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
       // check if there are multiple work experiences from different sources
       const workExperienceDataInDifferentSources = []
       for (const source of Object.keys(toBeSquashed)) {
-        if (
-          toBeSquashed[source].memberOrganizations &&
-          toBeSquashed[source].memberOrganizations.length > 0
-        ) {
-          workExperienceDataInDifferentSources.push(toBeSquashed[source].memberOrganizations)
+        const profile = toBeSquashed[source] as IMemberEnrichmentDataNormalized
+        if (profile.memberOrganizations && profile.memberOrganizations.length > 0) {
+          workExperienceDataInDifferentSources.push(profile.memberOrganizations)
         }
       }
 
@@ -347,7 +356,7 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
       args.memberId,
       existingMemberData,
       squashedPayload,
-      progaiLinkedinScraperProfileSelected && hasContributions,
+      !!progaiLinkedinScraperProfileSelected && hasContributions,
       !!crustDataProfileSelected,
     )
 

--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -39,7 +39,7 @@ const { squashMultipleValueAttributesWithLLM, squashWorkExperiencesWithLLM } = p
 function getEnrichmentAttributeValue(
   attributes: IMemberEnrichmentDataNormalized['attributes'],
   attributeName: string,
-): unknown {
+) {
   const values = attributes?.[attributeName]
   if (!values) {
     return undefined

--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -100,7 +100,11 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
     Array.isArray(toBeSquashed[source]),
   )
 
-  if (arraySources.length > 0) {
+  // Only resolve arrays when an apply path can run afterward.
+  if (
+    arraySources.length > 0 &&
+    (Object.keys(toBeSquashed).length === 1 || args.activityCount > 100)
+  ) {
     existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
 
     const orderedArraySources = [

--- a/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
+++ b/services/apps/members_enrichment_worker/src/workflows/processMemberSources.ts
@@ -4,6 +4,7 @@ import { MemberEnrichmentSource, PlatformType } from '@crowd/types'
 
 import * as activities from '../activities'
 import { IMemberEnrichmentDataNormalized, IProcessMemberSourcesArgs } from '../types'
+import { SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES } from '../utils/config'
 
 const {
   findMemberEnrichmentCache,
@@ -78,7 +79,45 @@ export async function processMemberSources(args: IProcessMemberSourcesArgs): Pro
     }
   }
 
-  if (Object.keys(toBeSquashed).length > 1) {
+  const sourceKeys = Object.keys(toBeSquashed)
+
+  // A single source isn't reliable enough for a full profile update, but some attributes
+  // are still useful for aggregate consumers, where coverage matters more than certainty.
+  if (sourceKeys.length === 1) {
+    const source = sourceKeys[0]
+    const normalized = toBeSquashed[source]
+
+    if (!Array.isArray(normalized) && normalized.attributes) {
+      const attributes = {}
+
+      for (const attributeName of SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES) {
+        const value = normalized.attributes[attributeName]?.[`enrichment-${source}`]
+        if (value) {
+          attributes[attributeName] = {
+            enrichment: await cleanAttributeValue(value),
+          }
+        }
+      }
+
+      if (Object.keys(attributes).length > 0) {
+        const existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
+        return updateMemberUsingSquashedPayload(
+          args.memberId,
+          existingMemberData,
+          {
+            identities: [],
+            attributes,
+            memberOrganizations: [],
+            reach: {},
+          },
+          false,
+          false,
+        )
+      }
+    }
+  }
+
+  if (sourceKeys.length > 1 && args.activityCount > 100) {
     const existingMemberData = await fetchMemberDataForLLMSquashing(args.memberId)
 
     let progaiLinkedinScraperProfileSelected: IMemberEnrichmentDataNormalized = null


### PR DESCRIPTION
## Summary
Single-source enrichment can now apply a small allowlisted attribute set (location, country today) so aggregate downstream consumers get better coverage without relaxing the multi-source quality bar for a full profile update.

`processMemberSources` was also refactored so array-shaped sources (e.g. LinkedIn scrapers) are resolved the same way regardless of apply mode — pick one profile first, then apply.

## Structure
Mental model after this change:

```
normalize caches
  → resolve arrays to a single profile (shared)
  → apply by post-resolve source count
       1 source  → allowlisted attributes only
       2+ sources & activity > 100 → full squash
       otherwise → touch lastTriedAt
```

1. **Normalize** — load enrichment caches into `toBeSquashed` (object or array per source).
2. **Resolve** — any array-shaped source goes through the existing profile-selection activity (LLM when needed). Selected profile replaces the array; no selection drops the source; discarded LinkedIn identities still cascade-remove matching sources. Order preserved: Crustdata → ProgAI LinkedIn scraper → other arrays.
3. **Apply** — decided from **what remains after resolve**:
   - **1 source** → write only `SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES`
   - **2+ sources & activity > 100** → existing full squash (identities, attributes, orgs, reach)
4. **Fallback** — touch `lastTriedAt` when neither apply path runs.

Attribute reads use any `enrichment-*` key on the attribute (not hard-coded to `enrichment-${source}`), so wrapped normalizers (e.g. scraper → ProgAI keys) still work.

## Changes
- Add `SINGLE_SOURCE_ENRICHMENT_ATTRIBUTES` and pass `activityCount` into `processMemberSources`
- Always call `processMemberSources` on enrichment cache changes; move the activity gate into the multi-source full-squash path
- Shared array→profile resolve before apply (removes duplicated Crustdata / ProgAI scraper blocks)
- Single-source path applies allowlisted attributes after resolve
- Multi-source squash uses the same enrichment-attribute lookup helper