### PR TITLE
fix: scope leaderboards snapshot filter per type (CM-XXXX)

### DIFF
--- a/services/libs/tinybird/pipes/leaderboards.pipe
+++ b/services/libs/tinybird/pipes/leaderboards.pipe
@@ -1,48 +1,57 @@
 DESCRIPTION >
     Main leaderboard query endpoint that retrieves leaderboard data from the consolidated datasource.
     Supports filtering by project slug, leaderboard type, and search term. Includes pagination support.
-    Automatically filters to the latest snapshotId for fresh data.
+    Automatically filters to the latest snapshotId per leaderboardType for fresh data.
 
 NODE leaderboards_list
 DESCRIPTION >
     Queries the unified leaderboards datasource with optional filtering and pagination.
-    Always filters by the latest snapshotId to return current data.
+    Always filters to each leaderboardType's own latest snapshotId, since the 14 copy pipes
+    that populate this table run on a staggered daily schedule (not all at once) — filtering
+    against a single table-wide max(snapshotId) would hide every type whose pipe hasn't run
+    yet today behind whichever type's pipe ran first.
 
 SQL >
     %
     SELECT
-        rank,
-        id,
-        segmentId,
-        name,
-        slug,
-        logoUrl,
-        leaderboardType,
-        value,
-        previousPeriodValue,
-        collectionsSlugs,
-        isLF,
-        githubHandleArray,
-        status,
-        totalCount
-    FROM leaderboards_copy_ds
+        l.rank AS rank,
+        l.id AS id,
+        l.segmentId AS segmentId,
+        l.name AS name,
+        l.slug AS slug,
+        l.logoUrl AS logoUrl,
+        l.leaderboardType AS leaderboardType,
+        l.value AS value,
+        l.previousPeriodValue AS previousPeriodValue,
+        l.collectionsSlugs AS collectionsSlugs,
+        l.isLF AS isLF,
+        l.githubHandleArray AS githubHandleArray,
+        l.status AS status,
+        l.totalCount AS totalCount
+    FROM leaderboards_copy_ds AS l
+    INNER JOIN (
+        SELECT leaderboardType, max(snapshotId) AS maxSnapshotId
+        FROM leaderboards_copy_ds
+        GROUP BY leaderboardType
+    ) AS latest
+    ON l.leaderboardType = latest.leaderboardType AND l.snapshotId = latest.maxSnapshotId
     WHERE
-        snapshotId = (SELECT max(snapshotId) FROM leaderboards_copy_ds)
+        1
         {% if defined(slug) %}
-            AND slug = {{ String(slug, description="Project slug", required=False) }}
+            AND l.slug = {{ String(slug, description="Project slug", required=False) }}
         {% end %}
         {% if defined(leaderboardType) %}
-            AND leaderboardType
+            AND l.leaderboardType
             = {{ String(leaderboardType, description="Leaderboard type", required=False) }}
         {% end %}
         {% if defined(collectionSlug) %}
             AND has(
-                collectionsSlugs,
+                l.collectionsSlugs,
                 {{ String(collectionSlug, description="Filter collection by slug", required=False) }}
             )
         {% end %}
         {% if defined(search) %}
-            AND name
+            AND l.name
             ilike '%'
             || {{
                 String(
@@ -54,7 +63,7 @@ SQL >
             || '%'
         {% end %}
         {% if defined(maxRank) %}
-            AND rank
+            AND l.rank
             <= {{
                 Int32(
                     maxRank,
@@ -63,7 +72,7 @@ SQL >
                 )
             }}
         {% end %}
-    ORDER BY rank ASC
+    ORDER BY l.rank ASC
     {% if not defined(maxRank) %}
         LIMIT {{ Int32(pageSize, 20) }} OFFSET {{ Int32(page, 0) * Int32(pageSize, 20) }}
     {% end %}

--- a/services/libs/tinybird/pipes/leaderboards.pipe
+++ b/services/libs/tinybird/pipes/leaderboards.pipe
@@ -29,12 +29,14 @@ SQL >
         l.status AS status,
         l.totalCount AS totalCount
     FROM leaderboards_copy_ds AS l
-    INNER JOIN (
-        SELECT leaderboardType, max(snapshotId) AS maxSnapshotId
-        FROM leaderboards_copy_ds
-        GROUP BY leaderboardType
-    ) AS latest
-    ON l.leaderboardType = latest.leaderboardType AND l.snapshotId = latest.maxSnapshotId
+    INNER JOIN
+        (
+            SELECT leaderboardType, max(snapshotId) AS maxSnapshotId
+            FROM leaderboards_copy_ds
+            GROUP BY leaderboardType
+        ) AS latest
+        ON l.leaderboardType = latest.leaderboardType
+        AND l.snapshotId = latest.maxSnapshotId
     WHERE
         1
         {% if defined(slug) %}


### PR DESCRIPTION
## Summary
- `leaderboards.pipe` filtered to `snapshotId = (SELECT max(snapshotId) FROM leaderboards_copy_ds)` — a single table-wide latest snapshot, not one per `leaderboardType`
- The 14 copy pipes that populate `leaderboards_copy_ds` run on a staggered schedule across ~1:00–3:10 AM UTC (see #4420), each writing a daily snapshot truncated to midnight. The first pipes to land each day push the table-wide max forward immediately, while types that haven't run yet that day are still on yesterday's snapshotId — the strict equality then excludes them entirely
- Confirmed live: at `2026-08-04 01:41 UTC`, global `max(snapshotId)` was already `2026-08-04`, but `contributors` was still on `2026-08-03` — its rows were excluded from every `leaderboardType=contributors` query, so `insights.linuxfoundation.org/leaderboards` rendered empty for that type (and any other type whose pipe hadn't run yet)
- Not the same bug as #4420: that fixed pipes getting stuck permanently `queued` on the copy-job quota (confirmed resolved — all pipes have landed `ok` since Aug 2). This is a separate freshness-filter bug that recurs every day regardless of quota contention
- Fix: join against a per-`leaderboardType` max-snapshot subquery instead of a single global scalar (ClickHouse doesn't support correlated subqueries referencing the outer row, so a `GROUP BY` + `INNER JOIN` is used instead of a per-row correlated subquery)
- Verified the new join query against production data returns correct `contributors` rows at their own latest snapshot

## Test plan
- [x] Ran both the old and new SQL directly against production `leaderboards_copy_ds` via the Tinybird SQL API — old query returns 0 rows for `contributors` right now, new query returns the expected top-ranked rows
- [ ] After deploy, confirm `leaderboards?leaderboardType=contributors` (and other types) return non-empty results throughout the day, including during the 1:00–3:10 AM UTC window while pipes are still staggering