### PR TITLE
feat: add maven ecosystem to blast (CM-1358)

### DIFF
--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -11,8 +11,8 @@ info:
 
     Packages, Advisories and Contacts endpoints are implemented. Blast Radius
     submit (2a) and poll (2b) are both implemented, backed by a 4-stage
-    Temporal pipeline (intel, dependents, reachability, report) for npm and go
-    packages; other ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. The
+    Temporal pipeline (intel, dependents, reachability, report) for npm, go, and
+    maven packages; other ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. The
     7-day result cache is specced separately and not yet built.
 
 
@@ -61,7 +61,7 @@ tags:
     description: >
       Advisory reachability analysis — submit (2a) and poll (2b) are both
       implemented, each with a bulk counterpart. Submitting kicks off a
-      Temporal workflow that runs the npm or go reachability pipeline (other
+      Temporal workflow that runs the npm, go, or maven reachability pipeline (other
       ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED); poll returns job
       status and, once done, results. Bulk submit (jobs:batch) is capped at
       20 jobs per request (10 recommended as the default batch size) — each
@@ -411,9 +411,9 @@ components:
           example: GHSA-jf85-cpcp-j695
         ecosystem:
           type: string
-          enum: [npm, go]
+          enum: [npm, go, maven]
           description: >
-            Required. The reachability pipeline supports npm and go today —
+            Required. The reachability pipeline supports npm, go, and maven today —
             any other value, or a missing ecosystem, is rejected with a 400.
           example: npm
         package:
@@ -448,7 +448,7 @@ components:
           description: Echoes the request's package. Null when the request omitted it.
         ecosystem:
           type: string
-          enum: [npm, go]
+          enum: [npm, go, maven]
           description: Echoes the request's ecosystem. Always present — the request requires it.
         status:
           type: string
@@ -609,7 +609,7 @@ components:
           nullable: true
         ecosystem:
           type: string
-          enum: [npm, go]
+          enum: [npm, go, maven]
         submittedAt:
           type: string
           nullable: true
@@ -1240,7 +1240,7 @@ paths:
         Always exactly one job per request — no bulk submit. Omit package for
         an advisory-wide analysis; provide it to narrow to a single package.
         Starts a Temporal workflow running the 4-stage reachability pipeline
-        (intel, dependents, reachability, report) for npm or go; other
+        (intel, dependents, reachability, report) for npm, go, or maven; other
         ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. Poll status/results
         via GET /jobs/{analysisId}.
 
@@ -1268,7 +1268,7 @@ paths:
         '400':
           description: >
             Validation error (missing/empty advisoryId), or an unsupported
-            ecosystem — only npm and go are supported today, so any other
+            ecosystem — only npm, go, and maven are supported today, so any other
             value (including a missing ecosystem) is rejected before a
             workflow is started.
           content:

--- a/backend/src/api/public/v1/packages/blastRadius.ts
+++ b/backend/src/api/public/v1/packages/blastRadius.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = ['npm', 'go'] as const
+export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = ['npm', 'go', 'maven'] as const
 
 // Always exactly one job per request — advisory-wide (package omitted) or narrowed
 // to a single package. package accepts either a full purl or a bare package name,

--- a/backend/src/api/public/v1/packages/blastRadiusAnalysis.ts
+++ b/backend/src/api/public/v1/packages/blastRadiusAnalysis.ts
@@ -48,11 +48,25 @@ function toResultConfidence(confidence: number): BlastRadiusResultConfidence {
   return 'low'
 }
 
+// d.name shape varies by ecosystem: npm/go store a plain name, maven stores
+// "groupId:artifactId" — split on the first colon only, artifactId may itself contain one.
+//
 // Scoped npm names (@scope/name) need their leading @ percent-encoded to %40 —
 // matching both purl.ts's normalizePurl and the contract's own example response
 // bodies (e.g. pkg:npm/%40angular/core in openapi.yaml).
-function toPurl(name: string): string {
-  return `pkg:npm/${name.replace(/^@/, '%40')}`
+function toPurl(ecosystem: BlastRadiusJobEcosystem, name: string): string {
+  switch (ecosystem) {
+    case 'maven': {
+      const colon = name.indexOf(':')
+      if (colon === -1) return `pkg:maven/${name}`
+      return `pkg:maven/${name.slice(0, colon)}/${name.slice(colon + 1)}`
+    }
+    case 'go':
+      return `pkg:golang/${name}`
+    case 'npm':
+    default:
+      return `pkg:npm/${name.replace(/^@/, '%40')}`
+  }
 }
 
 function flattenEvidence(evidence: Record<string, unknown>[] | null): string | null {
@@ -81,10 +95,13 @@ function toVerdict(reachableVerdict: string): BlastRadiusVerdict {
   return 'unclear'
 }
 
-function toResultItem(row: VerdictResultRow): BlastRadiusResultItem {
+function toResultItem(
+  ecosystem: BlastRadiusJobEcosystem,
+  row: VerdictResultRow,
+): BlastRadiusResultItem {
   const verdict = toVerdict(row.reachable_verdict)
   return {
-    dependent: toPurl(row.name),
+    dependent: toPurl(ecosystem, row.name),
     affected: verdict === 'affected',
     verdict,
     confidence: toResultConfidence(row.confidence),
@@ -128,15 +145,16 @@ export function toBlastRadiusAnalysis(
 ): BlastRadiusAnalysis {
   const status = analysis.status as BlastRadiusJobStatus
   const done = status === 'done'
+  const ecosystem = analysis.ecosystem as BlastRadiusJobEcosystem
 
-  const results = done ? verdictRows.map(toResultItem) : null
+  const results = done ? verdictRows.map((row) => toResultItem(ecosystem, row)) : null
 
   return {
     analysisId: analysis.id,
     status,
     advisoryId: analysis.advisory_osv_id,
     package: analysis.package_name,
-    ecosystem: analysis.ecosystem as BlastRadiusJobEcosystem,
+    ecosystem,
     submittedAt: analysis.started_at,
     completedAt: analysis.completed_at,
     errorMessage: analysis.error,

--- a/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.test.ts
+++ b/backend/src/api/public/v1/packages/submitBlastRadiusJobBatch.test.ts
@@ -94,7 +94,7 @@ describe('submitBlastRadiusJobBatch', () => {
     const { req, res, start } = mockReqRes({
       jobs: [
         { advisoryId: 'GHSA-jf85-cpcp-j695', ecosystem: 'npm' },
-        { advisoryId: 'GHSA-652q-gvq3-74qv', ecosystem: 'maven' },
+        { advisoryId: 'GHSA-652q-gvq3-74qv', ecosystem: 'pypi' },
       ],
     })
 

--- a/services/apps/packages_worker/src/blast-radius/agent/__tests__/mavenPrompts.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/__tests__/mavenPrompts.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { MAVEN_INTEL_SCHEMA } from '../mavenPrompts'
+
+describe('MAVEN_INTEL_SCHEMA', () => {
+  it('keeps import_signatures.properties keys in sync with its required list', () => {
+    const importSignatures = MAVEN_INTEL_SCHEMA.properties.import_signatures
+    const propertyKeys = Object.keys(importSignatures.properties).sort()
+    const requiredKeys = [...importSignatures.required].sort()
+    expect(propertyKeys).toEqual(requiredKeys)
+  })
+
+  it('keeps the top-level schema properties in sync with its required list', () => {
+    const propertyKeys = Object.keys(MAVEN_INTEL_SCHEMA.properties).sort()
+    const requiredKeys = [...MAVEN_INTEL_SCHEMA.required].sort()
+    expect(propertyKeys).toEqual(requiredKeys)
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/agent/mavenPrompts.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/mavenPrompts.ts
@@ -1,0 +1,127 @@
+// Parallels prompts.ts (npm) / goPrompts.ts (go) — shared shape lives in promptKit.ts;
+// only Java-specific keys/enum and system-prompt prose live here.
+import {
+  buildIntelPrompt,
+  buildIntelSchema,
+  buildReachabilitySymbolsBlock,
+  buildVerdictSchema,
+} from './promptKit'
+import { SymbolSpec } from './prompts'
+
+// ---------- STAGE 1: INTEL ----------
+
+const IMPORT_SIGNATURE_KEYS = [
+  'import_statement',
+  'static_import',
+  'wildcard_import',
+  'fqcn_reference',
+]
+
+export const MAVEN_INTEL_SCHEMA = buildIntelSchema(IMPORT_SIGNATURE_KEYS)
+
+export const MAVEN_INTEL_SYSTEM_PROMPT = `You are a vulnerability analyst. Your working directory contains the FULL SOURCE (decompiled
+from the sources jar) of the vulnerable version of a Maven artifact (Java/Kotlin). You are
+given the security advisory and the patch (diff) that fixed the vulnerability.
+
+Your job is to determine, precisely, WHAT is vulnerable — so that downstream analysts can
+check whether other artifacts actually reach the vulnerable code.
+
+Rules:
+- Identify the exact vulnerable class(es)/method(s)/field(s) from the patch and the source.
+  Be minimal and precise: do NOT include similar-but-unaffected symbols. If the patch only
+  touches a private/package-private helper, trace which PUBLIC (or otherwise externally
+  visible) symbols route through it and list those as the reachable surface (note the
+  helper in \`notes\`).
+- Read the source to verify visibility — only \`public\` (and \`protected\` on a non-final
+  class) members are reachable from outside the defining package; note the exact fully
+  qualified class name (FQCN, e.g. \`com.example.pkg.Foo\`) each symbol lives in.
+- Build \`import_signatures\`: concrete code patterns a Java/Kotlin dependent would contain
+  if it uses the vulnerable symbol. Cover: a plain \`import com.example.pkg.Foo;\` followed
+  by \`Foo.method()\`/\`new Foo()\` usage, a static import (\`import static
+  com.example.pkg.Foo.method;\`), a wildcard import (\`import com.example.pkg.*;\`), and a
+  fully-qualified reference used inline without any import
+  (\`com.example.pkg.Foo.method()\`). These are the patterns analysts will grep for — make
+  them literal and greppable, not prose.
+- \`reachability_notes\` must state what does NOT count (e.g. sibling methods that look
+  similar but are not affected, usage confined to \`src/test/\` or example modules) and any
+  conditions required for exploitability.
+- Set \`confidence\` for your identification: 0.9+ only if the patch unambiguously
+  identifies the symbol(s); lower if you had to infer from indirect evidence.`
+
+export const buildMavenIntelPrompt = buildIntelPrompt
+
+// ---------- STAGE 3: REACHABILITY ----------
+
+const IMPORT_STYLE_ENUM = [
+  'plain-import',
+  'static-import',
+  'wildcard-import',
+  'fqcn-reference',
+  'reexport',
+  'none',
+]
+
+export const MAVEN_VERDICT_SCHEMA = buildVerdictSchema(IMPORT_STYLE_ENUM)
+
+export function buildMavenReachabilitySystemPrompt(spec: SymbolSpec): string {
+  const { symbolsText, signatures } = buildReachabilitySymbolsBlock(spec)
+
+  return `You are a security reachability analyst. Your working directory contains the published
+source (decompiled from the sources jar) of ONE Maven artifact (the "dependent") that
+declares a dependency on \`${spec.package}\`, which has a known vulnerability (${spec.vuln_id}).
+
+## The vulnerability
+${spec.summary}
+
+Vulnerable symbol(s) in \`${spec.package}\`:
+${symbolsText}
+
+Exploit preconditions: ${spec.exploit_preconditions}
+
+Analyst notes: ${spec.reachability_notes}
+
+## Import signatures to look for
+${signatures}
+
+## Your task
+Decide whether THIS dependent's own code actually reaches the vulnerable symbol(s).
+
+Scope rules — follow strictly:
+1. Only the dependent's OWN shipped code counts. Ignore anything under \`src/test/\`, and
+   any bundled/shaded copies of third-party code. Usage of the vulnerable symbol inside
+   the dependent's other dependencies is OUT OF SCOPE (that is second-level analysis, done
+   separately).
+2. Merely declaring \`${spec.package}\` as a dependency (present in \`pom.xml\`/\`build.gradle\`)
+   is NOT enough — the vulnerable symbol itself must be reached. Uses of other classes/
+   methods from the artifact are irrelevant.
+3. Usage only in \`src/test/\` or example/sample modules that are not part of the shipped
+   runtime code → \`not_affected\` (explain in reasoning).
+4. If the dependent RE-EXPORTS the vulnerable symbol to its own consumers (a thin
+   wrapper class/method that passes arguments through, or a subclass that doesn't override
+   the vulnerable method), that DOES count as \`affected\` with \`import_style: "reexport"\` —
+   it propagates the vulnerable surface.
+5. Watch for indirect reachability inside the dependent's own code: fully-qualified
+   references without an import, static imports, wildcard imports, interface
+   implementation, and reflection-based dispatch.
+6. \`import_style\` describes how the VULNERABLE SYMBOL is reached, not how the artifact is
+   imported: report \`none\` whenever the vulnerable symbol itself is not reached, even if
+   the artifact is imported for other functionality.
+
+Method: grep for the import signatures (and the bare symbol names) across the source,
+open every hit, and trace whether the symbol is actually invoked. Check \`pom.xml\`/
+\`build.gradle\` to confirm the declared dependency and its version. Exclude \`src/test/\`
+and example/sample modules from consideration.
+
+## Confidence calibration
+- 0.8–1.0: direct evidence — you found (or ruled out) the import AND the call site
+  explicitly; source was readable.
+- 0.4–0.8: symbol is imported but the call path is ambiguous (interface dispatch,
+  conditional use, generated/bytecode-only code).
+- <0.4 and/or \`unclear\`: source is generated/absent, or indirection you could not resolve.
+
+Report evidence as exact file paths, line numbers, and short verbatim snippets.`
+}
+
+export const MAVEN_REACHABILITY_PROMPT =
+  'Analyze this artifact per your instructions and produce the structured verdict. ' +
+  'Start by listing the package structure and grepping for the import signatures.'

--- a/services/apps/packages_worker/src/blast-radius/clients/__tests__/mavenSourcesJar.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/__tests__/mavenSourcesJar.test.ts
@@ -1,0 +1,95 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import type { ReadableStreamDefaultController as WebReadableStreamDefaultController } from 'stream/web'
+import { ReadableStream } from 'stream/web'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { downloadAndExtractMavenSources } from '../mavenSourcesJar'
+
+import { buildStoredZip } from './zipFixture'
+
+const GROUP_ID = 'com.example'
+const ARTIFACT_ID = 'foo'
+const VERSION = '1.2.3'
+
+function fakeJarResponse(status: number, buf?: Buffer): Response {
+  if (!buf) {
+    return { status, ok: false, statusText: 'Not Found', body: null } as unknown as Response
+  }
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller: WebReadableStreamDefaultController<Uint8Array>) {
+      controller.enqueue(new Uint8Array(buf))
+      controller.close()
+    },
+  })
+  return {
+    status,
+    ok: true,
+    body: stream,
+  } as unknown as Response
+}
+
+let destDir: string
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  if (destDir && existsSync(destDir)) rmSync(destDir, { recursive: true, force: true })
+})
+
+describe('downloadAndExtractMavenSources', () => {
+  it('extracts file contents from the sources jar', async () => {
+    const zip = buildStoredZip([
+      { path: 'com/example/Foo.java', content: 'package com.example;\n' },
+      { path: 'com/example/util/Bar.java', content: 'package com.example.util;\n' },
+    ])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeJarResponse(200, zip)))
+
+    destDir = mkdtempSync(path.join(os.tmpdir(), 'mavensourcesjar-test-'))
+    await downloadAndExtractMavenSources(GROUP_ID, ARTIFACT_ID, VERSION, destDir)
+
+    expect(readFileSync(path.join(destDir, 'com/example/Foo.java'), 'utf8')).toBe(
+      'package com.example;\n',
+    )
+    expect(readFileSync(path.join(destDir, 'com/example/util/Bar.java'), 'utf8')).toBe(
+      'package com.example.util;\n',
+    )
+  })
+
+  it('rejects entries whose relative path escapes the destination directory', async () => {
+    const zip = buildStoredZip([{ path: '../../evil.txt', content: 'pwned' }])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeJarResponse(200, zip)))
+
+    destDir = mkdtempSync(path.join(os.tmpdir(), 'mavensourcesjar-test-'))
+    await expect(
+      downloadAndExtractMavenSources(GROUP_ID, ARTIFACT_ID, VERSION, destDir),
+    ).rejects.toThrow(/escapes destination dir/)
+  })
+
+  it('rejects jars exceeding the extracted file-count cap', async () => {
+    const entries = Array.from({ length: 20_001 }, (_, i) => ({
+      path: `file${i}.txt`,
+      content: 'x',
+    }))
+    const zip = buildStoredZip(entries)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeJarResponse(200, zip)))
+
+    destDir = mkdtempSync(path.join(os.tmpdir(), 'mavensourcesjar-test-'))
+    await expect(
+      downloadAndExtractMavenSources(GROUP_ID, ARTIFACT_ID, VERSION, destDir),
+    ).rejects.toThrow(/size\/file limits/)
+  })
+
+  it('throws MavenSourcesNotFoundError on a 404 response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeJarResponse(404)))
+
+    destDir = mkdtempSync(path.join(os.tmpdir(), 'mavensourcesjar-test-'))
+    await expect(
+      downloadAndExtractMavenSources(GROUP_ID, ARTIFACT_ID, VERSION, destDir),
+    ).rejects.toThrow(/No sources jar published/)
+  })
+
+  // The download-size cap itself (500 MiB) is unit-tested directly against
+  // createDownloadLimiter in downloadLimits.test.ts with a KiB-scale fixture —
+  // building a fixture that large here would burn CI memory/time for no extra coverage.
+})

--- a/services/apps/packages_worker/src/blast-radius/clients/mavenSourcesJar.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/mavenSourcesJar.ts
@@ -1,0 +1,112 @@
+import { createWriteStream, mkdirSync, rmSync } from 'fs'
+import * as path from 'path'
+import { Readable } from 'stream'
+import { pipeline } from 'stream/promises'
+import type { ReadableStream as NodeWebReadableStream } from 'stream/web'
+import unzipper from 'unzipper'
+
+import { resolveRegistryBaseUrl } from '../../maven/registry'
+
+import {
+  FETCH_TIMEOUT_MS,
+  MAX_EXTRACTED_BYTES,
+  MAX_EXTRACTED_FILES,
+  createDownloadLimiter,
+} from './downloadLimits'
+
+// Thrown when the artifact has no `-sources.jar` published (404) — a common, expected
+// case (many artifacts only ship a binary jar), distinct from a transient fetch failure.
+export class MavenSourcesNotFoundError extends Error {
+  constructor(url: string) {
+    super(`No sources jar published at ${url}`)
+    this.name = 'MavenSourcesNotFoundError'
+  }
+}
+
+// Jars are zips — same central-directory-at-the-end constraint as Go module zips means
+// we can't stream-extract incrementally either; download to a scratch file first.
+export async function downloadAndExtractMavenSources(
+  groupId: string,
+  artifactId: string,
+  version: string,
+  destDir: string,
+): Promise<void> {
+  mkdirSync(destDir, { recursive: true })
+  const jarPath = `${destDir}.jar`
+  const groupPath = groupId.replace(/\./g, '/')
+  const url = `${resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}-sources.jar`
+
+  const controller = new AbortController()
+  const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    let res: Response
+    try {
+      res = await fetch(url, { signal: controller.signal })
+    } catch (e) {
+      throw new Error(`Failed to fetch Maven sources jar: ${(e as Error).message}`)
+    }
+    if (res.status === 404) {
+      throw new MavenSourcesNotFoundError(url)
+    }
+    if (!res.ok) {
+      throw new Error(`Failed to fetch Maven sources jar: ${res.status} ${res.statusText}`)
+    }
+    if (!res.body) {
+      throw new Error('No response body from Maven sources jar fetch')
+    }
+
+    const downloadLimiter = createDownloadLimiter('Maven sources jar download exceeded size limit')
+
+    try {
+      await pipeline(
+        Readable.fromWeb(res.body as unknown as NodeWebReadableStream<Uint8Array>),
+        downloadLimiter,
+        createWriteStream(jarPath),
+      )
+
+      let directory: unzipper.CentralDirectory
+      try {
+        directory = await unzipper.Open.file(jarPath)
+      } catch (err) {
+        throw new Error(`Malformed Maven sources jar from ${url}: ${(err as Error).message}`)
+      }
+
+      const extractedByteCounter = { bytes: 0 }
+      let extractedFiles = 0
+
+      for (const entry of directory.files) {
+        if (entry.type !== 'File') continue
+        if (!entry.path) continue
+
+        // Sources jars are third-party content — guard path traversal defensively
+        // rather than trust the archive (same rationale as goModuleZip.ts).
+        const resolvedPath = path.resolve(destDir, entry.path)
+        if (resolvedPath !== destDir && !resolvedPath.startsWith(destDir + path.sep)) {
+          throw new Error(`Maven sources jar entry escapes destination dir: ${entry.path}`)
+        }
+
+        extractedFiles++
+        if (extractedFiles > MAX_EXTRACTED_FILES) {
+          throw new Error('Maven sources jar extraction exceeded size/file limits')
+        }
+
+        mkdirSync(path.dirname(resolvedPath), { recursive: true })
+
+        // Stream to disk and count actual decompressed bytes as they flow, rather than
+        // trusting entry.uncompressedSize or materializing the whole entry in memory.
+        const extractionLimiter = createDownloadLimiter(
+          'Maven sources jar extraction exceeded size/file limits',
+          MAX_EXTRACTED_BYTES,
+          extractedByteCounter,
+        )
+
+        await pipeline(entry.stream(), extractionLimiter, createWriteStream(resolvedPath))
+      }
+    } finally {
+      rmSync(jarPath, { force: true })
+    }
+  } finally {
+    clearTimeout(timeoutHandle)
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/clients/mavenSourcesJar.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/mavenSourcesJar.ts
@@ -5,7 +5,7 @@ import { pipeline } from 'stream/promises'
 import type { ReadableStream as NodeWebReadableStream } from 'stream/web'
 import unzipper from 'unzipper'
 
-import { resolveRegistryBaseUrl } from '../../maven/registry'
+import { resolveBlastRadiusMavenBaseUrl } from '../../maven/registry'
 
 import {
   FETCH_TIMEOUT_MS,
@@ -34,7 +34,7 @@ export async function downloadAndExtractMavenSources(
   mkdirSync(destDir, { recursive: true })
   const jarPath = `${destDir}.jar`
   const groupPath = groupId.replace(/\./g, '/')
-  const url = `${resolveRegistryBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}-sources.jar`
+  const url = `${resolveBlastRadiusMavenBaseUrl(groupId)}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}-sources.jar`
 
   const controller = new AbortController()
   const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)

--- a/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
+++ b/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
@@ -1,10 +1,12 @@
 import { ApplicationFailure } from '@temporalio/workflow'
 
+// Single source of truth for supported ecosystems — kept in this leaf, I/O-free file
+// (no activities/DAL imports) so the workflow bundle stays deterministic-safe.
+export const SUPPORTED_ECOSYSTEMS = ['npm', 'go', 'maven'] as const
+export type Ecosystem = (typeof SUPPORTED_ECOSYSTEMS)[number]
+
 // Pure so it's testable outside the workflow sandbox (Workflow.log/context calls
 // throw when invoked outside a running workflow — this helper makes none).
-// The reachability pipeline isn't built yet — npm is the only ecosystem that will
-// eventually get true reachability analysis, others a basic scoring result — so
-// every ecosystem fails today, npm included.
 export function buildEcosystemNotSupportedFailure(ecosystem: string | null): ApplicationFailure {
   return ApplicationFailure.nonRetryable(
     `Blast-radius analysis not supported for ecosystem "${ecosystem ?? 'unknown'}"`,

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -43,3 +43,29 @@ export function toBareGoModule(input: string): string {
 
   return name
 }
+
+// Maven has no single "bare name" — accepts either the "groupId:artifactId" coordinate
+// (OSV's package.name spelling) or a purl (pkg:maven/groupId/artifactId@version).
+export function toBareMavenCoordinate(input: string): { groupId: string; artifactId: string } {
+  let name = input.trim()
+
+  const q = name.indexOf('?')
+  const h = name.indexOf('#')
+  const cut = q === -1 ? h : h === -1 ? q : Math.min(q, h)
+  if (cut !== -1) name = name.slice(0, cut)
+
+  name = decodeURIComponent(name)
+
+  if (name.startsWith('pkg:maven/')) {
+    name = name.slice('pkg:maven/'.length)
+    name = name.replace(/@[^/@]+$/, '')
+    const slash = name.indexOf('/')
+    if (slash === -1) return { groupId: name, artifactId: '' }
+    return { groupId: name.slice(0, slash), artifactId: name.slice(slash + 1) }
+  }
+
+  name = name.replace(/@[^/@]+$/, '')
+  const colon = name.indexOf(':')
+  if (colon === -1) return { groupId: '', artifactId: name }
+  return { groupId: name.slice(0, colon), artifactId: name.slice(colon + 1) }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
@@ -7,6 +7,9 @@ import { runDependentsStageGo } from '../go/dependentsGo'
 import { runIntelStageGo } from '../go/intelGo'
 import { goReachabilityConfig } from '../go/reachabilityConfig'
 import { runIntelStage } from '../intel'
+import { runDependentsStageMaven } from '../maven/dependentsMaven'
+import { runIntelStageMaven } from '../maven/intelMaven'
+import { mavenReachabilityConfig } from '../maven/reachabilityConfig'
 import { runDependentsStageNpm } from '../npm/dependentsNpm'
 import { runIntelStageNpm } from '../npm/intelNpm'
 import { npmReachabilityConfig } from '../npm/reachabilityConfig'
@@ -18,11 +21,17 @@ vi.mock('@crowd/data-access-layer/src/packages/blastRadius', () => ({
 }))
 vi.mock('../go/intelGo', () => ({ runIntelStageGo: vi.fn().mockResolvedValue(undefined) }))
 vi.mock('../npm/intelNpm', () => ({ runIntelStageNpm: vi.fn().mockResolvedValue(undefined) }))
+vi.mock('../maven/intelMaven', () => ({
+  runIntelStageMaven: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../go/dependentsGo', () => ({
   runDependentsStageGo: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('../npm/dependentsNpm', () => ({
   runDependentsStageNpm: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../maven/dependentsMaven', () => ({
+  runDependentsStageMaven: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('../reachabilityStage', () => ({
   runReachabilityStage: vi.fn().mockResolvedValue(undefined),
@@ -37,12 +46,13 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('stage dispatchers', () => {
+describe('stage dispatchers (EcosystemConfig registry)', () => {
   it('routes intel to the Go body when ecosystem is go', async () => {
     mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'go' } as never)
     await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
     expect(runIntelStageGo).toHaveBeenCalledWith(qx, 'analysis-1', 'GHSA-xxxx', undefined)
     expect(runIntelStageNpm).not.toHaveBeenCalled()
+    expect(runIntelStageMaven).not.toHaveBeenCalled()
   })
 
   it('routes intel to the npm body when ecosystem is npm', async () => {
@@ -50,6 +60,15 @@ describe('stage dispatchers', () => {
     await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
     expect(runIntelStageNpm).toHaveBeenCalledWith(qx, 'analysis-1', 'GHSA-xxxx', undefined)
     expect(runIntelStageGo).not.toHaveBeenCalled()
+    expect(runIntelStageMaven).not.toHaveBeenCalled()
+  })
+
+  it('routes intel to the Maven body when ecosystem is maven', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'maven' } as never)
+    await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageMaven).toHaveBeenCalledWith(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageGo).not.toHaveBeenCalled()
+    expect(runIntelStageNpm).not.toHaveBeenCalled()
   })
 
   it('routes intel to the npm body when ecosystem is missing/unknown', async () => {
@@ -57,12 +76,22 @@ describe('stage dispatchers', () => {
     await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
     expect(runIntelStageNpm).toHaveBeenCalled()
     expect(runIntelStageGo).not.toHaveBeenCalled()
+    expect(runIntelStageMaven).not.toHaveBeenCalled()
   })
 
   it('routes dependents to the Go body when ecosystem is go', async () => {
     mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'go' } as never)
     await runDependentsStage(qx, 'analysis-1', undefined, undefined)
     expect(runDependentsStageGo).toHaveBeenCalled()
+    expect(runDependentsStageNpm).not.toHaveBeenCalled()
+    expect(runDependentsStageMaven).not.toHaveBeenCalled()
+  })
+
+  it('routes dependents to the Maven body when ecosystem is maven', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'maven' } as never)
+    await runDependentsStage(qx, 'analysis-1', undefined, undefined)
+    expect(runDependentsStageMaven).toHaveBeenCalled()
+    expect(runDependentsStageGo).not.toHaveBeenCalled()
     expect(runDependentsStageNpm).not.toHaveBeenCalled()
   })
 
@@ -71,6 +100,7 @@ describe('stage dispatchers', () => {
     await runDependentsStage(qx, 'analysis-1', undefined, undefined)
     expect(runDependentsStageNpm).toHaveBeenCalled()
     expect(runDependentsStageGo).not.toHaveBeenCalled()
+    expect(runDependentsStageMaven).not.toHaveBeenCalled()
   })
 
   it('routes reachability to the Go config when ecosystem is go', async () => {
@@ -80,6 +110,17 @@ describe('stage dispatchers', () => {
       qx,
       'analysis-1',
       goReachabilityConfig,
+      undefined,
+    )
+  })
+
+  it('routes reachability to the Maven config when ecosystem is maven', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'maven' } as never)
+    await runReachabilityStage(qx, 'analysis-1', undefined)
+    expect(mockRunReachabilityStageWithConfig).toHaveBeenCalledWith(
+      qx,
+      'analysis-1',
+      mavenReachabilityConfig,
       undefined,
     )
   })

--- a/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/dependents.ts
@@ -1,8 +1,7 @@
 import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
-import { runDependentsStageGo } from './go/dependentsGo'
-import { runDependentsStageNpm } from './npm/dependentsNpm'
+import { getEcosystemConfig } from './ecosystems'
 
 export async function runDependentsStage(
   qx: QueryExecutor,
@@ -11,8 +10,6 @@ export async function runDependentsStage(
   signal?: AbortSignal,
 ): Promise<void> {
   const detail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
-  if ((detail?.ecosystem ?? 'npm') === 'go') {
-    return runDependentsStageGo(qx, analysisId, onProgress, signal)
-  }
-  return runDependentsStageNpm(qx, analysisId, onProgress, signal)
+  const cfg = getEcosystemConfig(detail?.ecosystem)
+  return cfg.runDependents(qx, analysisId, onProgress, signal)
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
@@ -1,0 +1,54 @@
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { Ecosystem } from '../ecosystemSupport'
+
+import { runDependentsStageGo } from './go/dependentsGo'
+import { runIntelStageGo } from './go/intelGo'
+import { goReachabilityConfig } from './go/reachabilityConfig'
+import { runDependentsStageMaven } from './maven/dependentsMaven'
+import { runIntelStageMaven } from './maven/intelMaven'
+import { mavenReachabilityConfig } from './maven/reachabilityConfig'
+import { runDependentsStageNpm } from './npm/dependentsNpm'
+import { runIntelStageNpm } from './npm/intelNpm'
+import { npmReachabilityConfig } from './npm/reachabilityConfig'
+import { ReachabilitySourceConfig } from './reachabilityStage'
+
+// Replaces the 3 scattered `if (ecosystem === 'go')` dispatch branches. Record<Ecosystem, …>
+// enforces at compile time that every SUPPORTED_ECOSYSTEMS entry has a config.
+interface EcosystemConfig {
+  runIntel: (
+    qx: QueryExecutor,
+    analysisId: string,
+    advisoryOsvId: string,
+    onProgress?: () => void,
+  ) => Promise<void>
+  runDependents: (
+    qx: QueryExecutor,
+    analysisId: string,
+    onProgress?: () => void,
+    signal?: AbortSignal,
+  ) => Promise<void>
+  reachability: ReachabilitySourceConfig
+}
+
+const ECOSYSTEMS: Record<Ecosystem, EcosystemConfig> = {
+  npm: {
+    runIntel: runIntelStageNpm,
+    runDependents: runDependentsStageNpm,
+    reachability: npmReachabilityConfig,
+  },
+  go: {
+    runIntel: runIntelStageGo,
+    runDependents: runDependentsStageGo,
+    reachability: goReachabilityConfig,
+  },
+  maven: {
+    runIntel: runIntelStageMaven,
+    runDependents: runDependentsStageMaven,
+    reachability: mavenReachabilityConfig,
+  },
+}
+
+export function getEcosystemConfig(ecosystem: string | null | undefined): EcosystemConfig {
+  return ECOSYSTEMS[ecosystem as Ecosystem] ?? ECOSYSTEMS.npm
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/intel.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/intel.ts
@@ -1,12 +1,11 @@
 import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
-import { runIntelStageGo } from './go/intelGo'
-import { runIntelStageNpm } from './npm/intelNpm'
+import { getEcosystemConfig } from './ecosystems'
 
-// Thin ecosystem dispatcher — bodies live under stages/npm and stages/go. Reads the
+// Thin ecosystem dispatcher — bodies live under stages/{npm,go,maven}. Reads the
 // ecosystem straight from the analysis row already fetched for this stage, so no extra
-// DB round trip beyond what runIntelStageNpm already did before this refactor.
+// DB round trip beyond what the per-ecosystem body already did before this refactor.
 export async function runIntelStage(
   qx: QueryExecutor,
   analysisId: string,
@@ -14,8 +13,6 @@ export async function runIntelStage(
   onProgress?: () => void,
 ): Promise<void> {
   const detail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
-  if ((detail?.ecosystem ?? 'npm') === 'go') {
-    return runIntelStageGo(qx, analysisId, advisoryOsvId, onProgress)
-  }
-  return runIntelStageNpm(qx, analysisId, advisoryOsvId, onProgress)
+  const cfg = getEcosystemConfig(detail?.ecosystem)
+  return cfg.runIntel(qx, analysisId, advisoryOsvId, onProgress)
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
@@ -78,4 +78,18 @@ describe('mavenConstraintMayInclude', () => {
     expect(mavenConstraintMayInclude('(1.0)', ['1.5'])).toBe('unparseable-included')
     expect(mavenConstraintMayInclude('[1.0)', ['1.5'])).toBe('unparseable-included')
   })
+
+  it('conservatively includes a null constraint instead of throwing', () => {
+    expect(mavenConstraintMayInclude(null, ['1.5'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a range with trailing garbage after the closed interval', () => {
+    // Must not silently accept the "[1.0,2.0)" prefix and exclude 3.0 — the malformed
+    // trailing text makes the whole constraint unparseable.
+    expect(mavenConstraintMayInclude('[1.0,2.0)garbage', ['3.0'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a range with a dangling unmatched opening bracket', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0', ['3.0'])).toBe('unparseable-included')
+  })
 })

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { mavenConstraintMayInclude } from '../mavenConstraint'
+
+describe('mavenConstraintMayInclude', () => {
+  it('matches a soft version floor below the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('1.0', '1.5')).toBe('matched')
+  })
+
+  it('matches a soft version floor equal to the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('1.5', '1.5')).toBe('matched')
+  })
+
+  it('excludes a soft version floor above the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('2.0', '1.5')).toBe('excluded')
+  })
+
+  it('matches a half-open hard range containing the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0)', '1.5')).toBe('matched')
+  })
+
+  it('excludes a half-open hard range that excludes the upper bound', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0)', '2.0')).toBe('excluded')
+  })
+
+  it('matches a closed hard range including its upper bound', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0]', '2.0')).toBe('matched')
+  })
+
+  it('matches an open-ended lower-bound range', () => {
+    expect(mavenConstraintMayInclude('(,1.0]', '1.0')).toBe('matched')
+  })
+
+  it('excludes an open-ended lower-bound range above the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('(,1.0]', '1.5')).toBe('excluded')
+  })
+
+  it('matches an open-ended upper-bound range', () => {
+    expect(mavenConstraintMayInclude('[1.5,)', '1.5')).toBe('matched')
+  })
+
+  it('matches an exact-version range', () => {
+    expect(mavenConstraintMayInclude('[1.0]', '1.0')).toBe('matched')
+  })
+
+  it('excludes an exact-version range that does not equal the max vulnerable version', () => {
+    expect(mavenConstraintMayInclude('[1.0]', '1.5')).toBe('excluded')
+  })
+
+  it('matches when any interval in a comma-separated union matches', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', '3.5')).toBe('matched')
+  })
+
+  it('excludes when no interval in a comma-separated union matches', () => {
+    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', '2.5')).toBe('excluded')
+  })
+
+  it('conservatively includes an empty constraint', () => {
+    // parseMavenRange itself is the only source of 'unparseable-included' — a soft floor
+    // whose bound compareVersion can't tokenize (e.g. "---") is still over-inclusive
+    // via intervalMayInclude's null handling, which reports as 'matched', not this branch.
+    expect(mavenConstraintMayInclude('', '1.5')).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a malformed bracket expression', () => {
+    expect(mavenConstraintMayInclude('[1.0,', '1.5')).toBe('unparseable-included')
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
@@ -4,65 +4,78 @@ import { mavenConstraintMayInclude } from '../mavenConstraint'
 
 describe('mavenConstraintMayInclude', () => {
   it('matches a soft version floor below the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('1.0', '1.5')).toBe('matched')
+    expect(mavenConstraintMayInclude('1.0', ['1.5'])).toBe('matched')
   })
 
   it('matches a soft version floor equal to the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('1.5', '1.5')).toBe('matched')
+    expect(mavenConstraintMayInclude('1.5', ['1.5'])).toBe('matched')
   })
 
   it('excludes a soft version floor above the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('2.0', '1.5')).toBe('excluded')
+    expect(mavenConstraintMayInclude('2.0', ['1.5'])).toBe('excluded')
   })
 
   it('matches a half-open hard range containing the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('[1.0,2.0)', '1.5')).toBe('matched')
+    expect(mavenConstraintMayInclude('[1.0,2.0)', ['1.5'])).toBe('matched')
   })
 
   it('excludes a half-open hard range that excludes the upper bound', () => {
-    expect(mavenConstraintMayInclude('[1.0,2.0)', '2.0')).toBe('excluded')
+    expect(mavenConstraintMayInclude('[1.0,2.0)', ['2.0'])).toBe('excluded')
   })
 
   it('matches a closed hard range including its upper bound', () => {
-    expect(mavenConstraintMayInclude('[1.0,2.0]', '2.0')).toBe('matched')
+    expect(mavenConstraintMayInclude('[1.0,2.0]', ['2.0'])).toBe('matched')
   })
 
   it('matches an open-ended lower-bound range', () => {
-    expect(mavenConstraintMayInclude('(,1.0]', '1.0')).toBe('matched')
+    expect(mavenConstraintMayInclude('(,1.0]', ['1.0'])).toBe('matched')
   })
 
   it('excludes an open-ended lower-bound range above the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('(,1.0]', '1.5')).toBe('excluded')
+    expect(mavenConstraintMayInclude('(,1.0]', ['1.5'])).toBe('excluded')
   })
 
   it('matches an open-ended upper-bound range', () => {
-    expect(mavenConstraintMayInclude('[1.5,)', '1.5')).toBe('matched')
+    expect(mavenConstraintMayInclude('[1.5,)', ['1.5'])).toBe('matched')
   })
 
   it('matches an exact-version range', () => {
-    expect(mavenConstraintMayInclude('[1.0]', '1.0')).toBe('matched')
+    expect(mavenConstraintMayInclude('[1.0]', ['1.0'])).toBe('matched')
   })
 
   it('excludes an exact-version range that does not equal the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('[1.0]', '1.5')).toBe('excluded')
+    expect(mavenConstraintMayInclude('[1.0]', ['1.5'])).toBe('excluded')
   })
 
   it('matches when any interval in a comma-separated union matches', () => {
-    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', '3.5')).toBe('matched')
+    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', ['3.5'])).toBe('matched')
   })
 
   it('excludes when no interval in a comma-separated union matches', () => {
-    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', '2.5')).toBe('excluded')
+    expect(mavenConstraintMayInclude('[1.0,2.0),[3.0,4.0)', ['2.5'])).toBe('excluded')
   })
 
   it('conservatively includes an empty constraint', () => {
     // parseMavenRange itself is the only source of 'unparseable-included' — a soft floor
     // whose bound compareVersion can't tokenize (e.g. "---") is still over-inclusive
     // via intervalMayInclude's null handling, which reports as 'matched', not this branch.
-    expect(mavenConstraintMayInclude('', '1.5')).toBe('unparseable-included')
+    expect(mavenConstraintMayInclude('', ['1.5'])).toBe('unparseable-included')
   })
 
   it('conservatively includes a malformed bracket expression', () => {
-    expect(mavenConstraintMayInclude('[1.0,', '1.5')).toBe('unparseable-included')
+    expect(mavenConstraintMayInclude('[1.0,', ['1.5'])).toBe('unparseable-included')
+  })
+
+  it('matches a bounded range containing an older vulnerable version but not the max', () => {
+    expect(mavenConstraintMayInclude('[1.0,1.2]', ['1.1', '2.9'])).toBe('matched')
+  })
+
+  it('matches an exact-version range equal to an older vulnerable version, not the max', () => {
+    expect(mavenConstraintMayInclude('[1.0]', ['1.0', '2.9'])).toBe('matched')
+  })
+
+  it('conservatively includes a mismatched-bracket exact range instead of treating it as exact', () => {
+    expect(mavenConstraintMayInclude('(1.0)', ['1.5'])).toBe('unparseable-included')
+    expect(mavenConstraintMayInclude('[1.0)', ['1.5'])).toBe('unparseable-included')
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenConstraint.test.ts
@@ -1,18 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { mavenConstraintMayInclude } from '../mavenConstraint'
+import { mavenConstraintMayInclude, mavenDependencyMayIncludeVuln } from '../mavenConstraint'
 
 describe('mavenConstraintMayInclude', () => {
-  it('matches a soft version floor below the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('1.0', ['1.5'])).toBe('matched')
-  })
-
-  it('matches a soft version floor equal to the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('1.5', ['1.5'])).toBe('matched')
-  })
-
-  it('excludes a soft version floor above the max vulnerable version', () => {
-    expect(mavenConstraintMayInclude('2.0', ['1.5'])).toBe('excluded')
+  it('conservatively includes a bare soft-requirement version instead of treating it as a floor', () => {
+    // Maven bare versions are recommendations, not enforced ranges — mediation elsewhere in
+    // the tree can resolve to any other version, so ">= 1.0" can't be assumed.
+    expect(mavenConstraintMayInclude('1.0', ['1.5'])).toBe('unparseable-included')
+    expect(mavenConstraintMayInclude('1.5', ['1.5'])).toBe('unparseable-included')
+    expect(mavenConstraintMayInclude('2.0', ['1.5'])).toBe('unparseable-included')
   })
 
   it('matches a half-open hard range containing the max vulnerable version', () => {
@@ -56,9 +52,6 @@ describe('mavenConstraintMayInclude', () => {
   })
 
   it('conservatively includes an empty constraint', () => {
-    // parseMavenRange itself is the only source of 'unparseable-included' — a soft floor
-    // whose bound compareVersion can't tokenize (e.g. "---") is still over-inclusive
-    // via intervalMayInclude's null handling, which reports as 'matched', not this branch.
     expect(mavenConstraintMayInclude('', ['1.5'])).toBe('unparseable-included')
   })
 
@@ -91,5 +84,31 @@ describe('mavenConstraintMayInclude', () => {
 
   it('conservatively includes a range with a dangling unmatched opening bracket', () => {
     expect(mavenConstraintMayInclude('[1.0,2.0', ['3.0'])).toBe('unparseable-included')
+  })
+})
+
+describe('mavenDependencyMayIncludeVuln', () => {
+  it('matches when the resolved version equals a vulnerable version', () => {
+    expect(mavenDependencyMayIncludeVuln('1.5', '[9.0,)', ['1.5'])).toBe('matched')
+  })
+
+  it('excludes a resolved version outside the vulnerable set even if the declared range would match', () => {
+    // Mediation elsewhere in the tree can override even a hard declared range — the
+    // concrete resolved version wins over the constraint.
+    expect(mavenDependencyMayIncludeVuln('5.0', '[1.0,10.0)', ['1.5'])).toBe('excluded')
+  })
+
+  it('conservatively includes an unparseable resolved version', () => {
+    // compareMaven only returns null for punctuation-only/empty input (see versionCompare.ts) —
+    // a plain string like "not-a-version" still tokenizes and compares fine.
+    expect(mavenDependencyMayIncludeVuln('---', '[9.0,)', ['1.5'])).toBe('unparseable-included')
+  })
+
+  it('falls back to the declared constraint when resolution is unavailable', () => {
+    expect(mavenDependencyMayIncludeVuln(null, '[1.0,2.0)', ['1.5'])).toBe('matched')
+  })
+
+  it('conservatively includes a bare soft-requirement constraint when resolution is unavailable', () => {
+    expect(mavenDependencyMayIncludeVuln(null, '1.0', ['1.5'])).toBe('unparseable-included')
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenVersions.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenVersions.test.ts
@@ -48,8 +48,8 @@ describe('mavenVersions', () => {
 
     it('excludes when an unparseable bound makes a bound comparison ambiguous', () => {
       const versions = ['1.0']
-      const ranges = [{ introduced: null, fixed: null, lastAffected: null }]
-      expect(versionsInRanges(versions, ranges)).toEqual(['1.0'])
+      const ranges = [{ introduced: '---', fixed: null, lastAffected: null }]
+      expect(versionsInRanges(versions, ranges)).toEqual([])
     })
   })
 

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenVersions.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/__tests__/mavenVersions.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+
+import { highestVersion, mavenRangeEvents, versionsInRanges } from '../mavenVersions'
+
+describe('mavenVersions', () => {
+  describe('mavenRangeEvents', () => {
+    it('reads ECOSYSTEM-typed ranges with an introduced/fixed pair', () => {
+      const events = mavenRangeEvents({
+        package: { ecosystem: 'Maven', name: 'com.example:foo' },
+        ranges: [
+          {
+            type: 'ECOSYSTEM',
+            events: [{ introduced: '1.0' }, { fixed: '2.0' }],
+          },
+        ],
+      })
+      expect(events).toEqual([{ introduced: '1.0', fixed: '2.0', lastAffected: null }])
+    })
+
+    it('ignores SEMVER-typed ranges', () => {
+      const events = mavenRangeEvents({
+        package: { ecosystem: 'Maven', name: 'com.example:foo' },
+        ranges: [{ type: 'SEMVER', events: [{ introduced: '1.0' }, { fixed: '2.0' }] }],
+      })
+      expect(events).toEqual([])
+    })
+
+    it('falls back to the explicit versions list when there are no ranges', () => {
+      const events = mavenRangeEvents({
+        package: { ecosystem: 'Maven', name: 'com.example:foo' },
+        versions: ['1.0', '1.1'],
+      })
+      expect(events).toEqual([
+        { introduced: '1.0', fixed: null, lastAffected: '1.0' },
+        { introduced: '1.1', fixed: null, lastAffected: '1.1' },
+      ])
+    })
+  })
+
+  describe('versionsInRanges', () => {
+    it('filters versions ordered via Maven comparison, not lexical/semver', () => {
+      const versions = ['1.0', '1.9', '1.10', '2.0']
+      const ranges = [{ introduced: '1.0', fixed: '2.0', lastAffected: null }]
+      // Lexically "1.10" < "1.9", but Maven orders 1.10 > 1.9 — both must be included,
+      // and the fixed version 2.0 must be excluded.
+      expect(versionsInRanges(versions, ranges)).toEqual(['1.0', '1.9', '1.10'])
+    })
+
+    it('excludes when an unparseable bound makes a bound comparison ambiguous', () => {
+      const versions = ['1.0']
+      const ranges = [{ introduced: null, fixed: null, lastAffected: null }]
+      expect(versionsInRanges(versions, ranges)).toEqual(['1.0'])
+    })
+  })
+
+  describe('highestVersion', () => {
+    it('returns the Maven-ordered highest version', () => {
+      expect(highestVersion(['1.0', '1.10', '1.9'])).toBe('1.10')
+    })
+
+    it('handles an empty list', () => {
+      expect(highestVersion([])).toBeNull()
+    })
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsMaven.ts
@@ -1,0 +1,113 @@
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { findPackageIdsByGroupArtifact } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { toBareMavenCoordinate } from '../../packageIdentifier'
+
+import { scanMavenDependents } from './dependentsScanMaven'
+
+export async function runDependentsStageMaven(
+  qx: QueryExecutor,
+  analysisId: string,
+  onProgress?: () => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'dependents')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'dependents',
+      status: 'running',
+      model: null,
+    })
+
+    const spec = await blastRadiusDal.getSymbolSpec(qx, analysisId)
+    if (!spec) {
+      throw new Error('Symbol spec not found; stage 1 (intel) must run first')
+    }
+
+    // See dependentsNpm.ts for why this unconditional clear is safe: reachability
+    // hasn't produced any verdicts yet at this point in the pipeline.
+    await blastRadiusDal.deleteDependents(qx, analysisId)
+
+    const analysis = await blastRadiusDal.getAnalysis(qx, analysisId)
+    if (!analysis?.package_id) {
+      throw new Error('Vulnerable module package_id not resolved; stage 1 (intel) must run first')
+    }
+
+    const vulnerableVersions = (spec.vulnerable_versions || []) as string[]
+
+    // Heartbeat before the scan starts, not just after it completes — the scan is a
+    // single DB round trip that could otherwise run past the activity's heartbeat
+    // timeout with no heartbeat sent in between.
+    onProgress?.()
+
+    const scanResult = await scanMavenDependents(
+      qx,
+      String(analysis.package_id),
+      vulnerableVersions,
+      25,
+    )
+
+    if (signal?.aborted) {
+      throw new Error('Dependents scan cancelled')
+    }
+    onProgress?.()
+
+    const pairs = scanResult.analyzed.map((d) => toBareMavenCoordinate(d.name))
+    const packageIdsByCoordinate = await findPackageIdsByGroupArtifact(qx, 'maven', pairs)
+
+    const dependentInputs = [
+      ...scanResult.analyzed.map((d) => ({
+        analysisId,
+        packageId: packageIdsByCoordinate.get(d.name) ?? null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: false,
+        exclusionReason: null,
+      })),
+      ...scanResult.excludedByRange.map((d) => ({
+        analysisId,
+        packageId: null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: true,
+        exclusionReason: `Constraint does not include vulnerable versions (${d.rangeCheck})`,
+      })),
+    ]
+
+    await blastRadiusDal.insertDependents(qx, dependentInputs)
+    await blastRadiusDal.setDependentsMeta(
+      qx,
+      analysisId,
+      scanResult.source,
+      scanResult.candidatesConsidered,
+    )
+
+    const duration = Date.now() - startTime
+    await blastRadiusDal.completeStageRun(qx, analysisId, 'dependents', duration, 0)
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'dependents', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
@@ -31,7 +31,7 @@ export async function scanMavenDependents(
   const rows = await getReverseDependents(qx, vulnerablePackageId, 'maven', scanLimit)
 
   const candidates: DependentCandidate[] = rows.map((row) => {
-    const rangeCheck = mavenConstraintMayInclude(row.versionConstraint, maxVulnerableVersion)
+    const rangeCheck = mavenConstraintMayInclude(row.versionConstraint, vulnerableVersions)
     return {
       name: `${row.namespace}:${row.name}`,
       version: row.versionNumber,

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
@@ -1,0 +1,57 @@
+import { getReverseDependents } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
+
+import { mavenConstraintMayInclude } from './mavenConstraint'
+import { highestVersion } from './mavenVersions'
+
+// Maven dependents come from package_dependencies (deps.dev BigQuery ingestion), same as
+// Go — no download-count signal, so ranking uses dependent_repos_count/dependent_count.
+export async function scanMavenDependents(
+  qx: QueryExecutor,
+  vulnerablePackageId: string,
+  vulnerableVersions: string[],
+  topN: number,
+): Promise<ScanDependentsResult> {
+  const maxVulnerableVersion = highestVersion(vulnerableVersions)
+  if (!maxVulnerableVersion) {
+    return {
+      source: 'package_dependencies',
+      candidatesConsidered: 0,
+      analyzed: [],
+      excludedByRange: [],
+      excludedByRangeCount: 0,
+    }
+  }
+
+  // Cap distinct from topN: gather a wider pool so excludedByRange candidates are
+  // still visible for diagnostics, same pattern as Go/npm's scanLimit.
+  const scanLimit = Math.max(topN * 8, 200)
+  const rows = await getReverseDependents(qx, vulnerablePackageId, 'maven', scanLimit)
+
+  const candidates: DependentCandidate[] = rows.map((row) => {
+    const rangeCheck = mavenConstraintMayInclude(row.versionConstraint, maxVulnerableVersion)
+    return {
+      name: `${row.namespace}:${row.name}`,
+      version: row.versionNumber,
+      downloads: row.dependentReposCount ?? row.dependentCount ?? null,
+      declaredRange: row.versionConstraint,
+      dependencyKind: row.dependencyKind,
+      rangeIncludesVuln: rangeCheck !== 'excluded',
+      rangeCheck,
+      tarballUrl: null,
+    }
+  })
+
+  const included = candidates.filter((c) => c.rangeIncludesVuln)
+  const excluded = candidates.filter((c) => !c.rangeIncludesVuln)
+
+  return {
+    source: 'package_dependencies',
+    candidatesConsidered: candidates.length,
+    analyzed: included.slice(0, topN),
+    excludedByRange: excluded.slice(0, 200),
+    excludedByRangeCount: excluded.length,
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/dependentsScanMaven.ts
@@ -3,7 +3,7 @@ import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
 
-import { mavenConstraintMayInclude } from './mavenConstraint'
+import { mavenDependencyMayIncludeVuln } from './mavenConstraint'
 import { highestVersion } from './mavenVersions'
 
 // Maven dependents come from package_dependencies (deps.dev BigQuery ingestion), same as
@@ -31,7 +31,11 @@ export async function scanMavenDependents(
   const rows = await getReverseDependents(qx, vulnerablePackageId, 'maven', scanLimit)
 
   const candidates: DependentCandidate[] = rows.map((row) => {
-    const rangeCheck = mavenConstraintMayInclude(row.versionConstraint, vulnerableVersions)
+    const rangeCheck = mavenDependencyMayIncludeVuln(
+      row.resolvedVersionNumber,
+      row.versionConstraint,
+      vulnerableVersions,
+    )
     return {
       name: `${row.namespace}:${row.name}`,
       version: row.versionNumber,

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/intelMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/intelMaven.ts
@@ -1,0 +1,185 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { getVersionNumbers } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { findPackageId } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { resolveVersionsList } from '../../../maven/metadata'
+import {
+  MAVEN_INTEL_SCHEMA,
+  MAVEN_INTEL_SYSTEM_PROMPT,
+  buildMavenIntelPrompt,
+} from '../../agent/mavenPrompts'
+import { runAnalysisAgent } from '../../agent/runner'
+import { fetchPatch } from '../../clients/githubPatch'
+import { downloadAndExtractMavenSources } from '../../clients/mavenSourcesJar'
+import {
+  affectedEntriesForEcosystem,
+  fetchOsvVuln,
+  fixReferenceUrls,
+} from '../../clients/osvClient'
+import { toBareMavenCoordinate } from '../../packageIdentifier'
+
+import { highestVersion, mavenRangeEvents, versionsInRanges } from './mavenVersions'
+
+// OSV spells the Maven ecosystem 'Maven' (capital), unlike our DB's lowercase 'maven' —
+// see ADR-0001 §OSV "Ecosystem normalization" for the DB-side convention.
+const OSV_MAVEN_ECOSYSTEM = 'Maven'
+
+export async function runIntelStageMaven(
+  qx: QueryExecutor,
+  analysisId: string,
+  advisoryOsvId: string,
+  onProgress?: () => void,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    // Check if already done. Guard on the stage_run's own status rather than symbol-spec
+    // presence — a crash between upsertSymbolSpec and completeStageRun would otherwise
+    // leave the stage_run stuck failed/running forever while retries skip past it.
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'intel')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'intel',
+      status: 'running',
+      model: 'claude-opus-4-8',
+    })
+
+    const osv = await fetchOsvVuln(advisoryOsvId)
+
+    const mavenEntries = affectedEntriesForEcosystem(osv, OSV_MAVEN_ECOSYSTEM)
+    if (mavenEntries.length === 0) {
+      throw new Error(`No Maven entries found in advisory ${advisoryOsvId}`)
+    }
+
+    // Multi-artifact advisories list one Maven entry per affected artifact — pick the one
+    // the analysis was actually requested for, falling back to the first entry otherwise.
+    const analysisDetail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
+    const requested = analysisDetail?.package_name
+      ? toBareMavenCoordinate(analysisDetail.package_name)
+      : null
+    const entry =
+      (requested &&
+        mavenEntries.find((e) => {
+          const coord = toBareMavenCoordinate(e.package.name)
+          return coord.groupId === requested.groupId && coord.artifactId === requested.artifactId
+        })) ||
+      mavenEntries[0]
+
+    const { groupId, artifactId } = toBareMavenCoordinate(entry.package.name)
+    const coordinate = `${groupId}:${artifactId}`
+    const ecosystem = 'maven'
+    const relatedAffectedPackages = mavenEntries
+      .map((e) => e.package.name)
+      .filter((name) => name !== entry.package.name)
+
+    // Resolve vulnerable versions from OSV ranges first (Maven OSV ranges are
+    // ECOSYSTEM-typed, not SEMVER — Maven versions don't follow semver ordering).
+    const ranges = mavenRangeEvents(entry)
+
+    const packageId = await findPackageId(qx, { ecosystem, namespace: groupId, name: artifactId })
+
+    // maven-metadata.xml is the authoritative version list; fall back to our own
+    // ingested `versions` rows (deps.dev) if the registry is unreachable/rate-limited
+    // and the artifact is already known to us.
+    const versionListResult = await resolveVersionsList(groupId, artifactId)
+    let allVersions: string[]
+    if (!('kind' in versionListResult)) {
+      allVersions = versionListResult.versions
+    } else if (packageId) {
+      allVersions = await getVersionNumbers(qx, String(packageId))
+    } else {
+      throw new Error(
+        `Failed to fetch maven-metadata.xml for ${coordinate} (${versionListResult.kind}) and artifact is not in our DB`,
+      )
+    }
+
+    const vulnerableVersions = versionsInRanges(allVersions, ranges)
+
+    const analyzed = highestVersion(vulnerableVersions)
+    if (!analyzed) {
+      throw new Error(`Could not determine analyzed version for ${coordinate}`)
+    }
+
+    const pkgsrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mvnsrc-'))
+    const patches: Record<string, string> = {}
+
+    try {
+      await downloadAndExtractMavenSources(groupId, artifactId, analyzed, pkgsrcDir)
+
+      const patchUrls = fixReferenceUrls(osv)
+      for (const url of patchUrls.slice(0, 3)) {
+        try {
+          const patchText = await fetchPatch(url)
+          const slug = new URL(url).pathname.split('/').filter(Boolean).join('-')
+          patches[slug] = patchText
+        } catch {
+          // Ignore patch fetch errors
+        }
+      }
+
+      const agentPrompt = buildMavenIntelPrompt(
+        osv.id || advisoryOsvId,
+        osv.aliases || [],
+        osv.details || osv.summary || '',
+        analyzed,
+        patches,
+      )
+
+      const agentResult = await runAnalysisAgent({
+        prompt: agentPrompt,
+        systemPrompt: MAVEN_INTEL_SYSTEM_PROMPT,
+        cwd: pkgsrcDir,
+        model: 'claude-opus-4-8',
+        schema: MAVEN_INTEL_SCHEMA,
+        maxTurns: 15,
+        timeoutMs: 600_000,
+        onProgress,
+      })
+
+      if (agentResult.isError || !agentResult.structuredOutput) {
+        throw new Error(`Agent failed: ${agentResult.errorMessage}`)
+      }
+
+      const output = agentResult.structuredOutput
+      await blastRadiusDal.upsertSymbolSpec(qx, {
+        analysisId,
+        vulnId: osv.id || advisoryOsvId,
+        aliases: osv.aliases || [],
+        package: coordinate,
+        ecosystem,
+        affectedRanges: ranges as unknown as Record<string, unknown>[],
+        vulnerableVersions,
+        analyzedVersion: analyzed,
+        relatedAffectedPackages,
+        vulnerableSymbols: (output.vulnerable_symbols || []) as Record<string, unknown>[],
+        importSignatures: (output.import_signatures || {}) as Record<string, unknown>,
+        exploitPreconditions: String(output.exploit_preconditions || ''),
+        reachabilityNotes: String(output.reachability_notes || ''),
+        confidence: Number(output.confidence ?? 0.5),
+        sources: [advisoryOsvId],
+        summary: String(output.summary || ''),
+      })
+
+      await blastRadiusDal.resolveAdvisoryAndPackageIds(qx, analysisId, advisoryOsvId, packageId)
+
+      const duration = Date.now() - startTime
+      await blastRadiusDal.completeStageRun(qx, analysisId, 'intel', duration, agentResult.costUsd)
+    } finally {
+      fs.rmSync(pkgsrcDir, { recursive: true, force: true })
+    }
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'intel', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/intelMaven.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/intelMaven.ts
@@ -8,6 +8,7 @@ import { findPackageId } from '@crowd/data-access-layer/src/packages/osv'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { resolveVersionsList } from '../../../maven/metadata'
+import { resolveBlastRadiusMavenBaseUrl } from '../../../maven/registry'
 import {
   MAVEN_INTEL_SCHEMA,
   MAVEN_INTEL_SYSTEM_PROMPT,
@@ -90,7 +91,11 @@ export async function runIntelStageMaven(
     // maven-metadata.xml is the authoritative version list; fall back to our own
     // ingested `versions` rows (deps.dev) if the registry is unreachable/rate-limited
     // and the artifact is already known to us.
-    const versionListResult = await resolveVersionsList(groupId, artifactId)
+    const versionListResult = await resolveVersionsList(
+      groupId,
+      artifactId,
+      resolveBlastRadiusMavenBaseUrl(groupId),
+    )
     let allVersions: string[]
     if (!('kind' in versionListResult)) {
       allVersions = versionListResult.versions

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
@@ -41,7 +41,9 @@ function parseMavenInterval(seg: string): MavenInterval | null {
   const comma = body.indexOf(',')
 
   if (comma === -1) {
-    // Exact version, e.g. "[1.0]"
+    // Exact version, e.g. "[1.0]" — requires both brackets closed, unlike a mismatched
+    // "(1.0)" or "[1.0)", which is malformed and must fall through to unparseable-included.
+    if (!lowerInclusive || !upperInclusive) return null
     const exact = body.trim()
     if (!exact) return null
     return { lower: exact, lowerInclusive: true, upper: exact, upperInclusive: true }
@@ -89,12 +91,19 @@ function intervalMayInclude(interval: MavenInterval, version: string): boolean {
 
 // Over-inclusive by design: the reachability stage (real source analysis) is the
 // actual precision filter, so an unparseable constraint is always surfaced, never dropped.
+//
+// Checks against every vulnerable version, not just the highest one: unlike Go's
+// unbounded-above floors (where the max alone determines the match), Maven hard ranges
+// like "[1.0,1.2]" or "[1.0]" are bounded and can include an older vulnerable version
+// without including the max.
 export function mavenConstraintMayInclude(
   constraint: string,
-  maxVulnerableVersion: string,
+  vulnerableVersions: string[],
 ): MavenConstraintMatch {
   const intervals = parseMavenRange(constraint)
   if (!intervals) return 'unparseable-included'
-  const matched = intervals.some((interval) => intervalMayInclude(interval, maxVulnerableVersion))
+  const matched = intervals.some((interval) =>
+    vulnerableVersions.some((version) => intervalMayInclude(interval, version)),
+  )
   return matched ? 'matched' : 'excluded'
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
@@ -60,28 +60,25 @@ function parseMavenInterval(seg: string): MavenInterval | null {
   return { lower, lowerInclusive, upper, upperInclusive }
 }
 
-// A soft requirement (bare version, e.g. "1.5") is Maven's recommended version, not an
-// enforced range — modeled as a floor: an unbounded-above interval starting there.
+// A bare version (e.g. "1.5") is Maven's soft requirement, not an enforced floor — mediation
+// elsewhere in the tree can override it, so it's treated as unparseable rather than ">= 1.5".
 function parseMavenRange(constraint: string | null): MavenInterval[] | null {
   // package_dependencies.version_constraint is nullable (deps.dev fill path) — treat a
   // missing constraint the same as an unparseable one, not a crash on .trim().
   if (constraint == null) return null
   const trimmed = constraint.trim()
   if (!trimmed) return null
+  if (!trimmed.startsWith('[') && !trimmed.startsWith('(')) return null
 
-  if (trimmed.startsWith('[') || trimmed.startsWith('(')) {
-    const segments = splitTopLevelCommas(trimmed)
-    if (!segments || segments.length === 0) return null
-    const intervals: MavenInterval[] = []
-    for (const seg of segments) {
-      const interval = parseMavenInterval(seg)
-      if (!interval) return null
-      intervals.push(interval)
-    }
-    return intervals
+  const segments = splitTopLevelCommas(trimmed)
+  if (!segments || segments.length === 0) return null
+  const intervals: MavenInterval[] = []
+  for (const seg of segments) {
+    const interval = parseMavenInterval(seg)
+    if (!interval) return null
+    intervals.push(interval)
   }
-
-  return [{ lower: trimmed, lowerInclusive: true, upper: null, upperInclusive: false }]
+  return intervals
 }
 
 function intervalMayInclude(interval: MavenInterval, version: string): boolean {
@@ -115,4 +112,21 @@ export function mavenConstraintMayInclude(
     vulnerableVersions.some((version) => intervalMayInclude(interval, version)),
   )
   return matched ? 'matched' : 'excluded'
+}
+
+// Prefers the edge's concrete resolved version over the declared constraint when known — mediation
+// can override even an explicit range, and it's the only sound way to evaluate a bare requirement.
+export function mavenDependencyMayIncludeVuln(
+  resolvedVersion: string | null,
+  constraint: string | null,
+  vulnerableVersions: string[],
+): MavenConstraintMatch {
+  if (!resolvedVersion) return mavenConstraintMayInclude(constraint, vulnerableVersions)
+
+  const comparisons = vulnerableVersions.map((version) =>
+    compareVersion('maven', resolvedVersion, version),
+  )
+  if (comparisons.includes(0)) return 'matched'
+  if (comparisons.includes(null)) return 'unparseable-included'
+  return 'excluded'
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
@@ -11,7 +11,11 @@ interface MavenInterval {
 
 // A top-level comma joins alternative intervals, e.g. "[1.0,2.0),[3.0,4.0)" — track
 // bracket depth only to skip the comma inside an interval's own lower/upper bound.
-function splitTopLevelCommas(s: string): string[] {
+// Returns null (not a partial result) on unmatched brackets or trailing text after
+// the last closed interval, e.g. "[1.0,2.0)garbage" — accepting the valid-looking
+// prefix there would silently drop the "garbage" tail and could wrongly exclude a
+// vulnerable version instead of falling through to unparseable-included.
+function splitTopLevelCommas(s: string): string[] | null {
   const parts: string[] = []
   let depth = 0
   let start = 0
@@ -19,6 +23,7 @@ function splitTopLevelCommas(s: string): string[] {
     if (s[i] === '[' || s[i] === '(') depth++
     else if (s[i] === ']' || s[i] === ')') {
       depth--
+      if (depth < 0) return null
       if (depth === 0) {
         parts.push(s.slice(start, i + 1))
         start = i + 1
@@ -26,6 +31,7 @@ function splitTopLevelCommas(s: string): string[] {
       }
     }
   }
+  if (depth !== 0 || start !== s.length) return null
   return parts.filter(Boolean)
 }
 
@@ -56,13 +62,16 @@ function parseMavenInterval(seg: string): MavenInterval | null {
 
 // A soft requirement (bare version, e.g. "1.5") is Maven's recommended version, not an
 // enforced range — modeled as a floor: an unbounded-above interval starting there.
-function parseMavenRange(constraint: string): MavenInterval[] | null {
+function parseMavenRange(constraint: string | null): MavenInterval[] | null {
+  // package_dependencies.version_constraint is nullable (deps.dev fill path) — treat a
+  // missing constraint the same as an unparseable one, not a crash on .trim().
+  if (constraint == null) return null
   const trimmed = constraint.trim()
   if (!trimmed) return null
 
   if (trimmed.startsWith('[') || trimmed.startsWith('(')) {
     const segments = splitTopLevelCommas(trimmed)
-    if (segments.length === 0) return null
+    if (!segments || segments.length === 0) return null
     const intervals: MavenInterval[] = []
     for (const seg of segments) {
       const interval = parseMavenInterval(seg)
@@ -97,7 +106,7 @@ function intervalMayInclude(interval: MavenInterval, version: string): boolean {
 // like "[1.0,1.2]" or "[1.0]" are bounded and can include an older vulnerable version
 // without including the max.
 export function mavenConstraintMayInclude(
-  constraint: string,
+  constraint: string | null,
   vulnerableVersions: string[],
 ): MavenConstraintMatch {
   const intervals = parseMavenRange(constraint)

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/mavenConstraint.ts
@@ -1,0 +1,100 @@
+import { compareVersion } from '../../../osv/versionCompare'
+
+export type MavenConstraintMatch = 'matched' | 'excluded' | 'unparseable-included'
+
+interface MavenInterval {
+  lower: string | null
+  lowerInclusive: boolean
+  upper: string | null
+  upperInclusive: boolean
+}
+
+// A top-level comma joins alternative intervals, e.g. "[1.0,2.0),[3.0,4.0)" — track
+// bracket depth only to skip the comma inside an interval's own lower/upper bound.
+function splitTopLevelCommas(s: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '[' || s[i] === '(') depth++
+    else if (s[i] === ']' || s[i] === ')') {
+      depth--
+      if (depth === 0) {
+        parts.push(s.slice(start, i + 1))
+        start = i + 1
+        if (s[start] === ',') start++
+      }
+    }
+  }
+  return parts.filter(Boolean)
+}
+
+function parseMavenInterval(seg: string): MavenInterval | null {
+  const s = seg.trim()
+  if (s.length < 2) return null
+  if (s[0] !== '[' && s[0] !== '(') return null
+  if (s[s.length - 1] !== ']' && s[s.length - 1] !== ')') return null
+
+  const lowerInclusive = s[0] === '['
+  const upperInclusive = s[s.length - 1] === ']'
+  const body = s.slice(1, -1)
+  const comma = body.indexOf(',')
+
+  if (comma === -1) {
+    // Exact version, e.g. "[1.0]"
+    const exact = body.trim()
+    if (!exact) return null
+    return { lower: exact, lowerInclusive: true, upper: exact, upperInclusive: true }
+  }
+
+  const lower = body.slice(0, comma).trim() || null
+  const upper = body.slice(comma + 1).trim() || null
+  return { lower, lowerInclusive, upper, upperInclusive }
+}
+
+// A soft requirement (bare version, e.g. "1.5") is Maven's recommended version, not an
+// enforced range — modeled as a floor: an unbounded-above interval starting there.
+function parseMavenRange(constraint: string): MavenInterval[] | null {
+  const trimmed = constraint.trim()
+  if (!trimmed) return null
+
+  if (trimmed.startsWith('[') || trimmed.startsWith('(')) {
+    const segments = splitTopLevelCommas(trimmed)
+    if (segments.length === 0) return null
+    const intervals: MavenInterval[] = []
+    for (const seg of segments) {
+      const interval = parseMavenInterval(seg)
+      if (!interval) return null
+      intervals.push(interval)
+    }
+    return intervals
+  }
+
+  return [{ lower: trimmed, lowerInclusive: true, upper: null, upperInclusive: false }]
+}
+
+function intervalMayInclude(interval: MavenInterval, version: string): boolean {
+  if (interval.lower) {
+    const c = compareVersion('maven', version, interval.lower)
+    if (c === null) return true // unparseable bound — over-inclusive
+    if (interval.lowerInclusive ? c < 0 : c <= 0) return false
+  }
+  if (interval.upper) {
+    const c = compareVersion('maven', version, interval.upper)
+    if (c === null) return true
+    if (interval.upperInclusive ? c > 0 : c >= 0) return false
+  }
+  return true
+}
+
+// Over-inclusive by design: the reachability stage (real source analysis) is the
+// actual precision filter, so an unparseable constraint is always surfaced, never dropped.
+export function mavenConstraintMayInclude(
+  constraint: string,
+  maxVulnerableVersion: string,
+): MavenConstraintMatch {
+  const intervals = parseMavenRange(constraint)
+  if (!intervals) return 'unparseable-included'
+  const matched = intervals.some((interval) => intervalMayInclude(interval, maxVulnerableVersion))
+  return matched ? 'matched' : 'excluded'
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/mavenVersions.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/mavenVersions.ts
@@ -1,0 +1,96 @@
+import { compareVersion } from '../../../osv/versionCompare'
+import { OsvAffectedPackage } from '../../clients/osvClient'
+
+// Maven-specific counterpart to semverRange.ts — OSV Maven advisories use ECOSYSTEM-typed
+// ranges, ordered via compareVersion('maven', …) instead of node-semver.
+export interface MavenRange {
+  introduced: string | null
+  fixed: string | null
+  lastAffected: string | null
+}
+
+export function mavenRangeEvents(entry: OsvAffectedPackage): MavenRange[] {
+  const events: MavenRange[] = []
+
+  if (entry.ranges) {
+    for (const range of entry.ranges) {
+      if (range.type !== 'ECOSYSTEM' || !range.events) continue
+
+      let introduced: string | null = null
+
+      for (const event of range.events) {
+        if (event.introduced) introduced = event.introduced
+
+        if (event.fixed) {
+          events.push({ introduced, fixed: event.fixed, lastAffected: null })
+          introduced = null
+        } else if (event.last_affected) {
+          events.push({ introduced, fixed: null, lastAffected: event.last_affected })
+          introduced = null
+        }
+      }
+
+      if (introduced !== null) {
+        events.push({ introduced, fixed: null, lastAffected: null })
+      }
+    }
+  }
+
+  // Fallback: if no ECOSYSTEM ranges, use the explicit version list as exact
+  // vulnerable versions.
+  if (events.length === 0 && (entry.versions ?? []).length > 0) {
+    for (const v of entry.versions ?? []) {
+      events.push({ introduced: v, fixed: null, lastAffected: v })
+    }
+  }
+
+  return events
+}
+
+function compareOrNull(a: string, b: string): number | null {
+  return compareVersion('maven', a, b)
+}
+
+// Unparseable bound → treated as NOT in range (unlike mavenConstraint.ts's over-inclusive
+// stance — this only decides the vulnerable-version set, not dependent reachability).
+function isInRange(version: string, range: MavenRange): boolean {
+  if (range.introduced) {
+    const c = compareOrNull(version, range.introduced)
+    if (c === null || c < 0) return false
+  }
+  if (range.fixed) {
+    const c = compareOrNull(version, range.fixed)
+    if (c === null || c >= 0) return false
+  }
+  if (range.lastAffected) {
+    const c = compareOrNull(version, range.lastAffected)
+    if (c === null || c > 0) return false
+  }
+  return true
+}
+
+export function versionsInRanges(versions: string[], ranges: MavenRange[]): string[] {
+  const result: string[] = []
+  for (const v of versions) {
+    for (const range of ranges) {
+      if (isInRange(v, range)) {
+        result.push(v)
+        break
+      }
+    }
+  }
+  return result
+}
+
+export function highestVersion(versions: string[]): string | null {
+  let best: string | null = null
+  for (const v of versions) {
+    if (best === null) {
+      best = v
+      continue
+    }
+    const c = compareOrNull(v, best)
+    if (c !== null && c > 0) best = v
+  }
+  return best
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/reachabilityConfig.ts
@@ -1,0 +1,31 @@
+import { resolveLatestVersion } from '../../../maven/metadata'
+import {
+  MAVEN_REACHABILITY_PROMPT,
+  MAVEN_VERDICT_SCHEMA,
+  buildMavenReachabilitySystemPrompt,
+} from '../../agent/mavenPrompts'
+import { downloadAndExtractMavenSources } from '../../clients/mavenSourcesJar'
+import { toBareMavenCoordinate } from '../../packageIdentifier'
+import { ReachabilitySourceConfig } from '../reachabilityStage'
+
+// Prefer the version the reverse-dependency edge resolved against; fall back to
+// Maven Central's current release when the dependent only declared a range/floor.
+async function resolveMavenVersion(groupId: string, artifactId: string): Promise<string | null> {
+  return resolveLatestVersion(groupId, artifactId)
+}
+
+export const mavenReachabilityConfig: ReachabilitySourceConfig = {
+  prompt: MAVEN_REACHABILITY_PROMPT,
+  schema: MAVEN_VERDICT_SCHEMA,
+  buildSystemPrompt: buildMavenReachabilitySystemPrompt,
+  prepareSource: async (dep) => {
+    const { groupId, artifactId } = toBareMavenCoordinate(dep.name)
+    const version = dep.version ?? (await resolveMavenVersion(groupId, artifactId))
+    if (!version) return null
+    return {
+      download: (destDir) => downloadAndExtractMavenSources(groupId, artifactId, version, destDir),
+    }
+  },
+  noSourceMessage: 'Could not resolve a concrete Maven artifact version',
+  downloadErrorPrefix: 'Maven sources jar download failed',
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/maven/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/maven/reachabilityConfig.ts
@@ -1,4 +1,5 @@
 import { resolveLatestVersion } from '../../../maven/metadata'
+import { resolveBlastRadiusMavenBaseUrl } from '../../../maven/registry'
 import {
   MAVEN_REACHABILITY_PROMPT,
   MAVEN_VERDICT_SCHEMA,
@@ -11,7 +12,7 @@ import { ReachabilitySourceConfig } from '../reachabilityStage'
 // Prefer the version the reverse-dependency edge resolved against; fall back to
 // Maven Central's current release when the dependent only declared a range/floor.
 async function resolveMavenVersion(groupId: string, artifactId: string): Promise<string | null> {
-  return resolveLatestVersion(groupId, artifactId)
+  return resolveLatestVersion(groupId, artifactId, resolveBlastRadiusMavenBaseUrl(groupId))
 }
 
 export const mavenReachabilityConfig: ReachabilitySourceConfig = {

--- a/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/reachability.ts
@@ -1,8 +1,7 @@
 import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
-import { goReachabilityConfig } from './go/reachabilityConfig'
-import { npmReachabilityConfig } from './npm/reachabilityConfig'
+import { getEcosystemConfig } from './ecosystems'
 import { runReachabilityStage as runReachabilityStageWithConfig } from './reachabilityStage'
 
 // Thin ecosystem dispatcher — the stage body lives in reachabilityStage.ts, shared by
@@ -13,6 +12,6 @@ export async function runReachabilityStage(
   onProgress?: () => void,
 ): Promise<void> {
   const detail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
-  const cfg = (detail?.ecosystem ?? 'npm') === 'go' ? goReachabilityConfig : npmReachabilityConfig
-  return runReachabilityStageWithConfig(qx, analysisId, cfg, onProgress)
+  const cfg = getEcosystemConfig(detail?.ecosystem)
+  return runReachabilityStageWithConfig(qx, analysisId, cfg.reachability, onProgress)
 }

--- a/services/apps/packages_worker/src/blast-radius/workflows.ts
+++ b/services/apps/packages_worker/src/blast-radius/workflows.ts
@@ -3,9 +3,7 @@ import { ApplicationFailure, log, proxyActivities, rootCause } from '@temporalio
 import type { ITriggerBlastRadiusAnalysis } from '@crowd/types'
 
 import type * as activities from './activities'
-import { buildEcosystemNotSupportedFailure } from './ecosystemSupport'
-
-const SUPPORTED_ECOSYSTEMS = ['npm', 'go']
+import { SUPPORTED_ECOSYSTEMS, buildEcosystemNotSupportedFailure } from './ecosystemSupport'
 
 const { blastRadiusStart, blastRadiusFail } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
@@ -54,7 +52,7 @@ const { blastRadiusReport } = proxyActivities<typeof activities>({
 export async function analyzeBlastRadius(input: ITriggerBlastRadiusAnalysis): Promise<void> {
   log.info('analyzeBlastRadius received', { ...input })
 
-  if (!SUPPORTED_ECOSYSTEMS.includes(input.ecosystem)) {
+  if (!(SUPPORTED_ECOSYSTEMS as readonly string[]).includes(input.ecosystem)) {
     throw buildEcosystemNotSupportedFailure(input.ecosystem)
   }
 

--- a/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
+++ b/services/apps/packages_worker/src/maven/__tests__/registry.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import {
   GRADLE_PLUGIN_PORTAL_BASE_URL,
   JITPACK_BASE_URL,
   MAVEN_CENTRAL_BASE_URL,
+  MAVEN_GCS_MIRROR_BASE_URL,
   isJitpackNamespace,
   jitpackPageUrl,
+  resolveBlastRadiusMavenBaseUrl,
   resolveRegistryBaseUrl,
   resolveRegistryPageUrl,
   resolveRegistryPageUrlFromBase,
@@ -167,6 +169,28 @@ describe('resolveRegistryBaseUrl', () => {
 
   it('returns Maven Central for io.githubfoo (no dot boundary)', () => {
     expect(resolveRegistryBaseUrl('io.githubfoo')).toBe(MAVEN_CENTRAL_BASE_URL)
+  })
+})
+
+describe('resolveBlastRadiusMavenBaseUrl', () => {
+  afterEach(() => {
+    delete process.env.BLAST_RADIUS_MAVEN_BASE_URL
+  })
+
+  it('defaults to the GCS mirror for an unknown namespace', () => {
+    expect(resolveBlastRadiusMavenBaseUrl('org.apache.commons')).toBe(MAVEN_GCS_MIRROR_BASE_URL)
+  })
+
+  it('honors BLAST_RADIUS_MAVEN_BASE_URL when set', () => {
+    process.env.BLAST_RADIUS_MAVEN_BASE_URL = 'https://example.test/mirror'
+    expect(resolveBlastRadiusMavenBaseUrl('org.apache.commons')).toBe('https://example.test/mirror')
+  })
+
+  it('bypasses the mirror for alternative-registry namespaces regardless of the env var', () => {
+    process.env.BLAST_RADIUS_MAVEN_BASE_URL = 'https://example.test/mirror'
+    expect(resolveBlastRadiusMavenBaseUrl('androidx.annotation')).toBe(
+      'https://dl.google.com/dl/android/maven2',
+    )
   })
 })
 

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -20,6 +20,8 @@
 export const MAVEN_CENTRAL_BASE_URL = 'https://repo1.maven.org/maven2'
 export const GRADLE_PLUGIN_PORTAL_BASE_URL = 'https://plugins.gradle.org/m2'
 export const JITPACK_BASE_URL = 'https://jitpack.io'
+export const MAVEN_GCS_MIRROR_BASE_URL =
+  'https://maven-central.storage-download.googleapis.com/maven2'
 
 interface RegistryEntry {
   prefix: string
@@ -150,6 +152,14 @@ function findEntry(groupId: string): RegistryEntry | undefined {
   )
 }
 
+// Shared by resolveRegistryBaseUrl and resolveBlastRadiusMavenBaseUrl: alternative
+// registries always win, everything else falls back to a caller-chosen env var/default.
+function resolveBaseUrl(groupId: string, envVarName: string, defaultUrl: string): string {
+  const entry = findEntry(groupId)
+  if (entry) return entry.baseUrl
+  return process.env[envVarName] ?? defaultUrl
+}
+
 /**
  * Returns the Maven repository base URL for the given groupId.
  *
@@ -159,9 +169,7 @@ function findEntry(groupId: string): RegistryEntry | undefined {
  * For everything else, falls back to MAVEN_FETCHER_BASE_URL ?? Maven Central.
  */
 export function resolveRegistryBaseUrl(groupId: string): string {
-  const entry = findEntry(groupId)
-  if (entry) return entry.baseUrl
-  return process.env.MAVEN_FETCHER_BASE_URL ?? MAVEN_CENTRAL_BASE_URL
+  return resolveBaseUrl(groupId, 'MAVEN_FETCHER_BASE_URL', MAVEN_CENTRAL_BASE_URL)
 }
 
 /**
@@ -172,6 +180,21 @@ export function resolveRegistryBaseUrl(groupId: string): string {
  */
 export function isAlternativeRegistry(groupId: string): boolean {
   return findEntry(groupId) !== undefined
+}
+
+/**
+ * Like resolveRegistryBaseUrl, but for the blast-radius pipeline, which fetches
+ * one artifact/version at a time rather than the daily critical-batch ingestion.
+ *
+ * Blast-radius uses its own env var (BLAST_RADIUS_MAVEN_BASE_URL, defaulting to a
+ * GCS mirror of Central) instead of MAVEN_FETCHER_BASE_URL, because activities.ts
+ * mutates MAVEN_FETCHER_BASE_URL at runtime for the daily job — sharing it would
+ * make blast-radius's registry target flip depending on whether that job just ran
+ * in the same worker process. Alternative-registry namespaces still bypass any
+ * override, same as resolveRegistryBaseUrl.
+ */
+export function resolveBlastRadiusMavenBaseUrl(groupId: string): string {
+  return resolveBaseUrl(groupId, 'BLAST_RADIUS_MAVEN_BASE_URL', MAVEN_GCS_MIRROR_BASE_URL)
 }
 
 /**

--- a/services/libs/data-access-layer/src/packages/blastRadiusDependents.ts
+++ b/services/libs/data-access-layer/src/packages/blastRadiusDependents.ts
@@ -7,6 +7,7 @@ export interface ReverseDependentRow {
   name: string
   versionNumber: string
   versionConstraint: string
+  resolvedVersionNumber: string | null
   dependencyKind: string
   dependentCount: number | null
   // bigint column — the packages DB connection only overrides the NUMERIC/int4 type
@@ -37,10 +38,12 @@ export async function getReverseDependents(
               p.id AS package_id, p.purl, p.namespace, p.name,
               v.number AS version_number,
               pd.version_constraint, pd.dependency_kind,
+              rv.number AS resolved_version_number,
               p.dependent_count, p.transitive_dependent_count, p.dependent_repos_count
          FROM package_dependencies pd
          JOIN packages p ON p.id = pd.package_id
          JOIN versions v ON v.id = pd.version_id AND v.package_id = pd.package_id
+         LEFT JOIN versions rv ON rv.id = pd.depends_on_version_id AND rv.package_id = pd.depends_on_id
         WHERE pd.depends_on_id = $(dependsOnId)
           AND p.ecosystem = $(ecosystem)
         ORDER BY p.id, v.is_latest DESC NULLS LAST, v.published_at DESC NULLS LAST
@@ -59,6 +62,7 @@ export async function getReverseDependents(
     name: row.name as string,
     versionNumber: row.version_number as string,
     versionConstraint: row.version_constraint as string,
+    resolvedVersionNumber: row.resolved_version_number as string | null,
     dependencyKind: row.dependency_kind as string,
     dependentCount: row.dependent_count as number | null,
     transitiveDependentCount: row.transitive_dependent_count as string | null,

--- a/services/libs/data-access-layer/src/packages/osv.ts
+++ b/services/libs/data-access-layer/src/packages/osv.ts
@@ -143,6 +143,31 @@ export async function findPackageIdsByName(
   return new Map(rows.map((r) => [r.name, r.id]))
 }
 
+// Batched form of findPackageId for (groupId, artifactId) pairs — kept separate from
+// findPackageIdsByName's '/'-joined reconstruction. Map keys are "groupId:artifactId".
+export async function findPackageIdsByGroupArtifact(
+  qx: QueryExecutor,
+  ecosystem: string,
+  pairs: Array<{ groupId: string; artifactId: string }>,
+): Promise<Map<string, string>> {
+  if (pairs.length === 0) return new Map()
+  const rows: Array<{ id: string; group_id: string; artifact_id: string }> = await qx.select(
+    `
+    SELECT p.id, u.group_id, u.artifact_id
+    FROM packages p
+    JOIN unnest($(groupIds)::text[], $(artifactIds)::text[]) AS u(group_id, artifact_id)
+      ON p.namespace = u.group_id AND p.name = u.artifact_id
+    WHERE p.ecosystem = $(ecosystem)
+    `,
+    {
+      ecosystem,
+      groupIds: pairs.map((p) => p.groupId),
+      artifactIds: pairs.map((p) => p.artifactId),
+    },
+  )
+  return new Map(rows.map((r) => [`${r.group_id}:${r.artifact_id}`, r.id]))
+}
+
 export async function upsertAdvisoryPackage(
   qx: QueryExecutor,
   input: AdvisoryPackageUpsertInput,


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Adds Maven ecosystem support to the blast-radius analysis pipeline (intel, dependents,
reachability stages), alongside the existing npm/go support, and refactors the three
scattered `if (ecosystem === 'go')` stage dispatchers into a single `EcosystemConfig`
registry.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- Adds Maven intel/dependents/reachability stages (`stages/maven/*`) mirroring the go/npm
  ones, sourcing dependents from our own `package_dependencies` table (populated via
  deps.dev BigQuery ingestion), same as Go.
- Maven declares dependency versions either as a soft recommended version (a floor, like
  Go's MVS `require` directive) or a hard range (`[1.0,2.0)`, `(,1.0]`, exact `[1.0]`,
  comma-separated unions). `mavenConstraint.ts` models both and is intentionally
  over-inclusive: an unparseable constraint or ambiguous bound is always surfaced as a
  candidate rather than silently dropped — the reachability stage (real source analysis)
  is the actual precision filter.
- Maven's OSV advisory ranges are `ECOSYSTEM`-typed, not `SEMVER`-typed like npm/go —
  `mavenVersions.ts` reads them and orders via `compareVersion('maven', …)` rather than
  node-semver.
- New `maven/registry.ts`/`maven/metadata.ts`-backed sources-jar downloader
  (`clients/mavenSourcesJar.ts`), mirroring `clients/goModuleZip.ts`'s download-limiter +
  path-traversal-guarded extraction pattern.
- New `findPackageIdsByGroupArtifact` DAL function (`data-access-layer/src/packages/osv.ts`)
  — a batched `(groupId, artifactId)` lookup joining on the real `namespace`/`name`
  columns, kept separate from `findPackageIdsByName` rather than overloading its
  `/`-joined reconstruction.
- Refactors `stages/{intel,dependents,reachability}.ts` from three separate
  `ecosystem === 'go' ? … : …` dispatches into a single `EcosystemConfig` registry
  (`stages/ecosystems.ts`), backed by `Record<Ecosystem, EcosystemConfig>` so adding a
  supported ecosystem without a matching config entry is a compile-time error.
  `SUPPORTED_ECOSYSTEMS`/`Ecosystem` now live in `ecosystemSupport.ts` as the single
  source of truth, imported by both the workflow gate check and the registry.
- Maven ecosystem support is enabled in both `SUPPORTED_ECOSYSTEMS` (`workflows.ts`) and
  `SUPPORTED_BLAST_RADIUS_ECOSYSTEMS` (`packages/blastRadius.ts`). The public API's
  `openapi.yaml` (`akrites-external`) is updated to document `maven` in the `ecosystem`
  enum and description text to match.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1358](https://linuxfoundation.atlassian.net/browse/CM-1358)


[CM-1358]: https://linuxfoundation.atlassian.net/browse/CM-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ