### PR TITLE
feat: add project-level health score v2 category breakdown rollup (IN-1212)

### DIFF
--- a/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_copy_ds.datasource
@@ -37,6 +37,9 @@ DESCRIPTION >
     - `lifecycleLabel` column is the project's aggregated maintenance state across its packages, using best-state-wins precedence (active > stable > declining > abandoned > archived) over `ossPackages_enriched_ds.lifecycleLabel`.
     - `impactScore` column is the average Osprey criticality `impact` (0-100) across the project's packages. Null when the project has no linked package data.
     - `impactLabel` column buckets `impactScore`: 'foundational' (85-100), 'major' (60-84), 'moderate' (30-59), 'minor' (0-29). Null when `impactScore` is null.
+    - `maintainerHealthScoreV2` column is the project-level rollup (0-40) of `health_score_v2_repo_copy_ds.maintainerHealthScoreV2` — mean across the project's enabled, non-excluded repos, same convention as `healthScoreV2`. Null when no repo has a value.
+    - `securitySupplyChainScoreV2` column is the project-level rollup (0-35) of `health_score_v2_repo_copy_ds.securitySupplyChainScoreV2` — mean across the project's enabled, non-excluded repos. Null when no repo has a value.
+    - `developmentActivityScoreV2` column is the project-level rollup (0-25) of `health_score_v2_repo_copy_ds.developmentActivityScoreV2` — mean across the project's enabled, non-excluded repos. Null when no repo has a value.
 
 TAGS "Project insights", "Metrics"
 
@@ -75,7 +78,10 @@ SCHEMA >
     `healthLabel` Nullable(String),
     `lifecycleLabel` Nullable(String),
     `impactScore` Nullable(UInt8),
-    `impactLabel` Nullable(String)
+    `impactLabel` Nullable(String),
+    `maintainerHealthScoreV2` Nullable(UInt8),
+    `securitySupplyChainScoreV2` Nullable(UInt8),
+    `developmentActivityScoreV2` Nullable(UInt8)
 
 ENGINE MergeTree
 ENGINE_SORTING_KEY type, id

--- a/services/libs/tinybird/pipes/project_insights.pipe
+++ b/services/libs/tinybird/pipes/project_insights.pipe
@@ -13,6 +13,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project records with all insights metrics including achievements as array of (leaderboardType, rank, totalCount) tuples
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the project has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the project-level rollup of the Health Score v2 category breakdown (IN-1212) — the three categories that sum to `healthScoreV2`. Null when no repo in the project has a value for that category.
 
 TAGS "Insights, Widget", "Project"
 
@@ -52,7 +53,10 @@ SQL >
         healthLabel,
         lifecycleLabel,
         impactScore,
-        impactLabel
+        impactLabel,
+        maintainerHealthScoreV2,
+        securitySupplyChainScoreV2,
+        developmentActivityScoreV2
     FROM project_insights_copy_ds
     WHERE
         type = 'project'

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -111,6 +111,11 @@ DESCRIPTION >
     - impactScoreRaw: MAX across the project's repos (each repo's own value is already a MAX over its
     published packages) — matches the spec's "MAX(packages.impact) over packages published by any
     repo in the project," since max-of-maxes = max-over-all.
+    - maintainerHealthScoreV2 / securitySupplyChainScoreV2 / developmentActivityScoreV2 (IN-1212): same
+    straight-mean rollup as healthScoreV2, over the same repo set — kept consistent since healthScoreV2
+    is itself defined as the sum of these three categories at repo level (see
+    health_score_v2_repo_copy_ds). `avg()` (not avgOrNull) matches the healthScoreV2 idiom above and
+    already returns NULL, not 0/NaN, when every repo is NULL for a category (confirmed live).
 
 SQL >
     SELECT
@@ -129,7 +134,10 @@ SQL >
                 )
             )
         ) AS lifecycleLabelV2,
-        maxOrNull(hv2.impactScore) AS impactScoreRaw
+        maxOrNull(hv2.impactScore) AS impactScoreRaw,
+        avg(hv2.maintainerHealthScoreV2) AS maintainerHealthScoreV2,
+        avg(hv2.securitySupplyChainScoreV2) AS securitySupplyChainScoreV2,
+        avg(hv2.developmentActivityScoreV2) AS developmentActivityScoreV2
     FROM repositories rep FINAL
     INNER JOIN health_score_v2_repo_copy_ds hv2 ON hv2.repoUrl = rep.url
     WHERE rep.insightsProjectId != '' AND rep.enabled = true AND rep.excluded = false
@@ -197,7 +205,10 @@ SQL >
             hv2.impactScoreRaw >= 30,
             'moderate',
             'minor'
-        ) AS impactLabel
+        ) AS impactLabel,
+        toUInt8(round(hv2.maintainerHealthScoreV2)) AS maintainerHealthScoreV2,
+        toUInt8(round(hv2.securitySupplyChainScoreV2)) AS securitySupplyChainScoreV2,
+        toUInt8(round(hv2.developmentActivityScoreV2)) AS developmentActivityScoreV2
     FROM project_insights_copy_base_projects AS base
     LEFT JOIN project_insights_copy_dependency_metrics AS dep ON base.slug = dep.slug
     LEFT JOIN project_insights_copy_achievements AS ach ON base.slug = ach.slug

--- a/services/libs/tinybird/pipes/project_insights_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_copy.pipe
@@ -325,7 +325,10 @@ SQL >
             hv2.impactScore >= 30,
             'moderate',
             'minor'
-        ) AS impactLabel
+        ) AS impactLabel,
+        hv2.maintainerHealthScoreV2 AS maintainerHealthScoreV2,
+        hv2.securitySupplyChainScoreV2 AS securitySupplyChainScoreV2,
+        hv2.developmentActivityScoreV2 AS developmentActivityScoreV2
     FROM project_insights_copy_repo_base AS base
     LEFT JOIN repo_health_score_copy_ds AS hs ON base.repoUrl = hs.channel
     LEFT JOIN project_insights_copy_repo_period_metrics AS rm ON base.repoUrl = rm.channel


### PR DESCRIPTION
## Summary

Adds a project-level rollup of the Health Score v2 3-category breakdown (Maintainer Health, Security & Supply Chain, Development Activity), needed for IN-1212's new project overview page "Health breakdown" section. Today `health_score_v2_repo_copy_ds` only has these per-repo; no project-level rollup existed.

Extends the existing `project_insights_copy.pipe` / `project_insights_copy_ds` / `project_insights.pipe` rather than adding a new pipe — the health-v2 rollup node (`project_insights_copy_health_v2_project`) already does the exact join needed (`repositories FINAL INNER JOIN health_score_v2_repo_copy_ds`, filtered `enabled=true AND excluded=false`, grouped by project), so this reuses it instead of adding a second join/scan.

**New columns** (all `Nullable(UInt8)`, appended to the end of `project_insights_copy_ds`'s SCHEMA — purely additive, same pattern IN-1196 used to add `healthScoreV2`/`lifecycleLabel`/`impactScore`):
- `maintainerHealthScoreV2` (0-40)
- `securitySupplyChainScoreV2` (0-35)
- `developmentActivityScoreV2` (0-25)

**Aggregation method:** straight mean (`avg()`) across a project's enabled, non-excluded repos, per category — same idiom already used for the existing `healthScoreV2` rollup in the same node. This is consistent because `healthScoreV2` is itself documented as "the sum of the three categories" at repo level, so averaging the categories independently and averaging the sum should track closely (confirmed in validation below). `avg()` (not `avgOrNull`) matches the existing idiom and was confirmed live to return NULL — not 0 or NaN — when every repo in a project is NULL for a category.

Also threads the 3 new columns through `project_insights.pipe` (the public endpoint `insights/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts` reads from), since that's what Insights will need to actually consume this.

## Validation (read-only, against live production data)

- Bounds check across **all 11,257 projects** with a rollup: 0 out-of-bounds values (against 0-40/0-35/0-25), 0 NaNs.
- Spot-checked 10 real multi-repo projects (Kubernetes, TensorFlow, Envoy, gRPC, containerd, etcd, Helm, Prometheus, Linkerd, OpenTelemetry — 1 to 105 repos each): all sane, non-negative, within bounds.
- Sum-of-categories vs. existing `healthScoreV2` rollup tracks within a few points across all 10 (expected drift: `healthScoreV2` is rounded per-repo then averaged; categories are averaged then rounded independently).
- NULL edge case confirmed: single-repo projects with a NULL category in the source data (e.g. `alecaivazis-survey`, `taxel-plextraktsync`) correctly propagate NULL at the project level rather than 0/NaN.
- `tb check` clean on all 3 changed files.

## Bug found and fixed during deploy — first production push attempt failed

The first production deploy of `project_insights_copy.pipe` was **rejected by Tinybird** with `[Error] UNION different number of columns in queries. (TYPE_MISMATCH)`. Root cause: the pipe's final node does `SELECT * FROM project_insights_copy_project_results UNION ALL SELECT * FROM project_insights_copy_repo_results`, and the 3 new columns had only been added to the project-side branch, not the repo-side branch — 36 vs 33 columns. `tb check` does not catch this (it validates each node's syntax, not the final unioned shape), so this only surfaced at the actual production push.

**Nothing broke.** Tinybird rejected the deploy cleanly before applying it — the copy pipe kept running its pre-change version throughout, and `project_insights_copy_ds`'s table was untouched at its prior row count. Only the (harmless, additive, unused-until-this-fix) datasource schema change had already landed.

**Fix**: added the same 3 columns to `project_insights_copy_repo_results`, sourced directly from `hv2` (`health_score_v2_repo_copy_ds`, already `LEFT JOIN`ed in that node at repo grain — no aggregation needed there, unlike the project-side average-across-repos rollup). Same column order/position as the project-side branch.

## Deploy status

**Deployed to production and verified.** All three files (`project_insights_copy_ds.datasource`, `project_insights_copy.pipe`, `project_insights.pipe`) are live.

- Copy pipe re-ran and repopulated `project_insights_copy_ds`. Full-table scan post-copy: **0 out-of-bounds values** across all 42,685 rows (31,059 repo-type + 11,626 project-type), against the 0-40/0-35/0-25 bounds.
- Kubernetes (`k8s`) sample: `maintainerHealthScoreV2=27`, `securitySupplyChainScoreV2=22`, `developmentActivityScoreV2=14` (sums to 63, tracks `healthScoreV2=61` within the expected rounding-order drift noted above).
- Public endpoint (`project_insights.json?slug=k8s`) confirmed returning all 3 real values, matching the table.

## Downstream impact

Already consumed — the Insights overview page redesign (insights PR #2054) was built against this exact contract and is now live end-to-end against production data, not just types waiting for a backend. No further coordination PR needed on the Insights side.

## Test plan

- [x] `tb check` on all changed files
- [x] Deploy to production — first attempt failed (UNION mismatch, see above), fixed, second attempt succeeded
- [x] Full-table bounds/NaN scan on the materialized `project_insights_copy_ds` output post-deploy — 0 anomalies across 42,685 rows
- [x] Live public endpoint verification against real project data