### PR TITLE
feat: add cargo ecosystem to blast (CM-1358)

### DIFF
--- a/backend/src/api/public/v1/akrites-external/openapi.yaml
+++ b/backend/src/api/public/v1/akrites-external/openapi.yaml
@@ -11,8 +11,8 @@ info:
 
     Packages, Advisories and Contacts endpoints are implemented. Blast Radius
     submit (2a) and poll (2b) are both implemented, backed by a 4-stage
-    Temporal pipeline (intel, dependents, reachability, report) for npm, go, and
-    maven packages; other ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. The
+    Temporal pipeline (intel, dependents, reachability, report) for npm, go, maven, and
+    cargo packages; other ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. The
     7-day result cache is specced separately and not yet built.
 
 
@@ -61,7 +61,7 @@ tags:
     description: >
       Advisory reachability analysis — submit (2a) and poll (2b) are both
       implemented, each with a bulk counterpart. Submitting kicks off a
-      Temporal workflow that runs the npm, go, or maven reachability pipeline (other
+      Temporal workflow that runs the npm, go, maven, or cargo reachability pipeline (other
       ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED); poll returns job
       status and, once done, results. Bulk submit (jobs:batch) is capped at
       20 jobs per request (10 recommended as the default batch size) — each
@@ -411,9 +411,9 @@ components:
           example: GHSA-jf85-cpcp-j695
         ecosystem:
           type: string
-          enum: [npm, go, maven]
+          enum: [npm, go, maven, cargo]
           description: >
-            Required. The reachability pipeline supports npm, go, and maven today —
+            Required. The reachability pipeline supports npm, go, maven, and cargo today —
             any other value, or a missing ecosystem, is rejected with a 400.
           example: npm
         package:
@@ -450,7 +450,7 @@ components:
           description: Echoes the request's package. Null when the request omitted it.
         ecosystem:
           type: string
-          enum: [npm, go, maven]
+          enum: [npm, go, maven, cargo]
           description: Echoes the request's ecosystem. Always present — the request requires it.
         status:
           type: string
@@ -611,7 +611,7 @@ components:
           nullable: true
         ecosystem:
           type: string
-          enum: [npm, go, maven]
+          enum: [npm, go, maven, cargo]
         submittedAt:
           type: string
           nullable: true
@@ -1244,7 +1244,7 @@ paths:
         advisories); provide it to narrow to one package, which is required
         for advisories affecting more than one. Starts a Temporal workflow
         running the 4-stage reachability pipeline
-        (intel, dependents, reachability, report) for npm, go, or maven; other
+        (intel, dependents, reachability, report) for npm, go, maven, or cargo; other
         ecosystems fail fast with ECOSYSTEM_NOT_SUPPORTED. Poll status/results
         via GET /jobs/{analysisId}.
 
@@ -1272,7 +1272,7 @@ paths:
         '400':
           description: >
             Validation error (missing/empty advisoryId), or an unsupported
-            ecosystem — only npm, go, and maven are supported today, so any other
+            ecosystem — only npm, go, maven, and cargo are supported today, so any other
             value (including a missing ecosystem) is rejected before a
             workflow is started.
           content:

--- a/backend/src/api/public/v1/packages/blastRadius.ts
+++ b/backend/src/api/public/v1/packages/blastRadius.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = ['npm', 'go', 'maven'] as const
+export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = ['npm', 'go', 'maven', 'cargo'] as const
 
 // Always exactly one job per request — advisory-wide (package omitted) or narrowed
 // to a single package. package accepts either a full purl or a bare package name,

--- a/backend/src/api/public/v1/packages/blastRadiusAnalysis.ts
+++ b/backend/src/api/public/v1/packages/blastRadiusAnalysis.ts
@@ -63,6 +63,8 @@ function toPurl(ecosystem: BlastRadiusJobEcosystem, name: string): string {
     }
     case 'go':
       return `pkg:golang/${name}`
+    case 'cargo':
+      return `pkg:cargo/${name}`
     case 'npm':
     default:
       return `pkg:npm/${name.replace(/^@/, '%40')}`

--- a/services/apps/packages_worker/src/blast-radius/__tests__/ecosystemSupport.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/__tests__/ecosystemSupport.test.ts
@@ -1,7 +1,13 @@
 import { ApplicationFailure } from '@temporalio/workflow'
 import { describe, expect, it } from 'vitest'
 
-import { buildEcosystemNotSupportedFailure } from '../ecosystemSupport'
+import { SUPPORTED_ECOSYSTEMS, buildEcosystemNotSupportedFailure } from '../ecosystemSupport'
+
+describe('SUPPORTED_ECOSYSTEMS', () => {
+  it('includes cargo alongside npm, go, and maven', () => {
+    expect(SUPPORTED_ECOSYSTEMS).toEqual(['npm', 'go', 'maven', 'cargo'])
+  })
+})
 
 describe('buildEcosystemNotSupportedFailure', () => {
   it('builds a non-retryable ApplicationFailure tagged ECOSYSTEM_NOT_SUPPORTED', () => {

--- a/services/apps/packages_worker/src/blast-radius/__tests__/packageIdentifier.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/__tests__/packageIdentifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { toBareNpmName } from '../packageIdentifier'
+import { toBareNpmName, toDbCargoName } from '../packageIdentifier'
 
 describe('toBareNpmName', () => {
   it('returns a bare name unchanged', () => {
@@ -29,5 +29,19 @@ describe('toBareNpmName', () => {
 
   it('strips qualifiers and subpath', () => {
     expect(toBareNpmName('pkg:npm/lodash@4.17.21?foo=bar#sub')).toBe('lodash')
+  })
+})
+
+describe('toDbCargoName', () => {
+  it('leaves an already-underscored name unchanged', () => {
+    expect(toDbCargoName('serde_json')).toBe('serde_json')
+  })
+
+  it('converts hyphens to underscores, matching packages.name for hyphenated crates', () => {
+    expect(toDbCargoName('serde-json')).toBe('serde_json')
+  })
+
+  it('lowercases mixed-case names', () => {
+    expect(toDbCargoName('Actix-Web')).toBe('actix_web')
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/agent/__tests__/cargoPrompts.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/__tests__/cargoPrompts.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { CARGO_INTEL_SCHEMA } from '../cargoPrompts'
+
+describe('CARGO_INTEL_SCHEMA', () => {
+  it('keeps import_signatures.properties keys in sync with its required list', () => {
+    const importSignatures = CARGO_INTEL_SCHEMA.properties.import_signatures
+    const propertyKeys = Object.keys(importSignatures.properties).sort()
+    const requiredKeys = [...importSignatures.required].sort()
+    expect(propertyKeys).toEqual(requiredKeys)
+  })
+
+  it('keeps the top-level schema properties in sync with its required list', () => {
+    const propertyKeys = Object.keys(CARGO_INTEL_SCHEMA.properties).sort()
+    const requiredKeys = [...CARGO_INTEL_SCHEMA.required].sort()
+    expect(propertyKeys).toEqual(requiredKeys)
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/agent/cargoPrompts.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/cargoPrompts.ts
@@ -1,0 +1,127 @@
+// Parallels goPrompts.ts — schema shape and the intel prompt builder are shared via
+// promptKit.ts; only the Rust-specific keys/enum and system-prompt prose live here.
+import {
+  buildIntelPrompt,
+  buildIntelSchema,
+  buildReachabilitySymbolsBlock,
+  buildVerdictSchema,
+} from './promptKit'
+import { SymbolSpec } from './prompts'
+
+// ---------- STAGE 1: INTEL ----------
+
+const IMPORT_SIGNATURE_KEYS = [
+  'use_path',
+  'extern_crate',
+  'macro_invocation',
+  'fully_qualified_path',
+]
+
+export const CARGO_INTEL_SCHEMA = buildIntelSchema(IMPORT_SIGNATURE_KEYS)
+
+export const CARGO_INTEL_SYSTEM_PROMPT = `You are a vulnerability analyst. Your working directory contains the FULL SOURCE of the
+vulnerable version of a Rust crate. You are given the security advisory and the patch
+(diff) that fixed the vulnerability.
+
+Your job is to determine, precisely, WHAT is vulnerable — so that downstream analysts can
+check whether other crates actually reach the vulnerable code.
+
+Rules:
+- Identify the exact vulnerable function(s)/method(s)/type(s)/macro(s) from the patch and
+  the source. Be minimal and precise: do NOT include similar-but-unaffected symbols. If the
+  patch only touches a private (non-\`pub\`) helper, trace which \`pub\` symbols route through
+  it and list those as the reachable surface (note the helper in \`notes\`).
+- Read the crate source to verify how each vulnerable symbol is exported — only items
+  marked \`pub\` (or \`pub(crate)\`/\`pub(super)\`, which are NOT reachable from other crates)
+  are visible outside the crate; note the exact module path each symbol lives in (e.g.
+  \`crate::foo::bar\`), and whether it's re-exported elsewhere via \`pub use\`.
+- Build \`import_signatures\`: concrete code patterns a dependent crate would contain if it
+  uses the vulnerable symbol. Cover: a plain \`use crate_name::path::Symbol\` followed by bare
+  \`Symbol\` usage, an \`extern crate crate_name;\` (2018-edition-and-earlier style) followed by
+  fully-qualified use, invocation of a vulnerable macro (\`crate_name::macro_name!(...)\` or
+  \`use\`d then bare \`macro_name!(...)\`), and a fully-qualified path call
+  (\`crate_name::path::Symbol::method(...)\`) without any \`use\`. These are the patterns
+  analysts will grep for — make them literal and greppable, not prose.
+- \`reachability_notes\` must state what does NOT count (e.g. sibling functions that look
+  similar but are not affected, usage confined to \`tests/\`, \`examples/\`, or code behind
+  \`#[cfg(test)]\`) and any conditions required for exploitability (e.g. a specific Cargo
+  feature flag must be enabled).
+- Set \`confidence\` for your identification: 0.9+ only if the patch unambiguously
+  identifies the symbol(s); lower if you had to infer from indirect evidence.`
+
+export const buildCargoIntelPrompt = buildIntelPrompt
+
+// ---------- STAGE 3: REACHABILITY ----------
+
+const IMPORT_STYLE_ENUM = [
+  'use-path',
+  'extern-crate',
+  'macro-invocation',
+  'fully-qualified-path',
+  'reexport',
+  'none',
+]
+
+export const CARGO_VERDICT_SCHEMA = buildVerdictSchema(IMPORT_STYLE_ENUM)
+
+export function buildCargoReachabilitySystemPrompt(spec: SymbolSpec): string {
+  const { symbolsText, signatures } = buildReachabilitySymbolsBlock(spec)
+
+  return `You are a security reachability analyst. Your working directory contains the published
+source of ONE Rust crate (the "dependent") that declares a dependency on
+\`${spec.package}\`, which has a known vulnerability (${spec.vuln_id}).
+
+## The vulnerability
+${spec.summary}
+
+Vulnerable symbol(s) in \`${spec.package}\`:
+${symbolsText}
+
+Exploit preconditions: ${spec.exploit_preconditions}
+
+Analyst notes: ${spec.reachability_notes}
+
+## Import signatures to look for
+${signatures}
+
+## Your task
+Decide whether THIS dependent's own code actually reaches the vulnerable symbol(s).
+
+Scope rules — follow strictly:
+1. Only the dependent's OWN shipped code counts (\`src/\`). Usage of the vulnerable symbol
+   inside the dependent's OTHER dependencies (its own \`Cargo.toml\` deps) is OUT OF SCOPE
+   (that is second-level analysis, done separately).
+2. Merely declaring a dependency on \`${spec.package}\` (present in \`Cargo.toml\`) is NOT
+   enough — the vulnerable symbol itself must be reached. Uses of other items from the
+   crate are irrelevant.
+3. Usage only in \`tests/\`, \`examples/\`, \`benches/\`, or code gated behind \`#[cfg(test)]\`
+   that is not part of the shipped runtime code → \`not_affected\` (explain in reasoning).
+4. If the dependent RE-EXPORTS the vulnerable symbol to its own consumers (\`pub use\`, or a
+   thin wrapper function/type that passes arguments through), that DOES count as \`affected\`
+   with \`import_style: "reexport"\` — it propagates the vulnerable surface.
+5. Watch for indirect reachability inside the dependent's own code: fully-qualified paths
+   (\`crate_name::module::Symbol\`), trait method calls through a re-exported trait, macro
+   invocations, and generic/dyn dispatch through the vulnerable type.
+6. \`import_style\` describes how the VULNERABLE SYMBOL is reached, not how the crate is
+   declared: report \`none\` whenever the vulnerable symbol itself is not reached, even if
+   the crate is a dependency for other functionality.
+
+Method: grep for the import signatures (and the bare symbol/macro names) across the source,
+open every hit, and trace whether the symbol is actually invoked. Check \`Cargo.toml\` to
+confirm the declared dependency, its version requirement, and whether any feature flags
+gate the vulnerable code path. Exclude \`tests/\`, \`examples/\`, \`benches/\`, and
+\`#[cfg(test)]\`-gated code from consideration.
+
+## Confidence calibration
+- 0.8–1.0: direct evidence — you found (or ruled out) the import AND the call site
+  explicitly; source was readable.
+- 0.4–0.8: symbol is imported but the call path is ambiguous (trait dispatch, conditional
+  compilation, generated/macro-expanded code).
+- <0.4 and/or \`unclear\`: source is generated/absent, or indirection you could not resolve.
+
+Report evidence as exact file paths, line numbers, and short verbatim snippets.`
+}
+
+export const CARGO_REACHABILITY_PROMPT =
+  'Analyze this crate per your instructions and produce the structured verdict. ' +
+  'Start by listing the crate structure and grepping for the import signatures.'

--- a/services/apps/packages_worker/src/blast-radius/crates/__tests__/registryClient.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/__tests__/registryClient.test.ts
@@ -36,7 +36,7 @@ describe('fetchCrateVersions', () => {
       ),
     )
     const result = await fetchCrateVersions('serde', 5000)
-    expect(result).toEqual(['1.0.0', '1.1.0', '2.0.0'])
+    expect(result).toEqual({ name: 'serde', versions: ['1.0.0', '1.1.0', '2.0.0'] })
   })
 
   it('filters out entries with missing num field', async () => {
@@ -49,7 +49,20 @@ describe('fetchCrateVersions', () => {
       ),
     )
     const result = await fetchCrateVersions('serde', 5000)
-    expect(result).toEqual(['1.0.0', '1.1.0'])
+    expect(result).toEqual({ name: 'serde', versions: ['1.0.0', '1.1.0'] })
+  })
+
+  it('resolves the canonical crate name from a versions entry', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          versions: [{ num: '1.0.0', crate: 'serde-json' }],
+        }),
+      ),
+    )
+    const result = await fetchCrateVersions('serde_json', 5000)
+    expect(result).toEqual({ name: 'serde-json', versions: ['1.0.0'] })
   })
 
   it('maps a 404 to NOT_FOUND', async () => {
@@ -106,7 +119,7 @@ describe('fetchCrateVersions', () => {
     await vi.runAllTimersAsync()
 
     const result = await promise
-    expect(result).toEqual(['1.0.0'])
+    expect(result).toEqual({ name: 'serde', versions: ['1.0.0'] })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
@@ -141,7 +154,7 @@ describe('fetchCrateLatestVersion', () => {
       ),
     )
     const result = await fetchCrateLatestVersion('serde', 5000)
-    expect(result).toBe('1.5.0')
+    expect(result).toEqual({ name: 'serde', version: '1.5.0' })
   })
 
   it('falls back to max_version when newest_version is missing', async () => {
@@ -154,7 +167,20 @@ describe('fetchCrateLatestVersion', () => {
       ),
     )
     const result = await fetchCrateLatestVersion('serde', 5000)
-    expect(result).toBe('1.4.0')
+    expect(result).toEqual({ name: 'serde', version: '1.4.0' })
+  })
+
+  it('resolves the canonical crate name from crate.name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          crate: { name: 'serde-json', newest_version: '1.0.0' },
+        }),
+      ),
+    )
+    const result = await fetchCrateLatestVersion('serde_json', 5000)
+    expect(result).toEqual({ name: 'serde-json', version: '1.0.0' })
   })
 
   it('returns MALFORMED when neither newest_version nor max_version present', async () => {
@@ -185,7 +211,7 @@ describe('fetchCrateLatestVersion', () => {
     await vi.runAllTimersAsync()
 
     const result = await promise
-    expect(result).toBe('1.5.0')
+    expect(result).toEqual({ name: 'serde', version: '1.5.0' })
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/crates/__tests__/registryClient.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/__tests__/registryClient.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { crateSourceUrl, fetchCrateLatestVersion, fetchCrateVersions } from '../registryClient'
+
+function fakeResponse(
+  status: number,
+  body?: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    json: async () => body ?? {},
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  process.env.SECURITY_CONTACTS_USER_AGENT = 'test-agent'
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+  delete process.env.SECURITY_CONTACTS_USER_AGENT
+})
+
+describe('fetchCrateVersions', () => {
+  it('parses versions array from API response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          versions: [{ num: '1.0.0' }, { num: '1.1.0' }, { num: '2.0.0' }],
+        }),
+      ),
+    )
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toEqual(['1.0.0', '1.1.0', '2.0.0'])
+  })
+
+  it('filters out entries with missing num field', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          versions: [{ num: '1.0.0' }, { other: 'field' }, { num: '1.1.0' }],
+        }),
+      ),
+    )
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toEqual(['1.0.0', '1.1.0'])
+  })
+
+  it('maps a 404 to NOT_FOUND', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(404)))
+    const result = await fetchCrateVersions('nonexistent-crate', 5000)
+    expect(result).toMatchObject({ kind: 'NOT_FOUND', statusCode: 404 })
+  })
+
+  it('maps a 403 to NOT_FOUND', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(403)))
+    const result = await fetchCrateVersions('forbidden-crate', 5000)
+    expect(result).toMatchObject({ kind: 'NOT_FOUND', statusCode: 403 })
+  })
+
+  it('maps a 500 to TRANSIENT', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(500)))
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toMatchObject({ kind: 'TRANSIENT', statusCode: 500 })
+  })
+
+  it('maps malformed JSON to MALFORMED', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: { get: () => null },
+      json: async () => {
+        throw new Error('Invalid JSON')
+      },
+    } as unknown as Response)
+    vi.stubGlobal('fetch', mockFetch)
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toMatchObject({ kind: 'MALFORMED', message: 'invalid json' })
+  })
+
+  it('maps missing versions array to MALFORMED', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(200, { crate: {} })))
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toMatchObject({ kind: 'MALFORMED', message: 'missing versions array' })
+  })
+
+  it('retries on 429 with Retry-After and eventually succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(429, undefined, { 'retry-after': '0' }))
+      .mockResolvedValueOnce(
+        fakeResponse(200, {
+          versions: [{ num: '1.0.0' }],
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+
+    const promise = fetchCrateVersions('serde', 5000)
+    await vi.runAllTimersAsync()
+
+    const result = await promise
+    expect(result).toEqual(['1.0.0'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up after max retries on 429', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(fakeResponse(429))
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+
+    const promise = fetchCrateVersions('serde', 5000)
+    await vi.runAllTimersAsync()
+
+    const result = await promise
+    expect(result).toMatchObject({ kind: 'RATE_LIMIT', statusCode: 429 })
+    expect(fetchMock).toHaveBeenCalledTimes(6) // 0 to 5 inclusive
+  })
+
+  it('maps network error to TRANSIENT', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNRESET')))
+    const result = await fetchCrateVersions('serde', 5000)
+    expect(result).toMatchObject({ kind: 'TRANSIENT' })
+  })
+})
+
+describe('fetchCrateLatestVersion', () => {
+  it('returns newest_version when present', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          crate: { newest_version: '1.5.0', max_version: '1.4.0' },
+        }),
+      ),
+    )
+    const result = await fetchCrateLatestVersion('serde', 5000)
+    expect(result).toBe('1.5.0')
+  })
+
+  it('falls back to max_version when newest_version is missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        fakeResponse(200, {
+          crate: { max_version: '1.4.0' },
+        }),
+      ),
+    )
+    const result = await fetchCrateLatestVersion('serde', 5000)
+    expect(result).toBe('1.4.0')
+  })
+
+  it('returns MALFORMED when neither newest_version nor max_version present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(200, { crate: {} })))
+    const result = await fetchCrateLatestVersion('serde', 5000)
+    expect(result).toMatchObject({ kind: 'MALFORMED' })
+  })
+
+  it('maps a 404 to NOT_FOUND', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(fakeResponse(404)))
+    const result = await fetchCrateLatestVersion('nonexistent-crate', 5000)
+    expect(result).toMatchObject({ kind: 'NOT_FOUND', statusCode: 404 })
+  })
+
+  it('retries on 429 and eventually succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResponse(429, undefined, { 'retry-after': '0' }))
+      .mockResolvedValueOnce(
+        fakeResponse(200, {
+          crate: { newest_version: '1.5.0' },
+        }),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+    vi.useFakeTimers()
+
+    const promise = fetchCrateLatestVersion('serde', 5000)
+    await vi.runAllTimersAsync()
+
+    const result = await promise
+    expect(result).toBe('1.5.0')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('crateSourceUrl', () => {
+  it('constructs the static.crates.io download URL with proper encoding', () => {
+    const url = crateSourceUrl('serde', '1.0.0')
+    expect(url).toBe('https://static.crates.io/crates/serde/serde-1.0.0.crate')
+  })
+
+  it('encodes special characters in crate names and versions', () => {
+    const url = crateSourceUrl('my-crate', '1.0.0-rc.1+build')
+    expect(url).toBe('https://static.crates.io/crates/my-crate/my-crate-1.0.0-rc.1%2Bbuild.crate')
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
@@ -50,7 +50,9 @@ async function getWithRetry(url: string, timeoutMs: number): Promise<Response | 
     return res
   }
 
-  return { kind: 'RATE_LIMIT', statusCode: 429, message: '429 after retries' }
+  // Unreachable: every loop iteration returns or continues, and the final
+  // attempt (attempt === MAX_429_RETRIES) always returns on a 429.
+  throw new Error('unreachable')
 }
 
 // GET /api/v1/crates/{name}/versions — includes yanked versions (still installable/vulnerable).
@@ -94,7 +96,7 @@ export async function fetchCrateLatestVersion(
   }
   const version = body.crate?.newest_version ?? body.crate?.max_version
   if (version === undefined || version === null) {
-    return { kind: 'MALFORMED', message: 'missing crate.newest_version' }
+    return { kind: 'MALFORMED', message: 'missing crate.newest_version and crate.max_version' }
   }
 
   return version

--- a/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
@@ -55,19 +55,26 @@ async function getWithRetry(url: string, timeoutMs: number): Promise<Response | 
   throw new Error('unreachable')
 }
 
+export interface CrateVersionsResult {
+  // crates.io's canonical (as-published) spelling — see fetchCrateLatestVersion for why
+  // this can differ from the queried `name`.
+  name: string
+  versions: string[]
+}
+
 // GET /api/v1/crates/{name}/versions — includes yanked versions (still installable/vulnerable).
 export async function fetchCrateVersions(
   name: string,
   timeoutMs: number,
-): Promise<string[] | FetchError> {
+): Promise<CrateVersionsResult | FetchError> {
   const url = `${API_BASE}/api/v1/crates/${encodeURIComponent(name)}/versions`
 
   const res = await getWithRetry(url, timeoutMs)
   if (!('ok' in res)) return res
 
-  let body: { versions?: Array<{ num?: string }> }
+  let body: { versions?: Array<{ num?: string; crate?: string }> }
   try {
-    body = (await res.json()) as { versions?: Array<{ num?: string }> }
+    body = (await res.json()) as { versions?: Array<{ num?: string; crate?: string }> }
   } catch {
     return { kind: 'MALFORMED', message: 'invalid json' }
   }
@@ -75,22 +82,34 @@ export async function fetchCrateVersions(
     return { kind: 'MALFORMED', message: 'missing versions array' }
   }
 
-  return body.versions.map((v) => v.num).filter((num): num is string => Boolean(num))
+  return {
+    name: body.versions.find((v) => v.crate)?.crate ?? name,
+    versions: body.versions.map((v) => v.num).filter((num): num is string => Boolean(num)),
+  }
+}
+
+export interface CrateLatestVersionResult {
+  // static.crates.io requires this exact canonical spelling for downloads, unlike
+  // this API's lookup, which normalizes '-'/'_' in the queried `name`.
+  name: string
+  version: string
 }
 
 // GET /api/v1/crates/{name} — lightweight call for latest version (avoids full list).
 export async function fetchCrateLatestVersion(
   name: string,
   timeoutMs: number,
-): Promise<string | FetchError> {
+): Promise<CrateLatestVersionResult | FetchError> {
   const url = `${API_BASE}/api/v1/crates/${encodeURIComponent(name)}`
 
   const res = await getWithRetry(url, timeoutMs)
   if (!('ok' in res)) return res
 
-  let body: { crate?: { newest_version?: string; max_version?: string } }
+  let body: { crate?: { name?: string; newest_version?: string; max_version?: string } }
   try {
-    body = (await res.json()) as { crate?: { newest_version?: string; max_version?: string } }
+    body = (await res.json()) as {
+      crate?: { name?: string; newest_version?: string; max_version?: string }
+    }
   } catch {
     return { kind: 'MALFORMED', message: 'invalid json' }
   }
@@ -99,7 +118,7 @@ export async function fetchCrateLatestVersion(
     return { kind: 'MALFORMED', message: 'missing crate.newest_version and crate.max_version' }
   }
 
-  return version
+  return { name: body.crate?.name ?? name, version }
 }
 
 // static.crates.io serves .crate files at a fixed, predictable path — no API call needed.

--- a/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
@@ -1,9 +1,7 @@
 import { getSecurityContactsConfig } from '../../config'
 import { FetchError } from '../../go/types'
 
-// crates.io API client for blast-radius's per-crate needs — separate from the bulk
-// db-dump worker in ../../cargo/ (that ingests the full registry, this fetches one
-// crate at a time). Mirrors go/proxyClient.ts's 429-retry/backoff shape.
+// crates.io API client for blast-radius; mirrors go/proxyClient.ts's retry/backoff shape.
 
 const API_BASE = process.env.CRATES_IO_BASE_URL ?? 'https://crates.io'
 const STATIC_BASE = process.env.CRATES_STATIC_BASE_URL ?? 'https://static.crates.io'
@@ -55,9 +53,7 @@ async function getWithRetry(url: string, timeoutMs: number): Promise<Response | 
   return { kind: 'RATE_LIMIT', statusCode: 429, message: '429 after retries' }
 }
 
-// GET /api/v1/crates/{name}/versions — returns every published version, including
-// yanked ones (a yanked version can still be installed/vulnerable, so it must stay
-// in the candidate pool for vulnerable-version resolution).
+// GET /api/v1/crates/{name}/versions — includes yanked versions (still installable/vulnerable).
 export async function fetchCrateVersions(
   name: string,
   timeoutMs: number,
@@ -80,9 +76,7 @@ export async function fetchCrateVersions(
   return body.versions.map((v) => v.num).filter((num): num is string => Boolean(num))
 }
 
-// GET /api/v1/crates/{name} — single lightweight call for just the newest version,
-// avoiding a full /versions fetch (hundreds of entries for popular crates) when only
-// the latest is needed.
+// GET /api/v1/crates/{name} — lightweight call for latest version (avoids full list).
 export async function fetchCrateLatestVersion(
   name: string,
   timeoutMs: number,
@@ -99,7 +93,7 @@ export async function fetchCrateLatestVersion(
     return { kind: 'MALFORMED', message: 'invalid json' }
   }
   const version = body.crate?.newest_version ?? body.crate?.max_version
-  if (!version) {
+  if (version === undefined || version === null) {
     return { kind: 'MALFORMED', message: 'missing crate.newest_version' }
   }
 

--- a/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
+++ b/services/apps/packages_worker/src/blast-radius/crates/registryClient.ts
@@ -1,0 +1,112 @@
+import { getSecurityContactsConfig } from '../../config'
+import { FetchError } from '../../go/types'
+
+// crates.io API client for blast-radius's per-crate needs — separate from the bulk
+// db-dump worker in ../../cargo/ (that ingests the full registry, this fetches one
+// crate at a time). Mirrors go/proxyClient.ts's 429-retry/backoff shape.
+
+const API_BASE = process.env.CRATES_IO_BASE_URL ?? 'https://crates.io'
+const STATIC_BASE = process.env.CRATES_STATIC_BASE_URL ?? 'https://static.crates.io'
+const MAX_429_RETRIES = 5
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+async function getWithRetry(url: string, timeoutMs: number): Promise<Response | FetchError> {
+  // crates.io rejects requests without an identifying User-Agent.
+  const headers = { 'User-Agent': getSecurityContactsConfig().userAgent }
+
+  for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+
+    let res: Response
+    try {
+      res = await fetch(url, { signal: controller.signal, headers })
+    } catch (e) {
+      return { kind: 'TRANSIENT', message: `network error: ${(e as Error).message}` }
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (res.status === 429) {
+      if (attempt === MAX_429_RETRIES) {
+        return { kind: 'RATE_LIMIT', statusCode: 429, message: '429 after retries' }
+      }
+      const retryAfterSec = parseInt(res.headers.get('retry-after') ?? '', 10)
+      const waitMs = Number.isNaN(retryAfterSec) ? 1000 * 2 ** attempt : retryAfterSec * 1000
+      await sleep(waitMs)
+      continue
+    }
+    if (res.status >= 400 && res.status < 500) {
+      return { kind: 'NOT_FOUND', statusCode: res.status, message: `${res.status}` }
+    }
+    if (res.status !== 200) {
+      return {
+        kind: 'TRANSIENT',
+        statusCode: res.status,
+        message: `unexpected status ${res.status}`,
+      }
+    }
+    return res
+  }
+
+  return { kind: 'RATE_LIMIT', statusCode: 429, message: '429 after retries' }
+}
+
+// GET /api/v1/crates/{name}/versions — returns every published version, including
+// yanked ones (a yanked version can still be installed/vulnerable, so it must stay
+// in the candidate pool for vulnerable-version resolution).
+export async function fetchCrateVersions(
+  name: string,
+  timeoutMs: number,
+): Promise<string[] | FetchError> {
+  const url = `${API_BASE}/api/v1/crates/${encodeURIComponent(name)}/versions`
+
+  const res = await getWithRetry(url, timeoutMs)
+  if (!('ok' in res)) return res
+
+  let body: { versions?: Array<{ num?: string }> }
+  try {
+    body = (await res.json()) as { versions?: Array<{ num?: string }> }
+  } catch {
+    return { kind: 'MALFORMED', message: 'invalid json' }
+  }
+  if (!Array.isArray(body.versions)) {
+    return { kind: 'MALFORMED', message: 'missing versions array' }
+  }
+
+  return body.versions.map((v) => v.num).filter((num): num is string => Boolean(num))
+}
+
+// GET /api/v1/crates/{name} — single lightweight call for just the newest version,
+// avoiding a full /versions fetch (hundreds of entries for popular crates) when only
+// the latest is needed.
+export async function fetchCrateLatestVersion(
+  name: string,
+  timeoutMs: number,
+): Promise<string | FetchError> {
+  const url = `${API_BASE}/api/v1/crates/${encodeURIComponent(name)}`
+
+  const res = await getWithRetry(url, timeoutMs)
+  if (!('ok' in res)) return res
+
+  let body: { crate?: { newest_version?: string; max_version?: string } }
+  try {
+    body = (await res.json()) as { crate?: { newest_version?: string; max_version?: string } }
+  } catch {
+    return { kind: 'MALFORMED', message: 'invalid json' }
+  }
+  const version = body.crate?.newest_version ?? body.crate?.max_version
+  if (!version) {
+    return { kind: 'MALFORMED', message: 'missing crate.newest_version' }
+  }
+
+  return version
+}
+
+// static.crates.io serves .crate files at a fixed, predictable path — no API call needed.
+export function crateSourceUrl(name: string, version: string): string {
+  return `${STATIC_BASE}/crates/${encodeURIComponent(name)}/${encodeURIComponent(name)}-${encodeURIComponent(version)}.crate`
+}

--- a/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
+++ b/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
@@ -2,7 +2,7 @@ import { ApplicationFailure } from '@temporalio/workflow'
 
 // Single source of truth for supported ecosystems — kept in this leaf, I/O-free file
 // (no activities/DAL imports) so the workflow bundle stays deterministic-safe.
-export const SUPPORTED_ECOSYSTEMS = ['npm', 'go', 'maven'] as const
+export const SUPPORTED_ECOSYSTEMS = ['npm', 'go', 'maven', 'cargo'] as const
 export type Ecosystem = (typeof SUPPORTED_ECOSYSTEMS)[number]
 
 // Pure so it's testable outside the workflow sandbox (Workflow.log/context calls

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -65,6 +65,14 @@ export function toBareCargoName(input: string): string {
   return name
 }
 
+// crates.io treats '-' and '_' as the same crate (you can't publish both), and our
+// packages/purl rows store the '_' form (see cargo/loadDump.ts's DENORMALIZE join) while
+// OSV/crates.io always spell names with '-'. Apply this ONLY at the packages-table lookup
+// boundary — never to the name shown to users, crates.io API calls, or OSV entry matching.
+export function toDbCargoName(name: string): string {
+  return name.toLowerCase().replace(/-/g, '_')
+}
+
 // Maven has no single "bare name" — accepts either the "groupId:artifactId" coordinate
 // (OSV's package.name spelling) or a purl (pkg:maven/groupId/artifactId@version).
 export function toBareMavenCoordinate(input: string): { groupId: string; artifactId: string } {

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -44,6 +44,27 @@ export function toBareGoModule(input: string): string {
   return name
 }
 
+// Same normalization as toBareGoModule, but for Cargo: crates.io purls spell the
+// ecosystem 'cargo' and crate names never contain '@' themselves either.
+export function toBareCargoName(input: string): string {
+  let name = input.trim()
+
+  const q = name.indexOf('?')
+  const h = name.indexOf('#')
+  const cut = q === -1 ? h : h === -1 ? q : Math.min(q, h)
+  if (cut !== -1) name = name.slice(0, cut)
+
+  name = decodeURIComponent(name)
+
+  if (name.startsWith('pkg:cargo/')) {
+    name = name.slice('pkg:cargo/'.length)
+  }
+
+  name = name.replace(/@[^/@]+$/, '')
+
+  return name
+}
+
 // Maven has no single "bare name" — accepts either the "groupId:artifactId" coordinate
 // (OSV's package.name spelling) or a purl (pkg:maven/groupId/artifactId@version).
 export function toBareMavenCoordinate(input: string): { groupId: string; artifactId: string } {

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -1,8 +1,5 @@
-// The blast-radius submit endpoint accepts either a bare npm package name
-// ("lodash", "@babel/core") or a full purl ("pkg:npm/lodash", "pkg:npm/%40babel/core@4.17.21")
-// for the `package` field — see blastRadiusJobRequestSchema. OSV affected-package entries and
-// the npm registry only ever use bare names, so a purl must be reduced to that form before
-// it's compared against them (raw string equality otherwise never matches a purl input).
+// Accepts a bare npm name or a full purl (see blastRadiusJobRequestSchema) and reduces
+// it to the bare form OSV/the npm registry compare against.
 export function toBareNpmName(input: string): string {
   let name = input.trim()
 
@@ -65,10 +62,8 @@ export function toBareCargoName(input: string): string {
   return name
 }
 
-// crates.io treats '-' and '_' as the same crate (you can't publish both), and our
-// packages/purl rows store the '_' form (see cargo/loadDump.ts's DENORMALIZE join) while
-// OSV/crates.io always spell names with '-'. Apply this ONLY at the packages-table lookup
-// boundary — never to the name shown to users, crates.io API calls, or OSV entry matching.
+// packages/purl rows store cargo names '_'-normalized (see cargo/loadDump.ts) while
+// OSV/crates.io use '-'. Apply ONLY at the packages-table lookup boundary.
 export function toDbCargoName(name: string): string {
   return name.toLowerCase().replace(/-/g, '_')
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getAnalysisDetail } from '@crowd/data-access-layer/src/packages/blastRadius'
 
+import { runDependentsStageCargo } from '../cargo/dependentsCargo'
+import { runIntelStageCargo } from '../cargo/intelCargo'
+import { cargoReachabilityConfig } from '../cargo/reachabilityConfig'
 import { runDependentsStage } from '../dependents'
 import { runDependentsStageGo } from '../go/dependentsGo'
 import { runIntelStageGo } from '../go/intelGo'
@@ -24,6 +27,9 @@ vi.mock('../npm/intelNpm', () => ({ runIntelStageNpm: vi.fn().mockResolvedValue(
 vi.mock('../maven/intelMaven', () => ({
   runIntelStageMaven: vi.fn().mockResolvedValue(undefined),
 }))
+vi.mock('../cargo/intelCargo', () => ({
+  runIntelStageCargo: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../go/dependentsGo', () => ({
   runDependentsStageGo: vi.fn().mockResolvedValue(undefined),
 }))
@@ -32,6 +38,9 @@ vi.mock('../npm/dependentsNpm', () => ({
 }))
 vi.mock('../maven/dependentsMaven', () => ({
   runDependentsStageMaven: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../cargo/dependentsCargo', () => ({
+  runDependentsStageCargo: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('../reachabilityStage', () => ({
   runReachabilityStage: vi.fn().mockResolvedValue(undefined),
@@ -71,6 +80,15 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
     expect(runIntelStageNpm).not.toHaveBeenCalled()
   })
 
+  it('routes intel to the Cargo body when ecosystem is cargo', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'cargo' } as never)
+    await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageCargo).toHaveBeenCalledWith(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageGo).not.toHaveBeenCalled()
+    expect(runIntelStageNpm).not.toHaveBeenCalled()
+    expect(runIntelStageMaven).not.toHaveBeenCalled()
+  })
+
   it('routes intel to the npm body when ecosystem is missing/unknown', async () => {
     mockGetAnalysisDetail.mockResolvedValue(null)
     await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
@@ -93,6 +111,15 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
     expect(runDependentsStageMaven).toHaveBeenCalled()
     expect(runDependentsStageGo).not.toHaveBeenCalled()
     expect(runDependentsStageNpm).not.toHaveBeenCalled()
+  })
+
+  it('routes dependents to the Cargo body when ecosystem is cargo', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'cargo' } as never)
+    await runDependentsStage(qx, 'analysis-1', undefined, undefined)
+    expect(runDependentsStageCargo).toHaveBeenCalled()
+    expect(runDependentsStageGo).not.toHaveBeenCalled()
+    expect(runDependentsStageNpm).not.toHaveBeenCalled()
+    expect(runDependentsStageMaven).not.toHaveBeenCalled()
   })
 
   it('routes dependents to the npm body for npm/unknown ecosystems', async () => {
@@ -121,6 +148,17 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
       qx,
       'analysis-1',
       mavenReachabilityConfig,
+      undefined,
+    )
+  })
+
+  it('routes reachability to the Cargo config when ecosystem is cargo', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'cargo' } as never)
+    await runReachabilityStage(qx, 'analysis-1', undefined)
+    expect(mockRunReachabilityStageWithConfig).toHaveBeenCalledWith(
+      qx,
+      'analysis-1',
+      cargoReachabilityConfig,
       undefined,
     )
   })

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/__tests__/cargoConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/__tests__/cargoConstraint.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+
+import { cargoConstraintMayInclude, cargoDependencyMayIncludeVuln } from '../cargoConstraint'
+
+describe('cargoConstraintMayInclude', () => {
+  const vulnerable = ['1.2.0', '1.2.1', '1.3.0']
+
+  it('treats a bare version as caret (matches within the same major)', () => {
+    expect(cargoConstraintMayInclude('1.2.0', vulnerable)).toBe('matched')
+  })
+
+  it('excludes a bare version outside the caret range', () => {
+    expect(cargoConstraintMayInclude('2.0.0', vulnerable)).toBe('excluded')
+  })
+
+  it('passes through explicit caret/tilde/equals operators', () => {
+    expect(cargoConstraintMayInclude('^1.2', vulnerable)).toBe('matched')
+    expect(cargoConstraintMayInclude('~1.2.0', vulnerable)).toBe('matched')
+    expect(cargoConstraintMayInclude('=1.3.0', vulnerable)).toBe('matched')
+    expect(cargoConstraintMayInclude('=9.9.9', vulnerable)).toBe('excluded')
+  })
+
+  it('supports wildcard requirements', () => {
+    expect(cargoConstraintMayInclude('1.2.*', vulnerable)).toBe('matched')
+  })
+
+  it('supports comma-separated AND comparator ranges', () => {
+    expect(cargoConstraintMayInclude('>=1.2.1, <1.3.0', vulnerable)).toBe('matched')
+    expect(cargoConstraintMayInclude('>=1.4.0, <2.0.0', vulnerable)).toBe('excluded')
+  })
+
+  it('treats a bare prerelease version as caret, not an exact pin', () => {
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.0-alpha.1'])).toBe('matched')
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.4-alpha.2'])).toBe('matched')
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['2.0.0'])).toBe('excluded')
+  })
+
+  it('treats unparseable requirements as included rather than dropping them', () => {
+    expect(cargoConstraintMayInclude('git+https://example.com/crate', vulnerable)).toBe(
+      'unparseable-included',
+    )
+    expect(cargoConstraintMayInclude('', vulnerable)).toBe('unparseable-included')
+  })
+})
+
+describe('cargoDependencyMayIncludeVuln', () => {
+  const vulnerable = ['1.2.0', '1.2.1']
+
+  it('prefers the resolved version over the declared requirement when present', () => {
+    expect(cargoDependencyMayIncludeVuln('1.2.0', '^2.0.0', vulnerable)).toBe('matched')
+    expect(cargoDependencyMayIncludeVuln('9.9.9', '^1.2.0', vulnerable)).toBe('excluded')
+  })
+
+  it('falls back to the requirement when no resolved version is available', () => {
+    expect(cargoDependencyMayIncludeVuln(null, '^1.2.0', vulnerable)).toBe('matched')
+    expect(cargoDependencyMayIncludeVuln(null, '^3.0.0', vulnerable)).toBe('excluded')
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/__tests__/cargoConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/__tests__/cargoConstraint.test.ts
@@ -31,7 +31,9 @@ describe('cargoConstraintMayInclude', () => {
 
   it('treats a bare prerelease version as caret, not an exact pin', () => {
     expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.0-alpha.1'])).toBe('matched')
-    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.4-alpha.2'])).toBe('matched')
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.0-beta.1'])).toBe('matched')
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.2.4-alpha.2'])).toBe('excluded')
+    expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['1.3.0'])).toBe('matched')
     expect(cargoConstraintMayInclude('1.2.0-alpha.1', ['2.0.0'])).toBe('excluded')
   })
 

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/cargoConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/cargoConstraint.ts
@@ -2,13 +2,8 @@ import * as semver from 'semver'
 
 export type CargoConstraintMatch = 'matched' | 'excluded' | 'unparseable-included'
 
-// Cargo's requirement grammar (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)
-// is close to but not identical to node-semver's: a bare version ("1.2.3") means caret
-// ("^1.2.3", compatible updates), not an exact pin like node-semver treats it. `^ ~ = *`
-// operators and comparator ranges (">=1.2, <1.5") already mean the same thing in both
-// grammars, so only the bare/partial-version default needs translating. An unparseable
-// requirement is never silently dropped — same over-inclusive rationale as goConstraint.ts:
-// the reachability stage (stage 3, over real source) is the actual precision filter.
+// Cargo bare versions ("1.2.3") mean caret, unlike node-semver's exact pin. Filters out
+// unparseable requirements into the over-inclusive path (let reachability stage decide).
 function toNodeSemverRange(cargoReq: string): string | null {
   const trimmed = cargoReq.trim()
   if (!trimmed) return null
@@ -18,13 +13,10 @@ function toNodeSemverRange(cargoReq: string): string | null {
     .map((part) => {
       const clause = part.trim()
       if (!clause) return null
-      // Already an explicit operator or wildcard — pass through as-is. Cargo has no
-      // hyphen-range syntax, so a bare `-` here is always a prerelease tag (e.g.
-      // "1.2.3-alpha"), not a range operator, and must still get the caret prefix.
       if (/^[\^~=<>]/.test(clause) || /[xX*]/.test(clause)) return clause
-      // Bare version ("1.2.3", "1.2", "1") defaults to caret per Cargo semantics.
       return `^${clause}`
     })
+    .filter((x): x is string => x !== null)
     .join(' ')
 
   return translated || null
@@ -39,16 +31,12 @@ export function cargoConstraintMayInclude(
     return 'unparseable-included'
   }
 
-  const matches = vulnerableVersions.some((v) =>
-    semver.satisfies(v, range, { loose: true, includePrerelease: true }),
-  )
+  const matches = vulnerableVersions.some((v) => semver.satisfies(v, range, { loose: true }))
   return matches ? 'matched' : 'excluded'
 }
 
-// Prefers the concrete resolved version (the edge's actual installed version) over the
-// declared requirement when available — mirrors goConstraint/mavenConstraint's
-// resolved-version-first pattern, since a resolved version is ground truth while the
-// requirement is only what the dependent's Cargo.toml declares.
+// Prefers resolved version over requirement (ground truth vs. declared); mirrors
+// goConstraint/mavenConstraint's resolved-version-first pattern.
 export function cargoDependencyMayIncludeVuln(
   resolvedVersion: string | null,
   constraint: string,

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/cargoConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/cargoConstraint.ts
@@ -1,0 +1,61 @@
+import * as semver from 'semver'
+
+export type CargoConstraintMatch = 'matched' | 'excluded' | 'unparseable-included'
+
+// Cargo's requirement grammar (https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)
+// is close to but not identical to node-semver's: a bare version ("1.2.3") means caret
+// ("^1.2.3", compatible updates), not an exact pin like node-semver treats it. `^ ~ = *`
+// operators and comparator ranges (">=1.2, <1.5") already mean the same thing in both
+// grammars, so only the bare/partial-version default needs translating. An unparseable
+// requirement is never silently dropped — same over-inclusive rationale as goConstraint.ts:
+// the reachability stage (stage 3, over real source) is the actual precision filter.
+function toNodeSemverRange(cargoReq: string): string | null {
+  const trimmed = cargoReq.trim()
+  if (!trimmed) return null
+
+  const translated = trimmed
+    .split(',')
+    .map((part) => {
+      const clause = part.trim()
+      if (!clause) return null
+      // Already an explicit operator or wildcard — pass through as-is. Cargo has no
+      // hyphen-range syntax, so a bare `-` here is always a prerelease tag (e.g.
+      // "1.2.3-alpha"), not a range operator, and must still get the caret prefix.
+      if (/^[\^~=<>]/.test(clause) || /[xX*]/.test(clause)) return clause
+      // Bare version ("1.2.3", "1.2", "1") defaults to caret per Cargo semantics.
+      return `^${clause}`
+    })
+    .join(' ')
+
+  return translated || null
+}
+
+export function cargoConstraintMayInclude(
+  constraint: string,
+  vulnerableVersions: string[],
+): CargoConstraintMatch {
+  const range = constraint ? toNodeSemverRange(constraint) : null
+  if (!range || !semver.validRange(range, { loose: true })) {
+    return 'unparseable-included'
+  }
+
+  const matches = vulnerableVersions.some((v) =>
+    semver.satisfies(v, range, { loose: true, includePrerelease: true }),
+  )
+  return matches ? 'matched' : 'excluded'
+}
+
+// Prefers the concrete resolved version (the edge's actual installed version) over the
+// declared requirement when available — mirrors goConstraint/mavenConstraint's
+// resolved-version-first pattern, since a resolved version is ground truth while the
+// requirement is only what the dependent's Cargo.toml declares.
+export function cargoDependencyMayIncludeVuln(
+  resolvedVersion: string | null,
+  constraint: string,
+  vulnerableVersions: string[],
+): CargoConstraintMatch {
+  if (resolvedVersion) {
+    return vulnerableVersions.includes(resolvedVersion) ? 'matched' : 'excluded'
+  }
+  return cargoConstraintMayInclude(constraint, vulnerableVersions)
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
@@ -1,0 +1,114 @@
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { findPackageIdsByName } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { scanCargoDependents } from './dependentsScanCargo'
+
+export async function runDependentsStageCargo(
+  qx: QueryExecutor,
+  analysisId: string,
+  onProgress?: () => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'dependents')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'dependents',
+      status: 'running',
+      model: null,
+    })
+
+    const spec = await blastRadiusDal.getSymbolSpec(qx, analysisId)
+    if (!spec) {
+      throw new Error('Symbol spec not found; stage 1 (intel) must run first')
+    }
+
+    // See dependentsNpm.ts for why this unconditional clear is safe: reachability
+    // hasn't produced any verdicts yet at this point in the pipeline.
+    await blastRadiusDal.deleteDependents(qx, analysisId)
+
+    const analysis = await blastRadiusDal.getAnalysis(qx, analysisId)
+    if (!analysis?.package_id) {
+      throw new Error('Vulnerable crate package_id not resolved; stage 1 (intel) must run first')
+    }
+
+    const vulnerableVersions = (spec.vulnerable_versions || []) as string[]
+
+    // Heartbeat before the scan starts, not just after it completes — the scan is a
+    // single DB round trip that could otherwise run past the activity's heartbeat
+    // timeout with no heartbeat sent in between.
+    onProgress?.()
+
+    const scanResult = await scanCargoDependents(
+      qx,
+      String(analysis.package_id),
+      vulnerableVersions,
+      25,
+    )
+
+    if (signal?.aborted) {
+      throw new Error('Dependents scan cancelled')
+    }
+    onProgress?.()
+
+    const packageIdsByName = await findPackageIdsByName(
+      qx,
+      'cargo',
+      scanResult.analyzed.map((d) => d.name),
+    )
+
+    const dependentInputs = [
+      ...scanResult.analyzed.map((d) => ({
+        analysisId,
+        packageId: packageIdsByName.get(d.name) ?? null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: false,
+        exclusionReason: null,
+      })),
+      ...scanResult.excludedByRange.map((d) => ({
+        analysisId,
+        packageId: null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: true,
+        exclusionReason: `Requirement does not include vulnerable versions (${d.rangeCheck})`,
+      })),
+    ]
+
+    await blastRadiusDal.insertDependents(qx, dependentInputs)
+    await blastRadiusDal.setDependentsMeta(
+      qx,
+      analysisId,
+      scanResult.source,
+      scanResult.candidatesConsidered,
+    )
+
+    const duration = Date.now() - startTime
+    await blastRadiusDal.completeStageRun(qx, analysisId, 'dependents', duration, 0)
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'dependents', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
@@ -2,6 +2,8 @@ import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadi
 import { findPackageIdsByName } from '@crowd/data-access-layer/src/packages/osv'
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
+import { toDbCargoName } from '../../packageIdentifier'
+
 import { scanCargoDependents } from './dependentsScanCargo'
 
 export async function runDependentsStageCargo(
@@ -60,13 +62,13 @@ export async function runDependentsStageCargo(
     const packageIdsByName = await findPackageIdsByName(
       qx,
       'cargo',
-      scanResult.analyzed.map((d) => d.name),
+      scanResult.analyzed.map((d) => toDbCargoName(d.name)),
     )
 
     const dependentInputs = [
       ...scanResult.analyzed.map((d) => ({
         analysisId,
-        packageId: packageIdsByName.get(d.name) ?? null,
+        packageId: packageIdsByName.get(toDbCargoName(d.name)) ?? null,
         name: d.name,
         version: d.version,
         downloads: d.downloads,

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsCargo.ts
@@ -40,10 +40,8 @@ export async function runDependentsStageCargo(
     }
 
     const vulnerableVersions = (spec.vulnerable_versions || []) as string[]
+    const relatedAffectedPackages = (spec.related_affected_packages || []) as string[]
 
-    // Heartbeat before the scan starts, not just after it completes — the scan is a
-    // single DB round trip that could otherwise run past the activity's heartbeat
-    // timeout with no heartbeat sent in between.
     onProgress?.()
 
     const scanResult = await scanCargoDependents(
@@ -51,6 +49,7 @@ export async function runDependentsStageCargo(
       String(analysis.package_id),
       vulnerableVersions,
       25,
+      relatedAffectedPackages,
     )
 
     if (signal?.aborted) {

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
@@ -13,6 +13,7 @@ export async function scanCargoDependents(
   vulnerablePackageId: string,
   vulnerableVersions: string[],
   topN: number,
+  relatedAffectedPackages?: string[],
 ): Promise<ScanDependentsResult> {
   if (vulnerableVersions.length === 0) {
     return {
@@ -28,14 +29,20 @@ export async function scanCargoDependents(
   // still visible for diagnostics, same pattern as npm's scanLimit.
   const scanLimit = Math.max(topN * 8, 200)
   const rows = await getReverseDependents(qx, vulnerablePackageId, 'cargo', scanLimit)
+  const relatedPackageNames = new Set(relatedAffectedPackages || [])
 
-  const candidates: DependentCandidate[] = rows.map((row) => {
+  const included: DependentCandidate[] = []
+  const excluded: DependentCandidate[] = []
+
+  for (const row of rows) {
+    if (relatedPackageNames.has(row.name)) continue
+
     const rangeCheck = cargoDependencyMayIncludeVuln(
-      row.versionNumber,
+      row.resolvedVersionNumber,
       row.versionConstraint,
       vulnerableVersions,
     )
-    return {
+    const candidate: DependentCandidate = {
       name: row.name,
       version: row.versionNumber,
       downloads: row.dependentReposCount ?? row.dependentCount ?? null,
@@ -45,14 +52,16 @@ export async function scanCargoDependents(
       rangeCheck,
       tarballUrl: null,
     }
-  })
-
-  const included = candidates.filter((c) => c.rangeIncludesVuln)
-  const excluded = candidates.filter((c) => !c.rangeIncludesVuln)
+    if (candidate.rangeIncludesVuln) {
+      included.push(candidate)
+    } else {
+      excluded.push(candidate)
+    }
+  }
 
   return {
     source: 'package_dependencies',
-    candidatesConsidered: candidates.length,
+    candidatesConsidered: included.length + excluded.length,
     analyzed: included.slice(0, topN),
     excludedByRange: excluded.slice(0, 200),
     excludedByRangeCount: excluded.length,

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
@@ -1,0 +1,60 @@
+import { getReverseDependents } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
+
+import { cargoDependencyMayIncludeVuln } from './cargoConstraint'
+
+// Cargo dependents come straight from our own DB (package_dependencies, populated via
+// deps.dev BigQuery ingestion) rather than an external ranking list — no download-count
+// signal exists for crates.io the way npm has one, same as Go.
+export async function scanCargoDependents(
+  qx: QueryExecutor,
+  vulnerablePackageId: string,
+  vulnerableVersions: string[],
+  topN: number,
+): Promise<ScanDependentsResult> {
+  if (vulnerableVersions.length === 0) {
+    return {
+      source: 'package_dependencies',
+      candidatesConsidered: 0,
+      analyzed: [],
+      excludedByRange: [],
+      excludedByRangeCount: 0,
+    }
+  }
+
+  // Cap distinct from topN: gather a wider pool so excludedByRange candidates are
+  // still visible for diagnostics, same pattern as npm's scanLimit.
+  const scanLimit = Math.max(topN * 8, 200)
+  const rows = await getReverseDependents(qx, vulnerablePackageId, 'cargo', scanLimit)
+
+  const candidates: DependentCandidate[] = rows.map((row) => {
+    const rangeCheck = cargoDependencyMayIncludeVuln(
+      row.versionNumber,
+      row.versionConstraint,
+      vulnerableVersions,
+    )
+    return {
+      name: row.name,
+      version: row.versionNumber,
+      downloads: row.dependentReposCount ?? row.dependentCount ?? null,
+      declaredRange: row.versionConstraint,
+      dependencyKind: row.dependencyKind,
+      rangeIncludesVuln: rangeCheck !== 'excluded',
+      rangeCheck,
+      tarballUrl: null,
+    }
+  })
+
+  const included = candidates.filter((c) => c.rangeIncludesVuln)
+  const excluded = candidates.filter((c) => !c.rangeIncludesVuln)
+
+  return {
+    source: 'package_dependencies',
+    candidatesConsidered: candidates.length,
+    analyzed: included.slice(0, topN),
+    excludedByRange: excluded.slice(0, 200),
+    excludedByRangeCount: excluded.length,
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
@@ -2,6 +2,7 @@ import { getReverseDependents } from '@crowd/data-access-layer/src/packages/blas
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
+import { toDbCargoName } from '../../packageIdentifier'
 
 import { cargoDependencyMayIncludeVuln } from './cargoConstraint'
 
@@ -29,7 +30,9 @@ export async function scanCargoDependents(
   // still visible for diagnostics, same pattern as npm's scanLimit.
   const scanLimit = Math.max(topN * 8, 200)
   const rows = await getReverseDependents(qx, vulnerablePackageId, 'cargo', scanLimit)
-  const relatedPackageNames = new Set(relatedAffectedPackages || [])
+  // row.name comes from packages.name (the '_' form); relatedAffectedPackages are OSV-spelled
+  // ('-' form) — normalize to the DB form before comparing, see toDbCargoName.
+  const relatedPackageNames = new Set((relatedAffectedPackages || []).map(toDbCargoName))
 
   const included: DependentCandidate[] = []
   const excluded: DependentCandidate[] = []

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/dependentsScanCargo.ts
@@ -6,9 +6,8 @@ import { toDbCargoName } from '../../packageIdentifier'
 
 import { cargoDependencyMayIncludeVuln } from './cargoConstraint'
 
-// Cargo dependents come straight from our own DB (package_dependencies, populated via
-// deps.dev BigQuery ingestion) rather than an external ranking list — no download-count
-// signal exists for crates.io the way npm has one, same as Go.
+// Cargo dependents come from our own DB (package_dependencies), same as Go — no
+// download-count signal exists for crates.io the way npm has one.
 export async function scanCargoDependents(
   qx: QueryExecutor,
   vulnerablePackageId: string,

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
@@ -89,8 +89,8 @@ export async function runIntelStageCargo(
     // Use crates.io version list; fall back to our DB if unreachable and crate is known.
     const versionListResult = await fetchCrateVersions(crate, CRATES_IO_FETCH_TIMEOUT_MS)
     let allVersions: string[]
-    if (Array.isArray(versionListResult)) {
-      allVersions = versionListResult
+    if ('versions' in versionListResult) {
+      allVersions = versionListResult.versions
     } else if (packageId !== null) {
       allVersions = await getVersionNumbers(qx, String(packageId))
     } else {

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
@@ -40,9 +40,8 @@ export async function runIntelStageCargo(
   const startTime = Date.now()
 
   try {
-    // Check if already done. Guard on the stage_run's own status rather than symbol-spec
-    // presence — a crash between upsertSymbolSpec and completeStageRun would otherwise
-    // leave the stage_run stuck failed/running forever while retries skip past it.
+    // Guard on stage_run status to avoid stuck failed/running state if intel crashes
+    // between upsertSymbolSpec and completeStageRun.
     const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'intel')
     if (existingStatus === 'succeeded') {
       return
@@ -68,7 +67,7 @@ export async function runIntelStageCargo(
     const requestedCrate = analysisDetail?.package_name
       ? toBareCargoName(analysisDetail.package_name)
       : null
-    const entry = selectAdvisoryEntry(
+    const { entry, relatedAffectedPackages } = selectAdvisoryEntry(
       cargoEntries,
       requestedCrate,
       (e) => e.package.name === requestedCrate,
@@ -76,9 +75,6 @@ export async function runIntelStageCargo(
     )
     const crate = entry.package.name
     const ecosystem = 'cargo'
-    const relatedAffectedPackages = cargoEntries
-      .map((e) => e.package.name)
-      .filter((name) => name !== crate)
 
     // Resolve vulnerable versions from OSV ranges first (crates.io OSV ranges are
     // SEMVER-typed, same event shape as npm's/Go's).
@@ -86,9 +82,7 @@ export async function runIntelStageCargo(
 
     const packageId = await findPackageId(qx, { ecosystem, namespace: null, name: crate })
 
-    // crates.io's own version list is authoritative; fall back to our own ingested
-    // `versions` rows (deps.dev) if crates.io is unreachable/rate-limited and the crate
-    // is already known to us.
+    // Use crates.io version list; fall back to our DB if unreachable and crate is known.
     const versionListResult = await fetchCrateVersions(crate, CRATES_IO_FETCH_TIMEOUT_MS)
     let allVersions: string[]
     if (Array.isArray(versionListResult)) {
@@ -115,15 +109,18 @@ export async function runIntelStageCargo(
       await downloadAndExtractTarball(crateSourceUrl(crate, analyzed), pkgsrcDir)
 
       const patchUrls = fixReferenceUrls(osv)
-      for (const url of patchUrls.slice(0, 3)) {
-        try {
+      const patchResults = await Promise.allSettled(
+        patchUrls.slice(0, 3).map(async (url) => {
           const patchText = await fetchPatch(url)
           const slug = new URL(url).pathname.split('/').filter(Boolean).join('-')
-          patches[slug] = patchText
-        } catch {
-          // Ignore patch fetch errors
+          return { slug, patchText }
+        }),
+      )
+      patchResults.forEach((result) => {
+        if (result.status === 'fulfilled') {
+          patches[result.value.slug] = result.value.patchText
         }
-      }
+      })
 
       const agentPrompt = buildCargoIntelPrompt(
         osv.id || advisoryOsvId,

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
@@ -67,10 +67,11 @@ export async function runIntelStageCargo(
     const requestedCrate = analysisDetail?.package_name
       ? toBareCargoName(analysisDetail.package_name)
       : null
+    const requestedCrateDbName = requestedCrate !== null ? toDbCargoName(requestedCrate) : null
     const { entry, relatedAffectedPackages } = selectAdvisoryEntry(
       cargoEntries,
       requestedCrate,
-      (e) => e.package.name === requestedCrate,
+      (e) => toDbCargoName(e.package.name) === requestedCrateDbName,
       advisoryOsvId,
     )
     const crate = entry.package.name

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
@@ -22,7 +22,7 @@ import {
   semverRangeEvents,
 } from '../../clients/osvClient'
 import { crateSourceUrl, fetchCrateVersions } from '../../crates/registryClient'
-import { toBareCargoName } from '../../packageIdentifier'
+import { toBareCargoName, toDbCargoName } from '../../packageIdentifier'
 import { highestVersion, versionsInRanges } from '../../semverRange'
 import { selectAdvisoryEntry } from '../selectAdvisoryEntry'
 
@@ -80,14 +80,18 @@ export async function runIntelStageCargo(
     // SEMVER-typed, same event shape as npm's/Go's).
     const ranges = semverRangeEvents(entry)
 
-    const packageId = await findPackageId(qx, { ecosystem, namespace: null, name: crate })
+    const packageId = await findPackageId(qx, {
+      ecosystem,
+      namespace: null,
+      name: toDbCargoName(crate),
+    })
 
     // Use crates.io version list; fall back to our DB if unreachable and crate is known.
     const versionListResult = await fetchCrateVersions(crate, CRATES_IO_FETCH_TIMEOUT_MS)
     let allVersions: string[]
     if (Array.isArray(versionListResult)) {
       allVersions = versionListResult
-    } else if (packageId) {
+    } else if (packageId !== null) {
       allVersions = await getVersionNumbers(qx, String(packageId))
     } else {
       throw new Error(

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/intelCargo.ts
@@ -1,0 +1,184 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { getVersionNumbers } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { findPackageId } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import {
+  CARGO_INTEL_SCHEMA,
+  CARGO_INTEL_SYSTEM_PROMPT,
+  buildCargoIntelPrompt,
+} from '../../agent/cargoPrompts'
+import { runAnalysisAgent } from '../../agent/runner'
+import { fetchPatch } from '../../clients/githubPatch'
+import { downloadAndExtractTarball } from '../../clients/npmTarball'
+import {
+  affectedEntriesForEcosystem,
+  fetchOsvVuln,
+  fixReferenceUrls,
+  semverRangeEvents,
+} from '../../clients/osvClient'
+import { crateSourceUrl, fetchCrateVersions } from '../../crates/registryClient'
+import { toBareCargoName } from '../../packageIdentifier'
+import { highestVersion, versionsInRanges } from '../../semverRange'
+import { selectAdvisoryEntry } from '../selectAdvisoryEntry'
+
+// OSV spells the Cargo ecosystem 'crates.io', unlike our DB's lowercase 'cargo' — see
+// ADR-0001 §OSV "Ecosystem normalization" for the DB-side convention.
+const OSV_CARGO_ECOSYSTEM = 'crates.io'
+const CRATES_IO_FETCH_TIMEOUT_MS = 15_000
+
+export async function runIntelStageCargo(
+  qx: QueryExecutor,
+  analysisId: string,
+  advisoryOsvId: string,
+  onProgress?: () => void,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    // Check if already done. Guard on the stage_run's own status rather than symbol-spec
+    // presence — a crash between upsertSymbolSpec and completeStageRun would otherwise
+    // leave the stage_run stuck failed/running forever while retries skip past it.
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'intel')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'intel',
+      status: 'running',
+      model: 'claude-opus-4-8',
+    })
+
+    const osv = await fetchOsvVuln(advisoryOsvId)
+
+    const cargoEntries = affectedEntriesForEcosystem(osv, OSV_CARGO_ECOSYSTEM)
+    if (cargoEntries.length === 0) {
+      throw new Error(`No Cargo entries found in advisory ${advisoryOsvId}`)
+    }
+
+    // Pick the crate entry the analysis was requested for; see selectAdvisoryEntry for
+    // rejection rules on non-matching or omitted requests.
+    const analysisDetail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
+    const requestedCrate = analysisDetail?.package_name
+      ? toBareCargoName(analysisDetail.package_name)
+      : null
+    const entry = selectAdvisoryEntry(
+      cargoEntries,
+      requestedCrate,
+      (e) => e.package.name === requestedCrate,
+      advisoryOsvId,
+    )
+    const crate = entry.package.name
+    const ecosystem = 'cargo'
+    const relatedAffectedPackages = cargoEntries
+      .map((e) => e.package.name)
+      .filter((name) => name !== crate)
+
+    // Resolve vulnerable versions from OSV ranges first (crates.io OSV ranges are
+    // SEMVER-typed, same event shape as npm's/Go's).
+    const ranges = semverRangeEvents(entry)
+
+    const packageId = await findPackageId(qx, { ecosystem, namespace: null, name: crate })
+
+    // crates.io's own version list is authoritative; fall back to our own ingested
+    // `versions` rows (deps.dev) if crates.io is unreachable/rate-limited and the crate
+    // is already known to us.
+    const versionListResult = await fetchCrateVersions(crate, CRATES_IO_FETCH_TIMEOUT_MS)
+    let allVersions: string[]
+    if (Array.isArray(versionListResult)) {
+      allVersions = versionListResult
+    } else if (packageId) {
+      allVersions = await getVersionNumbers(qx, String(packageId))
+    } else {
+      throw new Error(
+        `Failed to fetch versions for ${crate} (${versionListResult.message}) and crate is not in our DB`,
+      )
+    }
+
+    const vulnerableVersions = versionsInRanges(allVersions, ranges)
+
+    const analyzed = highestVersion(vulnerableVersions)
+    if (!analyzed) {
+      throw new Error(`Could not determine analyzed version for ${crate}`)
+    }
+
+    const pkgsrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cratesrc-'))
+    const patches: Record<string, string> = {}
+
+    try {
+      await downloadAndExtractTarball(crateSourceUrl(crate, analyzed), pkgsrcDir)
+
+      const patchUrls = fixReferenceUrls(osv)
+      for (const url of patchUrls.slice(0, 3)) {
+        try {
+          const patchText = await fetchPatch(url)
+          const slug = new URL(url).pathname.split('/').filter(Boolean).join('-')
+          patches[slug] = patchText
+        } catch {
+          // Ignore patch fetch errors
+        }
+      }
+
+      const agentPrompt = buildCargoIntelPrompt(
+        osv.id || advisoryOsvId,
+        osv.aliases || [],
+        osv.details || osv.summary || '',
+        analyzed,
+        patches,
+      )
+
+      const agentResult = await runAnalysisAgent({
+        prompt: agentPrompt,
+        systemPrompt: CARGO_INTEL_SYSTEM_PROMPT,
+        cwd: pkgsrcDir,
+        model: 'claude-opus-4-8',
+        schema: CARGO_INTEL_SCHEMA,
+        maxTurns: 15,
+        timeoutMs: 600_000,
+        onProgress,
+      })
+
+      if (agentResult.isError || !agentResult.structuredOutput) {
+        throw new Error(`Agent failed: ${agentResult.errorMessage}`)
+      }
+
+      const output = agentResult.structuredOutput
+      await blastRadiusDal.upsertSymbolSpec(qx, {
+        analysisId,
+        vulnId: osv.id || advisoryOsvId,
+        aliases: osv.aliases || [],
+        package: crate,
+        ecosystem,
+        affectedRanges: ranges,
+        vulnerableVersions,
+        analyzedVersion: analyzed,
+        relatedAffectedPackages,
+        vulnerableSymbols: (output.vulnerable_symbols || []) as Record<string, unknown>[],
+        importSignatures: (output.import_signatures || {}) as Record<string, unknown>,
+        exploitPreconditions: String(output.exploit_preconditions || ''),
+        reachabilityNotes: String(output.reachability_notes || ''),
+        confidence: Number(output.confidence ?? 0.5),
+        sources: [advisoryOsvId],
+        summary: String(output.summary || ''),
+      })
+
+      await blastRadiusDal.resolveAdvisoryAndPackageIds(qx, analysisId, advisoryOsvId, packageId)
+
+      const duration = Date.now() - startTime
+      await blastRadiusDal.completeStageRun(qx, analysisId, 'intel', duration, agentResult.costUsd)
+    } finally {
+      fs.rmSync(pkgsrcDir, { recursive: true, force: true })
+    }
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'intel', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
@@ -14,11 +14,7 @@ import { ReachabilitySourceConfig } from '../reachabilityStage'
 
 const CRATES_IO_FETCH_TIMEOUT_MS = 15_000
 
-// Cargo dependents only carry a declared requirement (see cargoConstraint.ts), not
-// necessarily a resolved installed version — resolve a concrete version to analyze
-// here, falling back to the highest published version when no resolved version is
-// available on the edge. Tries the cheap single-crate endpoint first (mirrors
-// go/reachabilityConfig.ts's fetchLatest-then-list shape) before the full version list.
+// Resolve concrete crate version: try fetchCrateLatestVersion first, then full list.
 async function resolveCargoVersion(name: string): Promise<string | null> {
   const latest = await fetchCrateLatestVersion(name, CRATES_IO_FETCH_TIMEOUT_MS)
   if (typeof latest === 'string') return latest
@@ -33,9 +29,7 @@ export const cargoReachabilityConfig: ReachabilitySourceConfig = {
   schema: CARGO_VERDICT_SCHEMA,
   buildSystemPrompt: buildCargoReachabilitySystemPrompt,
   prepareSource: async (dep) => {
-    // Prefer the exact version the reverse-dependency edge was resolved against (see
-    // getReverseDependents) — falling back to the highest published version would
-    // analyze different code than the Cargo.lock that produced this constraint.
+    // Use resolved version; fall back to highest published (ensures Cargo.lock consistency).
     const version = dep.version ?? (await resolveCargoVersion(dep.name))
     if (!version) return null
     return {

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
@@ -1,0 +1,47 @@
+import {
+  CARGO_REACHABILITY_PROMPT,
+  CARGO_VERDICT_SCHEMA,
+  buildCargoReachabilitySystemPrompt,
+} from '../../agent/cargoPrompts'
+import { downloadAndExtractTarball } from '../../clients/npmTarball'
+import {
+  crateSourceUrl,
+  fetchCrateLatestVersion,
+  fetchCrateVersions,
+} from '../../crates/registryClient'
+import { highestVersion } from '../../semverRange'
+import { ReachabilitySourceConfig } from '../reachabilityStage'
+
+const CRATES_IO_FETCH_TIMEOUT_MS = 15_000
+
+// Cargo dependents only carry a declared requirement (see cargoConstraint.ts), not
+// necessarily a resolved installed version — resolve a concrete version to analyze
+// here, falling back to the highest published version when no resolved version is
+// available on the edge. Tries the cheap single-crate endpoint first (mirrors
+// go/reachabilityConfig.ts's fetchLatest-then-list shape) before the full version list.
+async function resolveCargoVersion(name: string): Promise<string | null> {
+  const latest = await fetchCrateLatestVersion(name, CRATES_IO_FETCH_TIMEOUT_MS)
+  if (typeof latest === 'string') return latest
+
+  const versions = await fetchCrateVersions(name, CRATES_IO_FETCH_TIMEOUT_MS)
+  if (Array.isArray(versions)) return highestVersion(versions)
+  return null
+}
+
+export const cargoReachabilityConfig: ReachabilitySourceConfig = {
+  prompt: CARGO_REACHABILITY_PROMPT,
+  schema: CARGO_VERDICT_SCHEMA,
+  buildSystemPrompt: buildCargoReachabilitySystemPrompt,
+  prepareSource: async (dep) => {
+    // Prefer the exact version the reverse-dependency edge was resolved against (see
+    // getReverseDependents) — falling back to the highest published version would
+    // analyze different code than the Cargo.lock that produced this constraint.
+    const version = dep.version ?? (await resolveCargoVersion(dep.name))
+    if (!version) return null
+    return {
+      download: (destDir) => downloadAndExtractTarball(crateSourceUrl(dep.name, version), destDir),
+    }
+  },
+  noSourceMessage: 'Could not resolve a concrete crate version',
+  downloadErrorPrefix: 'Crate download failed',
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/cargo/reachabilityConfig.ts
@@ -14,13 +14,18 @@ import { ReachabilitySourceConfig } from '../reachabilityStage'
 
 const CRATES_IO_FETCH_TIMEOUT_MS = 15_000
 
-// Resolve concrete crate version: try fetchCrateLatestVersion first, then full list.
-async function resolveCargoVersion(name: string): Promise<string | null> {
+// dep.name is packages.name ('-'/'_' normalized, see cargo/loadDump.ts), not necessarily
+// crates.io's published spelling — static.crates.io needs the latter, so always resolve it.
+async function resolveCargoCanonical(
+  name: string,
+): Promise<{ name: string; version: string | null } | null> {
   const latest = await fetchCrateLatestVersion(name, CRATES_IO_FETCH_TIMEOUT_MS)
-  if (typeof latest === 'string') return latest
+  if ('name' in latest) return { name: latest.name, version: latest.version }
 
-  const versions = await fetchCrateVersions(name, CRATES_IO_FETCH_TIMEOUT_MS)
-  if (Array.isArray(versions)) return highestVersion(versions)
+  const versionsResult = await fetchCrateVersions(name, CRATES_IO_FETCH_TIMEOUT_MS)
+  if ('name' in versionsResult) {
+    return { name: versionsResult.name, version: highestVersion(versionsResult.versions) }
+  }
   return null
 }
 
@@ -29,11 +34,14 @@ export const cargoReachabilityConfig: ReachabilitySourceConfig = {
   schema: CARGO_VERDICT_SCHEMA,
   buildSystemPrompt: buildCargoReachabilitySystemPrompt,
   prepareSource: async (dep) => {
-    // Use resolved version; fall back to highest published (ensures Cargo.lock consistency).
-    const version = dep.version ?? (await resolveCargoVersion(dep.name))
+    const canonical = await resolveCargoCanonical(dep.name)
+    if (!canonical) return null
+    // Prefer the already-resolved dependency version; fall back to highest published.
+    const version = dep.version ?? canonical.version
     if (!version) return null
     return {
-      download: (destDir) => downloadAndExtractTarball(crateSourceUrl(dep.name, version), destDir),
+      download: (destDir) =>
+        downloadAndExtractTarball(crateSourceUrl(canonical.name, version), destDir),
     }
   },
   noSourceMessage: 'Could not resolve a concrete crate version',

--- a/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
@@ -2,6 +2,9 @@ import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { Ecosystem } from '../ecosystemSupport'
 
+import { runDependentsStageCargo } from './cargo/dependentsCargo'
+import { runIntelStageCargo } from './cargo/intelCargo'
+import { cargoReachabilityConfig } from './cargo/reachabilityConfig'
 import { runDependentsStageGo } from './go/dependentsGo'
 import { runIntelStageGo } from './go/intelGo'
 import { goReachabilityConfig } from './go/reachabilityConfig'
@@ -46,6 +49,11 @@ const ECOSYSTEMS: Record<Ecosystem, EcosystemConfig> = {
     runIntel: runIntelStageMaven,
     runDependents: runDependentsStageMaven,
     reachability: mavenReachabilityConfig,
+  },
+  cargo: {
+    runIntel: runIntelStageCargo,
+    runDependents: runDependentsStageCargo,
+    reachability: cargoReachabilityConfig,
   },
 }
 


### PR DESCRIPTION
## Summary

Adds Cargo (Rust / crates.io) as a supported ecosystem in the blast-radius vulnerability
analysis pipeline, alongside the existing npm, Go, and Maven support. A Cargo advisory can
now go through the full intel → dependents → reachability → report flow, using the same
`EcosystemConfig` registry and Temporal stage infrastructure as the other ecosystems.

## Changes

- **Ecosystem registration**: added `'cargo'` to `SUPPORTED_ECOSYSTEMS`
  (`blast-radius/ecosystemSupport.ts`) and to the backend's
  `SUPPORTED_BLAST_RADIUS_ECOSYSTEMS` — the `Record<Ecosystem, EcosystemConfig>` type
  forces a matching entry in `stages/ecosystems.ts`, so the ecosystem can't be half-wired.
- **New crates.io API client** (`blast-radius/crates/registryClient.ts`): fetches a crate's
  published versions (including yanked ones — a yanked version can still be installed and
  vulnerable) and builds `.crate` download URLs. Mirrors `go/proxyClient.ts`'s 429-retry/backoff
  shape. Also exposes a cheap single-crate "latest version" lookup so the reachability stage
  doesn't have to pull a full version list (which can be hundreds of entries for popular crates)
  just to find the newest one.
- **Cargo requirement-grammar normalization** (`stages/cargo/cargoConstraint.ts`): Cargo's
  dependency-version grammar differs subtly from node-semver — a bare version like `"1.2.3"`
  means caret-compatible in Cargo, not an exact pin. Translates Cargo requirements to
  node-semver ranges before matching against known-vulnerable versions. Unparseable
  constraints are treated as inclusion candidates rather than dropped, since the reachability
  stage (real source analysis) is the actual precision filter.
- **New Cargo stage bodies** mirroring the Go implementation: `intelCargo.ts` (OSV lookup +
  crates.io version resolution + source download for the agent's static analysis),
  `dependentsCargo.ts` / `dependentsScanCargo.ts` (reverse-dependent scan and ranking), and
  `reachabilityConfig.ts` (per-dependent source resolution for the reachability agent).
- **Rust-specific agent prompts** (`agent/cargoPrompts.ts`): import-signature schema and
  analyst prose for `use` paths, `extern crate`, macro invocations, and fully-qualified paths,
  built on the same shared `promptKit.ts` helpers as the other ecosystems.
- **`.crate` download reuse**: `.crate` files are gzipped tarballs with a `{name}-{version}/`
  wrapper, structurally identical to npm tarballs' `package/` wrapper, so the existing
  `downloadAndExtractTarball` helper is reused unmodified — no new extraction code needed.
- **API/docs**: added `cargo` to the public API's ecosystem enum and updated the OpenAPI
  spec's prose wherever "npm, go, and maven" was mentioned.
- **Tests**: constraint-matching unit tests (including bare/caret/tilde/wildcard/comma-AND
  requirements and prerelease versions), prompt-schema consistency tests, and dispatch-routing
  tests confirming the registry selects the Cargo body/config for `ecosystem: 'cargo'`.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1358](https://linuxfoundation.atlassian.net/browse/CM-1358)

[CM-1358]: https://linuxfoundation.atlassian.net/browse/CM-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ