### PR TITLE
feat: add rubygems (CM-1358)

### DIFF
--- a/backend/src/api/public/v1/packages/blastRadius.ts
+++ b/backend/src/api/public/v1/packages/blastRadius.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod'
 
-export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = ['npm', 'go', 'maven', 'cargo', 'nuget'] as const
+export const SUPPORTED_BLAST_RADIUS_ECOSYSTEMS = [
+  'npm',
+  'go',
+  'maven',
+  'cargo',
+  'nuget',
+  'rubygems',
+] as const
 
 // Always exactly one job per request — advisory-wide (package omitted) or narrowed
 // to a single package. package accepts either a full purl or a bare package name,

--- a/services/apps/packages_worker/src/blast-radius/__tests__/ecosystemSupport.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/__tests__/ecosystemSupport.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, it } from 'vitest'
 import { SUPPORTED_ECOSYSTEMS, buildEcosystemNotSupportedFailure } from '../ecosystemSupport'
 
 describe('SUPPORTED_ECOSYSTEMS', () => {
-  it('includes cargo and nuget alongside npm, go, and maven', () => {
-    expect(SUPPORTED_ECOSYSTEMS).toEqual(['npm', 'go', 'maven', 'cargo', 'nuget'])
+  it('includes cargo, nuget, and rubygems alongside npm, go, and maven', () => {
+    expect(SUPPORTED_ECOSYSTEMS).toEqual(['npm', 'go', 'maven', 'cargo', 'nuget', 'rubygems'])
   })
 })
 

--- a/services/apps/packages_worker/src/blast-radius/__tests__/packageIdentifier.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/__tests__/packageIdentifier.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { toBareNpmName, toBareNuGetId, toDbCargoName } from '../packageIdentifier'
+import { toBareGemName, toBareNpmName, toBareNuGetId, toDbCargoName } from '../packageIdentifier'
 
 describe('toBareNpmName', () => {
   it('returns a bare name unchanged', () => {
@@ -67,5 +67,27 @@ describe('toBareNuGetId', () => {
     expect(toBareNuGetId('pkg:nuget/Microsoft.AspNetCore.Mvc@2.2.0')).toBe(
       'Microsoft.AspNetCore.Mvc',
     )
+  })
+})
+
+describe('toBareGemName', () => {
+  it('returns a bare name unchanged', () => {
+    expect(toBareGemName('rack')).toBe('rack')
+  })
+
+  it('strips the pkg:gem/ prefix', () => {
+    expect(toBareGemName('pkg:gem/rack')).toBe('rack')
+  })
+
+  it('strips a trailing version', () => {
+    expect(toBareGemName('pkg:gem/rack@3.0.8')).toBe('rack')
+  })
+
+  it('strips qualifiers and subpath', () => {
+    expect(toBareGemName('pkg:gem/rack@3.0.8?foo=bar#sub')).toBe('rack')
+  })
+
+  it('does not lowercase the name — preserves non-lowercase published spellings', () => {
+    expect(toBareGemName('pkg:gem/RedCloth@4.3.2')).toBe('RedCloth')
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/agent/rubygemsPrompts.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/rubygemsPrompts.ts
@@ -1,5 +1,3 @@
-// Parallels nugetPrompts.ts/goPrompts.ts — shared shape lives in promptKit.ts;
-// only Ruby-specific keys/enum and system-prompt prose live here.
 import {
   buildIntelPrompt,
   buildIntelSchema,
@@ -7,8 +5,6 @@ import {
   buildVerdictSchema,
 } from './promptKit'
 import { SymbolSpec } from './prompts'
-
-// ---------- STAGE 1: INTEL ----------
 
 const IMPORT_SIGNATURE_KEYS = ['require', 'require_relative', 'autoload', 'gem_dependency']
 
@@ -42,8 +38,6 @@ Rules:
   identifies the symbol(s); lower if you had to infer from indirect evidence.`
 
 export const buildRubyGemsIntelPrompt = buildIntelPrompt
-
-// ---------- STAGE 3: REACHABILITY ----------
 
 const IMPORT_STYLE_ENUM = [
   'require',

--- a/services/apps/packages_worker/src/blast-radius/agent/rubygemsPrompts.ts
+++ b/services/apps/packages_worker/src/blast-radius/agent/rubygemsPrompts.ts
@@ -1,0 +1,119 @@
+// Parallels nugetPrompts.ts/goPrompts.ts — shared shape lives in promptKit.ts;
+// only Ruby-specific keys/enum and system-prompt prose live here.
+import {
+  buildIntelPrompt,
+  buildIntelSchema,
+  buildReachabilitySymbolsBlock,
+  buildVerdictSchema,
+} from './promptKit'
+import { SymbolSpec } from './prompts'
+
+// ---------- STAGE 1: INTEL ----------
+
+const IMPORT_SIGNATURE_KEYS = ['require', 'require_relative', 'autoload', 'gem_dependency']
+
+export const RUBYGEMS_INTEL_SCHEMA = buildIntelSchema(IMPORT_SIGNATURE_KEYS)
+
+export const RUBYGEMS_INTEL_SYSTEM_PROMPT = `You are a vulnerability analyst. Your working directory contains the source (downloaded from
+rubygems.org) of the vulnerable version of a RubyGems gem. You are given the security advisory
+and the patch (diff) that fixed the vulnerability.
+
+Your job is to determine, precisely, WHAT is vulnerable — so that downstream analysts can
+check whether other gems actually reach the vulnerable code.
+
+Rules:
+- Identify the exact vulnerable method(s)/class(es)/module(s) from the patch and the source.
+  Be minimal and precise: do NOT include similar-but-unaffected symbols. If the patch only
+  touches a \`private\`/\`protected\` method, trace which public instance/module methods route
+  through it and list those as the reachable surface (note the helper in \`notes\`).
+- Ruby has no compile-time visibility enforcement — treat \`private\`/\`protected\` markers in
+  the source as the declared intent, and note the exact module/class-qualified name (e.g.
+  \`Rack::Utils.something\`) each symbol lives in.
+- Build \`import_signatures\`: concrete code patterns a Ruby dependent would contain if it uses
+  the vulnerable symbol. Cover: a plain \`require 'gem/path'\` followed by usage, a
+  \`require_relative\`, an \`autoload\` declaration, and the gem showing up as a
+  \`gem_dependency\` (a \`.gemspec\` \`add_dependency\`/\`add_runtime_dependency\` line, or a
+  \`Gemfile\` \`gem\` line). These are the patterns analysts will grep for — make them literal
+  and greppable, not prose.
+- \`reachability_notes\` must state what does NOT count (e.g. sibling methods that look similar
+  but are not affected, usage confined to \`spec/\`, \`test/\`, \`features/\`, or \`vendor/\`) and
+  any conditions required for exploitability.
+- Set \`confidence\` for your identification: 0.9+ only if the patch unambiguously
+  identifies the symbol(s); lower if you had to infer from indirect evidence.`
+
+export const buildRubyGemsIntelPrompt = buildIntelPrompt
+
+// ---------- STAGE 3: REACHABILITY ----------
+
+const IMPORT_STYLE_ENUM = [
+  'require',
+  'require_relative',
+  'autoload',
+  'gem_dependency',
+  'reexport',
+  'none',
+]
+
+export const RUBYGEMS_VERDICT_SCHEMA = buildVerdictSchema(IMPORT_STYLE_ENUM)
+
+export function buildRubyGemsReachabilitySystemPrompt(spec: SymbolSpec): string {
+  const { symbolsText, signatures } = buildReachabilitySymbolsBlock(spec)
+
+  return `You are a security reachability analyst. Your working directory contains the source
+(downloaded from rubygems.org) of ONE gem (the "dependent") that declares a dependency on
+\`${spec.package}\`, which has a known vulnerability (${spec.vuln_id}).
+
+## The vulnerability
+${spec.summary}
+
+Vulnerable symbol(s) in \`${spec.package}\`:
+${symbolsText}
+
+Exploit preconditions: ${spec.exploit_preconditions}
+
+Analyst notes: ${spec.reachability_notes}
+
+## Import signatures to look for
+${signatures}
+
+## Your task
+Decide whether THIS dependent's own code actually reaches the vulnerable symbol(s).
+
+Scope rules — follow strictly:
+1. Only the dependent's OWN shipped code counts. Ignore anything under \`spec/\`, \`test/\`,
+   \`features/\`, or \`vendor/\`. Usage of the vulnerable symbol inside the dependent's other
+   dependencies is OUT OF SCOPE (that is second-level analysis, done separately).
+2. Merely declaring \`${spec.package}\` as a dependency (a \`Gemfile\` \`gem\` line, or a
+   \`.gemspec\` \`add_dependency\`/\`add_runtime_dependency\`) is NOT enough — the vulnerable
+   symbol itself must be reached. Uses of other methods/classes from the gem are irrelevant.
+3. Usage only in \`spec/\`, \`test/\`, or \`features/\` that is not part of the shipped runtime
+   code → \`not_affected\` (explain in reasoning).
+4. If the dependent RE-EXPORTS the vulnerable symbol to its own consumers (a thin wrapper
+   method that passes arguments through, or a subclass that doesn't override the vulnerable
+   method), that DOES count as \`affected\` with \`import_style: "reexport"\` — it propagates
+   the vulnerable surface.
+5. Watch for indirect reachability inside the dependent's own code: \`method_missing\`
+   delegation, \`send\`/\`public_send\` dispatch, module mixins (\`include\`/\`extend\`/\`prepend\`),
+   and metaprogramming that defines methods dynamically.
+6. \`import_style\` describes how the VULNERABLE SYMBOL is reached, not how the gem is
+   required: report \`none\` whenever the vulnerable symbol itself is not reached, even if
+   the gem is required for other functionality.
+
+Method: grep for the import signatures (and the bare symbol names) across the source, open
+every hit, and trace whether the symbol is actually invoked. Check the \`.gemspec\` and
+\`Gemfile\`/\`Gemfile.lock\` to confirm the declared dependency and its version. Exclude
+\`spec/\`, \`test/\`, \`features/\`, and \`vendor/\` from consideration.
+
+## Confidence calibration
+- 0.8–1.0: direct evidence — you found (or ruled out) the require AND the call site
+  explicitly; source was readable.
+- 0.4–0.8: symbol is required but the call path is ambiguous (mixin dispatch, conditional
+  use, metaprogramming).
+- <0.4 and/or \`unclear\`: source is generated/absent, or indirection you could not resolve.
+
+Report evidence as exact file paths, line numbers, and short verbatim snippets.`
+}
+
+export const RUBYGEMS_REACHABILITY_PROMPT =
+  'Analyze this package per your instructions and produce the structured verdict. ' +
+  'Start by listing the project structure and grepping for the import signatures.'

--- a/services/apps/packages_worker/src/blast-radius/clients/__tests__/rubygemsSource.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/__tests__/rubygemsSource.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { Readable } from 'stream'
+import * as tar from 'tar'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RubyGemsSourceNotFoundError, downloadAndExtractRubyGemsSource } from '../rubygemsSource'
+
+// Builds a real .gem-shaped fixture: an uncompressed outer tar containing metadata.gz,
+// data.tar.gz and checksums.yaml.gz, where data.tar.gz is itself a gzip-tar with its
+// entries at the archive root — matching the real format verified against rubygems.org.
+async function buildFixtureGem(files: Record<string, string>): Promise<Buffer> {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemfixture-'))
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      const full = path.join(workDir, name)
+      fs.mkdirSync(path.dirname(full), { recursive: true })
+      fs.writeFileSync(full, content)
+    }
+
+    const dataTarGzPath = path.join(workDir, 'data.tar.gz')
+    await tar.create({ gzip: true, cwd: workDir, file: dataTarGzPath }, Object.keys(files))
+
+    fs.writeFileSync(path.join(workDir, 'metadata.gz'), 'fake-metadata')
+    fs.writeFileSync(path.join(workDir, 'checksums.yaml.gz'), 'fake-checksums')
+
+    const outerTarPath = path.join(workDir, 'fixture.gem')
+    await tar.create({ cwd: workDir, file: outerTarPath }, [
+      'metadata.gz',
+      'data.tar.gz',
+      'checksums.yaml.gz',
+    ])
+
+    return fs.readFileSync(outerTarPath)
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true })
+  }
+}
+
+function mockFetchOnce(response: { status?: number; ok?: boolean; body?: Buffer | null }): void {
+  const body = response.body
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      status: response.status ?? 200,
+      ok: response.ok ?? true,
+      statusText: 'OK',
+      body: body ? Readable.toWeb(Readable.from(body)) : null,
+    }),
+  )
+}
+
+describe('downloadAndExtractRubyGemsSource', () => {
+  let destDir: string
+
+  beforeEach(() => {
+    destDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemdest-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(destDir, { recursive: true, force: true })
+    vi.unstubAllGlobals()
+  })
+
+  it('extracts data.tar.gz entries to destDir root, with no wrapper directory', async () => {
+    const gemBuffer = await buildFixtureGem({
+      'lib/rack.rb': 'module Rack; end',
+      'README.md': '# rack',
+    })
+    mockFetchOnce({ body: gemBuffer })
+
+    await downloadAndExtractRubyGemsSource('rack', '3.0.8', destDir)
+
+    expect(fs.readFileSync(path.join(destDir, 'lib/rack.rb'), 'utf8')).toBe('module Rack; end')
+    expect(fs.readFileSync(path.join(destDir, 'README.md'), 'utf8')).toBe('# rack')
+  })
+
+  it('throws RubyGemsSourceNotFoundError on a 404', async () => {
+    mockFetchOnce({ status: 404, ok: false, body: null })
+
+    await expect(
+      downloadAndExtractRubyGemsSource('nonexistent-gem', '1.0.0', destDir),
+    ).rejects.toThrow(RubyGemsSourceNotFoundError)
+  })
+
+  it('throws RubyGemsSourceNotFoundError when the fetch itself rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')))
+
+    await expect(downloadAndExtractRubyGemsSource('rack', '3.0.8', destDir)).rejects.toThrow(
+      RubyGemsSourceNotFoundError,
+    )
+  })
+
+  it('throws RubyGemsSourceNotFoundError when the .gem has no data.tar.gz entry', async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gembroken-'))
+    try {
+      fs.writeFileSync(path.join(workDir, 'metadata.gz'), 'fake-metadata')
+      const outerTarPath = path.join(workDir, 'broken.gem')
+      await tar.create({ cwd: workDir, file: outerTarPath }, ['metadata.gz'])
+      const gemBuffer = fs.readFileSync(outerTarPath)
+
+      mockFetchOnce({ body: gemBuffer })
+
+      await expect(downloadAndExtractRubyGemsSource('rack', '3.0.8', destDir)).rejects.toThrow(
+        RubyGemsSourceNotFoundError,
+      )
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/clients/__tests__/rubygemsSource.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/__tests__/rubygemsSource.test.ts
@@ -7,9 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RubyGemsSourceNotFoundError, downloadAndExtractRubyGemsSource } from '../rubygemsSource'
 
-// Builds a real .gem-shaped fixture: an uncompressed outer tar containing metadata.gz,
-// data.tar.gz and checksums.yaml.gz, where data.tar.gz is itself a gzip-tar with its
-// entries at the archive root — matching the real format verified against rubygems.org.
+vi.mock('../downloadLimits', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../downloadLimits')>()
+  return { ...actual, MAX_EXTRACTED_FILES: 5 }
+})
+
 async function buildFixtureGem(files: Record<string, string>): Promise<Buffer> {
   const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemfixture-'))
   try {
@@ -89,6 +91,43 @@ describe('downloadAndExtractRubyGemsSource', () => {
 
     await expect(downloadAndExtractRubyGemsSource('rack', '3.0.8', destDir)).rejects.toThrow(
       RubyGemsSourceNotFoundError,
+    )
+  })
+
+  it('requests the platform-suffixed URL when a non-ruby platform is passed', async () => {
+    const gemBuffer = await buildFixtureGem({ 'lib/x.rb': 'X' })
+    mockFetchOnce({ body: gemBuffer })
+
+    await downloadAndExtractRubyGemsSource('nokogiri', '1.13.0', destDir, 'x86_64-linux')
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://rubygems.org/downloads/nokogiri-1.13.0-x86_64-linux.gem',
+      expect.anything(),
+    )
+  })
+
+  it('omits the platform suffix for the default "ruby" platform', async () => {
+    const gemBuffer = await buildFixtureGem({ 'lib/x.rb': 'X' })
+    mockFetchOnce({ body: gemBuffer })
+
+    await downloadAndExtractRubyGemsSource('rack', '3.0.8', destDir, 'ruby')
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://rubygems.org/downloads/rack-3.0.8.gem',
+      expect.anything(),
+    )
+  })
+
+  it('destroys extraction instead of silently truncating when the file count exceeds the limit', async () => {
+    const files: Record<string, string> = {}
+    for (let i = 0; i < 7; i++) {
+      files[`lib/file${i}.rb`] = `# file ${i}`
+    }
+    const gemBuffer = await buildFixtureGem(files)
+    mockFetchOnce({ body: gemBuffer })
+
+    await expect(downloadAndExtractRubyGemsSource('bloated-gem', '1.0.0', destDir)).rejects.toThrow(
+      'Gem exceeded size/file limits',
     )
   })
 

--- a/services/apps/packages_worker/src/blast-radius/clients/rubygemsSource.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/rubygemsSource.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { Readable, Writable } from 'stream'
+import type { ReadableStream as NodeWebReadableStream } from 'stream/web'
+import * as tar from 'tar'
+
+import {
+  FETCH_TIMEOUT_MS,
+  MAX_EXTRACTED_BYTES,
+  MAX_EXTRACTED_FILES,
+  createDownloadLimiter,
+} from './downloadLimits'
+
+// Thrown when no downloadable gem exists for this name/version — the reachability
+// stage turns this into a clean "no source" verdict rather than a retry.
+export class RubyGemsSourceNotFoundError extends Error {
+  constructor(packageName: string, version: string) {
+    super(`No downloadable gem for ${packageName}@${version}`)
+    this.name = 'RubyGemsSourceNotFoundError'
+  }
+}
+
+function gemDownloadUrl(packageName: string, version: string): string {
+  return `https://rubygems.org/downloads/${packageName}-${version}.gem`
+}
+
+// A .gem is an uncompressed POSIX tar containing metadata.gz, data.tar.gz and
+// checksums.yaml.gz — unlike npm/cargo, the actual source lives one level deeper, inside
+// data.tar.gz, whose entries sit at the archive root with no wrapper directory.
+export async function downloadAndExtractRubyGemsSource(
+  packageName: string,
+  version: string,
+  destDir: string,
+): Promise<void> {
+  fs.mkdirSync(destDir, { recursive: true })
+
+  const url = gemDownloadUrl(packageName, version)
+  const controller = new AbortController()
+  const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  const outerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemouter-'))
+
+  try {
+    let res: Response
+    try {
+      res = await fetch(url, { signal: controller.signal })
+    } catch {
+      throw new RubyGemsSourceNotFoundError(packageName, version)
+    }
+    if (res.status === 404) {
+      throw new RubyGemsSourceNotFoundError(packageName, version)
+    }
+    if (!res.ok || !res.body) {
+      throw new Error(`Failed to fetch gem: ${res.status} ${res.statusText}`)
+    }
+
+    let outerExtractedFiles = 0
+    let outerExtractedBytes = 0
+    const outerExtract = tar.extract({
+      cwd: outerDir,
+      strict: true,
+      filter: (entryPath) => entryPath === 'data.tar.gz',
+      onentry: (entry) => {
+        outerExtractedFiles++
+        outerExtractedBytes += entry.size ?? 0
+        if (
+          outerExtractedFiles > MAX_EXTRACTED_FILES ||
+          outerExtractedBytes > MAX_EXTRACTED_BYTES
+        ) {
+          ;(outerExtract as unknown as Writable).destroy(new Error('Gem exceeded size/file limits'))
+        }
+      },
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      Readable.fromWeb(res.body as unknown as NodeWebReadableStream<Uint8Array>)
+        .on('error', reject)
+        .pipe(createDownloadLimiter('Gem download exceeded size limit'))
+        .on('error', reject)
+        .pipe(outerExtract as unknown as NodeJS.WritableStream)
+        .on('finish', resolve)
+        .on('error', reject)
+    })
+
+    const dataTarPath = path.join(outerDir, 'data.tar.gz')
+    if (!fs.existsSync(dataTarPath)) {
+      throw new RubyGemsSourceNotFoundError(packageName, version)
+    }
+
+    let innerExtractedFiles = 0
+    let innerExtractedBytes = 0
+    const innerExtract = tar.extract({
+      cwd: destDir,
+      strict: true,
+      filter: () => {
+        innerExtractedFiles++
+        if (innerExtractedFiles > MAX_EXTRACTED_FILES) return false
+        return true
+      },
+      onentry: (entry) => {
+        innerExtractedBytes += entry.size ?? 0
+        if (innerExtractedBytes > MAX_EXTRACTED_BYTES) {
+          ;(innerExtract as unknown as Writable).destroy(new Error('Gem exceeded size/file limits'))
+        }
+      },
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      fs.createReadStream(dataTarPath)
+        .on('error', reject)
+        .pipe(innerExtract as unknown as NodeJS.WritableStream)
+        .on('finish', resolve)
+        .on('error', reject)
+    })
+  } finally {
+    clearTimeout(timeoutHandle)
+    fs.rmSync(outerDir, { recursive: true, force: true })
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/clients/rubygemsSource.ts
+++ b/services/apps/packages_worker/src/blast-radius/clients/rubygemsSource.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import { Readable, Writable } from 'stream'
+import { Readable } from 'stream'
 import type { ReadableStream as NodeWebReadableStream } from 'stream/web'
 import * as tar from 'tar'
 
@@ -21,21 +21,25 @@ export class RubyGemsSourceNotFoundError extends Error {
   }
 }
 
-function gemDownloadUrl(packageName: string, version: string): string {
-  return `https://rubygems.org/downloads/${packageName}-${version}.gem`
+// rubygems.org omits the platform suffix only for the default 'ruby' platform; every
+// other platform (java, x86_64-linux, ...) requires it, and some gems/versions are only
+// ever published for a non-'ruby' platform.
+function gemDownloadUrl(packageName: string, version: string, platform?: string | null): string {
+  const suffix = platform && platform !== 'ruby' ? `-${platform}` : ''
+  return `https://rubygems.org/downloads/${packageName}-${version}${suffix}.gem`
 }
 
-// A .gem is an uncompressed POSIX tar containing metadata.gz, data.tar.gz and
-// checksums.yaml.gz — unlike npm/cargo, the actual source lives one level deeper, inside
-// data.tar.gz, whose entries sit at the archive root with no wrapper directory.
+// A .gem is an uncompressed POSIX tar wrapping metadata.gz/data.tar.gz/checksums.yaml.gz —
+// the actual source lives one level deeper, inside data.tar.gz, with no wrapper directory.
 export async function downloadAndExtractRubyGemsSource(
   packageName: string,
   version: string,
   destDir: string,
+  platform?: string | null,
 ): Promise<void> {
   fs.mkdirSync(destDir, { recursive: true })
 
-  const url = gemDownloadUrl(packageName, version)
+  const url = gemDownloadUrl(packageName, version, platform)
   const controller = new AbortController()
   const timeoutHandle = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
@@ -68,7 +72,7 @@ export async function downloadAndExtractRubyGemsSource(
           outerExtractedFiles > MAX_EXTRACTED_FILES ||
           outerExtractedBytes > MAX_EXTRACTED_BYTES
         ) {
-          ;(outerExtract as unknown as Writable).destroy(new Error('Gem exceeded size/file limits'))
+          outerExtract.abort(new Error('Gem exceeded size/file limits'))
         }
       },
     })
@@ -93,15 +97,14 @@ export async function downloadAndExtractRubyGemsSource(
     const innerExtract = tar.extract({
       cwd: destDir,
       strict: true,
-      filter: () => {
-        innerExtractedFiles++
-        if (innerExtractedFiles > MAX_EXTRACTED_FILES) return false
-        return true
-      },
       onentry: (entry) => {
+        innerExtractedFiles++
         innerExtractedBytes += entry.size ?? 0
-        if (innerExtractedBytes > MAX_EXTRACTED_BYTES) {
-          ;(innerExtract as unknown as Writable).destroy(new Error('Gem exceeded size/file limits'))
+        if (
+          innerExtractedFiles > MAX_EXTRACTED_FILES ||
+          innerExtractedBytes > MAX_EXTRACTED_BYTES
+        ) {
+          innerExtract.abort(new Error('Gem exceeded size/file limits'))
         }
       },
     })

--- a/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
+++ b/services/apps/packages_worker/src/blast-radius/ecosystemSupport.ts
@@ -2,7 +2,7 @@ import { ApplicationFailure } from '@temporalio/workflow'
 
 // Single source of truth for supported ecosystems — kept in this leaf, I/O-free file
 // (no activities/DAL imports) so the workflow bundle stays deterministic-safe.
-export const SUPPORTED_ECOSYSTEMS = ['npm', 'go', 'maven', 'cargo', 'nuget'] as const
+export const SUPPORTED_ECOSYSTEMS = ['npm', 'go', 'maven', 'cargo', 'nuget', 'rubygems'] as const
 export type Ecosystem = (typeof SUPPORTED_ECOSYSTEMS)[number]
 
 // Pure so it's testable outside the workflow sandbox (Workflow.log/context calls

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -31,7 +31,11 @@ export function toBareGoModule(input: string): string {
 
   name = stripQueryAndFragment(name)
 
-  name = decodeURIComponent(name)
+  try {
+    name = decodeURIComponent(name)
+  } catch {
+    return name
+  }
 
   if (name.startsWith('pkg:golang/')) {
     name = name.slice('pkg:golang/'.length)
@@ -49,7 +53,11 @@ export function toBareCargoName(input: string): string {
 
   name = stripQueryAndFragment(name)
 
-  name = decodeURIComponent(name)
+  try {
+    name = decodeURIComponent(name)
+  } catch {
+    return name
+  }
 
   if (name.startsWith('pkg:cargo/')) {
     name = name.slice('pkg:cargo/'.length)
@@ -67,7 +75,11 @@ export function toBareNuGetId(input: string): string {
 
   name = stripQueryAndFragment(name)
 
-  name = decodeURIComponent(name)
+  try {
+    name = decodeURIComponent(name)
+  } catch {
+    return name
+  }
 
   if (name.startsWith('pkg:nuget/')) {
     name = name.slice('pkg:nuget/'.length)
@@ -78,16 +90,18 @@ export function toBareNuGetId(input: string): string {
   return name
 }
 
-// Same normalization as toBareGoModule, but for RubyGems: purls spell the type 'gem'
-// (not 'rubygems'), and gem names never contain '@' themselves either. Deliberately does
-// NOT lowercase — deps.dev and rubygems.org both store the canonical published spelling,
-// which is not universally lowercase (e.g. RedCloth, Ascii85).
+// Same as toBareGoModule, but purls spell the type 'gem'. Deliberately does NOT lowercase —
+// deps.dev/rubygems.org store the canonical published spelling (e.g. RedCloth, Ascii85).
 export function toBareGemName(input: string): string {
   let name = input.trim()
 
   name = stripQueryAndFragment(name)
 
-  name = decodeURIComponent(name)
+  try {
+    name = decodeURIComponent(name)
+  } catch {
+    return name
+  }
 
   if (name.startsWith('pkg:gem/')) {
     name = name.slice('pkg:gem/'.length)

--- a/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
+++ b/services/apps/packages_worker/src/blast-radius/packageIdentifier.ts
@@ -78,6 +78,26 @@ export function toBareNuGetId(input: string): string {
   return name
 }
 
+// Same normalization as toBareGoModule, but for RubyGems: purls spell the type 'gem'
+// (not 'rubygems'), and gem names never contain '@' themselves either. Deliberately does
+// NOT lowercase — deps.dev and rubygems.org both store the canonical published spelling,
+// which is not universally lowercase (e.g. RedCloth, Ascii85).
+export function toBareGemName(input: string): string {
+  let name = input.trim()
+
+  name = stripQueryAndFragment(name)
+
+  name = decodeURIComponent(name)
+
+  if (name.startsWith('pkg:gem/')) {
+    name = name.slice('pkg:gem/'.length)
+  }
+
+  name = name.replace(/@[^/@]+$/, '')
+
+  return name
+}
+
 // packages/purl rows store cargo names '_'-normalized (see cargo/loadDump.ts) while
 // OSV/crates.io use '-'. Apply ONLY at the packages-table lookup boundary.
 export function toDbCargoName(name: string): string {

--- a/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/__tests__/dispatch.test.ts
@@ -21,6 +21,9 @@ import { runIntelStageNuGet } from '../nuget/intelNuGet'
 import { nugetReachabilityConfig } from '../nuget/reachabilityConfig'
 import { runReachabilityStage } from '../reachability'
 import { runReachabilityStage as runReachabilityStageWithConfig } from '../reachabilityStage'
+import { runDependentsStageRubyGems } from '../rubygems/dependentsRubyGems'
+import { runIntelStageRubyGems } from '../rubygems/intelRubyGems'
+import { rubygemsReachabilityConfig } from '../rubygems/reachabilityConfig'
 
 vi.mock('@crowd/data-access-layer/src/packages/blastRadius', () => ({
   getAnalysisDetail: vi.fn(),
@@ -36,6 +39,9 @@ vi.mock('../cargo/intelCargo', () => ({
 vi.mock('../nuget/intelNuGet', () => ({
   runIntelStageNuGet: vi.fn().mockResolvedValue(undefined),
 }))
+vi.mock('../rubygems/intelRubyGems', () => ({
+  runIntelStageRubyGems: vi.fn().mockResolvedValue(undefined),
+}))
 vi.mock('../go/dependentsGo', () => ({
   runDependentsStageGo: vi.fn().mockResolvedValue(undefined),
 }))
@@ -50,6 +56,9 @@ vi.mock('../cargo/dependentsCargo', () => ({
 }))
 vi.mock('../nuget/dependentsNuGet', () => ({
   runDependentsStageNuGet: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../rubygems/dependentsRubyGems', () => ({
+  runDependentsStageRubyGems: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('../reachabilityStage', () => ({
   runReachabilityStage: vi.fn().mockResolvedValue(undefined),
@@ -107,6 +116,15 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
     expect(runIntelStageMaven).not.toHaveBeenCalled()
   })
 
+  it('routes intel to the RubyGems body when ecosystem is rubygems', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'rubygems' } as never)
+    await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageRubyGems).toHaveBeenCalledWith(qx, 'analysis-1', 'GHSA-xxxx', undefined)
+    expect(runIntelStageGo).not.toHaveBeenCalled()
+    expect(runIntelStageNpm).not.toHaveBeenCalled()
+    expect(runIntelStageMaven).not.toHaveBeenCalled()
+  })
+
   it('routes intel to the npm body when ecosystem is missing/unknown', async () => {
     mockGetAnalysisDetail.mockResolvedValue(null)
     await runIntelStage(qx, 'analysis-1', 'GHSA-xxxx', undefined)
@@ -145,6 +163,15 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
     mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'nuget' } as never)
     await runDependentsStage(qx, 'analysis-1', undefined, undefined)
     expect(runDependentsStageNuGet).toHaveBeenCalled()
+    expect(runDependentsStageGo).not.toHaveBeenCalled()
+    expect(runDependentsStageNpm).not.toHaveBeenCalled()
+    expect(runDependentsStageMaven).not.toHaveBeenCalled()
+  })
+
+  it('routes dependents to the RubyGems body when ecosystem is rubygems', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'rubygems' } as never)
+    await runDependentsStage(qx, 'analysis-1', undefined, undefined)
+    expect(runDependentsStageRubyGems).toHaveBeenCalled()
     expect(runDependentsStageGo).not.toHaveBeenCalled()
     expect(runDependentsStageNpm).not.toHaveBeenCalled()
     expect(runDependentsStageMaven).not.toHaveBeenCalled()
@@ -199,6 +226,17 @@ describe('stage dispatchers (EcosystemConfig registry)', () => {
       qx,
       'analysis-1',
       nugetReachabilityConfig,
+      undefined,
+    )
+  })
+
+  it('routes reachability to the RubyGems config when ecosystem is rubygems', async () => {
+    mockGetAnalysisDetail.mockResolvedValue({ ecosystem: 'rubygems' } as never)
+    await runReachabilityStage(qx, 'analysis-1', undefined)
+    expect(mockRunReachabilityStageWithConfig).toHaveBeenCalledWith(
+      qx,
+      'analysis-1',
+      rubygemsReachabilityConfig,
       undefined,
     )
   })

--- a/services/apps/packages_worker/src/blast-radius/stages/__tests__/ecosystemVersions.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/__tests__/ecosystemVersions.test.ts
@@ -66,6 +66,12 @@ describe('ecosystemVersions', () => {
       const ranges = [{ introduced: '4.5.0.0', fixed: '4.6.0.0', lastAffected: null }]
       expect(versionsInRanges('nuget', versions, ranges)).toEqual(['4.5.0.0', '4.5.0.1'])
     })
+
+    it('includes four-component RubyGems versions, which node-semver cannot parse', () => {
+      const versions = ['3.0.9.0', '3.0.9.1', '3.0.10.0']
+      const ranges = [{ introduced: '3.0.0', fixed: '3.0.9.1', lastAffected: null }]
+      expect(versionsInRanges('rubygems', versions, ranges)).toEqual(['3.0.9.0'])
+    })
   })
 
   describe('highestVersion', () => {
@@ -83,6 +89,10 @@ describe('ecosystemVersions', () => {
 
     it('picks the correct highest four-component NuGet version', () => {
       expect(highestVersion('nuget', ['4.5.0.0', '4.5.0.10', '4.5.0.2'])).toBe('4.5.0.10')
+    })
+
+    it('picks the correct highest four-component RubyGems version', () => {
+      expect(highestVersion('rubygems', ['2.2.8.0', '2.2.8.10', '2.2.8.2'])).toBe('2.2.8.10')
     })
   })
 })

--- a/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/ecosystems.ts
@@ -18,6 +18,9 @@ import { runDependentsStageNuGet } from './nuget/dependentsNuGet'
 import { runIntelStageNuGet } from './nuget/intelNuGet'
 import { nugetReachabilityConfig } from './nuget/reachabilityConfig'
 import { ReachabilitySourceConfig } from './reachabilityStage'
+import { runDependentsStageRubyGems } from './rubygems/dependentsRubyGems'
+import { runIntelStageRubyGems } from './rubygems/intelRubyGems'
+import { rubygemsReachabilityConfig } from './rubygems/reachabilityConfig'
 
 // Replaces the 3 scattered `if (ecosystem === 'go')` dispatch branches. Record<Ecosystem, …>
 // enforces at compile time that every SUPPORTED_ECOSYSTEMS entry has a config.
@@ -62,6 +65,11 @@ const ECOSYSTEMS: Record<Ecosystem, EcosystemConfig> = {
     runIntel: runIntelStageNuGet,
     runDependents: runDependentsStageNuGet,
     reachability: nugetReachabilityConfig,
+  },
+  rubygems: {
+    runIntel: runIntelStageRubyGems,
+    runDependents: runDependentsStageRubyGems,
+    reachability: rubygemsReachabilityConfig,
   },
 }
 

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/__tests__/rubygemsConstraint.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/__tests__/rubygemsConstraint.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { rubygemsConstraintMayInclude } from '../rubygemsConstraint'
+
+describe('rubygemsConstraintMayInclude', () => {
+  it("treats a bare version as exact equality, unlike NuGet's inclusive floor", () => {
+    expect(rubygemsConstraintMayInclude('1.0.0', ['1.0.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('1.0.0', ['1.5.0'])).toBe('excluded')
+  })
+
+  it('matches ">=" and excludes below it', () => {
+    expect(rubygemsConstraintMayInclude('>= 1.0.0', ['1.5.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('>= 2.0.0', ['1.5.0'])).toBe('excluded')
+  })
+
+  it('matches "<" and excludes at/above it', () => {
+    expect(rubygemsConstraintMayInclude('< 2.0.0', ['1.5.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('< 1.0.0', ['1.5.0'])).toBe('excluded')
+  })
+
+  it('matches "!=" for anything but the excluded version', () => {
+    expect(rubygemsConstraintMayInclude('!= 1.0.0', ['1.5.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('!= 1.5.0', ['1.5.0'])).toBe('excluded')
+  })
+
+  it('ANDs comma-separated clauses', () => {
+    expect(rubygemsConstraintMayInclude('>= 1.0.0, < 2.0.0', ['1.5.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('>= 1.0.0, < 2.0.0', ['2.0.0'])).toBe('excluded')
+  })
+
+  it('expands "~>" with two segments to a floor/ceiling pair on the first segment', () => {
+    // Per RubyGems' documented pessimistic-operator semantics, "~> 1.2" means
+    // ">= 1.2, < 2.0" (bumps the major, not the minor) — only a 3-segment "~>" bumps
+    // the minor. See https://guides.rubygems.org/patterns/#pessimistic-version-constraint.
+    expect(rubygemsConstraintMayInclude('~> 1.2', ['1.9.5'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('~> 1.2', ['2.0.0'])).toBe('excluded')
+    expect(rubygemsConstraintMayInclude('~> 1.2', ['1.1.9'])).toBe('excluded')
+  })
+
+  it('expands "~>" with three segments to a floor/ceiling pair on the third segment', () => {
+    expect(rubygemsConstraintMayInclude('~> 1.2.3', ['1.2.9'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('~> 1.2.3', ['1.3.0'])).toBe('excluded')
+    expect(rubygemsConstraintMayInclude('~> 1.2.3', ['1.2.2'])).toBe('excluded')
+  })
+
+  it('matches four-segment versions, which node-semver cannot parse', () => {
+    expect(rubygemsConstraintMayInclude('< 3.0.9.1', ['3.0.9.0'])).toBe('matched')
+    expect(rubygemsConstraintMayInclude('< 3.0.9.1', ['3.0.9.1'])).toBe('excluded')
+  })
+
+  it('matches a bounded range containing an older vulnerable version but not the max', () => {
+    expect(rubygemsConstraintMayInclude('>= 1.0.0, < 1.2.0', ['1.1.0', '2.9.0'])).toBe('matched')
+  })
+
+  it('conservatively includes an empty constraint', () => {
+    expect(rubygemsConstraintMayInclude('', ['1.5.0'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a null constraint instead of throwing', () => {
+    expect(rubygemsConstraintMayInclude(null, ['1.5.0'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a malformed "~>" version', () => {
+    expect(rubygemsConstraintMayInclude('~> abc', ['1.5.0'])).toBe('unparseable-included')
+    expect(rubygemsConstraintMayInclude('~> 1', ['1.5.0'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a clause with a missing version', () => {
+    expect(rubygemsConstraintMayInclude('>=', ['1.5.0'])).toBe('unparseable-included')
+    expect(rubygemsConstraintMayInclude('>', ['1.5.0'])).toBe('unparseable-included')
+  })
+
+  it('conservatively includes a trailing dangling comma', () => {
+    expect(rubygemsConstraintMayInclude('>= 1.0.0,', ['1.5.0'])).toBe('unparseable-included')
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/__tests__/rubygemsPlatform.test.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/__tests__/rubygemsPlatform.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { RubyGemsVersionItem } from '../../../../rubygems/types'
+import { pickPlatform } from '../rubygemsPlatform'
+
+describe('pickPlatform', () => {
+  it('prefers the "ruby" platform when both it and a platform-specific artifact exist', () => {
+    const entries: RubyGemsVersionItem[] = [
+      { number: '1.13.0', created_at: '', platform: 'x86_64-linux' },
+      { number: '1.13.0', created_at: '', platform: 'ruby' },
+    ]
+    expect(pickPlatform(entries, '1.13.0')).toBe('ruby')
+  })
+
+  it('treats a missing platform field as "ruby"', () => {
+    const entries: RubyGemsVersionItem[] = [{ number: '1.0.0', created_at: '' }]
+    expect(pickPlatform(entries, '1.0.0')).toBe('ruby')
+  })
+
+  it('falls back to the only available platform when "ruby" was never published', () => {
+    const entries: RubyGemsVersionItem[] = [{ number: '2.0.0', created_at: '', platform: 'java' }]
+    expect(pickPlatform(entries, '2.0.0')).toBe('java')
+  })
+
+  it('returns null when no entry matches the requested version', () => {
+    const entries: RubyGemsVersionItem[] = [{ number: '1.0.0', created_at: '', platform: 'ruby' }]
+    expect(pickPlatform(entries, '9.9.9')).toBeNull()
+  })
+})

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsRubyGems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsRubyGems.ts
@@ -1,0 +1,111 @@
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { findPackageIdsByName } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { scanRubyGemsDependents } from './dependentsScanRubyGems'
+
+export async function runDependentsStageRubyGems(
+  qx: QueryExecutor,
+  analysisId: string,
+  onProgress?: () => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'dependents')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'dependents',
+      status: 'running',
+      model: null,
+    })
+
+    const spec = await blastRadiusDal.getSymbolSpec(qx, analysisId)
+    if (!spec) {
+      throw new Error('Symbol spec not found; stage 1 (intel) must run first')
+    }
+
+    // See dependentsNpm.ts for why this unconditional clear is safe: reachability
+    // hasn't produced any verdicts yet at this point in the pipeline.
+    await blastRadiusDal.deleteDependents(qx, analysisId)
+
+    const analysis = await blastRadiusDal.getAnalysis(qx, analysisId)
+    if (!analysis?.package_id) {
+      throw new Error('Vulnerable module package_id not resolved; stage 1 (intel) must run first')
+    }
+
+    const vulnerableVersions = (spec.vulnerable_versions || []) as string[]
+
+    // Heartbeat before the scan starts, not just after it completes — the scan is a
+    // single DB round trip that could otherwise run past the activity's heartbeat
+    // timeout with no heartbeat sent in between.
+    onProgress?.()
+
+    const scanResult = await scanRubyGemsDependents(
+      qx,
+      String(analysis.package_id),
+      vulnerableVersions,
+      25,
+    )
+
+    if (signal?.aborted) {
+      throw new Error('Dependents scan cancelled')
+    }
+    onProgress?.()
+
+    const names = scanResult.analyzed.map((d) => d.name)
+    const packageIdsByName = await findPackageIdsByName(qx, 'rubygems', names)
+
+    const dependentInputs = [
+      ...scanResult.analyzed.map((d) => ({
+        analysisId,
+        packageId: packageIdsByName.get(d.name) ?? null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: false,
+        exclusionReason: null,
+      })),
+      ...scanResult.excludedByRange.map((d) => ({
+        analysisId,
+        packageId: null,
+        name: d.name,
+        version: d.version,
+        downloads: d.downloads,
+        declaredRange: d.declaredRange,
+        dependencyKind: d.dependencyKind,
+        rangeIncludesVuln: d.rangeIncludesVuln,
+        rangeCheck: d.rangeCheck,
+        tarballUrl: d.tarballUrl,
+        excludedByRange: true,
+        exclusionReason: `Constraint does not include vulnerable versions (${d.rangeCheck})`,
+      })),
+    ]
+
+    await blastRadiusDal.insertDependents(qx, dependentInputs)
+    await blastRadiusDal.setDependentsMeta(
+      qx,
+      analysisId,
+      scanResult.source,
+      scanResult.candidatesConsidered,
+    )
+
+    const duration = Date.now() - startTime
+    await blastRadiusDal.completeStageRun(qx, analysisId, 'dependents', duration, 0)
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'dependents', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsScanRubyGems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsScanRubyGems.ts
@@ -2,21 +2,18 @@ import { getReverseDependents } from '@crowd/data-access-layer/src/packages/blas
 import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
 
 import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
-import { highestVersion } from '../ecosystemVersions'
 
 import { rubygemsConstraintMayInclude } from './rubygemsConstraint'
 
-// RubyGems dependents come from package_dependencies (deps.dev BigQuery ingestion), same as
-// Maven/Go/NuGet — no download-count signal, and deps.dev never resolves a concrete version
-// for RubyGems edges, so matching goes purely through version_constraint.
+// Same as Maven/Go/NuGet: no download-count signal, and deps.dev never resolves a
+// concrete version for RubyGems edges, so matching goes purely through version_constraint.
 export async function scanRubyGemsDependents(
   qx: QueryExecutor,
   vulnerablePackageId: string,
   vulnerableVersions: string[],
   topN: number,
 ): Promise<ScanDependentsResult> {
-  const maxVulnerableVersion = highestVersion('rubygems', vulnerableVersions)
-  if (!maxVulnerableVersion) {
+  if (vulnerableVersions.length === 0) {
     return {
       source: 'package_dependencies',
       candidatesConsidered: 0,

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsScanRubyGems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/dependentsScanRubyGems.ts
@@ -1,0 +1,58 @@
+import { getReverseDependents } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { DependentCandidate, ScanDependentsResult } from '../../dependentsScan'
+import { highestVersion } from '../ecosystemVersions'
+
+import { rubygemsConstraintMayInclude } from './rubygemsConstraint'
+
+// RubyGems dependents come from package_dependencies (deps.dev BigQuery ingestion), same as
+// Maven/Go/NuGet — no download-count signal, and deps.dev never resolves a concrete version
+// for RubyGems edges, so matching goes purely through version_constraint.
+export async function scanRubyGemsDependents(
+  qx: QueryExecutor,
+  vulnerablePackageId: string,
+  vulnerableVersions: string[],
+  topN: number,
+): Promise<ScanDependentsResult> {
+  const maxVulnerableVersion = highestVersion('rubygems', vulnerableVersions)
+  if (!maxVulnerableVersion) {
+    return {
+      source: 'package_dependencies',
+      candidatesConsidered: 0,
+      analyzed: [],
+      excludedByRange: [],
+      excludedByRangeCount: 0,
+    }
+  }
+
+  // Cap distinct from topN: gather a wider pool so excludedByRange candidates are
+  // still visible for diagnostics, same pattern as Maven/Go/NuGet's scanLimit.
+  const scanLimit = Math.max(topN * 8, 200)
+  const rows = await getReverseDependents(qx, vulnerablePackageId, 'rubygems', scanLimit)
+
+  const candidates: DependentCandidate[] = rows.map((row) => {
+    const rangeCheck = rubygemsConstraintMayInclude(row.versionConstraint, vulnerableVersions)
+    return {
+      name: row.name,
+      version: row.versionNumber,
+      downloads: row.dependentReposCount ?? row.dependentCount ?? null,
+      declaredRange: row.versionConstraint,
+      dependencyKind: row.dependencyKind,
+      rangeIncludesVuln: rangeCheck !== 'excluded',
+      rangeCheck,
+      tarballUrl: null,
+    }
+  })
+
+  const included = candidates.filter((c) => c.rangeIncludesVuln)
+  const excluded = candidates.filter((c) => !c.rangeIncludesVuln)
+
+  return {
+    source: 'package_dependencies',
+    candidatesConsidered: candidates.length,
+    analyzed: included.slice(0, topN),
+    excludedByRange: excluded.slice(0, 200),
+    excludedByRangeCount: excluded.length,
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/intelRubyGems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/intelRubyGems.ts
@@ -26,7 +26,8 @@ import { toBareGemName } from '../../packageIdentifier'
 import { ecosystemRangeEvents, highestVersion, versionsInRanges } from '../ecosystemVersions'
 import { selectAdvisoryEntry } from '../selectAdvisoryEntry'
 
-// OSV spells the RubyGems ecosystem 'RubyGems' (mixed case), unlike our DB's lowercase 'rubygems'.
+import { pickPlatform } from './rubygemsPlatform'
+
 const OSV_RUBYGEMS_ECOSYSTEM = 'RubyGems'
 
 export async function runIntelStageRubyGems(
@@ -59,8 +60,6 @@ export async function runIntelStageRubyGems(
       throw new Error(`No RubyGems entries found in advisory ${advisoryOsvId}`)
     }
 
-    // Pick the RubyGems entry the analysis was requested for; see selectAdvisoryEntry for
-    // rejection rules on non-matching or omitted requests.
     const analysisDetail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
     const requestedName =
       analysisDetail?.package_name != null ? toBareGemName(analysisDetail.package_name) : null
@@ -85,8 +84,7 @@ export async function runIntelStageRubyGems(
     })
 
     // rubygems.org is the authoritative version list; fall back to our own ingested
-    // `versions` rows (deps.dev/rubygems sync) if the registry is unreachable/rate-limited
-    // and the package is already known to us.
+    // `versions` rows if the registry is unreachable/rate-limited and we know the package.
     const versionsResult = await fetchVersions(gemName)
     let allVersions: string[]
     if (!isRubyGemsFetchError(versionsResult)) {
@@ -106,11 +104,17 @@ export async function runIntelStageRubyGems(
       throw new Error(`Could not determine analyzed version for ${gemName}`)
     }
 
+    // Platform is only known when versionsResult came from the live registry — the
+    // DB fallback doesn't carry it.
+    const platform = isRubyGemsFetchError(versionsResult)
+      ? null
+      : pickPlatform(versionsResult, analyzed)
+
     const pkgsrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemsrc-'))
     const patches: Record<string, string> = {}
 
     try {
-      await downloadAndExtractRubyGemsSource(gemName, analyzed, pkgsrcDir)
+      await downloadAndExtractRubyGemsSource(gemName, analyzed, pkgsrcDir, platform)
       onProgress?.()
 
       const patchUrls = fixReferenceUrls(osv)

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/intelRubyGems.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/intelRubyGems.ts
@@ -1,0 +1,183 @@
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import * as blastRadiusDal from '@crowd/data-access-layer/src/packages/blastRadius'
+import { getVersionNumbers } from '@crowd/data-access-layer/src/packages/blastRadiusDependents'
+import { findPackageId } from '@crowd/data-access-layer/src/packages/osv'
+import { QueryExecutor } from '@crowd/data-access-layer/src/queryExecutor'
+
+import { fetchVersions } from '../../../rubygems/client'
+import { isRubyGemsFetchError } from '../../../rubygems/types'
+import {
+  RUBYGEMS_INTEL_SCHEMA,
+  RUBYGEMS_INTEL_SYSTEM_PROMPT,
+  buildRubyGemsIntelPrompt,
+} from '../../agent/rubygemsPrompts'
+import { runAnalysisAgent } from '../../agent/runner'
+import { fetchPatch } from '../../clients/githubPatch'
+import {
+  affectedEntriesForEcosystem,
+  fetchOsvVuln,
+  fixReferenceUrls,
+} from '../../clients/osvClient'
+import { downloadAndExtractRubyGemsSource } from '../../clients/rubygemsSource'
+import { toBareGemName } from '../../packageIdentifier'
+import { ecosystemRangeEvents, highestVersion, versionsInRanges } from '../ecosystemVersions'
+import { selectAdvisoryEntry } from '../selectAdvisoryEntry'
+
+// OSV spells the RubyGems ecosystem 'RubyGems' (mixed case), unlike our DB's lowercase 'rubygems'.
+const OSV_RUBYGEMS_ECOSYSTEM = 'RubyGems'
+
+export async function runIntelStageRubyGems(
+  qx: QueryExecutor,
+  analysisId: string,
+  advisoryOsvId: string,
+  onProgress?: () => void,
+): Promise<void> {
+  const startTime = Date.now()
+
+  try {
+    // Check if already done — avoid clobbering a succeeded stage_run's status/started_at
+    // on a redundant re-invocation (startStageRun's ON CONFLICT always overwrites status).
+    const existingStatus = await blastRadiusDal.getStageRunStatus(qx, analysisId, 'intel')
+    if (existingStatus === 'succeeded') {
+      return
+    }
+
+    await blastRadiusDal.startStageRun(qx, {
+      analysisId,
+      stage: 'intel',
+      status: 'running',
+      model: 'claude-opus-4-8',
+    })
+
+    const osv = await fetchOsvVuln(advisoryOsvId)
+
+    const rubygemsEntries = affectedEntriesForEcosystem(osv, OSV_RUBYGEMS_ECOSYSTEM)
+    if (rubygemsEntries.length === 0) {
+      throw new Error(`No RubyGems entries found in advisory ${advisoryOsvId}`)
+    }
+
+    // Pick the RubyGems entry the analysis was requested for; see selectAdvisoryEntry for
+    // rejection rules on non-matching or omitted requests.
+    const analysisDetail = await blastRadiusDal.getAnalysisDetail(qx, analysisId)
+    const requestedName =
+      analysisDetail?.package_name != null ? toBareGemName(analysisDetail.package_name) : null
+    const { entry, relatedAffectedPackages } = selectAdvisoryEntry(
+      rubygemsEntries,
+      requestedName,
+      (e) => e.package.name === requestedName,
+      advisoryOsvId,
+    )
+
+    const gemName = entry.package.name
+    const ecosystem = 'rubygems'
+
+    // Resolve vulnerable versions from OSV ranges first (RubyGems OSV ranges are
+    // ECOSYSTEM-typed, not SEMVER — same shape as Maven/Go/NuGet, see ecosystemVersions.ts).
+    const ranges = ecosystemRangeEvents(entry)
+
+    const dbPackageId = await findPackageId(qx, {
+      ecosystem,
+      namespace: null,
+      name: gemName,
+    })
+
+    // rubygems.org is the authoritative version list; fall back to our own ingested
+    // `versions` rows (deps.dev/rubygems sync) if the registry is unreachable/rate-limited
+    // and the package is already known to us.
+    const versionsResult = await fetchVersions(gemName)
+    let allVersions: string[]
+    if (!isRubyGemsFetchError(versionsResult)) {
+      allVersions = versionsResult.map((v) => v.number)
+    } else if (dbPackageId) {
+      allVersions = await getVersionNumbers(qx, String(dbPackageId))
+    } else {
+      throw new Error(
+        `Failed to fetch RubyGems version list for ${gemName} (${versionsResult.kind}) and package is not in our DB`,
+      )
+    }
+
+    const vulnerableVersions = versionsInRanges('rubygems', allVersions, ranges)
+
+    const analyzed = highestVersion('rubygems', vulnerableVersions)
+    if (!analyzed) {
+      throw new Error(`Could not determine analyzed version for ${gemName}`)
+    }
+
+    const pkgsrcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gemsrc-'))
+    const patches: Record<string, string> = {}
+
+    try {
+      await downloadAndExtractRubyGemsSource(gemName, analyzed, pkgsrcDir)
+      onProgress?.()
+
+      const patchUrls = fixReferenceUrls(osv)
+      for (const url of patchUrls.slice(0, 3)) {
+        try {
+          const patchText = await fetchPatch(url)
+          const slug = new URL(url).pathname.split('/').filter(Boolean).join('-')
+          patches[slug] = patchText
+        } catch {
+          // Ignore patch fetch errors
+        }
+      }
+
+      const agentPrompt = buildRubyGemsIntelPrompt(
+        osv.id || advisoryOsvId,
+        osv.aliases || [],
+        osv.details || osv.summary || '',
+        analyzed,
+        patches,
+      )
+
+      const agentResult = await runAnalysisAgent({
+        prompt: agentPrompt,
+        systemPrompt: RUBYGEMS_INTEL_SYSTEM_PROMPT,
+        cwd: pkgsrcDir,
+        model: 'claude-opus-4-8',
+        schema: RUBYGEMS_INTEL_SCHEMA,
+        maxTurns: 15,
+        timeoutMs: 600_000,
+        onProgress,
+      })
+
+      if (agentResult.isError || !agentResult.structuredOutput) {
+        throw new Error(`Agent failed: ${agentResult.errorMessage}`)
+      }
+
+      const output = agentResult.structuredOutput
+      await blastRadiusDal.upsertSymbolSpec(qx, {
+        analysisId,
+        vulnId: osv.id || advisoryOsvId,
+        aliases: osv.aliases || [],
+        package: gemName,
+        ecosystem,
+        affectedRanges: ranges as unknown as Record<string, unknown>[],
+        vulnerableVersions,
+        analyzedVersion: analyzed,
+        relatedAffectedPackages,
+        vulnerableSymbols: (output.vulnerable_symbols || []) as Record<string, unknown>[],
+        importSignatures: (output.import_signatures || {}) as Record<string, unknown>,
+        exploitPreconditions: String(output.exploit_preconditions || ''),
+        reachabilityNotes: String(output.reachability_notes || ''),
+        confidence: Number(output.confidence ?? 0.5),
+        sources: [advisoryOsvId],
+        summary: String(output.summary || ''),
+      })
+
+      await blastRadiusDal.resolveAdvisoryAndPackageIds(qx, analysisId, advisoryOsvId, dbPackageId)
+
+      const duration = Date.now() - startTime
+      await blastRadiusDal.completeStageRun(qx, analysisId, 'intel', duration, agentResult.costUsd)
+    } finally {
+      fs.rmSync(pkgsrcDir, { recursive: true, force: true })
+    }
+  } catch (err) {
+    const duration = Date.now() - startTime
+    const errorMsg = err instanceof Error ? err.message : String(err)
+    await blastRadiusDal.failStageRun(qx, analysisId, 'intel', duration, errorMsg)
+    throw err
+  }
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/reachabilityConfig.ts
@@ -1,37 +1,29 @@
-import { fetchVersions } from '../../../rubygems/client'
-import { isRubyGemsFetchError } from '../../../rubygems/types'
 import {
   RUBYGEMS_REACHABILITY_PROMPT,
   RUBYGEMS_VERDICT_SCHEMA,
   buildRubyGemsReachabilitySystemPrompt,
 } from '../../agent/rubygemsPrompts'
 import { downloadAndExtractRubyGemsSource } from '../../clients/rubygemsSource'
-import { highestVersion } from '../ecosystemVersions'
 import { ReachabilitySourceConfig } from '../reachabilityStage'
 
-// deps.dev never resolves a concrete version for RubyGems edges (see
-// dependentsScanRubyGems.ts), so dep.version is always null — fall back to the package's
-// current highest published version.
-async function resolveRubyGemsVersion(packageName: string): Promise<string | null> {
-  const versionsResult = await fetchVersions(packageName)
-  if (isRubyGemsFetchError(versionsResult)) return null
-  return highestVersion(
-    'rubygems',
-    versionsResult.map((v) => v.number),
-  )
-}
+import { resolveGemPlatform } from './rubygemsPlatform'
 
+// Unlike Go/NuGet, RubyGems dependent rows carry the dependent's own declared version
+// (never null) — noSourceMessage below is only reachable if that guarantee is violated.
 export const rubygemsReachabilityConfig: ReachabilitySourceConfig = {
   prompt: RUBYGEMS_REACHABILITY_PROMPT,
   schema: RUBYGEMS_VERDICT_SCHEMA,
   buildSystemPrompt: buildRubyGemsReachabilitySystemPrompt,
   prepareSource: async (dep) => {
-    const version = dep.version ?? (await resolveRubyGemsVersion(dep.name))
-    if (!version) return null
+    if (!dep.version) return null
+    const version = dep.version
     return {
-      download: (destDir) => downloadAndExtractRubyGemsSource(dep.name, version, destDir),
+      download: async (destDir: string) => {
+        const platform = await resolveGemPlatform(dep.name, version)
+        await downloadAndExtractRubyGemsSource(dep.name, version, destDir, platform)
+      },
     }
   },
-  noSourceMessage: 'Could not resolve a concrete RubyGems package version',
+  noSourceMessage: 'Dependent has no recorded version',
   downloadErrorPrefix: 'RubyGems source download failed',
 }

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/reachabilityConfig.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/reachabilityConfig.ts
@@ -1,0 +1,37 @@
+import { fetchVersions } from '../../../rubygems/client'
+import { isRubyGemsFetchError } from '../../../rubygems/types'
+import {
+  RUBYGEMS_REACHABILITY_PROMPT,
+  RUBYGEMS_VERDICT_SCHEMA,
+  buildRubyGemsReachabilitySystemPrompt,
+} from '../../agent/rubygemsPrompts'
+import { downloadAndExtractRubyGemsSource } from '../../clients/rubygemsSource'
+import { highestVersion } from '../ecosystemVersions'
+import { ReachabilitySourceConfig } from '../reachabilityStage'
+
+// deps.dev never resolves a concrete version for RubyGems edges (see
+// dependentsScanRubyGems.ts), so dep.version is always null — fall back to the package's
+// current highest published version.
+async function resolveRubyGemsVersion(packageName: string): Promise<string | null> {
+  const versionsResult = await fetchVersions(packageName)
+  if (isRubyGemsFetchError(versionsResult)) return null
+  return highestVersion(
+    'rubygems',
+    versionsResult.map((v) => v.number),
+  )
+}
+
+export const rubygemsReachabilityConfig: ReachabilitySourceConfig = {
+  prompt: RUBYGEMS_REACHABILITY_PROMPT,
+  schema: RUBYGEMS_VERDICT_SCHEMA,
+  buildSystemPrompt: buildRubyGemsReachabilitySystemPrompt,
+  prepareSource: async (dep) => {
+    const version = dep.version ?? (await resolveRubyGemsVersion(dep.name))
+    if (!version) return null
+    return {
+      download: (destDir) => downloadAndExtractRubyGemsSource(dep.name, version, destDir),
+    }
+  },
+  noSourceMessage: 'Could not resolve a concrete RubyGems package version',
+  downloadErrorPrefix: 'RubyGems source download failed',
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsConstraint.ts
@@ -1,0 +1,103 @@
+import { compareVersion } from '../../../osv/versionCompare'
+
+export type RubyGemsConstraintMatch = 'matched' | 'excluded' | 'unparseable-included'
+
+type Op = '=' | '!=' | '>' | '<' | '>=' | '<='
+
+interface RubyGemsClause {
+  op: Op
+  version: string
+}
+
+const OPERATORS: (Op | '~>')[] = ['!=', '>=', '<=', '~>', '>', '<', '=']
+
+// deps.dev's d.Requirement for RubyGems is a Gem::Requirement string: comma-separated
+// clauses ANDed together, each "<op> <version>" (bare version means "="). "~>" is the
+// pessimistic operator — expands to a floor/ceiling pair below, not a single clause.
+// Longest operators are checked first (a naive single regex backtracks ">=" into ">"
+// plus a bogus "=" version when nothing follows the operator).
+function parseClause(raw: string): RubyGemsClause[] | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  for (const op of OPERATORS) {
+    if (trimmed.startsWith(op)) {
+      const version = trimmed.slice(op.length).trim()
+      if (!version) return null
+      if (op === '~>') return expandPessimistic(version)
+      return [{ op, version }]
+    }
+  }
+
+  return [{ op: '=', version: trimmed }]
+}
+
+// "~> 1.2" means ">= 1.2, < 2.0"; "~> 1.2.3" means ">= 1.2.3, < 1.3.0" — drop the last
+// segment and bump the segment now at the end, per Gem::Requirement's documented semantics.
+function expandPessimistic(version: string): RubyGemsClause[] | null {
+  const segments = version.split('.')
+  if (segments.length < 2 || segments.some((s) => !/^\d+$/.test(s))) return null
+
+  const bumped = segments.slice(0, -1)
+  const last = Number(bumped[bumped.length - 1])
+  bumped[bumped.length - 1] = String(last + 1)
+
+  return [
+    { op: '>=', version },
+    { op: '<', version: bumped.join('.') },
+  ]
+}
+
+function parseRequirement(constraint: string | null): RubyGemsClause[] | null {
+  // package_dependencies.version_constraint is nullable (deps.dev fill path) — treat a
+  // missing constraint the same as an unparseable one, not a crash on .split.
+  if (constraint == null) return null
+  const trimmed = constraint.trim()
+  if (!trimmed) return null
+
+  const clauses: RubyGemsClause[] = []
+  for (const part of trimmed.split(',')) {
+    const parsed = parseClause(part)
+    if (!parsed) return null
+    clauses.push(...parsed)
+  }
+  return clauses.length > 0 ? clauses : null
+}
+
+function clauseMatches(clause: RubyGemsClause, version: string): boolean {
+  const c = compareVersion('rubygems', version, clause.version)
+  if (c === null) return true // unparseable bound — over-inclusive
+
+  switch (clause.op) {
+    case '=':
+      return c === 0
+    case '!=':
+      return c !== 0
+    case '>':
+      return c > 0
+    case '<':
+      return c < 0
+    case '>=':
+      return c >= 0
+    case '<=':
+      return c <= 0
+  }
+}
+
+// Over-inclusive by design: the reachability stage (real source analysis) is the actual
+// precision filter, so an unparseable constraint is always surfaced, never dropped.
+//
+// Checks against every vulnerable version, not just the highest one: a bounded "~>"
+// constraint can include an older vulnerable version without including the max.
+export function rubygemsConstraintMayInclude(
+  constraint: string | null,
+  vulnerableVersions: string[],
+): RubyGemsConstraintMatch {
+  const clauses = parseRequirement(constraint)
+  if (!clauses) return 'unparseable-included'
+
+  const matched = vulnerableVersions.some((version) =>
+    clauses.every((clause) => clauseMatches(clause, version)),
+  )
+  return matched ? 'matched' : 'excluded'
+}

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsConstraint.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsConstraint.ts
@@ -11,11 +11,8 @@ interface RubyGemsClause {
 
 const OPERATORS: (Op | '~>')[] = ['!=', '>=', '<=', '~>', '>', '<', '=']
 
-// deps.dev's d.Requirement for RubyGems is a Gem::Requirement string: comma-separated
-// clauses ANDed together, each "<op> <version>" (bare version means "="). "~>" is the
-// pessimistic operator — expands to a floor/ceiling pair below, not a single clause.
-// Longest operators are checked first (a naive single regex backtracks ">=" into ">"
-// plus a bogus "=" version when nothing follows the operator).
+// Gem::Requirement clauses: comma-separated "<op> <version>" (bare version means "=").
+// Longest operators checked first — a naive regex backtracks ">=" into ">" plus a bogus "=".
 function parseClause(raw: string): RubyGemsClause[] | null {
   const trimmed = raw.trim()
   if (!trimmed) return null
@@ -61,7 +58,7 @@ function parseRequirement(constraint: string | null): RubyGemsClause[] | null {
     if (!parsed) return null
     clauses.push(...parsed)
   }
-  return clauses.length > 0 ? clauses : null
+  return clauses
 }
 
 function clauseMatches(clause: RubyGemsClause, version: string): boolean {
@@ -84,11 +81,8 @@ function clauseMatches(clause: RubyGemsClause, version: string): boolean {
   }
 }
 
-// Over-inclusive by design: the reachability stage (real source analysis) is the actual
-// precision filter, so an unparseable constraint is always surfaced, never dropped.
-//
-// Checks against every vulnerable version, not just the highest one: a bounded "~>"
-// constraint can include an older vulnerable version without including the max.
+// Over-inclusive by design — reachability is the real precision filter. Checks every
+// vulnerable version, not just the highest: a bounded "~>" can include an older one.
 export function rubygemsConstraintMayInclude(
   constraint: string | null,
   vulnerableVersions: string[],

--- a/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsPlatform.ts
+++ b/services/apps/packages_worker/src/blast-radius/stages/rubygems/rubygemsPlatform.ts
@@ -1,0 +1,17 @@
+import { fetchVersions } from '../../../rubygems/client'
+import { isRubyGemsFetchError } from '../../../rubygems/types'
+import { RubyGemsVersionItem } from '../../../rubygems/types'
+
+// Multiple platform-specific artifacts can share the same version `number`; prefer the
+// universal `ruby` platform, falling back since some gems are never published for it.
+export function pickPlatform(entries: RubyGemsVersionItem[], version: string): string | null {
+  const matches = entries.filter((v) => v.number === version)
+  if (matches.some((v) => (v.platform ?? 'ruby') === 'ruby')) return 'ruby'
+  return matches[0]?.platform ?? null
+}
+
+export async function resolveGemPlatform(name: string, version: string): Promise<string | null> {
+  const versionsResult = await fetchVersions(name)
+  if (isRubyGemsFetchError(versionsResult)) return null
+  return pickPlatform(versionsResult, version)
+}

--- a/services/apps/packages_worker/src/rubygems/types.ts
+++ b/services/apps/packages_worker/src/rubygems/types.ts
@@ -34,6 +34,7 @@ export interface RubyGemsVersionItem {
   created_at: string
   prerelease?: boolean
   licenses?: string[] | null
+  platform?: string
 }
 
 export interface RubyGemsOwner {

--- a/services/libs/data-access-layer/src/packages/blastRadiusDependents.ts
+++ b/services/libs/data-access-layer/src/packages/blastRadiusDependents.ts
@@ -6,7 +6,7 @@ export interface ReverseDependentRow {
   namespace: string | null
   name: string
   versionNumber: string
-  versionConstraint: string
+  versionConstraint: string | null
   resolvedVersionNumber: string | null
   dependencyKind: string
   dependentCount: number | null
@@ -61,7 +61,7 @@ export async function getReverseDependents(
     namespace: row.namespace as string | null,
     name: row.name as string,
     versionNumber: row.version_number as string,
-    versionConstraint: row.version_constraint as string,
+    versionConstraint: row.version_constraint as string | null,
     resolvedVersionNumber: row.resolved_version_number as string | null,
     dependencyKind: row.dependency_kind as string,
     dependentCount: row.dependent_count as number | null,


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Adds RubyGems as a supported blast-radius ecosystem, following the same intel → dependents → reachability → report pipeline already in place for npm, go, maven, cargo, and nuget.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- Registers `rubygems` in `SUPPORTED_ECOSYSTEMS` and the backend's `SUPPORTED_BLAST_RADIUS_ECOSYSTEMS`, and wires the new stage implementations into `stages/ecosystems.ts`'s `ECOSYSTEMS` record.
- Adds `toBareGemName` to `packageIdentifier.ts`, stripping the `pkg:gem/` purl prefix without lowercasing — gem names aren't universally lowercase (`RedCloth`, `Ascii85`), and both deps.dev and rubygems.org store the canonical published spelling.
- Implements `rubygemsConstraintMayInclude` (`stages/rubygems/rubygemsConstraint.ts`), a native comparator-based parser for the Gem::Requirement grammar (comma-separated `<op> <version>` clauses ANDed together), since real RubyGems versions are 4-segment and node-semver can't parse them. Correctly expands the pessimistic operator per RubyGems' documented semantics: `~> 1.2` → `>= 1.2, < 2.0`, `~> 1.2.3` → `>= 1.2.3, < 1.3.0` (drop the last segment, bump the new last segment).
- Adds `clients/rubygemsSource.ts` to download and extract the real published `.gem` source directly from rubygems.org, instead of guessing at a GitHub tarball as NuGet has to — gems ship uncompressed source, so this avoids the monorepo/heartbeat problems hit on the NuGet source-download path.
- Adds the RubyGems stage trio (`intelRubyGems.ts`, `dependentsRubyGems.ts`/`dependentsScanRubyGems.ts`, `reachabilityConfig.ts`), modeled directly on the NuGet implementation since both are manifest-style ecosystems (deps.dev never resolves a concrete `to_version`).
- Adds `agent/rubygemsPrompts.ts` with Ruby-specific intel/reachability prompts (import styles: `require`, `require_relative`, `autoload`, `gem_dependency`; excludes `spec/`, `test/`, `features/`, `vendor/`).
- Full unit test coverage for the new constraint parser, source extraction (using real `tar`-built fixtures, not mocks), identifier helper, and dispatch routing; extended `ecosystemVersions.test.ts` for 4-segment version ordering.

## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1358](https://linuxfoundation.atlassian.net/browse/CM-1358)

[CM-1358]: https://linuxfoundation.atlassian.net/browse/CM-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ