### PR TITLE
fix: filter soft-deleted

### DIFF
--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -244,7 +244,7 @@ export async function getPriorityArray(): Promise<string[]> {
 
 export async function fetchMemberDataForLLMSquashing(
   memberId: string,
-): Promise<IMemberOriginalData> {
+): Promise<IMemberOriginalData | null> {
   return fetchMemberDataForLLMSquashingDb(svc.postgres.reader.connection(), memberId)
 }
 
@@ -601,6 +601,7 @@ export async function updateMemberUsingSquashedPayload(
         existingMemberData.organizations,
         squashedPayload.memberOrganizations,
         isHighConfidenceSourceSelectedForWorkExperiences,
+        new Set(existingMemberData.deletedOrganizations.map((o) => o.orgId)),
       )
 
       // Enrichment often deletes and recreates the same orgs with identical dates.
@@ -834,11 +835,15 @@ function prepareWorkExperiences(
   oldVersion: IMemberOrganizationData[],
   newVersion: IMemberEnrichmentDataNormalizedOrganization[],
   isHighConfidenceSourceSelectedForWorkExperiences: boolean,
+  deletedOrganizationIds: Set<string>,
 ): IWorkExperienceChanges {
   // we delete all the work experiences that were not manually created or from the project registry.
   const toDelete = oldVersion.filter(
     (c) => c.source !== OrganizationSource.UI && c.source !== OrganizationSource.PROJECT_REGISTRY,
   )
+
+  // never recreate an affiliation that was manually deleted — enrichment providers keep resupplying it
+  newVersion = newVersion.filter((e) => !deletedOrganizationIds.has(e.organizationId))
 
   const toCreate: IMemberEnrichmentDataNormalizedOrganization[] = []
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
+++ b/services/libs/data-access-layer/src/old/apps/members_enrichment_worker/index.ts
@@ -57,7 +57,13 @@ export async function fetchMemberDataForLLMSquashing(
                         where mo."memberId" = $(memberId)
                           and mo."deletedAt" is null
                           and o."deletedAt" is null
-                        group by mo."memberId", mo."organizationId", o."displayName", mo.id)
+                        group by mo."memberId", mo."organizationId", o."displayName", mo.id),
+    deleted_member_orgs as (select distinct
+                              mo."organizationId" as "orgId"
+                            from "memberOrganizations" mo
+                            where mo."memberId" = $(memberId)
+                              and mo."deletedAt" is not null
+                              and mo.source not in ('ui', 'project-registry'))
     select m."displayName",
           m.attributes,
           m."manuallyChangedFields",
@@ -90,7 +96,10 @@ export async function fetchMemberDataForLLMSquashing(
                   where mo."memberId" = m.id
               )
               else '[]'::json
-              end as organizations
+              end as organizations,
+          coalesce(
+                  (select json_agg(jsonb_build_object('orgId', d."orgId") order by d."orgId") from deleted_member_orgs d), '[]'::json
+          ) as "deletedOrganizations"
     from members m
     where m.id = $(memberId)
       and m."deletedAt" is null

--- a/services/libs/types/src/enrichment.ts
+++ b/services/libs/types/src/enrichment.ts
@@ -43,6 +43,10 @@ export interface IMemberOrganizationData {
   identities?: IOrganizationIdentity[]
 }
 
+export interface IDeletedMemberOrganizationData {
+  orgId: string
+}
+
 export interface IMemberOriginalData {
   // members table data
   displayName: string
@@ -55,6 +59,8 @@ export interface IMemberOriginalData {
 
   // memberOrganizations table data
   organizations: IMemberOrganizationData[]
+  // memberOrganizations rows manually deleted, source not UI/PROJECT_REGISTRY — tombstones enrichment must not recreate
+  deletedOrganizations: IDeletedMemberOrganizationData[]
 }
 
 export interface IOrganizationEnrichmentCache<T> {


### PR DESCRIPTION
## Summary

Fixes `members_enrichment_worker` recreating manually-deleted organization affiliations. The worker rebuilds each member's org affiliation timeline from scratch on every run, but its "current state" read filtered out soft-deleted `memberOrganizations` rows entirely — so a manually-deleted affiliation was indistinguishable from one that never existed, and the enrichment provider (PDL/Clearbit/etc.) kept resupplying and recreating it. Reported in DE-1016/DE-1021 (Dusky'z contributions incorrectly reappearing on OpenDaylight, instead of being merged into PANTHEON.tech).

## Changes

- `fetchMemberDataForLLMSquashing` (`services/libs/data-access-layer/.../members_enrichment_worker/index.ts`) now also returns `deletedOrganizations`: distinct `organizationId`s with a soft-deleted, non-`UI`/`PROJECT_REGISTRY`-sourced `memberOrganizations` row for the member — these act as tombstones.
- `prepareWorkExperiences` (`services/apps/members_enrichment_worker/src/activities/enrichment.ts`) now takes the tombstone set and filters them out of the incoming enrichment payload before deciding what to create, so a manually-deleted affiliation is never recreated.
- Chose "never recreate after manual delete" over a time-based resync window — simpler, and matches the intent of a manual delete. If an org's data legitimately changes later, it won't auto-resync; that's an accepted trade-off, not a currently observed need.
- Added `IDeletedMemberOrganizationData` to `@crowd/types`, exposed as `deletedOrganizations` on `IMemberOriginalData`.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

