### PR TITLE
feat: prefer organization country in Tinybird geo pipes (CM-1366)

### DIFF
--- a/services/libs/tinybird/datasources/organizations.datasource
+++ b/services/libs/tinybird/datasources/organizations.datasource
@@ -5,6 +5,7 @@ DESCRIPTION >
     - `id` is the primary key identifier for the organization record.
     - `displayName` is the organization's primary name or brand.
     - `location` is the organization's headquarters or primary location (empty string if not provided).
+    - `country` is the organization's country inferred from location (empty string if not determined).
     - `logo` contains the URL to the organization's logo image (empty string if no logo).
     - `tags` is an array of labels or categories associated with the organization (empty array default).
     - `employees` is the number of employees in the organization (0 default if unknown).
@@ -20,6 +21,7 @@ SCHEMA >
     `id` String `json:$.record.id`,
     `displayName` String `json:$.record.displayName`,
     `location` String `json:$.record.location` DEFAULT '',
+    `country` String `json:$.record.country` DEFAULT '',
     `logo` String `json:$.record.logo` DEFAULT '',
     `tags` Array(String) `json:$.record.tags[:]` DEFAULT [],
     `employees` UInt32 `json:$.record.employees` DEFAULT 0,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_0.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_1.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_2.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_3.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_4.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_5.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_6.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_7.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_8.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_bucket_clean_enrich_copy_pipe_9.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_0.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_0
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_1.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_1
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_2.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_2
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_3.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_3
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_4.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_4
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_5.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_5
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_6.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_6
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_7.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_7
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_8
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_collection_bucket_clean_enrich_copy_pipe_9.pipe
@@ -14,7 +14,7 @@ SQL >
 NODE activityRelations_collection_deduplicated_cleaned_denormalized_9
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_0.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_0.pipe
@@ -11,7 +11,7 @@ SQL >
 NODE activityRelations_deduplicated_enriched_bucket_0
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_1.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_1.pipe
@@ -11,7 +11,7 @@ SQL >
 NODE activityRelations_deduplicated_enriched_bucket_1
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_2.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_enrich_initial_snapshot_2.pipe
@@ -11,7 +11,7 @@ SQL >
 NODE activityRelations_deduplicated_enriched_bucket_2
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/activityRelations_enrich_snapshot_MV.pipe
+++ b/services/libs/tinybird/pipes/activityRelations_enrich_snapshot_MV.pipe
@@ -5,7 +5,7 @@ SQL >
 NODE activityRelations_deduplicated_cleaned_denormalized
 SQL >
     WITH
-        upperUTF8(o.location) AS search_u,
+        upperUTF8(coalesce(nullIf(o.country, ''), o.location)) AS search_u,
         (SELECT arrayMap(x -> upperUTF8(x .1), country_data) FROM country_mapping_array) AS names_u,
         (SELECT country_data FROM country_mapping_array) AS mapping,
         multiSearchFirstIndexUTF8(search_u, names_u) AS idx,

--- a/services/libs/tinybird/pipes/organizations_geo_distribution.pipe
+++ b/services/libs/tinybird/pipes/organizations_geo_distribution.pipe
@@ -1,6 +1,6 @@
 DESCRIPTION >
     - `organizations_geo_distribution.pipe` serves the organization geographic distribution widget showing organization counts by country.
-    - Maps organization locations to countries using fuzzy matching with the `country_mapping` lookup table.
+    - Prefers country when set, otherwise falls back to location for country mapping.
     - Handles unknown/unmappable locations by grouping them under "Unknown" with ❓ flag and 'XX' country code.
     - Calculates both absolute organization counts and percentage distribution for visualization.
     - Primary use case: displaying geographic diversity of organizations in project insights.
@@ -25,8 +25,9 @@ SQL >
     SELECT
         o.id,
         o.location,
+        o.country,
         arrayFilter(
-            x -> position(upper(o.location), upper(x .1)) > 0,
+            x -> position(upper(coalesce(nullIf(o.country, ''), o.location)), upper(x .1)) > 0,
             (SELECT country_data FROM country_mapping_array)
         ) AS matched_countries,
         arrayJoin(


### PR DESCRIPTION
## Summary
- Add `country` to the Tinybird `organizations` datasource so Sequin-synced values are available in Insights
- Prefer organization `country` over `location` for geo mapping, same pattern as members

## Changes
- Add `country` field to `organizations.datasource`
- Update `organizations_geo_distribution` to `coalesce(country, location)`
- Update activityRelations enrich copy/snapshot pipes to use the same fallback for `organizationCountryCode`