### PR TITLE
feat: add fallback on personal account (CM-1357)

### DIFF
--- a/services/libs/anthropic-aws/src/agent.ts
+++ b/services/libs/anthropic-aws/src/agent.ts
@@ -1,6 +1,6 @@
 import { getServiceChildLogger } from '@crowd/logging'
 
-import { getAnthropicAwsAgentSdkEnv } from './credentials'
+import { getAnthropicAwsAgentSdkEnv, getAnthropicPersonalAuthEnv } from './credentials'
 
 const log = getServiceChildLogger('anthropic-aws-agent')
 
@@ -70,16 +70,22 @@ export async function runClaudeAgentQuery(
     onProgress,
   } = input
 
-  // Build environment: if Claude Platform on AWS credentials are configured, route
-  // the agent through them; otherwise omit to fall back to local CLI auth (dev only).
+  // Build environment: prefer Claude Platform on AWS, then a personal `claude
+  // setup-token` OAuth token (local dev), then omit to fall back to local CLI auth.
   let env: NodeJS.ProcessEnv | undefined
   let authMode = 'fallback on local claude code token'
   try {
     env = { ...process.env, ...getAnthropicAwsAgentSdkEnv() }
     authMode = 'claude-platform-on-aws'
   } catch (err) {
-    env = undefined
-    log.warn({ err }, 'anthropic-aws agent: Claude Platform on AWS not configured, falling back')
+    const personalAuthEnv = getAnthropicPersonalAuthEnv()
+    if (personalAuthEnv) {
+      env = { ...process.env, ...personalAuthEnv }
+      authMode = 'personal-oauth-token'
+    } else {
+      env = undefined
+      log.warn({ err }, 'anthropic-aws agent: Claude Platform on AWS not configured, falling back')
+    }
   }
 
   log.info({ authMode }, 'anthropic-aws agent: auth mode for this run')

--- a/services/libs/anthropic-aws/src/credentials.ts
+++ b/services/libs/anthropic-aws/src/credentials.ts
@@ -32,3 +32,11 @@ export function getAnthropicAwsAgentSdkEnv(
     ANTHROPIC_AWS_API_KEY: credentials.apiKey,
   }
 }
+
+export function getAnthropicPersonalAuthEnv(): Record<string, string> | undefined {
+  const oauthToken = process.env.CROWD_AKRITES_CLAUDE_CODE_DEV_OAUTH_TOKEN
+  if (!oauthToken) {
+    return undefined
+  }
+  return { CLAUDE_CODE_OAUTH_TOKEN: oauthToken }
+}


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->
Adds a personal-OAuth-token fallback to the Anthropic agent auth chain in `@crowd/anthropic-aws`, so `runClaudeAgentQuery` can still run when Claude Platform on AWS isn't configured — needed to test flows like blast-radius locally without AWS credentials or vault access.

## Changes
<!-- Bullet list of what changed. Focus on non-obvious decisions. -->
- `services/libs/anthropic-aws/src/credentials.ts` — new `getAnthropicPersonalAuthEnv()`, reads `CROWD_AKRITES_CLAUDE_CODE_DEV_OAUTH_TOKEN` and maps it to `CLAUDE_CODE_OAUTH_TOKEN`; returns `undefined` when unset.
- `services/libs/anthropic-aws/src/agent.ts` — auth resolution order in `runClaudeAgentQuery` is now: Claude Platform on AWS → personal OAuth token → local CLI auth (dev only). The AWS-failure warning log now only fires when the personal-token fallback is also unavailable, since that path no longer counts as a hard failure.


## Type of change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1357](https://linuxfoundation.atlassian.net/browse/CM-1357)

[CM-1357]: https://linuxfoundation.atlassian.net/browse/CM-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ