### PR TITLE
fix: use gs mirror as default on maven worker (CM-1370)

### DIFF
--- a/backend/.env.dist.local
+++ b/backend/.env.dist.local
@@ -216,7 +216,7 @@ MAVEN_FETCHER_NON_CRITICAL_CONCURRENCY=20
 MAVEN_FETCHER_REFRESH_DAYS=1
 MAVEN_FETCHER_GROUP_DELAY_MS=100
 MAVEN_FETCHER_BASE_URL_BACKFILL=https://maven-central.storage-download.googleapis.com/maven2
-MAVEN_FETCHER_BASE_URL_INCREMENTAL=https://repo1.maven.org/maven2
+MAVEN_FETCHER_BASE_URL_INCREMENTAL=https://maven-central.storage-download.googleapis.com/maven2
 
 # dockerhub-sync (see services/apps/packages_worker/src/dockerhub/)
 DOCKERHUB_API_BASE_URL=https://hub.docker.com/v2

--- a/services/apps/packages_worker/src/bin/maven-backfill.ts
+++ b/services/apps/packages_worker/src/bin/maven-backfill.ts
@@ -2,6 +2,7 @@ import { getServiceLogger } from '@crowd/logging'
 
 import { getMavenConfig } from '../config'
 import { getPackagesDb } from '../db'
+import { MAVEN_GCS_MIRROR_BASE_URL } from '../maven/registry'
 import {
   runMavenCriticalBackfill,
   runMavenCriticalForceBackfill,
@@ -25,8 +26,7 @@ process.on('SIGTERM', shutdown)
 
 const main = async () => {
   process.env.MAVEN_FETCHER_BASE_URL =
-    process.env.MAVEN_FETCHER_BASE_URL_BACKFILL ??
-    'https://maven-central.storage-download.googleapis.com/maven2'
+    process.env.MAVEN_FETCHER_BASE_URL_BACKFILL ?? MAVEN_GCS_MIRROR_BASE_URL
 
   // --force: re-run POM extraction over EVERY critical row, ignoring the
   // staleness window. Use to fully re-apply extraction changes (e.g. SCM

--- a/services/apps/packages_worker/src/maven/activities.ts
+++ b/services/apps/packages_worker/src/maven/activities.ts
@@ -3,13 +3,14 @@ import { getServiceChildLogger } from '@crowd/logging'
 import { getMavenConfig } from '../config'
 import { getPackagesDb } from '../db'
 
+import { MAVEN_GCS_MIRROR_BASE_URL } from './registry'
 import { BatchResult, processBatch } from './runMavenEnrichmentLoop'
 
 const log = getServiceChildLogger('maven-activity')
 
 export async function processMavenCriticalBatch(): Promise<BatchResult> {
   process.env.MAVEN_FETCHER_BASE_URL =
-    process.env.MAVEN_FETCHER_BASE_URL_INCREMENTAL ?? 'https://repo1.maven.org/maven2'
+    process.env.MAVEN_FETCHER_BASE_URL_INCREMENTAL ?? MAVEN_GCS_MIRROR_BASE_URL
 
   const config = getMavenConfig()
   const qx = await getPackagesDb()

--- a/services/apps/packages_worker/src/maven/registry.ts
+++ b/services/apps/packages_worker/src/maven/registry.ts
@@ -160,14 +160,8 @@ function resolveBaseUrl(groupId: string, envVarName: string, defaultUrl: string)
   return process.env[envVarName] ?? defaultUrl
 }
 
-/**
- * Returns the Maven repository base URL for the given groupId.
- *
- * For known alternative-registry namespaces, always returns the hardcoded
- * URL — the MAVEN_FETCHER_BASE_URL env var (used to point at a GCS mirror for
- * backfill) is intentionally bypassed for these groups because no mirror exists.
- * For everything else, falls back to MAVEN_FETCHER_BASE_URL ?? Maven Central.
- */
+// Alternative-registry groups bypass MAVEN_FETCHER_BASE_URL — no mirror exists for them.
+// Everything else: MAVEN_FETCHER_BASE_URL ?? Maven Central.
 export function resolveRegistryBaseUrl(groupId: string): string {
   return resolveBaseUrl(groupId, 'MAVEN_FETCHER_BASE_URL', MAVEN_CENTRAL_BASE_URL)
 }

--- a/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
+++ b/services/apps/packages_worker/src/maven/runMavenEnrichmentLoop.ts
@@ -229,8 +229,9 @@ async function processCriticalPackage(qx: QueryExecutor, pkg: PackageRow, forceF
     return { status: 'skipped' }
   }
 
-  // Phase 2: skip full POM extraction when upstream version matches what we already have.
-  if (!forceFullExtraction && version === pkg.latestVersion) {
+  // Phase 2: skip full POM extraction only if this row was already Maven-enriched —
+  // a version match on a never-extracted row (fresh promotion, error, deps_dev) is coincidental.
+  if (!forceFullExtraction && version === pkg.latestVersion && pkg.ingestionSource === 'maven-registry') {
     await touchPackageSyncedAt(qx, pkg.purl, {
       dependentPackagesCount: pkg.dependentPackagesCount,
       dependentReposCount: pkg.dependentReposCount,

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -25,6 +25,7 @@ export type MavenPackageToSync = Pick<
 > & {
   purl: string
   latestVersion: string | null
+  ingestionSource: string | null
 }
 
 // ingestion_source values this worker writes once it has attempted a package
@@ -67,7 +68,8 @@ export async function listMavenPackagesToSync(
         p.name,
         p.dependent_count          AS "dependentPackagesCount",
         p.dependent_repos_count    AS "dependentReposCount",
-        p.latest_version           AS "latestVersion"
+        p.latest_version           AS "latestVersion",
+        p.ingestion_source         AS "ingestionSource"
       FROM packages p
       WHERE
         p.ecosystem = 'maven'
@@ -97,7 +99,8 @@ export async function listMavenPackagesToSync(
       pu.name,
       pu.dependent_count          AS "dependentPackagesCount",
       pu.dependent_repos_count    AS "dependentReposCount",
-      p.latest_version            AS "latestVersion"
+      p.latest_version            AS "latestVersion",
+      p.ingestion_source          AS "ingestionSource"
     FROM packages_universe pu
     LEFT JOIN packages p ON p.purl = pu.purl
     WHERE
@@ -140,7 +143,8 @@ export async function listMavenCriticalPackagesById(
       p.name,
       p.dependent_count          AS "dependentPackagesCount",
       p.dependent_repos_count    AS "dependentReposCount",
-      p.latest_version           AS "latestVersion"
+      p.latest_version           AS "latestVersion",
+      p.ingestion_source         AS "ingestionSource"
     FROM packages p
     WHERE p.ecosystem = 'maven'
       AND p.is_critical
@@ -247,12 +251,8 @@ export async function updateMavenRepositoryUrls(
 // ─── packages touch ───────────────────────────────────────────────────────────
 
 /**
- * Bumps last_synced_at without re-fetching POM data.
- * Used when the upstream version is unchanged — avoids a full extraction pass
- * while keeping the staleness timer fresh and syncing latest universe metrics.
- * Also sets ingestion_source, otherwise it stays NULL forever and
- * listMavenPackagesToSync's `ingestion_source IS NULL` clause re-selects the
- * same row on every batch.
+ * Bumps last_synced_at (+ ingestion_source) without re-fetching POM data.
+ * Caller must only use this on rows already Maven-enriched — see processCriticalPackage.
  */
 export async function touchPackageSyncedAt(
   qx: QueryExecutor,

--- a/services/libs/data-access-layer/src/osspckgs/packages.ts
+++ b/services/libs/data-access-layer/src/osspckgs/packages.ts
@@ -250,6 +250,9 @@ export async function updateMavenRepositoryUrls(
  * Bumps last_synced_at without re-fetching POM data.
  * Used when the upstream version is unchanged — avoids a full extraction pass
  * while keeping the staleness timer fresh and syncing latest universe metrics.
+ * Also sets ingestion_source, otherwise it stays NULL forever and
+ * listMavenPackagesToSync's `ingestion_source IS NULL` clause re-selects the
+ * same row on every batch.
  */
 export async function touchPackageSyncedAt(
   qx: QueryExecutor,
@@ -263,12 +266,14 @@ export async function touchPackageSyncedAt(
     `
     UPDATE packages SET
       last_synced_at           = NOW(),
+      ingestion_source         = $(ingestionSource),
       dependent_count          = COALESCE($(dependentPackagesCount), dependent_count),
       dependent_repos_count    = COALESCE($(dependentReposCount),    dependent_repos_count)
     WHERE purl = $(purl)
     `,
     {
       purl,
+      ingestionSource: MAVEN_WORKER_OUTCOMES[0],
       dependentPackagesCount: metrics.dependentPackagesCount ?? null,
       dependentReposCount: metrics.dependentReposCount ?? null,
     },


### PR DESCRIPTION
## Summary
Switches the Maven daily critical (incremental) batch from hitting Maven Central directly (`repo1.maven.org`) to the GCS mirror (`maven-central.storage-download.googleapis.com`), aligning it with the backfill job which already uses the mirror. Reduces load against Central for the recurring daily job.

## Changes
- `activities.ts`: fallback default for `MAVEN_FETCHER_BASE_URL` (when `MAVEN_FETCHER_BASE_URL_INCREMENTAL` is unset) now points at the GCS mirror instead of `repo1.maven.org`, reusing the shared `MAVEN_GCS_MIRROR_BASE_URL` constant from `registry.ts` instead of a duplicated string literal.
- `maven-backfill.ts`: same constant reuse for the backfill entrypoint's fallback default (was a duplicated hardcoded literal, now imports `MAVEN_GCS_MIRROR_BASE_URL`).
- `registry.ts`: trimmed the `resolveRegistryBaseUrl` doc comment back down (kept it to the invariant — alternative-registry groups bypass the env override since no mirror exists for them — dropped the caller enumeration that would go stale).
- `.env.dist.local`: updated the local-dev default for `MAVEN_FETCHER_BASE_URL_INCREMENTAL` to the mirror, for consistency with the new code default.


## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1370](https://linuxfoundation.atlassian.net/browse/CM-1370)

[CM-1370]: https://linuxfoundation.atlassian.net/browse/CM-1370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ