### PR TITLE
fix: canonicalize invalid ProgAI work experience dates (CM-1376)

### DIFF
--- a/services/apps/members_enrichment_worker/src/sources/progai/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/progai/service.ts
@@ -331,7 +331,7 @@ export default class EnrichmentServiceProgAI extends LoggerBase implements IEnri
 
     if (date.startsWith('1970-01-01')) return null
 
-    return date.replace('Z', '+00:00')
+    return new Date(date).toISOString().replace('Z', '+00:00')
   }
 
   private getLinkedInProfileHandle(url: string): string | null {

--- a/services/apps/members_enrichment_worker/src/sources/progai/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/progai/service.ts
@@ -331,7 +331,10 @@ export default class EnrichmentServiceProgAI extends LoggerBase implements IEnri
 
     if (date.startsWith('1970-01-01')) return null
 
-    return new Date(date).toISOString().replace('Z', '+00:00')
+    const parsed = new Date(date)
+    if (Number.isNaN(parsed.getTime())) return null
+
+    return parsed.toISOString().replace('Z', '+00:00')
   }
 
   private getLinkedInProfileHandle(url: string): string | null {

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -195,7 +195,7 @@ export function sanitizeMemberOrganizationDateRange(
   throwError = false,
 ): MemberOrganizationDateRange {
   const normalize = (date: MemberOrganizationDateInput) =>
-    date === undefined || date === null || date === '' ? null : new Date(date)
+    date === undefined || date === null || date === '' ? null : date
 
   const start = normalize(dateStart)
   const end = normalize(dateEnd)
@@ -209,8 +209,8 @@ export function sanitizeMemberOrganizationDateRange(
     return handleError('Member organization with dateEnd and without dateStart!')
   }
 
-  const startTime = start ? start.getTime() : null
-  const endTime = end ? end.getTime() : null
+  const startTime = start ? new Date(start).getTime() : null
+  const endTime = end ? new Date(end).getTime() : null
 
   if ((start && Number.isNaN(startTime)) || (end && Number.isNaN(endTime))) {
     return handleError('Invalid member organization date format!')

--- a/services/libs/common/src/member.ts
+++ b/services/libs/common/src/member.ts
@@ -195,7 +195,7 @@ export function sanitizeMemberOrganizationDateRange(
   throwError = false,
 ): MemberOrganizationDateRange {
   const normalize = (date: MemberOrganizationDateInput) =>
-    date === undefined || date === null || date === '' ? null : date
+    date === undefined || date === null || date === '' ? null : new Date(date)
 
   const start = normalize(dateStart)
   const end = normalize(dateEnd)
@@ -209,8 +209,8 @@ export function sanitizeMemberOrganizationDateRange(
     return handleError('Member organization with dateEnd and without dateStart!')
   }
 
-  const startTime = start ? new Date(start).getTime() : null
-  const endTime = end ? new Date(end).getTime() : null
+  const startTime = start ? start.getTime() : null
+  const endTime = end ? end.getTime() : null
 
   if ((start && Number.isNaN(startTime)) || (end && Number.isNaN(endTime))) {
     return handleError('Invalid member organization date format!')


### PR DESCRIPTION
## Summary
- Fixes enrichment failures where ProgAI returned impossible calendar dates (e.g. `2026-02-29` in a non-leap year) that passed through unchanged and were rejected by Postgres `timestamptz`.
- Canonicalizes ProgAI dates via `Date` parse so invalid days overflow to the next real date before write; shared date sanitizer left unchanged.

## Changes
- `services/apps/members_enrichment_worker/src/sources/progai/service.ts`: `normalizeDate` now returns `new Date(date).toISOString()` (with existing `Z` → `+00:00` replace); epoch → null behavior unchanged.