### PR TITLE
feat: add overall_score_v2 field to health_score_sink pipe (IN-1218)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_sink.pipe
+++ b/services/libs/tinybird/pipes/health_score_sink.pipe
@@ -1,17 +1,19 @@
 NODE health_score_select_fields
 SQL >
     SELECT
-        id,
-        segmentId,
-        slug,
-        if(isNaN(overallScore), null, overallScore) as overallScore,
-        if(isNaN(securityPercentage), null, securityPercentage) as securityPercentage,
-        securityCategoryPercentage,
-        if(isNaN(contributorPercentage), null, contributorPercentage) as contributorPercentage,
-        if(isNaN(popularityPercentage), null, popularityPercentage) as popularityPercentage,
-        if(isNaN(developmentPercentage), null, developmentPercentage) as developmentPercentage,
+        hs.id,
+        hs.segmentId,
+        hs.slug,
+        if(isNaN(hs.overallScore), null, hs.overallScore) as overallScore,
+        if(isNaN(hs.securityPercentage), null, hs.securityPercentage) as securityPercentage,
+        hs.securityCategoryPercentage,
+        if(isNaN(hs.contributorPercentage), null, hs.contributorPercentage) as contributorPercentage,
+        if(isNaN(hs.popularityPercentage), null, hs.popularityPercentage) as popularityPercentage,
+        if(isNaN(hs.developmentPercentage), null, hs.developmentPercentage) as developmentPercentage,
+        p.healthScoreV2 as overall_score_v2,
         toStartOfDay(now()) as date
-    FROM health_score_copy_ds
+    FROM health_score_copy_ds AS hs
+    LEFT JOIN project_insights_copy_ds AS p ON hs.id = p.id AND p.type = 'project'
 
 TYPE SINK
 EXPORT_SERVICE kafka


### PR DESCRIPTION
## Summary
- Extends the existing v1 `health_score_sink` Tinybird pipe with a new `overall_score_v2` field, sourced via a LEFT JOIN to `project_insights_copy_ds.healthScoreV2`
- Lets downstream Snowflake/dbt consumers compare v1 (`overallScore`) and v2 (`overall_score_v2`) totals from the same daily snapshot, without waiting on the separate v2-only sink (IN-1212)
- No schedule, export target, or v1 field changes — all existing consumers unaffected

## Validated against prod data
- Row count preserved: 11,629 in → 11,629 out (LEFT JOIN drops no rows)
- `overall_score_v2` non-null for 96.1% of rows (projects with `healthScoreV2` populated), null for the rest — matches expected pre-cutover/no-data behavior
- All existing v1 fields confirmed unchanged
- Pipe deployed and live in production (staging skipped — SINK pipe requires the prod-only `lfx-oracle-kafka-streaming` Kafka connection; production validation covers correctness)

## Deploy order
This unblocks IN-1219 (dbt model update to consume `overall_score_v2`) and IN-1222 (v1 sink deprecation). Already deployed to prod as part of this change — IN-1219 can proceed.

JIRA: IN-1218