### PR TITLE
fix: skip unverified identities already on another member (CM-1365)

### DIFF
--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -52,6 +52,7 @@ paths:
       summary: Create a member profile
       description: >
         Create a new member profile in CDP with one or more identities.
+        Returns 409 if an identity already exists on another member.
       tags:
         - Members
       security:
@@ -265,8 +266,8 @@ paths:
       operationId: createMemberIdentity
       summary: Add a new identity
       description: >
-        Add a new identity to a member profile. Returns 409 if the identity
-        already exists on this member or is verified on another member.
+        Add a new identity to a member profile. Returns 200 if it already exists
+        on this member. Returns 409 if it already exists on another member.
       tags:
         - Member Identities
       security:

--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -8,6 +8,7 @@ import {
   findMembersByIdentities,
   createMember as insertMember,
   insertMemberIdentities,
+  lockMemberIdentityKeys,
 } from '@crowd/data-access-layer'
 import { MemberIdentityType } from '@crowd/types'
 
@@ -49,6 +50,8 @@ export async function createMember(req: Request, res: Response): Promise<void> {
     const unverified = identities.filter((identity) => !identity.verified)
 
     if (unverified.length > 0) {
+      await lockMemberIdentityKeys(tx, unverified)
+
       const owners = await findMembersByIdentities(tx, unverified)
 
       const hit = unverified.find((identity) =>
@@ -109,25 +112,24 @@ export async function createMember(req: Request, res: Response): Promise<void> {
     }
   })
 
-  await Promise.all([
-    captureApiChange(
-      req,
-      memberCreateAction(dbMember.id, async (captureNewState) => {
-        captureNewState({
-          memberId: dbMember.id,
-          displayName: dbMember.displayName,
-          manuallyCreated: true,
-        })
-      }),
-    ),
-    captureApiChange(
-      req,
-      memberEditIdentitiesAction(dbMember.id, async (captureOldState, captureNewState) => {
-        captureOldState({})
-        captureNewState(dbIdentities)
-      }),
-    ),
-  ])
+  await captureApiChange(
+    req,
+    memberCreateAction(dbMember.id, async (captureNewState) => {
+      captureNewState({
+        memberId: dbMember.id,
+        displayName: dbMember.displayName,
+        manuallyCreated: true,
+      })
+    }),
+  )
+
+  await captureApiChange(
+    req,
+    memberEditIdentitiesAction(dbMember.id, async (captureOldState, captureNewState) => {
+      captureOldState({})
+      captureNewState(dbIdentities)
+    }),
+  )
 
   created(res, { memberId: dbMember.id })
 }

--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -2,9 +2,10 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberCreateAction, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { getProperDisplayName } from '@crowd/common'
+import { ConflictError, getProperDisplayName } from '@crowd/common'
 import {
   findMemberIdByVerifiedIdentity,
+  findMembersByIdentities,
   createMember as insertMember,
   insertMemberIdentities,
 } from '@crowd/data-access-layer'
@@ -43,6 +44,27 @@ export async function createMember(req: Request, res: Response): Promise<void> {
   const normalizedDisplayName = getProperDisplayName(displayName)
 
   const { dbMember, dbIdentities } = await qx.tx(async (tx) => {
+    // Unverified identities aren't unique in the db, so the same handle or
+    // email can sit on several members. Reject it here if someone else has it.
+    const unverified = identities.filter((identity) => !identity.verified)
+
+    if (unverified.length > 0) {
+      const owners = await findMembersByIdentities(tx, unverified)
+
+      const hit = unverified.find((identity) =>
+        owners.has(`${identity.platform}:${identity.type}:${identity.value.trim()}`),
+      )
+
+      if (hit) {
+        throw new ConflictError('Identity already exists on another member', {
+          conflictMemberId: owners.get(`${hit.platform}:${hit.type}:${hit.value.trim()}`),
+          platform: hit.platform,
+          value: hit.value,
+          type: hit.type,
+        })
+      }
+    }
+
     try {
       const dbMember = await insertMember(tx, {
         displayName: normalizedDisplayName,
@@ -87,24 +109,25 @@ export async function createMember(req: Request, res: Response): Promise<void> {
     }
   })
 
-  await captureApiChange(
-    req,
-    memberCreateAction(dbMember.id, async (captureNewState) => {
-      captureNewState({
-        memberId: dbMember.id,
-        displayName: dbMember.displayName,
-        manuallyCreated: true,
-      })
-    }),
-  )
-
-  await captureApiChange(
-    req,
-    memberEditIdentitiesAction(dbMember.id, async (captureOldState, captureNewState) => {
-      captureOldState({})
-      captureNewState(dbIdentities)
-    }),
-  )
+  await Promise.all([
+    captureApiChange(
+      req,
+      memberCreateAction(dbMember.id, async (captureNewState) => {
+        captureNewState({
+          memberId: dbMember.id,
+          displayName: dbMember.displayName,
+          manuallyCreated: true,
+        })
+      }),
+    ),
+    captureApiChange(
+      req,
+      memberEditIdentitiesAction(dbMember.id, async (captureOldState, captureNewState) => {
+        captureOldState({})
+        captureNewState(dbIdentities)
+      }),
+    ),
+  ])
 
   created(res, { memberId: dbMember.id })
 }

--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -8,7 +8,6 @@ import {
   findMembersByIdentities,
   createMember as insertMember,
   insertMemberIdentities,
-  lockMemberIdentityKeys,
 } from '@crowd/data-access-layer'
 import { MemberIdentityType } from '@crowd/types'
 
@@ -50,8 +49,6 @@ export async function createMember(req: Request, res: Response): Promise<void> {
     const unverified = identities.filter((identity) => !identity.verified)
 
     if (unverified.length > 0) {
-      await lockMemberIdentityKeys(tx, unverified)
-
       const owners = await findMembersByIdentities(tx, unverified)
 
       const hit = unverified.find((identity) =>

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -2,12 +2,13 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { NotFoundError } from '@crowd/common'
+import { ConflictError, NotFoundError } from '@crowd/common'
 import {
   MemberField,
   findMemberById,
   findMemberIdByVerifiedIdentity,
   findMemberIdentitiesByValue,
+  findMemberIdentityConflict,
   insertMemberIdentities,
   touchMemberUpdatedAt,
   updateMemberIdentity,
@@ -47,7 +48,14 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     throw new NotFoundError('Member not found')
   }
 
-  let result!: IMemberIdentity
+  const conflictContext = {
+    memberId,
+    platform: data.platform,
+    value: data.value,
+    type: data.type,
+  }
+
+  let identity!: IMemberIdentity
   let alreadyExisted = false
 
   await captureApiChange(
@@ -55,18 +63,37 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     memberEditIdentitiesAction(memberId, async (captureOldState, captureNewState) => {
       captureOldState({})
 
-      await qx.tx(async (tx) => {
+      const outcome = await qx.tx(async (tx) => {
         const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
           type: data.type,
         })
-        const exactMatch = existing.find((i) => i.platform === data.platform)
+
+        const exactMatch = existing.find((row) => row.platform === data.platform)
+
+        let result = exactMatch
+        const existed = Boolean(exactMatch)
+
+        // Unverified identities aren't unique in the db, so the same handle or
+        // email can sit on several members. Reject it here if someone else has it.
+        if (!result && !data.verified) {
+          const conflict = await findMemberIdentityConflict(tx, {
+            value: data.value,
+            platform: data.platform,
+            type: data.type,
+            excludeMemberId: memberId,
+          })
+
+          if (conflict) {
+            throw new ConflictError('Identity already exists on another member', {
+              ...conflictContext,
+              conflictMemberId: conflict.memberId,
+            })
+          }
+        }
 
         try {
-          if (exactMatch) {
-            alreadyExisted = true
-            result = exactMatch
-          } else {
-            const [created] = await insertMemberIdentities(
+          if (!result) {
+            const [inserted] = await insertMemberIdentities(
               tx,
               [
                 {
@@ -82,40 +109,40 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
               true,
               true,
             )
-            result = created
+
+            result = inserted
           }
 
           // A verified identity confirms the same value for this member, so keep same-value
           // identities in sync instead of leaving stale unverified duplicates behind.
           if (data.verified && existing.length > 0) {
-            const updatedResults: IMemberIdentity[] = []
-            for (const identity of existing) {
-              const updated = await updateMemberIdentity(tx, memberId, identity.id, {
-                verified: true,
-                verifiedBy: data.verifiedBy,
-              })
-              if (updated) updatedResults.push(updated)
-            }
+            const updatedRows = await Promise.all(
+              existing.map((row) =>
+                updateMemberIdentity(tx, memberId, row.id, {
+                  verified: true,
+                  verifiedBy: data.verifiedBy,
+                }),
+              ),
+            )
 
-            if (alreadyExisted) {
-              result = updatedResults.find((r) => r.id === exactMatch.id) ?? result
+            const updatedExact = updatedRows.find((row) => row?.id === exactMatch?.id)
+
+            if (updatedExact) {
+              result = updatedExact
             }
           }
         } catch (error) {
           if (isMemberIdentityDbConflict(error)) {
             const conflictMemberId = await findMemberIdByVerifiedIdentity(
-              qx,
+              tx,
               data.platform,
               data.value,
               data.type,
             )
 
             rethrowDbConflict(error, {
-              memberId,
+              ...conflictContext,
               ...(conflictMemberId ? { conflictMemberId } : {}),
-              platform: data.platform,
-              value: data.value,
-              type: data.type,
             })
           }
 
@@ -123,22 +150,27 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
         }
 
         await touchMemberUpdatedAt(tx, memberId)
+
+        return { identity: result, alreadyExisted: existed }
       })
 
-      captureNewState(result)
+      identity = outcome.identity
+      alreadyExisted = outcome.alreadyExisted
+
+      captureNewState(identity)
     }),
   )
 
   const response = {
-    id: result.id,
-    value: result.value,
-    platform: result.platform,
-    type: result.type,
-    verified: result.verified,
-    verifiedBy: result.verifiedBy ?? null,
-    source: result.source ?? null,
-    createdAt: result.createdAt,
-    updatedAt: result.updatedAt,
+    id: identity.id,
+    value: identity.value,
+    platform: identity.platform,
+    type: identity.type,
+    verified: identity.verified,
+    verifiedBy: identity.verifiedBy ?? null,
+    source: identity.source ?? null,
+    createdAt: identity.createdAt,
+    updatedAt: identity.updatedAt,
   }
 
   if (alreadyExisted) {

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -10,7 +10,6 @@ import {
   findMemberIdentitiesByValue,
   findMemberIdentityConflict,
   insertMemberIdentities,
-  lockMemberIdentityKeys,
   touchMemberUpdatedAt,
   updateMemberIdentity,
 } from '@crowd/data-access-layer'
@@ -77,8 +76,6 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
         // Unverified identities aren't unique in the db, so the same handle or
         // email can sit on several members. Reject it here if someone else has it.
         if (!result && !data.verified) {
-          await lockMemberIdentityKeys(tx, [data])
-
           const conflict = await findMemberIdentityConflict(tx, {
             value: data.value,
             platform: data.platform,
@@ -137,7 +134,7 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
         } catch (error) {
           if (isMemberIdentityDbConflict(error)) {
             const conflictMemberId = await findMemberIdByVerifiedIdentity(
-              tx,
+              qx,
               data.platform,
               data.value,
               data.type,

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -10,6 +10,7 @@ import {
   findMemberIdentitiesByValue,
   findMemberIdentityConflict,
   insertMemberIdentities,
+  lockMemberIdentityKeys,
   touchMemberUpdatedAt,
   updateMemberIdentity,
 } from '@crowd/data-access-layer'
@@ -76,6 +77,8 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
         // Unverified identities aren't unique in the db, so the same handle or
         // email can sit on several members. Reject it here if someone else has it.
         if (!result && !data.verified) {
+          await lockMemberIdentityKeys(tx, [data])
+
           const conflict = await findMemberIdentityConflict(tx, {
             value: data.value,
             platform: data.platform,

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { ConflictError, NotFoundError } from '@crowd/common'
+import { ConflictError, NotFoundError, normalizeMemberIdentityValue } from '@crowd/common'
 import {
   MemberField,
   findMemberById,
@@ -40,7 +40,11 @@ const bodySchema = z
 
 export async function createMemberIdentity(req: Request, res: Response): Promise<void> {
   const { memberId } = validateOrThrow(paramsSchema, req.params)
-  const data = validateOrThrow(bodySchema, req.body)
+  const raw = validateOrThrow(bodySchema, req.body)
+  const data = {
+    ...raw,
+    value: normalizeMemberIdentityValue(raw.value),
+  }
 
   const qx = optionsQx(req)
   const member = await findMemberById(qx, memberId, [MemberField.ID])

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -15,6 +15,7 @@ import { signalMemberUpdate } from '@crowd/common_services'
 import {
   changeMemberOrganizationAffiliationOverrides,
   fetchManyOrganizationAffiliationPolicies,
+  findMembersByIdentities,
   insertMemberIdentities,
   updateMemberAttributes,
   updateMemberContributions,
@@ -314,20 +315,35 @@ export async function updateMemberUsingSquashedPayload(
 
     // process identities
     if (squashedPayload.identities.length > 0) {
-      svc.log.debug({ memberId }, 'Adding to member identities!')
-      didUpdate = true
-      await insertMemberIdentities(
-        qx,
-        squashedPayload.identities.map((i) => ({
+      // Unverified identities aren't unique in the db, so the same handle or
+      // email can sit on several members. Skip the ones already taken.
+      const unverified = squashedPayload.identities.filter((identity) => !identity.verified)
+
+      const owners =
+        unverified.length > 0
+          ? await findMembersByIdentities(qx, unverified, memberId)
+          : new Map<string, string>()
+
+      const identitiesToInsert = squashedPayload.identities
+        .filter(
+          (identity) =>
+            identity.verified ||
+            !owners.has(`${identity.platform}:${identity.type}:${identity.value.trim()}`),
+        )
+        .map((identity) => ({
           memberId,
-          platform: i.platform,
-          type: i.type,
-          value: i.value,
-          verified: i.verified,
+          platform: identity.platform,
+          type: identity.type,
+          value: identity.value,
+          verified: identity.verified,
           source: 'enrichment',
-        })),
-        true,
-      )
+        }))
+
+      if (identitiesToInsert.length > 0) {
+        svc.log.debug({ memberId }, 'Adding to member identities!')
+        didUpdate = true
+        await insertMemberIdentities(qx, identitiesToInsert, true)
+      }
     }
 
     // process contributions

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -17,6 +17,7 @@ import {
   fetchManyOrganizationAffiliationPolicies,
   findMembersByIdentities,
   insertMemberIdentities,
+  lockMemberIdentityKeys,
   updateMemberAttributes,
   updateMemberContributions,
   updateMemberReach,
@@ -318,6 +319,8 @@ export async function updateMemberUsingSquashedPayload(
       // Unverified identities aren't unique in the db, so the same handle or
       // email can sit on several members. Skip the ones already taken.
       const unverified = squashedPayload.identities.filter((identity) => !identity.verified)
+
+      await lockMemberIdentityKeys(qx, unverified)
 
       const owners =
         unverified.length > 0

--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -17,7 +17,6 @@ import {
   fetchManyOrganizationAffiliationPolicies,
   findMembersByIdentities,
   insertMemberIdentities,
-  lockMemberIdentityKeys,
   updateMemberAttributes,
   updateMemberContributions,
   updateMemberReach,
@@ -319,8 +318,6 @@ export async function updateMemberUsingSquashedPayload(
       // Unverified identities aren't unique in the db, so the same handle or
       // email can sit on several members. Skip the ones already taken.
       const unverified = squashedPayload.identities.filter((identity) => !identity.verified)
-
-      await lockMemberIdentityKeys(qx, unverified)
 
       const owners =
         unverified.length > 0

--- a/services/apps/members_enrichment_worker/src/activities/member.ts
+++ b/services/apps/members_enrichment_worker/src/activities/member.ts
@@ -3,6 +3,7 @@ import {
   MemberField,
   PgPromiseQueryExecutor,
   findMemberById,
+  findMembersByIdentities,
   insertMemberIdentities,
   pgpQx,
 } from '@crowd/data-access-layer'
@@ -89,17 +90,35 @@ export async function updateMemberWithEnrichmentData(
 ): Promise<void> {
   await svc.postgres.writer.connection().tx(async (tx) => {
     if (identities.length > 0) {
-      await insertMemberIdentities(
-        new PgPromiseQueryExecutor(tx),
-        identities.map((identity) => ({
+      const qx = new PgPromiseQueryExecutor(tx)
+
+      // Unverified identities aren't unique in the db, so the same handle or
+      // email can sit on several members. Skip the ones already taken.
+      const unverified = identities.filter((identity) => !identity.verified)
+
+      const owners =
+        unverified.length > 0
+          ? await findMembersByIdentities(qx, unverified, memberId)
+          : new Map<string, string>()
+
+      const identitiesToInsert = identities
+        .filter(
+          (identity) =>
+            Boolean(identity.verified) ||
+            !owners.has(`${identity.platform}:${identity.type}:${identity.value.trim()}`),
+        )
+        .map((identity) => ({
           memberId,
           platform: identity.platform,
           value: identity.value,
           type: identity.type,
           verified: identity.verified || false,
           source: 'enrichment',
-        })),
-      )
+        }))
+
+      if (identitiesToInsert.length > 0) {
+        await insertMemberIdentities(qx, identitiesToInsert)
+      }
     }
     if (attributes) {
       await updateMemberAttributes(tx, memberId, attributes)

--- a/services/apps/members_enrichment_worker/src/activities/member.ts
+++ b/services/apps/members_enrichment_worker/src/activities/member.ts
@@ -5,7 +5,6 @@ import {
   findMemberById,
   findMembersByIdentities,
   insertMemberIdentities,
-  lockMemberIdentityKeys,
   pgpQx,
 } from '@crowd/data-access-layer'
 import {
@@ -96,8 +95,6 @@ export async function updateMemberWithEnrichmentData(
       // Unverified identities aren't unique in the db, so the same handle or
       // email can sit on several members. Skip the ones already taken.
       const unverified = identities.filter((identity) => !identity.verified)
-
-      await lockMemberIdentityKeys(qx, unverified)
 
       const owners =
         unverified.length > 0

--- a/services/apps/members_enrichment_worker/src/activities/member.ts
+++ b/services/apps/members_enrichment_worker/src/activities/member.ts
@@ -5,6 +5,7 @@ import {
   findMemberById,
   findMembersByIdentities,
   insertMemberIdentities,
+  lockMemberIdentityKeys,
   pgpQx,
 } from '@crowd/data-access-layer'
 import {
@@ -95,6 +96,8 @@ export async function updateMemberWithEnrichmentData(
       // Unverified identities aren't unique in the db, so the same handle or
       // email can sit on several members. Skip the ones already taken.
       const unverified = identities.filter((identity) => !identity.verified)
+
+      await lockMemberIdentityKeys(qx, unverified)
 
       const owners =
         unverified.length > 0

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -57,35 +57,6 @@ interface FindMemberIdentityConflictParams {
   excludeMemberId?: string
 }
 
-interface MemberIdentityKey {
-  platform: string
-  type: MemberIdentityType
-  value: string
-}
-
-// The executor must use the transaction that performs the conflict check and insert.
-export async function lockMemberIdentityKeys(
-  qx: QueryExecutor,
-  identities: MemberIdentityKey[],
-): Promise<void> {
-  const keys = [
-    ...new Set(
-      identities.map((identity) =>
-        JSON.stringify([
-          'memberIdentity',
-          identity.platform,
-          identity.type,
-          normalizeMemberIdentityValue(identity.value).toLowerCase(),
-        ]),
-      ),
-    ),
-  ].sort()
-
-  for (const key of keys) {
-    await qx.result(`select pg_advisory_xact_lock(hashtext($(key))::bigint)`, { key })
-  }
-}
-
 export async function findMemberIdentityConflict(
   qx: QueryExecutor,
   params: FindMemberIdentityConflictParams,

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -57,6 +57,35 @@ interface FindMemberIdentityConflictParams {
   excludeMemberId?: string
 }
 
+interface MemberIdentityKey {
+  platform: string
+  type: MemberIdentityType
+  value: string
+}
+
+// The executor must use the transaction that performs the conflict check and insert.
+export async function lockMemberIdentityKeys(
+  qx: QueryExecutor,
+  identities: MemberIdentityKey[],
+): Promise<void> {
+  const keys = [
+    ...new Set(
+      identities.map((identity) =>
+        JSON.stringify([
+          'memberIdentity',
+          identity.platform,
+          identity.type,
+          normalizeMemberIdentityValue(identity.value).toLowerCase(),
+        ]),
+      ),
+    ),
+  ].sort()
+
+  for (const key of keys) {
+    await qx.result(`select pg_advisory_xact_lock(hashtext($(key))::bigint)`, { key })
+  }
+}
+
 export async function findMemberIdentityConflict(
   qx: QueryExecutor,
   params: FindMemberIdentityConflictParams,

--- a/services/libs/data-access-layer/src/members/identities.ts
+++ b/services/libs/data-access-layer/src/members/identities.ts
@@ -576,6 +576,10 @@ export async function findMembersByIdentities(
     conditions.push('mi.verified = true')
   }
 
+  if (identities.length === 0) {
+    return new Map()
+  }
+
   const identityTuples = identities.map((identity, i) => {
     params[`ip${i}`] = identity.platform
     params[`iv${i}`] = identity.value.trim()
@@ -596,7 +600,7 @@ export async function findMembersByIdentities(
         and lower(mi.value) = lower(i.value)
         and mi.type = i.type
         and mi."deletedAt" is null
-    where ${conditions.join(' and ')}
+    ${conditions.length > 0 ? `where ${conditions.join(' and ')}` : ''}
   `,
     params,
   )


### PR DESCRIPTION
## Summary
Unverified member identities are not globally unique in the db, so the same handle or email can end up on several members. This adds a write-path check so we do not attach an unverified identity that already belongs to someone else.

## Changes
- Public API create-member and create-identity return 409 when another member already has the unverified identity
- Enrichment skips unverified identities already taken by another member and continues with the rest
- `findMembersByIdentities` accepts an empty list and omits `WHERE` when there are no extra filters