### PR TITLE
feat: add mailing list frontend support (CM-1353)

### DIFF
--- a/frontend/src/assets/images/identities/mailing-list.svg
+++ b/frontend/src/assets/images/identities/mailing-list.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="4" width="20" height="16" rx="2"></rect>
+  <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
+</svg>

--- a/frontend/src/config/identities/index.ts
+++ b/frontend/src/config/identities/index.ts
@@ -16,6 +16,7 @@ import hackernews from './hackernews/config';
 import jira from './jira/config';
 import lfid from './lfx/config';
 import linkedin from './linkedin/config';
+import mailinglist from './mailinglist/config';
 import n8n from './n8n/config';
 import reddit from './reddit/config';
 import slack from './slack/config';
@@ -63,6 +64,7 @@ export const lfIdentities: Record<string, IdentityConfig> = {
   discourse,
   git,
   groupsio,
+  mailinglist,
   confluence,
   gerrit,
   jira,

--- a/frontend/src/config/identities/mailinglist/config.ts
+++ b/frontend/src/config/identities/mailinglist/config.ts
@@ -1,0 +1,20 @@
+import { IdentityConfig } from '@/config/identities';
+
+const image = new URL(
+  '@/assets/images/identities/mailing-list.svg',
+  import.meta.url,
+).href;
+
+const mailinglist: IdentityConfig = {
+  key: 'mailinglist',
+  name: 'Mailing List',
+  image,
+  member: {
+    placeholder: 'Mailing list email address',
+  },
+  activity: {
+    showLink: true,
+  },
+};
+
+export default mailinglist;

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/member/list.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/member/list.ts
@@ -14,5 +14,6 @@ export default [
   Platform.HUBSPOT,
   Platform.GIT,
   Platform.GROUPS_IO,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/member/profile.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/member/profile.ts
@@ -14,5 +14,6 @@ export default [
   Platform.HUBSPOT,
   Platform.GIT,
   Platform.GROUPS_IO,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/member/suggestions.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/member/suggestions.ts
@@ -14,5 +14,6 @@ export default [
   Platform.HUBSPOT,
   Platform.GIT,
   Platform.GROUPS_IO,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/organization/list.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/organization/list.ts
@@ -6,5 +6,6 @@ export default [
   Platform.TWITTER,
   Platform.CRUNCHBASE,
   Platform.HUBSPOT,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/organization/profile.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/organization/profile.ts
@@ -6,5 +6,6 @@ export default [
   Platform.TWITTER,
   Platform.CRUNCHBASE,
   Platform.HUBSPOT,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/identities/config/identitiesOrder/organization/suggestions.ts
+++ b/frontend/src/shared/modules/identities/config/identitiesOrder/organization/suggestions.ts
@@ -6,5 +6,6 @@ export default [
   Platform.TWITTER,
   Platform.CRUNCHBASE,
   Platform.HUBSPOT,
+  Platform.MAILING_LIST,
   Platform.CUSTOM,
 ];

--- a/frontend/src/shared/modules/platform/types/Platform.ts
+++ b/frontend/src/shared/modules/platform/types/Platform.ts
@@ -14,6 +14,7 @@ export enum Platform {
     HUBSPOT = 'hubspot',
     GIT = 'git',
     GROUPS_IO = 'groupsio',
+    MAILING_LIST = 'mailinglist',
     CUSTOM = 'custom',
     ENRICHMENT = 'enrichment',
     EMAIL = 'email',


### PR DESCRIPTION
## Summary

- Adds MAILING_LIST platform enum and identity configuration to enable mailing list activities and identities to display with platform icon and label across the frontend
- Follows existing patterns (groupsio as reference): minimal code, SVG icon, no integration card enabled
- Placeholder SVG icon included; final design asset must replace it before merge

## JIRA

CM-1353 — Frontend: display support for mailing list integration

## Notes

- QA Status: Filters (PASS), Integrations page (PASS), Icon placeholder (PASS), Design asset blocker noted
- Code quality: Minimal and follows established patterns
- Quality gates: lint ✅, build ✅
- Commit properly signed and formatted

**Blocker:** Icon asset from design must replace placeholder before merge (AC4)