### PR TITLE
fix: skip invalid emails in Crustdata enrichment

### DIFF
--- a/services/apps/members_enrichment_worker/src/sources/crustdata/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/crustdata/service.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-import { isDomainExcluded, replaceDoubleQuotes } from '@crowd/common'
+import { isDomainExcluded, isValidEmail, replaceDoubleQuotes } from '@crowd/common'
 import { Logger, LoggerBase } from '@crowd/logging'
 import {
   IMemberEnrichmentCache,
@@ -196,7 +196,7 @@ export default class EnrichmentServiceCrustdata extends LoggerBase implements IE
       }
 
       const email = identity.value?.trim().toLowerCase()
-      if (!email || !identity.verified || seen.has(email)) {
+      if (!email || !identity.verified || seen.has(email) || !isValidEmail(email)) {
         continue
       }
 


### PR DESCRIPTION
## Summary
- Crustdata person enrich was returning 400s because we sent tombstone identities like `user@gmail.com_old` as `business_emails`.
- Those values bypassed the personal-provider filter (`gmail.com_old` is not `gmail.com`) and are not valid emails.

## Changes
- `getWorkEmails` now also requires `isValidEmail()` before sending addresses to Crustdata, so only API-valid work emails are included.