### PR TITLE
fix: skip unverified identity inserts when another member owns it (CM-1365)

### DIFF
--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -141,9 +141,7 @@ export default class MemberService extends LoggerBase {
     // from firing when a payload contains the same identity twice with different verified values.
     const deduped = normalizeMemberIdentities(identities)
 
-    // Unverified identities are hints (e.g. GitHub twitterUsername), not ownership proof.
-    // Skip when another member already has the same row — matches enrichment and stops
-    // integration updates from re-opening duplicate groups after cleanup.
+    // Skip unverified rows another member already has (same as enrichment).
     const unverified = deduped.filter((identity) => !identity.verified)
     const owners =
       unverified.length > 0

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -141,6 +141,9 @@ export default class MemberService extends LoggerBase {
     // from firing when a payload contains the same identity twice with different verified values.
     const deduped = normalizeMemberIdentities(identities)
 
+    // Unverified identities are hints (e.g. GitHub twitterUsername), not ownership proof.
+    // Skip when another member already has the same row — matches enrichment and stops
+    // integration updates from re-opening duplicate groups after cleanup.
     const unverified = deduped.filter((identity) => !identity.verified)
     const owners =
       unverified.length > 0

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -141,8 +141,24 @@ export default class MemberService extends LoggerBase {
     // from firing when a payload contains the same identity twice with different verified values.
     const deduped = normalizeMemberIdentities(identities)
 
+    const unverified = deduped.filter((identity) => !identity.verified)
+    const owners =
+      unverified.length > 0
+        ? await findMembersByIdentities(this.pgQx, unverified, memberId)
+        : new Map<string, string>()
+
+    const toInsert = deduped.filter(
+      (identity) =>
+        identity.verified ||
+        !owners.has(`${identity.platform}:${identity.type}:${identity.value.trim()}`),
+    )
+
+    if (toInsert.length === 0) {
+      return
+    }
+
     try {
-      await this.memberRepo.insertIdentities(memberId, integrationId, deduped, true)
+      await this.memberRepo.insertIdentities(memberId, integrationId, toInsert, true)
     } catch (err) {
       if (
         !err?.constraint ||
@@ -152,7 +168,7 @@ export default class MemberService extends LoggerBase {
         throw err
       }
 
-      const verifiedIncoming = deduped.filter((i) => i.verified)
+      const verifiedIncoming = toInsert.filter((i) => i.verified)
       if (verifiedIncoming.length === 0) throw err
 
       // Use the structured identities array to find the owner — avoids fragile Postgres


### PR DESCRIPTION
## Summary

Extends the CM-1365 write-path guard to GitHub integration (data-sink). Unverified identities such as Twitter handles from GitHub profile fields are hints, not verified ownership — they should not be inserted when another member already has the same `(platform, type, value)`.

This stops integration ingest from re-opening duplicate unverified identity groups after the cleanup script removed a hint from a real member while an isolated member still holds it.

## Changes

- In `MemberService.insertIdentitiesWithConflictResolution`, look up existing owners for incoming unverified identities (excluding the target member) via `findMembersByIdentities`.
- Skip inserting unverified rows that are already live on another member; verified identity insert and merge-on-conflict behavior is unchanged.
- Applies to both member create and update paths that flow through data-sink identity inserts.

## Test plan

- [ ] Deploy data-sink worker with this change
- [ ] Re-run duplicate unverified identity cleanup script for remaining tail groups
- [ ] Confirm duplicate unverified identity group count stays near zero under ongoing GitHub ingest