### PR TITLE
fix: tombstone public API work experience deletes (CM-1383)

### DIFF
--- a/.github/scripts/public-api-e2e-tests.sh
+++ b/.github/scripts/public-api-e2e-tests.sh
@@ -452,7 +452,8 @@ suite_member_work_experiences() {
   check "POST create stint for delete" 201
   doomed_we="$(body_field id)"
 
-  api v1 DELETE "/members/${PERSON_ID}/work-experiences/${doomed_we}"
+  api v1 DELETE "/members/${PERSON_ID}/work-experiences/${doomed_we}" \
+    "$(json --arg by "$VERIFIED_BY" '{deletedBy: $by}')"
   check "DELETE work experience" 204
 
   api v1 GET "/members/${PERSON_ID}/work-experiences"

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -311,6 +311,7 @@ paths:
                   description: Whether the identity is verified.
                 verifiedBy:
                   type: string
+                  minLength: 1
                   description: Required when `verified` is true. Identifier of who verified.
             example:
               value: johndoe
@@ -383,6 +384,7 @@ paths:
                     `true` to verify the identity, `false` to reject it.
                 verifiedBy:
                   type: string
+                  minLength: 1
                   description: Identifier of who performed the verification.
             example:
               verified: true
@@ -628,6 +630,7 @@ paths:
                     `true` to verify, `false` to reject (soft-delete).
                 verifiedBy:
                   type: string
+                  minLength: 1
                   description: Identifier of who performed the verification.
             example:
               verified: true
@@ -675,6 +678,7 @@ paths:
               properties:
                 deletedBy:
                   type: string
+                  minLength: 1
                   description: Identifier of who performed the deletion.
             example:
               deletedBy: admin@lfx.dev
@@ -789,7 +793,7 @@ paths:
                         description: End date, or null if currently active.
                 verifiedBy:
                   type: string
-                  maxLength: 255
+                  minLength: 1
                   description: Required when `affiliations` is non-empty.
             example:
               affiliations:
@@ -1178,6 +1182,7 @@ components:
           description: Whether the identity is verified.
         verifiedBy:
           type: string
+          minLength: 1
           description: Required when `verified` is true. Identifier of who verified.
 
     MemberIdentity:
@@ -1372,6 +1377,7 @@ components:
           type: boolean
         verifiedBy:
           type: string
+          minLength: 1
           description: Identifier of who verified this work experience.
         source:
           type: string

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -664,9 +664,25 @@ paths:
       parameters:
         - $ref: '#/components/parameters/MemberId'
         - $ref: '#/components/parameters/WorkExperienceId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - deletedBy
+              properties:
+                deletedBy:
+                  type: string
+                  description: Identifier of who performed the deletion.
+            example:
+              deletedBy: admin@lfx.dev
       responses:
         '204':
           description: Work experience deleted. No response body.
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -675,8 +675,6 @@ paths:
               properties:
                 deletedBy:
                   type: string
-                  minLength: 1
-                  maxLength: 255
                   description: Identifier of who performed the deletion.
             example:
               deletedBy: admin@lfx.dev

--- a/backend/src/api/public/openapi.yaml
+++ b/backend/src/api/public/openapi.yaml
@@ -675,6 +675,8 @@ paths:
               properties:
                 deletedBy:
                   type: string
+                  minLength: 1
+                  maxLength: 255
                   description: Identifier of who performed the deletion.
             example:
               deletedBy: admin@lfx.dev

--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -27,7 +27,7 @@ const bodySchema = z.object({
           type: z.enum(MemberIdentityType),
           source: z.string().min(1),
           verified: z.boolean(),
-          verifiedBy: z.string().optional(),
+          verifiedBy: z.string().trim().min(1).optional(),
         })
         .refine((data) => !data.verified || data.verifiedBy, {
           message: 'verifiedBy is required when verified is true',

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -31,7 +31,7 @@ const bodySchema = z
     type: z.enum(MemberIdentityType),
     source: z.string().min(1),
     verified: z.boolean(),
-    verifiedBy: z.string().optional(),
+    verifiedBy: z.string().trim().min(1).optional(),
   })
   .refine((data) => !data.verified || data.verifiedBy, {
     message: 'verifiedBy is required when verified is true',

--- a/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/verifyMemberIdentity.ts
@@ -41,7 +41,7 @@ const paramsSchema = z.object({
 
 const bodySchema = z.object({
   verified: z.boolean(),
-  verifiedBy: z.string(),
+  verifiedBy: z.string().trim().min(1),
 })
 
 type MemberUnmergeContext = {

--- a/backend/src/api/public/v1/members/project-affiliations/patchProjectAffiliation.ts
+++ b/backend/src/api/public/v1/members/project-affiliations/patchProjectAffiliation.ts
@@ -40,7 +40,7 @@ const bodySchema = z
           message: 'dateEnd must be greater than or equal to dateStart',
         }),
     ),
-    verifiedBy: z.string().max(255).optional(),
+    verifiedBy: z.string().trim().min(1).optional(),
   })
   .refine((b) => b.affiliations.length === 0 || b.verifiedBy != null, {
     message: 'verifiedBy is required when affiliations is non-empty',

--- a/backend/src/api/public/v1/members/work-experiences/createMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/createMemberWorkExperience.ts
@@ -38,7 +38,7 @@ const bodySchema = z.object({
   organizationId: z.uuid(),
   jobTitle: z.string(),
   verified: z.boolean(),
-  verifiedBy: z.string(),
+  verifiedBy: z.string().trim().min(1),
   source: z.string(),
   startDate: z.coerce.date(),
   endDate: z.coerce.date().nullable().optional(),

--- a/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
@@ -21,8 +21,13 @@ const paramsSchema = z.object({
   workExperienceId: z.uuid(),
 })
 
+const bodySchema = z.object({
+  deletedBy: z.string(),
+})
+
 export async function deleteMemberWorkExperience(req: Request, res: Response): Promise<void> {
   const { memberId, workExperienceId } = validateOrThrow(paramsSchema, req.params)
+  const { deletedBy } = validateOrThrow(bodySchema, req.body)
 
   const qx = optionsQx(req)
 
@@ -53,7 +58,7 @@ export async function deleteMemberWorkExperience(req: Request, res: Response): P
       captureOldState(memberOrg)
 
       await qx.tx(async (tx) => {
-        await deleteMemberOrganizations(tx, memberId, memberOrgIdsToDelete)
+        await deleteMemberOrganizations(tx, memberId, memberOrgIdsToDelete, true, deletedBy)
       })
 
       // Signal after commit so the workflow sees persisted changes

--- a/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
@@ -22,7 +22,7 @@ const paramsSchema = z.object({
 })
 
 const bodySchema = z.object({
-  deletedBy: z.string(),
+  deletedBy: z.string().trim().min(1).max(255),
 })
 
 export async function deleteMemberWorkExperience(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
@@ -22,7 +22,7 @@ const paramsSchema = z.object({
 })
 
 const bodySchema = z.object({
-  deletedBy: z.string().trim().min(1).max(255),
+  deletedBy: z.string(),
 })
 
 export async function deleteMemberWorkExperience(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/deleteMemberWorkExperience.ts
@@ -22,7 +22,7 @@ const paramsSchema = z.object({
 })
 
 const bodySchema = z.object({
-  deletedBy: z.string(),
+  deletedBy: z.string().trim().min(1),
 })
 
 export async function deleteMemberWorkExperience(req: Request, res: Response): Promise<void> {

--- a/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/updateMemberWorkExperience.ts
@@ -55,7 +55,7 @@ const bodySchema = z.object({
   organizationId: z.uuid(),
   jobTitle: z.string(),
   verified: z.boolean(),
-  verifiedBy: z.string(),
+  verifiedBy: z.string().trim().min(1),
   source: z.string(),
   startDate: z.coerce.date(),
   endDate: z.coerce.date().nullable().optional(),

--- a/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
+++ b/backend/src/api/public/v1/members/work-experiences/verifyMemberWorkExperience.ts
@@ -30,7 +30,7 @@ const paramsSchema = z.object({
 
 const bodySchema = z.object({
   verified: z.boolean(),
-  verifiedBy: z.string(),
+  verifiedBy: z.string().trim().min(1),
 })
 
 export async function verifyMemberWorkExperience(req: Request, res: Response): Promise<void> {


### PR DESCRIPTION
## Summary

CM-1383 closes a gap left by CM-1367. The internal UI and PATCH reject paths already tombstone manually deleted work experiences via `deletedBy`, but public `DELETE /members/:memberId/work-experiences/:workExperienceId` recorded no actor. The Auth0 token on this API is machine-to-machine, so `req.actor` is the calling service — not the person who deleted — and enrichment could recreate the affiliation on the next run.

This change requires `deletedBy` in the DELETE body, matching `verifiedBy` on create/update/verify, and persists it so enrichment never recreates a human-deleted org.

## Changes

- Accept required `deletedBy` on public work-experience DELETE and tombstone via `deleteMemberOrganizations`
- Document the DELETE request body and `400` response in public OpenAPI
- Update the public API e2e DELETE case to send `deletedBy`