### PR TITLE
fix: add missing cncf_collection_activities_ds datasource and copy pipe

### DIFF
--- a/services/libs/tinybird/datasources/cncf_collection_activities_ds.datasource
+++ b/services/libs/tinybird/datasources/cncf_collection_activities_ds.datasource
@@ -1,0 +1,18 @@
+DESCRIPTION >
+    - `cncf_collection_activities_ds` contains activity relations pre-filtered to the CNCF collection (slug `cncf`, `cityHash64('cncf') % 10 = 8`, so all its rows live in bucket 8).
+    - Populated daily by `cncf_collection_activities_copy.pipe`, which reads from `activityRelations_collection_deduplicated_cleaned_bucket_8_ds` filtered to `collectionSlug = 'cncf'`.
+    - Exists so the CNCF geo-distribution report pipes (`collection_contributors_geo_distribution*`) don't have to scan/filter the full bucket on every request.
+    - Stores only the fields those report pipes need: organizationId, memberId, timestamp, platform, type.
+
+TAGS "Report"
+
+SCHEMA >
+    `organizationId` String DEFAULT '',
+    `memberId` String DEFAULT '',
+    `timestamp` DateTime64(3),
+    `platform` LowCardinality(String),
+    `type` LowCardinality(String)
+
+ENGINE MergeTree
+ENGINE_PARTITION_KEY toYear(timestamp)
+ENGINE_SORTING_KEY timestamp, organizationId

--- a/services/libs/tinybird/pipes/cncf_collection_activities_copy.pipe
+++ b/services/libs/tinybird/pipes/cncf_collection_activities_copy.pipe
@@ -1,7 +1,7 @@
 DESCRIPTION >
     - `cncf_collection_activities_copy.pipe` materializes CNCF-collection-scoped activity relations into `cncf_collection_activities_ds`.
     - Reads from `activityRelations_collection_deduplicated_cleaned_bucket_8_ds` filtered to `collectionSlug = 'cncf'` (`cityHash64('cncf') % 10 = 8`, so all CNCF rows land in bucket 8).
-    - Runs daily after bucket 8's clean/enrich copy pipe (`activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe`, scheduled 04:40), so it always reads that day's fresh full-replace of bucket 8.
+    - Runs daily at 06:15, well after bucket 8's clean/enrich copy pipe (`activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe`, scheduled 04:40) finishes, so it always reads that day's fresh full-replace of bucket 8. 06:15 also avoids the dense job clustering in hours 00:00-05:00 (bucket cleanup/copy stages), landing in one of the lightest windows in the schedule.
     - Full-replace, since the upstream bucket is itself a daily full recompute (not append-safe).
 
 TAGS "Report"
@@ -15,4 +15,4 @@ SQL >
 TYPE COPY
 TARGET_DATASOURCE cncf_collection_activities_ds
 COPY_MODE replace
-COPY_SCHEDULE 0 5 * * *
+COPY_SCHEDULE 15 6 * * *

--- a/services/libs/tinybird/pipes/cncf_collection_activities_copy.pipe
+++ b/services/libs/tinybird/pipes/cncf_collection_activities_copy.pipe
@@ -1,0 +1,18 @@
+DESCRIPTION >
+    - `cncf_collection_activities_copy.pipe` materializes CNCF-collection-scoped activity relations into `cncf_collection_activities_ds`.
+    - Reads from `activityRelations_collection_deduplicated_cleaned_bucket_8_ds` filtered to `collectionSlug = 'cncf'` (`cityHash64('cncf') % 10 = 8`, so all CNCF rows land in bucket 8).
+    - Runs daily after bucket 8's clean/enrich copy pipe (`activityRelations_collection_bucket_clean_enrich_copy_pipe_8.pipe`, scheduled 04:40), so it always reads that day's fresh full-replace of bucket 8.
+    - Full-replace, since the upstream bucket is itself a daily full recompute (not append-safe).
+
+TAGS "Report"
+
+NODE cncf_collection_activities_copy_result
+SQL >
+    SELECT organizationId, memberId, timestamp, platform, type
+    FROM activityRelations_collection_deduplicated_cleaned_bucket_8_ds
+    WHERE collectionSlug = 'cncf'
+
+TYPE COPY
+TARGET_DATASOURCE cncf_collection_activities_ds
+COPY_MODE replace
+COPY_SCHEDULE 0 5 * * *


### PR DESCRIPTION
## Summary
- The `insights` frontend's CNCF geo-distribution report (`/report/cncf`) is 404ing in production. Root cause: `collection_contributors_geo_distribution.pipe` and `collection_contributors_geo_distribution_over_time.pipe` both query `cncf_collection_activities_ds`, but that datasource (and the copy pipe meant to populate it) was never created — confirmed via `execute_query`, Tinybird itself returns `Resource 'cncf_collection_activities_ds' not found`.
- Adds `cncf_collection_activities_ds` (organizationId, memberId, timestamp, platform, type) and `cncf_collection_activities_copy.pipe`, which materializes it daily from `activityRelations_collection_deduplicated_cleaned_bucket_8_ds` filtered to `collectionSlug = 'cncf'` (`cityHash64('cncf') % 10 = 8`, verified against production — bucket 8 currently has ~28.5M rows for `cncf`).
- Scheduled at 05:00 daily, after bucket 8's own clean/enrich copy pipe finishes at 04:40.
- Modeled on the existing `ai_code_tracker_ds` / `ai_code_tracker_copy.pipe` pair.
- Validated locally with `tb push --dry-run` (no errors) and `tb fmt` (no changes needed).

## Test plan
- [ ] Tinybird-CI passes on the ephemeral branch for this PR
- [ ] After merge, `tb push` to production, then run `cncf_collection_activities_copy.pipe` once manually (or wait for the 05:00 schedule) to populate `cncf_collection_activities_ds`
- [ ] Confirm `collection_contributors_geo_distribution` and `collection_contributors_geo_distribution_over_time` return data instead of 404
- [ ] Confirm https://insights.linuxfoundation.org/report/cncf loads the geo-distribution widgets