### PR TITLE
fix: relocate leftover soft-deleted member orgs during merge

### DIFF
--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -847,6 +847,24 @@ export async function addMemberRole(
   return row?.id
 }
 
+async function relocateSoftDeletedRoles(
+  qx: QueryExecutor,
+  primaryId: string,
+  secondaryId: string,
+  entityIdField: EntityField,
+): Promise<void> {
+  await qx.result(
+    `
+      UPDATE "memberOrganizations"
+      SET "${entityIdField}" = $(primaryId),
+          "updatedAt" = NOW()
+      WHERE "${entityIdField}" = $(secondaryId)
+        AND "deletedAt" IS NOT NULL
+    `,
+    { primaryId, secondaryId },
+  )
+}
+
 async function moveRolesBetweenEntities(
   qx: QueryExecutor,
   primaryId: string,
@@ -993,6 +1011,8 @@ async function moveRolesBetweenEntities(
       shouldRecalculateAffiliations = true
     }
   }
+
+  await relocateSoftDeletedRoles(qx, primaryId, secondaryId, mergeStrat.entityIdField)
 
   return { shouldRecalculateAffiliations }
 }

--- a/services/libs/data-access-layer/src/members/organizations.ts
+++ b/services/libs/data-access-layer/src/members/organizations.ts
@@ -1012,6 +1012,8 @@ async function moveRolesBetweenEntities(
     }
   }
 
+  // Active roles were moved above; re-point deleted roles to the primary
+  // without restoring them so their tombstones are preserved.
   await relocateSoftDeletedRoles(qx, primaryId, secondaryId, mergeStrat.entityIdField)
 
   return { shouldRecalculateAffiliations }


### PR DESCRIPTION
## Summary
Org and member merges only moved live work experiences. Soft-deleted `memberOrganizations` (and their affiliation overrides) stayed on the secondary entity, so `finishOrganizationMerging` / `deleteOrganization` hit an FK failure when cascading the leftover rows.

## Changes
- After live roles are moved, re-point leftover soft-deleted `memberOrganizations` to the primary org or member in place.
- Rows stay deleted (`deletedAt` / `deletedBy` unchanged) so enrichment and stint-inference tombstones follow the kept entity instead of blocking the secondary delete.