### PR TITLE
fix: skip overlapping org pairs in the LLM merge workflow

### DIFF
--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -719,7 +719,6 @@ class OrganizationRepository {
     const qx = SequelizeRepository.getQueryExecutor(options)
 
     await insertOrganizationNoMerge(qx, organizationId, noMergeId)
-    await insertOrganizationNoMerge(qx, noMergeId, organizationId)
   }
 
   static async removeToMerge(

--- a/backend/src/database/repositories/organizationRepository.ts
+++ b/backend/src/database/repositories/organizationRepository.ts
@@ -12,6 +12,10 @@ import { Error400, Error404, Error409, RawQueryParser } from '@crowd/common'
 import { queryActivities, queryActivityRelations } from '@crowd/data-access-layer'
 import { findManyLfxMemberships } from '@crowd/data-access-layer/src/lfx_memberships'
 import {
+  insertOrganizationNoMerge,
+  removeOrganizationToMerge,
+} from '@crowd/data-access-layer/src/org_merge'
+import {
   IDbOrgAttribute,
   IDbOrganization,
   OrgIdentityField,
@@ -712,30 +716,10 @@ class OrganizationRepository {
     noMergeId: string,
     options: IRepositoryOptions,
   ): Promise<void> {
-    const seq = SequelizeRepository.getSequelize(options)
-    const transaction = SequelizeRepository.getTransaction(options)
+    const qx = SequelizeRepository.getQueryExecutor(options)
 
-    const query = `
-    insert into "organizationNoMerge" ("organizationId", "noMergeId", "createdAt", "updatedAt")
-    values
-    (:organizationId, :noMergeId, now(), now()),
-    (:noMergeId, :organizationId, now(), now())
-    on conflict do nothing;
-  `
-
-    try {
-      await seq.query(query, {
-        replacements: {
-          organizationId,
-          noMergeId,
-        },
-        type: QueryTypes.INSERT,
-        transaction,
-      })
-    } catch (error) {
-      options.log.error('Error adding organizations no merge!', error)
-      throw error
-    }
+    await insertOrganizationNoMerge(qx, organizationId, noMergeId)
+    await insertOrganizationNoMerge(qx, noMergeId, organizationId)
   }
 
   static async removeToMerge(
@@ -743,27 +727,9 @@ class OrganizationRepository {
     toMergeId: string,
     options: IRepositoryOptions,
   ): Promise<void> {
-    const seq = SequelizeRepository.getSequelize(options)
-    const transaction = SequelizeRepository.getTransaction(options)
+    const qx = SequelizeRepository.getQueryExecutor(options)
 
-    const query = `
-    delete from "organizationToMerge"
-    where ("organizationId" = :organizationId and "toMergeId" = :toMergeId) or ("organizationId" = :toMergeId and "toMergeId" = :organizationId);
-  `
-
-    try {
-      await seq.query(query, {
-        replacements: {
-          organizationId,
-          toMergeId,
-        },
-        type: QueryTypes.DELETE,
-        transaction,
-      })
-    } catch (error) {
-      options.log.error('Error while removing organizations to merge!', error)
-      throw error
-    }
+    await removeOrganizationToMerge(qx, organizationId, toMergeId)
   }
 
   static async findNonExistingIds(ids: string[], options: IRepositoryOptions): Promise<string[]> {

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -770,7 +770,6 @@ export default class MemberService extends LoggerBase {
 
     try {
       await MemberRepository.addNoMerge(memberOneId, memberTwoId, txOptions)
-      await MemberRepository.addNoMerge(memberTwoId, memberOneId, txOptions)
 
       // Removes from either order of the pair
       await MemberRepository.removeToMerge(memberOneId, memberTwoId, txOptions)

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -726,7 +726,7 @@ export default class OrganizationService extends LoggerBase {
             '[Merge Organizations] - Including original organisation into secondary organisation segments done!',
           )
 
-          // Secondary is gone; drop all of its leftover suggestions.
+          // Drop leftover suggestions that still mention the secondary.
           await removeOrganizationMergeSuggestions(optionsQx(repoOptions), toMergeId)
 
           await SequelizeRepository.commitTransaction(tx)

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -21,6 +21,7 @@ import {
   queryMergeActions,
   setMergeAction,
 } from '@crowd/data-access-layer/src/mergeActions/repo'
+import { removeOrganizationToMerge } from '@crowd/data-access-layer/src/org_merge'
 import {
   OrganizationField,
   addOrgsToSegments,
@@ -526,6 +527,7 @@ export default class OrganizationService extends LoggerBase {
 
           if (originalWithLfxMembership && toMergeWithLfxMembership) {
             await OrganizationRepository.addNoMerge(originalId, toMergeId, this.options)
+            await OrganizationRepository.removeToMerge(originalId, toMergeId, this.options)
             this.log.info(
               { originalId, toMergeId },
               '[Merge Organizations] - Skipping merge of two LFX membership orgs!',
@@ -724,6 +726,8 @@ export default class OrganizationService extends LoggerBase {
             '[Merge Organizations] - Including original organisation into secondary organisation segments done!',
           )
 
+          await removeOrganizationToMerge(optionsQx(repoOptions), originalId, toMergeId)
+
           await SequelizeRepository.commitTransaction(tx)
 
           this.log.info({ originalId, toMergeId }, '[Merge Organizations] - Transaction commited!')
@@ -829,9 +833,7 @@ export default class OrganizationService extends LoggerBase {
 
     try {
       await OrganizationRepository.addNoMerge(organizationId, noMergeId, txOptions)
-      await OrganizationRepository.addNoMerge(noMergeId, organizationId, txOptions)
       await OrganizationRepository.removeToMerge(organizationId, noMergeId, txOptions)
-      await OrganizationRepository.removeToMerge(noMergeId, organizationId, txOptions)
 
       await SequelizeRepository.commitTransaction(transaction)
     } catch (error) {

--- a/backend/src/services/organizationService.ts
+++ b/backend/src/services/organizationService.ts
@@ -21,7 +21,7 @@ import {
   queryMergeActions,
   setMergeAction,
 } from '@crowd/data-access-layer/src/mergeActions/repo'
-import { removeOrganizationToMerge } from '@crowd/data-access-layer/src/org_merge'
+import { removeOrganizationMergeSuggestions } from '@crowd/data-access-layer/src/org_merge'
 import {
   OrganizationField,
   addOrgsToSegments,
@@ -726,7 +726,8 @@ export default class OrganizationService extends LoggerBase {
             '[Merge Organizations] - Including original organisation into secondary organisation segments done!',
           )
 
-          await removeOrganizationToMerge(optionsQx(repoOptions), originalId, toMergeId)
+          // Secondary is gone; drop all of its leftover suggestions.
+          await removeOrganizationMergeSuggestions(optionsQx(repoOptions), toMergeId)
 
           await SequelizeRepository.commitTransaction(tx)
 

--- a/services/apps/merge_suggestions_worker/src/activities.ts
+++ b/services/apps/merge_suggestions_worker/src/activities.ts
@@ -24,7 +24,7 @@ import {
   getOrganizations,
   getOrganizationsForLLMConsumption,
   getRawOrganizationMergeSuggestions,
-  removeOrganizationMergeSuggestions,
+  removeOrganizationMergeSuggestion,
   updateOrganizationMergeSuggestionsLastGeneratedAt,
 } from './activities/organizationMergeSuggestions'
 
@@ -44,7 +44,7 @@ export {
   getMembersForLLMConsumption,
   getOrganizationsForLLMConsumption,
   getRawOrganizationMergeSuggestions,
-  removeOrganizationMergeSuggestions,
+  removeOrganizationMergeSuggestion,
   getRawMemberMergeSuggestions,
   removeMemberMergeSuggestion,
   saveLLMVerdict,

--- a/services/apps/merge_suggestions_worker/src/activities.ts
+++ b/services/apps/merge_suggestions_worker/src/activities.ts
@@ -13,7 +13,7 @@ import {
   getMembers,
   getMembersForLLMConsumption,
   getRawMemberMergeSuggestions,
-  removeMemberMergeSuggestion,
+  removeMemberMergePair,
   updateMemberMergeSuggestionsLastGeneratedAt,
 } from './activities/memberMergeSuggestions'
 import {
@@ -24,7 +24,7 @@ import {
   getOrganizations,
   getOrganizationsForLLMConsumption,
   getRawOrganizationMergeSuggestions,
-  removeOrganizationMergeSuggestion,
+  removeOrganizationMergePair,
   updateOrganizationMergeSuggestionsLastGeneratedAt,
 } from './activities/organizationMergeSuggestions'
 
@@ -44,9 +44,9 @@ export {
   getMembersForLLMConsumption,
   getOrganizationsForLLMConsumption,
   getRawOrganizationMergeSuggestions,
-  removeOrganizationMergeSuggestion,
+  removeOrganizationMergePair,
   getRawMemberMergeSuggestions,
-  removeMemberMergeSuggestion,
+  removeMemberMergePair,
   saveLLMVerdict,
   mergeMembers,
   mergeOrganizations,

--- a/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
@@ -498,7 +498,7 @@ export async function getRawMemberMergeSuggestions(
   return memberMergeSuggestionsRepo.getRawMemberSuggestions(similarityFilter, limit)
 }
 
-export async function removeMemberMergeSuggestion(suggestion: string[]): Promise<void> {
+export async function removeMemberMergePair(suggestion: string[]): Promise<void> {
   if (suggestion.length !== 2) {
     svc.log.debug(`Suggestions array must have two ids!`)
     return

--- a/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
@@ -516,5 +516,4 @@ export async function addMemberSuggestionToNoMerge(suggestion: string[]): Promis
   const qx = pgpQx(svc.postgres.writer.connection())
 
   await insertMemberNoMerge(qx, suggestion[0], suggestion[1])
-  await insertMemberNoMerge(qx, suggestion[1], suggestion[0])
 }

--- a/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
@@ -515,5 +515,15 @@ export async function addMemberSuggestionToNoMerge(suggestion: string[]): Promis
   }
   const qx = pgpQx(svc.postgres.writer.connection())
 
-  await insertMemberNoMerge(qx, suggestion[0], suggestion[1])
+  try {
+    await insertMemberNoMerge(qx, suggestion[0], suggestion[1])
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === '23503') {
+      svc.log.info({ suggestion }, 'Foreign key constraint violation, skipping no merge!')
+      return
+    }
+
+    svc.log.error({ error, suggestion }, 'Error adding member suggestion to no merge!')
+    throw error
+  }
 }

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -4,7 +4,10 @@ import uniqBy from 'lodash.uniqby'
 import { OrganizationField, findOrgById, queryOrgs } from '@crowd/data-access-layer'
 import { hasLfxMembership } from '@crowd/data-access-layer/src/lfx_memberships'
 import OrganizationMergeSuggestionsRepository from '@crowd/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo'
-import { addOrgNoMerge } from '@crowd/data-access-layer/src/org_merge'
+import {
+  insertOrganizationNoMerge,
+  removeOrganizationToMerge,
+} from '@crowd/data-access-layer/src/org_merge'
 import { fetchOrgIdentities, findOrgAttributes } from '@crowd/data-access-layer/src/organizations'
 import { QueryExecutor, pgpQx } from '@crowd/data-access-layer/src/queryExecutor'
 import { buildFullOrgForMergeSuggestions } from '@crowd/opensearch'
@@ -494,15 +497,14 @@ export async function getRawOrganizationMergeSuggestions(
   return suggestions
 }
 
-export async function removeOrganizationMergeSuggestions(
-  suggestion: string[],
-  table: OrganizationMergeSuggestionTable,
-): Promise<void> {
-  const organizationMergeSuggestionsRepo = new OrganizationMergeSuggestionsRepository(
-    svc.postgres.writer.connection(),
-    svc.log,
-  )
-  await organizationMergeSuggestionsRepo.removeOrganizationMergeSuggestions(suggestion, table)
+export async function removeOrganizationMergeSuggestion(suggestion: string[]): Promise<void> {
+  if (suggestion.length !== 2) {
+    svc.log.debug(`Suggestions array must have two ids!`)
+    return
+  }
+
+  const qx = pgpQx(svc.postgres.writer.connection())
+  await removeOrganizationToMerge(qx, suggestion[0], suggestion[1])
 }
 
 export async function addOrganizationSuggestionToNoMerge(suggestion: string[]): Promise<void> {
@@ -513,16 +515,6 @@ export async function addOrganizationSuggestionToNoMerge(suggestion: string[]): 
 
   const qx = pgpQx(svc.postgres.writer.connection())
 
-  try {
-    await addOrgNoMerge(qx, suggestion[0], suggestion[1])
-  } catch (error: unknown) {
-    // Handle foreign key constraint violation gracefully
-    if (error instanceof Error && 'code' in error && error.code === '23503') {
-      svc.log.info({ suggestion }, 'Foreign key constraint violation, skipping no merge!')
-      return
-    }
-
-    svc.log.error({ error, suggestion }, 'Error adding organization suggestion to no merge!')
-    throw error
-  }
+  await insertOrganizationNoMerge(qx, suggestion[0], suggestion[1])
+  await insertOrganizationNoMerge(qx, suggestion[1], suggestion[0])
 }

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -497,7 +497,7 @@ export async function getRawOrganizationMergeSuggestions(
   return suggestions
 }
 
-export async function removeOrganizationMergeSuggestion(suggestion: string[]): Promise<void> {
+export async function removeOrganizationMergePair(suggestion: string[]): Promise<void> {
   if (suggestion.length !== 2) {
     svc.log.debug(`Suggestions array must have two ids!`)
     return

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -516,5 +516,4 @@ export async function addOrganizationSuggestionToNoMerge(suggestion: string[]): 
   const qx = pgpQx(svc.postgres.writer.connection())
 
   await insertOrganizationNoMerge(qx, suggestion[0], suggestion[1])
-  await insertOrganizationNoMerge(qx, suggestion[1], suggestion[0])
 }

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -515,5 +515,15 @@ export async function addOrganizationSuggestionToNoMerge(suggestion: string[]): 
 
   const qx = pgpQx(svc.postgres.writer.connection())
 
-  await insertOrganizationNoMerge(qx, suggestion[0], suggestion[1])
+  try {
+    await insertOrganizationNoMerge(qx, suggestion[0], suggestion[1])
+  } catch (error: unknown) {
+    if (error instanceof Error && 'code' in error && error.code === '23503') {
+      svc.log.info({ suggestion }, 'Foreign key constraint violation, skipping no merge!')
+      return
+    }
+
+    svc.log.error({ error, suggestion }, 'Error adding organization suggestion to no merge!')
+    throw error
+  }
 }

--- a/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeMembersWithLLM.ts
@@ -9,7 +9,7 @@ import { removeEmailLikeIdentitiesFromMember } from '../utils'
 const {
   getRawMemberMergeSuggestions,
   getMembersForLLMConsumption,
-  removeMemberMergeSuggestion,
+  removeMemberMergePair,
   addMemberSuggestionToNoMerge,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
@@ -80,7 +80,7 @@ export async function mergeMembersWithLLM(
       console.log(
         `Skipping suggestion because a member was already merged away in this run: ${suggestion}`,
       )
-      await removeMemberMergeSuggestion(suggestion)
+      await removeMemberMergePair(suggestion)
       continue
     }
 
@@ -88,7 +88,7 @@ export async function mergeMembersWithLLM(
 
     if (members.length !== 2) {
       console.log(`Failed getting members data in suggestion. Skipping suggestion: ${suggestion}`)
-      await removeMemberMergeSuggestion(suggestion)
+      await removeMemberMergePair(suggestion)
       continue
     }
 
@@ -122,7 +122,7 @@ export async function mergeMembersWithLLM(
       console.log(
         `LLM doesn't think these members are the same. Removing from suggestions and adding to no merge: ${suggestion[0]} and ${suggestion[1]}!`,
       )
-      await removeMemberMergeSuggestion(suggestion)
+      await removeMemberMergePair(suggestion)
       await addMemberSuggestionToNoMerge(suggestion)
     }
   }

--- a/services/apps/merge_suggestions_worker/src/workflows/mergeOrganizationsWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeOrganizationsWithLLM.ts
@@ -8,7 +8,7 @@ import { ILLMResult, IProcessMergeOrganizationSuggestionsWithLLM } from '../type
 const {
   getRawOrganizationMergeSuggestions,
   getOrganizationsForLLMConsumption,
-  removeOrganizationMergeSuggestion,
+  removeOrganizationMergePair,
   addOrganizationSuggestionToNoMerge,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
@@ -60,7 +60,7 @@ export async function mergeOrganizationsWithLLM(
       console.log(
         `Skipping suggestion because an organization was already merged away in this run: ${suggestion}`,
       )
-      await removeOrganizationMergeSuggestion(suggestion)
+      await removeOrganizationMergePair(suggestion)
       continue
     }
 
@@ -70,7 +70,7 @@ export async function mergeOrganizationsWithLLM(
       console.log(
         `Failed getting organization data in suggestion. Skipping suggestion: ${suggestion}`,
       )
-      await removeOrganizationMergeSuggestion(suggestion)
+      await removeOrganizationMergePair(suggestion)
       continue
     }
 
@@ -104,7 +104,7 @@ export async function mergeOrganizationsWithLLM(
       console.log(
         `LLM doesn't think these orgs are the same. Removing from suggestions and adding to no merge: ${suggestion[0]} and ${suggestion[1]}!`,
       )
-      await removeOrganizationMergeSuggestion(suggestion)
+      await removeOrganizationMergePair(suggestion)
       await addOrganizationSuggestionToNoMerge(suggestion)
     }
   }

--- a/services/apps/merge_suggestions_worker/src/workflows/mergeOrganizationsWithLLM.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/mergeOrganizationsWithLLM.ts
@@ -1,6 +1,6 @@
 import { continueAsNew, proxyActivities } from '@temporalio/workflow'
 
-import { LLMSuggestionVerdictType, OrganizationMergeSuggestionTable } from '@crowd/types'
+import { LLMSuggestionVerdictType } from '@crowd/types'
 
 import type * as activities from '../activities'
 import { ILLMResult, IProcessMergeOrganizationSuggestionsWithLLM } from '../types'
@@ -8,7 +8,7 @@ import { ILLMResult, IProcessMergeOrganizationSuggestionsWithLLM } from '../type
 const {
   getRawOrganizationMergeSuggestions,
   getOrganizationsForLLMConsumption,
-  removeOrganizationMergeSuggestions,
+  removeOrganizationMergeSuggestion,
   addOrganizationSuggestionToNoMerge,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: '2 minutes',
@@ -50,21 +50,27 @@ export async function mergeOrganizationsWithLLM(
     return
   }
 
+  const mergedAwayOrganizationIds = new Set<string>()
+
   for (const suggestion of suggestions) {
+    if (
+      mergedAwayOrganizationIds.has(suggestion[0]) ||
+      mergedAwayOrganizationIds.has(suggestion[1])
+    ) {
+      console.log(
+        `Skipping suggestion because an organization was already merged away in this run: ${suggestion}`,
+      )
+      await removeOrganizationMergeSuggestion(suggestion)
+      continue
+    }
+
     const organizations = await getOrganizationsForLLMConsumption(suggestion)
 
     if (organizations.length !== 2) {
       console.log(
         `Failed getting organization data in suggestion. Skipping suggestion: ${suggestion}`,
       )
-      await removeOrganizationMergeSuggestions(
-        suggestion,
-        OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_FILTERED,
-      )
-      await removeOrganizationMergeSuggestions(
-        suggestion,
-        OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_RAW,
-      )
+      await removeOrganizationMergeSuggestion(suggestion)
       continue
     }
 
@@ -93,18 +99,12 @@ export async function mergeOrganizationsWithLLM(
         `LLM verdict says these two orgs are the same. Merging organizations: ${suggestion[0]} and ${suggestion[1]}!`,
       )
       await mergeOrganizations(suggestion[0], suggestion[1])
+      mergedAwayOrganizationIds.add(suggestion[1])
     } else {
       console.log(
         `LLM doesn't think these orgs are the same. Removing from suggestions and adding to no merge: ${suggestion[0]} and ${suggestion[1]}!`,
       )
-      await removeOrganizationMergeSuggestions(
-        suggestion,
-        OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_FILTERED,
-      )
-      await removeOrganizationMergeSuggestions(
-        suggestion,
-        OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_RAW,
-      )
+      await removeOrganizationMergeSuggestion(suggestion)
       await addOrganizationSuggestionToNoMerge(suggestion)
     }
   }

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -47,7 +47,7 @@ import {
   preferCompanyOverUniversityWhenOverlapping,
   updateMember,
 } from '@crowd/data-access-layer'
-import { removeMemberToMerge } from '@crowd/data-access-layer/src/member_merge'
+import { removeMemberMergeSuggestions } from '@crowd/data-access-layer/src/member_merge'
 import {
   deleteMemberSegmentAffiliations,
   findMemberAffiliations,
@@ -435,8 +435,8 @@ export class CommonMemberService extends LoggerBase {
             // update members that belong to source organization to destination org
             await moveOrgsBetweenMembers(txQx, originalId, toMergeId)
 
-            // Remove toMerge from original member
-            await removeMemberToMerge(txQx, originalId, toMergeId)
+            // Secondary is gone; drop all of its leftover suggestions.
+            await removeMemberMergeSuggestions(txQx, toMergeId)
 
             const secondMemberSegments = await getMemberSegments(txQx, toMergeId)
 

--- a/services/libs/common_services/src/services/common.member.service.ts
+++ b/services/libs/common_services/src/services/common.member.service.ts
@@ -435,7 +435,7 @@ export class CommonMemberService extends LoggerBase {
             // update members that belong to source organization to destination org
             await moveOrgsBetweenMembers(txQx, originalId, toMergeId)
 
-            // Secondary is gone; drop all of its leftover suggestions.
+            // Drop leftover suggestions that still mention the secondary.
             await removeMemberMergeSuggestions(txQx, toMergeId)
 
             const secondMemberSegments = await getMemberSegments(txQx, toMergeId)

--- a/services/libs/data-access-layer/src/member_merge/index.ts
+++ b/services/libs/data-access-layer/src/member_merge/index.ts
@@ -5,32 +5,42 @@ export async function removeMemberToMerge(
   memberId: string,
   toMergeId: string,
 ): Promise<void> {
-  const replacements = { memberId, toMergeId }
-
-  const whereClause = `
-    WHERE
-      ("memberId" = $(memberId) AND "toMergeId" = $(toMergeId))
-      OR
-      ("memberId" = $(toMergeId) AND "toMergeId" = $(memberId))
-  `
-
-  await qx.tx(async (tx) => {
-    await tx.result(
-      `
+  await qx.result(
+    `
+      WITH deleted_filtered AS (
         DELETE FROM "memberToMerge"
-        ${whereClause}
-      `,
-      replacements,
-    )
+        WHERE
+          ("memberId" = $(memberId) AND "toMergeId" = $(toMergeId))
+          OR
+          ("memberId" = $(toMergeId) AND "toMergeId" = $(memberId))
+      )
+      DELETE FROM "memberToMergeRaw"
+      WHERE
+        ("memberId" = $(memberId) AND "toMergeId" = $(toMergeId))
+        OR
+        ("memberId" = $(toMergeId) AND "toMergeId" = $(memberId))
+    `,
+    { memberId, toMergeId },
+  )
+}
 
-    await tx.result(
-      `
-        DELETE FROM "memberToMergeRaw"
-        ${whereClause}
-      `,
-      replacements,
-    )
-  })
+export async function removeMemberMergeSuggestions(
+  qx: QueryExecutor,
+  memberId: string,
+): Promise<void> {
+  await qx.result(
+    `
+      WITH deleted_filtered AS (
+        DELETE FROM "memberToMerge"
+        WHERE "memberId" = $(memberId)
+           OR "toMergeId" = $(memberId)
+      )
+      DELETE FROM "memberToMergeRaw"
+      WHERE "memberId" = $(memberId)
+         OR "toMergeId" = $(memberId)
+    `,
+    { memberId },
+  )
 }
 
 export async function insertMemberNoMerge(

--- a/services/libs/data-access-layer/src/member_merge/index.ts
+++ b/services/libs/data-access-layer/src/member_merge/index.ts
@@ -51,9 +51,9 @@ export async function insertMemberNoMerge(
   await qx.result(
     `
       INSERT INTO "memberNoMerge" ("memberId", "noMergeId", "createdAt", "updatedAt")
-      SELECT $(memberId), $(noMergeId), NOW(), NOW()
-      WHERE EXISTS (SELECT 1 FROM members WHERE id = $(memberId))
-        AND EXISTS (SELECT 1 FROM members WHERE id = $(noMergeId))
+      VALUES
+        ($(memberId), $(noMergeId), NOW(), NOW()),
+        ($(noMergeId), $(memberId), NOW(), NOW())
       ON CONFLICT ("memberId", "noMergeId") DO NOTHING
     `,
     { memberId, noMergeId },

--- a/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
@@ -323,31 +323,6 @@ class OrganizationMergeSuggestionsRepository {
 
     return results.map((r) => [r.organizationId, r.toMergeId])
   }
-
-  async removeOrganizationMergeSuggestions(
-    suggestion: string[],
-    table: OrganizationMergeSuggestionTable,
-  ): Promise<void> {
-    const query = `
-      delete from "${table}" 
-      where 
-        ("organizationId" = $(organizationId) and "toMergeId" = $(toMergeId))
-        or 
-        ("organizationId" = $(toMergeId) and "toMergeId" = $(organizationId))
-    `
-
-    const replacements = {
-      organizationId: suggestion[0],
-      toMergeId: suggestion[1],
-    }
-
-    try {
-      await this.connection.none(query, replacements)
-    } catch (error) {
-      this.log.error(`Error removing organization suggestions rom ${table}!`, error)
-      throw error
-    }
-  }
 }
 
 export default OrganizationMergeSuggestionsRepository

--- a/services/libs/data-access-layer/src/org_merge/index.ts
+++ b/services/libs/data-access-layer/src/org_merge/index.ts
@@ -24,32 +24,42 @@ export async function removeOrganizationToMerge(
   organizationId: string,
   toMergeId: string,
 ): Promise<void> {
-  const replacements = { organizationId, toMergeId }
-
-  const whereClause = `
-    WHERE
-      ("organizationId" = $(organizationId) AND "toMergeId" = $(toMergeId))
-      OR
-      ("organizationId" = $(toMergeId) AND "toMergeId" = $(organizationId))
-  `
-
-  await qx.tx(async (tx) => {
-    await tx.result(
-      `
+  await qx.result(
+    `
+      WITH deleted_filtered AS (
         DELETE FROM "organizationToMerge"
-        ${whereClause}
-      `,
-      replacements,
-    )
+        WHERE
+          ("organizationId" = $(organizationId) AND "toMergeId" = $(toMergeId))
+          OR
+          ("organizationId" = $(toMergeId) AND "toMergeId" = $(organizationId))
+      )
+      DELETE FROM "organizationToMergeRaw"
+      WHERE
+        ("organizationId" = $(organizationId) AND "toMergeId" = $(toMergeId))
+        OR
+        ("organizationId" = $(toMergeId) AND "toMergeId" = $(organizationId))
+    `,
+    { organizationId, toMergeId },
+  )
+}
 
-    await tx.result(
-      `
-        DELETE FROM "organizationToMergeRaw"
-        ${whereClause}
-      `,
-      replacements,
-    )
-  })
+export async function removeOrganizationMergeSuggestions(
+  qx: QueryExecutor,
+  organizationId: string,
+): Promise<void> {
+  await qx.result(
+    `
+      WITH deleted_filtered AS (
+        DELETE FROM "organizationToMerge"
+        WHERE "organizationId" = $(organizationId)
+           OR "toMergeId" = $(organizationId)
+      )
+      DELETE FROM "organizationToMergeRaw"
+      WHERE "organizationId" = $(organizationId)
+         OR "toMergeId" = $(organizationId)
+    `,
+    { organizationId },
+  )
 }
 
 export async function insertOrganizationNoMerge(

--- a/services/libs/data-access-layer/src/org_merge/index.ts
+++ b/services/libs/data-access-layer/src/org_merge/index.ts
@@ -19,23 +19,52 @@ export async function findOrgNoMergeIds(
   return rows.map((row: { noMergeId: string }) => row.noMergeId)
 }
 
-export async function addOrgNoMerge(
+export async function removeOrganizationToMerge(
+  qx: QueryExecutor,
+  organizationId: string,
+  toMergeId: string,
+): Promise<void> {
+  const replacements = { organizationId, toMergeId }
+
+  const whereClause = `
+    WHERE
+      ("organizationId" = $(organizationId) AND "toMergeId" = $(toMergeId))
+      OR
+      ("organizationId" = $(toMergeId) AND "toMergeId" = $(organizationId))
+  `
+
+  await qx.tx(async (tx) => {
+    await tx.result(
+      `
+        DELETE FROM "organizationToMerge"
+        ${whereClause}
+      `,
+      replacements,
+    )
+
+    await tx.result(
+      `
+        DELETE FROM "organizationToMergeRaw"
+        ${whereClause}
+      `,
+      replacements,
+    )
+  })
+}
+
+export async function insertOrganizationNoMerge(
   qx: QueryExecutor,
   organizationId: string,
   noMergeId: string,
 ): Promise<void> {
-  const currentTime = new Date()
   await qx.result(
     `
       INSERT INTO "organizationNoMerge" ("organizationId", "noMergeId", "createdAt", "updatedAt")
-      VALUES ($(organizationId), $(noMergeId), $(createdAt), $(updatedAt))
-      on conflict ("organizationId", "noMergeId") do nothing
+      SELECT $(organizationId), $(noMergeId), NOW(), NOW()
+      WHERE EXISTS (SELECT 1 FROM organizations WHERE id = $(organizationId))
+        AND EXISTS (SELECT 1 FROM organizations WHERE id = $(noMergeId))
+      ON CONFLICT ("organizationId", "noMergeId") DO NOTHING
     `,
-    {
-      organizationId,
-      noMergeId,
-      createdAt: currentTime,
-      updatedAt: currentTime,
-    },
+    { organizationId, noMergeId },
   )
 }

--- a/services/libs/data-access-layer/src/org_merge/index.ts
+++ b/services/libs/data-access-layer/src/org_merge/index.ts
@@ -70,9 +70,9 @@ export async function insertOrganizationNoMerge(
   await qx.result(
     `
       INSERT INTO "organizationNoMerge" ("organizationId", "noMergeId", "createdAt", "updatedAt")
-      SELECT $(organizationId), $(noMergeId), NOW(), NOW()
-      WHERE EXISTS (SELECT 1 FROM organizations WHERE id = $(organizationId))
-        AND EXISTS (SELECT 1 FROM organizations WHERE id = $(noMergeId))
+      VALUES
+        ($(organizationId), $(noMergeId), NOW(), NOW()),
+        ($(noMergeId), $(organizationId), NOW(), NOW())
       ON CONFLICT ("organizationId", "noMergeId") DO NOTHING
     `,
     { organizationId, noMergeId },


### PR DESCRIPTION
## Summary
The daily `mergeOrganizationsWithLLM` workflow 500'd when overlapping pairs ran in the same batch. After B merged into A, leftover suggestions still pointed at B. The next merge used a deleted org and identity move hit `organizationIdentities_organizationId_fkey`.

## Changes
- Skip LLM pairs when either id was already merged away in this run
- On successful merge, delete every leftover suggestion that mentions the secondary (orgs and members)
- Pair deletes run as one statement on the caller's executor (no nested transaction)
- No-merge inserts both directions in one `INSERT`