### PR TITLE
chore: remove unused `@crowd/snowflake` deps

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -63,7 +63,6 @@
     "@crowd/queue": "workspace:*",
     "@crowd/redis": "workspace:*",
     "@crowd/slack": "workspace:*",
-    "@crowd/snowflake": "workspace:*",
     "@crowd/telemetry": "workspace:*",
     "@crowd/temporal": "workspace:*",
     "@crowd/types": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       '@crowd/slack':
         specifier: workspace:*
         version: link:../services/libs/slack
-      '@crowd/snowflake':
-        specifier: workspace:*
-        version: link:../services/libs/snowflake
       '@crowd/telemetry':
         specifier: workspace:*
         version: link:../services/libs/telemetry
@@ -637,9 +634,6 @@ importers:
       '@crowd/slack':
         specifier: workspace:*
         version: link:../../libs/slack
-      '@crowd/snowflake':
-        specifier: workspace:*
-        version: link:../../libs/snowflake
       '@crowd/telemetry':
         specifier: workspace:*
         version: link:../../libs/telemetry
@@ -1565,9 +1559,6 @@ importers:
       '@crowd/redis':
         specifier: workspace:*
         version: link:../../libs/redis
-      '@crowd/snowflake':
-        specifier: workspace:*
-        version: link:../../libs/snowflake
       '@crowd/temporal':
         specifier: workspace:*
         version: link:../../libs/temporal
@@ -2339,9 +2330,6 @@ importers:
       '@crowd/logging':
         specifier: workspace:*
         version: link:../logging
-      '@crowd/snowflake':
-        specifier: workspace:*
-        version: link:../snowflake
       '@crowd/telemetry':
         specifier: workspace:*
         version: link:../telemetry

--- a/services/apps/cron_service/package.json
+++ b/services/apps/cron_service/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@crowd/common": "workspace:*",
-    "@crowd/snowflake": "workspace:*",
     "@crowd/data-access-layer": "workspace:*",
     "@crowd/logging": "workspace:*",
     "@crowd/nango": "workspace:*",

--- a/services/apps/script_executor_worker/package.json
+++ b/services/apps/script_executor_worker/package.json
@@ -27,7 +27,6 @@
     "@crowd/logging": "workspace:*",
     "@crowd/opensearch": "workspace:*",
     "@crowd/redis": "workspace:*",
-    "@crowd/snowflake": "workspace:*",
     "@crowd/types": "workspace:*",
     "@crowd/temporal": "workspace:*",
     "@temporalio/client": "~1.17.2",

--- a/services/libs/integrations/package.json
+++ b/services/libs/integrations/package.json
@@ -20,7 +20,6 @@
     "@crowd/logging": "workspace:*",
     "@crowd/telemetry": "workspace:*",
     "@crowd/types": "workspace:*",
-    "@crowd/snowflake": "workspace:*",
     "@gitbeaker/rest": "^43.5.0",
     "@octokit/auth-app": "^4.0.13",
     "@octokit/graphql": "^5.0.6",


### PR DESCRIPTION
## Summary
`@crowd/snowflake` is only imported by `snowflake-connectors` and `pcc-sync-worker`. Four other packages listed it as a dependency without using it.

snowflake-sdk 3 loads the AWS SDK on import and requires `AWS_REGION`. Leaving unused deps in place means those services would pull the driver (and that AWS requirement) for no reason.

## Changes
- Remove `@crowd/snowflake` from `backend`, `cron_service`, `script_executor_worker`, and `@crowd/integrations`
- Refresh `pnpm-lock.yaml`