### PR TITLE
ci: bump `actions/checkout` from v2 to v4

### DIFF
--- a/.github/workflows/backend-lint.yaml
+++ b/.github/workflows/backend-lint.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/lf-oracle-production-deploy.yaml
+++ b/.github/workflows/lf-oracle-production-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install OCI
         run: |

--- a/.github/workflows/lf-oracle-staging-deploy.yaml
+++ b/.github/workflows/lf-oracle-staging-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install OCI
         run: |


### PR DESCRIPTION
## Summary
Bump remaining GitHub Actions `checkout` steps from v2 to v4 so deploy and lint workflows stop running a Node 20 action on Node 24 runners.

## Changes
- `lf-oracle-production-deploy.yaml`: `actions/checkout@v2` → `@v4`
- `lf-oracle-staging-deploy.yaml`: `actions/checkout@v2` → `@v4`
- `frontend-lint.yml`: `actions/checkout@v2` → `@v4`
- `backend-lint.yaml`: two jobs `actions/checkout@v2` → `@v4`