### PR TITLE
fix: use bunyan `stdSerializers` for error fields

### DIFF
--- a/services/libs/logging/src/logger.ts
+++ b/services/libs/logging/src/logger.ts
@@ -5,36 +5,6 @@ import { IS_DEV_ENV, IS_TEST_ENV, LOG_LEVEL, SERVICE } from '@crowd/common'
 
 import { Logger } from './types'
 
-type SerializableError = {
-  toJSON?: () => unknown
-}
-
-function serializeError(err: unknown) {
-  if (err && typeof err === 'object') {
-    const toJSON = (err as SerializableError).toJSON
-
-    if (typeof toJSON === 'function') {
-      try {
-        const serialized = toJSON.call(err)
-
-        if (serialized !== undefined) {
-          return serialized
-        }
-      } catch {
-        // Fall back to Bunyan's standard error serialization.
-      }
-    }
-  }
-
-  return Bunyan.stdSerializers.err(err)
-}
-
-const serializers = {
-  ...Bunyan.stdSerializers,
-  err: serializeError,
-  error: serializeError,
-}
-
 const PRETTY_FORMAT = new BunyanFormat({
   outputMode: 'short',
   levelInString: true,
@@ -58,7 +28,10 @@ export function getServiceLogger(): Logger {
     name: SERVICE,
     level: LOG_LEVEL as Bunyan.LogLevel,
     stream: usePrettyLogs ? PRETTY_FORMAT : JSON_FORMAT,
-    serializers,
+    serializers: {
+      ...Bunyan.stdSerializers,
+      error: Bunyan.stdSerializers.err,
+    },
   }
 
   serviceLoggerInstance = Bunyan.createLogger(options)


### PR DESCRIPTION
## Summary
The Node 24 logging fix used Axios `toJSON()` so bunyan would not dump TLS sockets. That stopped the nango-worker crash, but `toJSON()` still includes the full request `config`, so prod logs for merge-suggestions 409s contained `Authorization: Bearer …`.

Bunyan 1.8.12 already allowlists error fields (`message`, `name`, `stack`, `code`, `signal`) for this reason. This PR switches to that serializer instead of a custom Axios shape.

## Changes
- Remove the homemade `toJSON()` error serializer in `@crowd/logging`
- Use `Bunyan.stdSerializers` for `err`
- Map Temporal’s top-level `error` field to the same bunyan serializer (`log.error(err)` already uses `err`; Temporal logs `{ error }`)