### PR TITLE
fix: treat same-member identity unique violations as already exists

### DIFF
--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -67,35 +67,37 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
     memberEditIdentitiesAction(memberId, async (captureOldState, captureNewState) => {
       captureOldState({})
 
-      const outcome = await qx.tx(async (tx) => {
-        const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
-          type: data.type,
-        })
+      let outcome: { identity: IMemberIdentity; alreadyExisted: boolean }
 
-        const exactMatch = existing.find((row) => row.platform === data.platform)
-
-        let result = exactMatch
-        const existed = Boolean(exactMatch)
-
-        // Unverified identities aren't unique in the db, so the same handle or
-        // email can sit on several members. Reject it here if someone else has it.
-        if (!result && !data.verified) {
-          const conflict = await findMemberIdentityConflict(tx, {
-            value: data.value,
-            platform: data.platform,
+      try {
+        outcome = await qx.tx(async (tx) => {
+          const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
             type: data.type,
-            excludeMemberId: memberId,
           })
 
-          if (conflict) {
-            throw new ConflictError('Identity already exists on another member', {
-              ...conflictContext,
-              conflictMemberId: conflict.memberId,
-            })
-          }
-        }
+          const exactMatch = existing.find((row) => row.platform === data.platform)
 
-        try {
+          let result = exactMatch
+          const existed = Boolean(exactMatch)
+
+          // Unverified identities aren't unique in the db, so the same handle or
+          // email can sit on several members. Reject it here if someone else has it.
+          if (!result && !data.verified) {
+            const conflict = await findMemberIdentityConflict(tx, {
+              value: data.value,
+              platform: data.platform,
+              type: data.type,
+              excludeMemberId: memberId,
+            })
+
+            if (conflict) {
+              throw new ConflictError('Identity already exists on another member', {
+                ...conflictContext,
+                conflictMemberId: conflict.memberId,
+              })
+            }
+          }
+
           if (!result) {
             const [inserted] = await insertMemberIdentities(
               tx,
@@ -135,28 +137,37 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
               result = updatedExact
             }
           }
-        } catch (error) {
-          if (isMemberIdentityDbConflict(error)) {
-            const conflictMemberId = await findMemberIdByVerifiedIdentity(
-              qx,
-              data.platform,
-              data.value,
-              data.type,
-            )
 
-            rethrowDbConflict(error, {
-              ...conflictContext,
-              ...(conflictMemberId ? { conflictMemberId } : {}),
-            })
-          }
+          await touchMemberUpdatedAt(tx, memberId)
 
+          return { identity: result, alreadyExisted: existed }
+        })
+      } catch (error) {
+        if (!isMemberIdentityDbConflict(error)) {
           throw error
         }
 
-        await touchMemberUpdatedAt(tx, memberId)
+        const existing = await findMemberIdentitiesByValue(qx, memberId, data.value, {
+          type: data.type,
+        })
+        const exactMatch = existing.find((row) => row.platform === data.platform)
 
-        return { identity: result, alreadyExisted: existed }
-      })
+        if (exactMatch) {
+          outcome = { identity: exactMatch, alreadyExisted: true }
+        } else {
+          const conflictMemberId = await findMemberIdByVerifiedIdentity(
+            qx,
+            data.platform,
+            data.value,
+            data.type,
+          )
+
+          rethrowDbConflict(error, {
+            ...conflictContext,
+            ...(conflictMemberId ? { conflictMemberId } : {}),
+          })
+        }
+      }
 
       identity = outcome.identity
       alreadyExisted = outcome.alreadyExisted

--- a/backend/src/utils/err.ts
+++ b/backend/src/utils/err.ts
@@ -3,8 +3,8 @@ import { ConflictError, getDbConstraint } from '@crowd/common'
 type ConflictFactory = (context?: Record<string, unknown>) => Error
 
 const DB_CONFLICT_MAP: Record<string, ConflictFactory> = {
-  uix_memberIdentities_platform_value_type_verified: (context) =>
-    new ConflictError('Identity already exists on another member', context),
+  uix_memberIdentities_memberId_platform_type_lower_value: (context) =>
+    new ConflictError('Identity already exists on this member', context),
   uix_memberIdentities_platform_type_lower_value_verified: (context) =>
     new ConflictError('Identity already exists on another member', context),
 }


### PR DESCRIPTION
## Summary
Concurrent `POST /v1/members/:id/identities` for an identity this member already has was hitting a unique constraint and returning 500 (`SequelizeUniqueConstraintError`). The conflict map still pointed at a dropped index and missed the live per-member unique index, so the existing unique-error catch never ran.

## Changes
- Map the live unique indexes (`uix_memberIdentities_memberId_platform_type_lower_value` and `uix_memberIdentities_platform_type_lower_value_verified`) with matching 409 messages.
- After a unique violation, re-read the member: if the identity is already here, return 200; otherwise 409 with `conflictMemberId`.