### PR TITLE
fix: return 409 when unique error leaves identity unverified

### DIFF
--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -71,6 +71,8 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
 
       try {
         outcome = await qx.tx(async (tx) => {
+          // Identities this member already has with the same value and type,
+          // on any platform (e.g. github email and custom email).
           const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
             type: data.type,
           })
@@ -80,8 +82,8 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
           let result = exactMatch
           const existed = Boolean(exactMatch)
 
-          // Unverified identities aren't unique in the db, so the same handle or
-          // email can sit on several members. Reject it here if someone else has it.
+          // Unverified identities aren't unique in the db, so reject here if
+          // someone else has it. Verified uniqueness is left to Postgres.
           if (!result && !data.verified) {
             const conflict = await findMemberIdentityConflict(tx, {
               value: data.value,
@@ -152,7 +154,9 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
         })
         const exactMatch = existing.find((row) => row.platform === data.platform)
 
-        if (exactMatch) {
+        // Rolled back unique error. 200 if this member already has what they
+        // asked for; asked to verify but still unverified is a failed verify (409).
+        if (exactMatch && (!data.verified || exactMatch.verified)) {
           outcome = { identity: exactMatch, alreadyExisted: true }
         } else {
           const conflictMemberId = await findMemberIdByVerifiedIdentity(

--- a/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
+++ b/backend/src/api/public/v1/members/identities/createMemberIdentity.ts
@@ -71,8 +71,6 @@ export async function createMemberIdentity(req: Request, res: Response): Promise
 
       try {
         outcome = await qx.tx(async (tx) => {
-          // Identities this member already has with the same value and type,
-          // on any platform (e.g. github email and custom email).
           const existing = await findMemberIdentitiesByValue(tx, memberId, data.value, {
             type: data.type,
           })


### PR DESCRIPTION
## Summary
A unique-constraint failure on `POST /v1/members/:id/identities` was treated as 200 whenever this member already had the identity row. That is correct for a duplicate insert, but wrong when the request asked to verify and the row is still unverified (another member already owns it verified).

## Changes
- After a rolled-back unique error, return 200 only if this member already has the identity in the requested verified state; otherwise 409 with `conflictMemberId`.