### PR TITLE
fix: keep merge suggestion UI in sync when pairs are rescored

### DIFF
--- a/services/apps/members_enrichment_worker/src/activities/enrichment.ts
+++ b/services/apps/members_enrichment_worker/src/activities/enrichment.ts
@@ -59,7 +59,6 @@ import {
   MemberIdentityType,
   OrganizationAttributeSource,
   OrganizationIdentityType,
-  OrganizationMergeSuggestionTable,
   PlatformType,
 } from '@crowd/types'
 
@@ -587,14 +586,7 @@ export async function updateMemberUsingSquashedPayload(
             if (mergeSuggestions.length > 0) {
               // A shared verified identity is a strong merge signal, unless the pair was
               // explicitly marked as no-merge by a reviewer.
-              await mergeSuggestionsRepo.addToMerge(
-                mergeSuggestions,
-                OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_RAW,
-              )
-              await mergeSuggestionsRepo.addToMerge(
-                mergeSuggestions,
-                OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_FILTERED,
-              )
+              await mergeSuggestionsRepo.addToMerge(mergeSuggestions)
             }
           }
         }

--- a/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/memberMergeSuggestions.ts
@@ -13,7 +13,6 @@ import {
   IMemberIdentity,
   IMemberMergeSuggestion,
   MemberIdentityType,
-  MemberMergeSuggestionTable,
   OpenSearchIndex,
   PlatformType,
 } from '@crowd/types'
@@ -379,14 +378,14 @@ export async function getMemberMergeSuggestions(
 
 export async function addMemberToMerge(
   suggestions: IMemberMergeSuggestion[],
-  table: MemberMergeSuggestionTable,
+  similarityThreshold = 0.75,
 ): Promise<void> {
   if (suggestions.length > 0) {
     const memberMergeSuggestionsRepo = new MemberMergeSuggestionsRepository(
       svc.postgres.writer.connection(),
       svc.log,
     )
-    await memberMergeSuggestionsRepo.addToMerge(suggestions, table)
+    await memberMergeSuggestionsRepo.addToMerge(suggestions, similarityThreshold)
   }
 }
 

--- a/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/activities/organizationMergeSuggestions.ts
@@ -20,7 +20,6 @@ import {
   IOrganizationOpensearch,
   OpenSearchIndex,
   OrganizationIdentityType,
-  OrganizationMergeSuggestionTable,
 } from '@crowd/types'
 
 import { svc } from '../main'
@@ -391,14 +390,14 @@ export async function getOrganizationMergeSuggestions(
 
 export async function addOrganizationToMerge(
   suggestions: IOrganizationMergeSuggestion[],
-  table: OrganizationMergeSuggestionTable,
+  similarityThreshold = 0.75,
 ): Promise<void> {
   if (suggestions.length > 0) {
     const organizationMergeSuggestionsRepo = new OrganizationMergeSuggestionsRepository(
       svc.postgres.writer.connection(),
       svc.log,
     )
-    await organizationMergeSuggestionsRepo.addToMerge(suggestions, table)
+    await organizationMergeSuggestionsRepo.addToMerge(suggestions, similarityThreshold)
   }
 }
 

--- a/services/apps/merge_suggestions_worker/src/workflows/generateMemberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/generateMemberMergeSuggestions.ts
@@ -49,7 +49,6 @@ export async function generateMemberMergeSuggestions(
   }
 
   if (allMergeSuggestions.length > 0) {
-    // Writes raw and UI together so a rescore below the threshold cannot leave a stale UI row.
     await activity.addMemberToMerge(allMergeSuggestions, SIMILARITY_CONFIDENCE_SCORE_THRESHOLD)
   }
 

--- a/services/apps/merge_suggestions_worker/src/workflows/generateMemberMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/generateMemberMergeSuggestions.ts
@@ -1,10 +1,6 @@
 import { continueAsNew, proxyActivities } from '@temporalio/workflow'
 
-import {
-  IMemberBaseForMergeSuggestions,
-  IMemberMergeSuggestion,
-  MemberMergeSuggestionTable,
-} from '@crowd/types'
+import { IMemberBaseForMergeSuggestions, IMemberMergeSuggestion } from '@crowd/types'
 
 import * as activities from '../activities/memberMergeSuggestions'
 import { IProcessGenerateMemberMergeSuggestionsArgs } from '../types'
@@ -52,17 +48,9 @@ export async function generateMemberMergeSuggestions(
     allMergeSuggestions.push(...mergeSuggestionsResults.flat())
   }
 
-  // Add all merge suggestions to add to merge
   if (allMergeSuggestions.length > 0) {
-    await activity.addMemberToMerge(
-      allMergeSuggestions,
-      MemberMergeSuggestionTable.MEMBER_TO_MERGE_RAW,
-    )
-
-    await activity.addMemberToMerge(
-      allMergeSuggestions.filter((s) => s.similarity > SIMILARITY_CONFIDENCE_SCORE_THRESHOLD),
-      MemberMergeSuggestionTable.MEMBER_TO_MERGE_FILTERED,
-    )
+    // Writes raw and UI together so a rescore below the threshold cannot leave a stale UI row.
+    await activity.addMemberToMerge(allMergeSuggestions, SIMILARITY_CONFIDENCE_SCORE_THRESHOLD)
   }
 
   await continueAsNew<typeof generateMemberMergeSuggestions>({ tenantId: args.tenantId, lastUuid })

--- a/services/apps/merge_suggestions_worker/src/workflows/generateOrganizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/generateOrganizationMergeSuggestions.ts
@@ -1,10 +1,6 @@
 import { continueAsNew, proxyActivities } from '@temporalio/workflow'
 
-import {
-  IOrganizationBaseForMergeSuggestions,
-  IOrganizationMergeSuggestion,
-  OrganizationMergeSuggestionTable,
-} from '@crowd/types'
+import { IOrganizationBaseForMergeSuggestions, IOrganizationMergeSuggestion } from '@crowd/types'
 
 import * as activities from '../activities/organizationMergeSuggestions'
 import { IProcessGenerateOrganizationMergeSuggestionsArgs } from '../types'
@@ -55,16 +51,11 @@ export async function generateOrganizationMergeSuggestions(
     allMergeSuggestions.push(...mergeSuggestionsResults.flat())
   }
 
-  // Add all merge suggestions to add to merge
   if (allMergeSuggestions.length > 0) {
+    // Writes raw and UI together so a rescore below the threshold cannot leave a stale UI row.
     await activity.addOrganizationToMerge(
       allMergeSuggestions,
-      OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_RAW,
-    )
-
-    await activity.addOrganizationToMerge(
-      allMergeSuggestions.filter((s) => s.similarity > SIMILARITY_CONFIDENCE_SCORE_THRESHOLD),
-      OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_FILTERED,
+      SIMILARITY_CONFIDENCE_SCORE_THRESHOLD,
     )
   }
 

--- a/services/apps/merge_suggestions_worker/src/workflows/generateOrganizationMergeSuggestions.ts
+++ b/services/apps/merge_suggestions_worker/src/workflows/generateOrganizationMergeSuggestions.ts
@@ -52,7 +52,6 @@ export async function generateOrganizationMergeSuggestions(
   }
 
   if (allMergeSuggestions.length > 0) {
-    // Writes raw and UI together so a rescore below the threshold cannot leave a stale UI row.
     await activity.addOrganizationToMerge(
       allMergeSuggestions,
       SIMILARITY_CONFIDENCE_SCORE_THRESHOLD,

--- a/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/memberMergeSuggestions.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/memberMergeSuggestions.repo.ts
@@ -141,9 +141,7 @@ class MemberMergeSuggestionsRepository {
       replacements: Record<string, unknown>,
       onlyAboveThreshold: boolean,
     ) => {
-      const thresholdFilter = onlyAboveThreshold
-        ? 'and v.similarity > $(similarityThreshold)'
-        : ''
+      const thresholdFilter = onlyAboveThreshold ? 'and v.similarity > $(similarityThreshold)' : ''
 
       // Update existing rows if they already exist
       await this.connection.none(

--- a/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/memberMergeSuggestions.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/memberMergeSuggestions.repo.ts
@@ -82,7 +82,7 @@ class MemberMergeSuggestionsRepository {
 
   async addToMerge(
     suggestions: IMemberMergeSuggestion[],
-    table: MemberMergeSuggestionTable,
+    similarityThreshold = 0.75,
   ): Promise<void> {
     // Remove possible duplicates
     suggestions = removeDuplicateSuggestions<IMemberMergeSuggestion>(
@@ -99,9 +99,9 @@ class MemberMergeSuggestionsRepository {
       }, new Set<string>()),
     )
 
-    // filter non existing member ids from suggestions
     const nonExistingIds = await this.findNonExistingIds(uniqueMemberIds)
 
+    // filter non existing member ids from suggestions
     suggestions = suggestions.filter(
       (s) => !nonExistingIds.includes(s.members[0]) && !nonExistingIds.includes(s.members[1]),
     )
@@ -135,9 +135,68 @@ class MemberMergeSuggestionsRepository {
       }
     }
 
+    const upsertTable = async (
+      table: MemberMergeSuggestionTable,
+      placeholders: string[],
+      replacements: Record<string, unknown>,
+      onlyAboveThreshold: boolean,
+    ) => {
+      const thresholdFilter = onlyAboveThreshold
+        ? 'and v.similarity > $(similarityThreshold)'
+        : ''
+
+      // Update existing rows if they already exist
+      await this.connection.none(
+        `
+            update "${table}" t
+            set
+              similarity = v.similarity,
+              "activityEstimate" = v."activityEstimate",
+              "updatedAt" = now()
+            from (
+              values
+                ${placeholders.join(', ')}
+            ) as v("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
+            where
+              (
+                (t."memberId" = v."memberId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
+                or
+                (t."memberId" = v."toMergeId"::uuid and t."toMergeId" = v."memberId"::uuid)
+              )
+              ${thresholdFilter};
+        `,
+        replacements,
+      )
+
+      // Insert only new rows and enforce bidirectional uniqueness
+      await this.connection.none(
+        `
+            insert into "${table}"
+              ("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
+            select v.*
+            from (
+              values
+                ${placeholders.join(', ')}
+            ) as v("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
+            where not exists (
+              select 1
+              from "${table}" t
+              where
+                (t."memberId" = v."memberId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
+                or
+                (t."memberId" = v."toMergeId"::uuid and t."toMergeId" = v."memberId"::uuid)
+            )
+            ${thresholdFilter};
+        `,
+        replacements,
+      )
+    }
+
     for (const suggestionChunk of suggestionChunks) {
       const placeholders: string[] = []
-      let replacements: Record<string, unknown> = {}
+      let replacements: Record<string, unknown> = {
+        similarityThreshold,
+      }
 
       suggestionChunk.forEach((suggestion, index) => {
         const { query, replacements: chunkReplacements } = insertValues(
@@ -152,45 +211,37 @@ class MemberMergeSuggestionsRepository {
       })
 
       try {
-        // 1. Update existing rows if they already exist
-        await this.connection.none(
-          `
-            update "${table}" t
-            set 
-              similarity = v.similarity,
-              "activityEstimate" = v."activityEstimate",
-              "updatedAt" = now()
-            from (
-              values
-                ${placeholders.join(', ')}
-            ) as v("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
-            where 
-              (t."memberId" = v."memberId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
-              or
-              (t."memberId" = v."toMergeId"::uuid and t."toMergeId" = v."memberId"::uuid);
-        `,
+        // memberToMerge is the high-confidence slice of raw (score > similarityThreshold).
+        // A later run can score the same pair lower, so drop it from UI when it falls to or below the cutoff.
+        await upsertTable(
+          MemberMergeSuggestionTable.MEMBER_TO_MERGE_RAW,
+          placeholders,
           replacements,
+          false,
         )
 
-        // 2. Insert only new rows and enforce bidirectional uniqueness
+        await upsertTable(
+          MemberMergeSuggestionTable.MEMBER_TO_MERGE_FILTERED,
+          placeholders,
+          replacements,
+          true,
+        )
+
         await this.connection.none(
           `
-            insert into "${table}" 
-              ("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
-            select v.*
-            from (
+            delete from "memberToMerge" t
+            using (
               values
                 ${placeholders.join(', ')}
             ) as v("memberId", "toMergeId", "similarity", "activityEstimate", "createdAt", "updatedAt")
-            where not exists (
-              select 1
-              from "${table}" t
-              where 
+            where
+              (
                 (t."memberId" = v."memberId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
                 or
                 (t."memberId" = v."toMergeId"::uuid and t."toMergeId" = v."memberId"::uuid)
-            );
-        `,
+              )
+              and v.similarity <= $(similarityThreshold);
+          `,
           replacements,
         )
       } catch (error) {

--- a/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
@@ -82,7 +82,7 @@ class OrganizationMergeSuggestionsRepository {
 
   async addToMerge(
     suggestions: IOrganizationMergeSuggestion[],
-    table: OrganizationMergeSuggestionTable,
+    similarityThreshold = 0.75,
   ): Promise<void> {
     // Remove possible duplicates
     suggestions = removeDuplicateSuggestions<IOrganizationMergeSuggestion>(
@@ -99,9 +99,9 @@ class OrganizationMergeSuggestionsRepository {
       }, new Set<string>()),
     )
 
-    // filter non existing organization ids from suggestions
     const nonExistingIds = await this.findNonExistingIds(uniqueOrganizationIds)
 
+    // filter non existing organization ids from suggestions
     suggestions = suggestions.filter(
       (s) =>
         !nonExistingIds.includes(s.organizations[0]) &&
@@ -131,27 +131,21 @@ class OrganizationMergeSuggestionsRepository {
       }
     }
 
-    for (const suggestionChunk of suggestionChunks) {
-      const placeholders: string[] = []
-      let replacements: Record<string, unknown> = {}
+    const upsertTable = async (
+      table: OrganizationMergeSuggestionTable,
+      placeholders: string[],
+      replacements: Record<string, unknown>,
+      onlyAboveThreshold: boolean,
+    ) => {
+      const thresholdFilter = onlyAboveThreshold
+        ? 'and v.similarity > $(similarityThreshold)'
+        : ''
 
-      suggestionChunk.forEach((suggestion, index) => {
-        const { query, replacements: chunkReplacements } = insertValues(
-          suggestion.organizations[0],
-          suggestion.organizations[1],
-          suggestion.similarity,
-          index,
-        )
-        placeholders.push(query)
-        replacements = { ...replacements, ...chunkReplacements }
-      })
-
-      try {
-        // 1. Update existing rows if they already exist
-        await this.connection.none(
-          `
+      // Update existing rows if they already exist
+      await this.connection.none(
+        `
             update "${table}" t
-            set 
+            set
               similarity = v.similarity,
               "updatedAt" = now()
             from (
@@ -159,16 +153,19 @@ class OrganizationMergeSuggestionsRepository {
                 ${placeholders.join(', ')}
             ) as v("organizationId", "toMergeId", "similarity", "createdAt", "updatedAt")
             where
-              (t."organizationId" = v."organizationId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
-              or
-              (t."organizationId" = v."toMergeId"::uuid and t."toMergeId" = v."organizationId"::uuid);
+              (
+                (t."organizationId" = v."organizationId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
+                or
+                (t."organizationId" = v."toMergeId"::uuid and t."toMergeId" = v."organizationId"::uuid)
+              )
+              ${thresholdFilter};
           `,
-          replacements,
-        )
+        replacements,
+      )
 
-        // 2. insert only new rows and enforce bidirectional uniqueness
-        await this.connection.none(
-          `
+      // insert only new rows and enforce bidirectional uniqueness
+      await this.connection.none(
+        `
             insert into "${table}"
               ("organizationId", "toMergeId", "similarity", "createdAt", "updatedAt")
             select v.*
@@ -183,7 +180,61 @@ class OrganizationMergeSuggestionsRepository {
                 (t."organizationId" = v."organizationId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
                 or
                 (t."organizationId" = v."toMergeId"::uuid and t."toMergeId" = v."organizationId"::uuid)
-            );
+            )
+            ${thresholdFilter};
+          `,
+        replacements,
+      )
+    }
+
+    for (const suggestionChunk of suggestionChunks) {
+      const placeholders: string[] = []
+      let replacements: Record<string, unknown> = {
+        similarityThreshold,
+      }
+
+      suggestionChunk.forEach((suggestion, index) => {
+        const { query, replacements: chunkReplacements } = insertValues(
+          suggestion.organizations[0],
+          suggestion.organizations[1],
+          suggestion.similarity,
+          index,
+        )
+        placeholders.push(query)
+        replacements = { ...replacements, ...chunkReplacements }
+      })
+
+      try {
+        // organizationToMerge is the high-confidence slice of raw (score > similarityThreshold).
+        // A later run can score the same pair lower, so drop it from UI when it falls to or below the cutoff.
+        await upsertTable(
+          OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_RAW,
+          placeholders,
+          replacements,
+          false,
+        )
+
+        await upsertTable(
+          OrganizationMergeSuggestionTable.ORGANIZATION_TO_MERGE_FILTERED,
+          placeholders,
+          replacements,
+          true,
+        )
+
+        await this.connection.none(
+          `
+            delete from "organizationToMerge" t
+            using (
+              values
+                ${placeholders.join(', ')}
+            ) as v("organizationId", "toMergeId", "similarity", "createdAt", "updatedAt")
+            where
+              (
+                (t."organizationId" = v."organizationId"::uuid and t."toMergeId" = v."toMergeId"::uuid)
+                or
+                (t."organizationId" = v."toMergeId"::uuid and t."toMergeId" = v."organizationId"::uuid)
+              )
+              and v.similarity <= $(similarityThreshold);
           `,
           replacements,
         )

--- a/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
+++ b/services/libs/data-access-layer/src/old/apps/merge_suggestions_worker/organizationMergeSuggestions.repo.ts
@@ -137,9 +137,7 @@ class OrganizationMergeSuggestionsRepository {
       replacements: Record<string, unknown>,
       onlyAboveThreshold: boolean,
     ) => {
-      const thresholdFilter = onlyAboveThreshold
-        ? 'and v.similarity > $(similarityThreshold)'
-        : ''
+      const thresholdFilter = onlyAboveThreshold ? 'and v.similarity > $(similarityThreshold)' : ''
 
       // Update existing rows if they already exist
       await this.connection.none(


### PR DESCRIPTION
## Summary
- `memberToMerge` / `organizationToMerge` could keep an old high similarity after a later run scored the same pair lower in the raw tables, so the UI showed stale merge suggestions.
- `addToMerge` now writes raw and UI together: always upsert raw, upsert UI only above the similarity threshold, and delete the UI row when the new score is at or below the cutoff.

## Changes
- Member and org `addToMerge` take an optional `similarityThreshold` (default `0.75`) instead of a target table. Generate workflows still pass the threshold; enrichment uses the default.
- One write path replaces the previous dual `addToMerge` calls (all pairs to raw, then a filtered subset to UI).
- Enrichment org suggestions go through that same write path so a later rescore cannot leave a stale UI row.