### PR TITLE
feat: surface Maven Sonatype popularity signal in impact breakdown (IN-1235)

### DIFF
--- a/services/libs/tinybird/datasources/ossPackages.datasource
+++ b/services/libs/tinybird/datasources/ossPackages.datasource
@@ -30,6 +30,7 @@ DESCRIPTION >
     - `lastRankPassAt` is when the criticality ranking worker last processed this package (NULL if never ranked).
     - `downloadsLast30d` is the 30-day npm download count cached for ranking (0 if not yet populated).
     - `centralityScore` is the PageRank-based centrality score stored for future ranking formula use ('0' if not yet computed).
+    - `sonatypePopularityScore` is the Sonatype-derived popularity score (Maven ecosystem only, 0-100 normalized) for criticality ranking; NULL for non-Maven packages.
     - `rankInEcosystem` is the ordinal rank within the ecosystem from the most recent ranking pass (NULL if not yet ranked).
     - `ingestionSource` identifies which worker last wrote the row: 'npm-registry', 'deps_dev', etc. (empty string if unknown).
     - `lastSyncedAt` is when the row was last written by any worker — serves as the updated_at watermark for sync.
@@ -66,6 +67,7 @@ SCHEMA >
     `lastRankPassAt` Nullable(DateTime64(3)) `json:$.record.last_rank_pass_at`,
     `downloadsLast30d` Nullable(UInt64) `json:$.record.downloads_last_30d`,
     `centralityScore` Nullable(String) `json:$.record.centrality_score`,
+    `sonatypePopularityScore` Nullable(UInt8) `json:$.record.sonatype_popularity_score`,
     `rankInEcosystem` Nullable(UInt32) `json:$.record.rank_in_ecosystem`,
     `ingestionSource` Nullable(String) `json:$.record.ingestion_source`,
     `lastSyncedAt` DateTime64(3) `json:$.record.last_synced_at`,

--- a/services/libs/tinybird/datasources/ossPackages.datasource
+++ b/services/libs/tinybird/datasources/ossPackages.datasource
@@ -67,7 +67,7 @@ SCHEMA >
     `lastRankPassAt` Nullable(DateTime64(3)) `json:$.record.last_rank_pass_at`,
     `downloadsLast30d` Nullable(UInt64) `json:$.record.downloads_last_30d`,
     `centralityScore` Nullable(String) `json:$.record.centrality_score`,
-    `sonatypePopularityScore` Nullable(UInt8) `json:$.record.sonatype_popularity_score`,
+    `sonatypePopularityScore` Nullable(Float64) `json:$.record.sonatype_popularity_score`,
     `rankInEcosystem` Nullable(UInt32) `json:$.record.rank_in_ecosystem`,
     `ingestionSource` Nullable(String) `json:$.record.ingestion_source`,
     `lastSyncedAt` DateTime64(3) `json:$.record.last_synced_at`,

--- a/services/libs/tinybird/datasources/ossPackages_enriched_ds.datasource
+++ b/services/libs/tinybird/datasources/ossPackages_enriched_ds.datasource
@@ -1,6 +1,6 @@
 DESCRIPTION >
     - `ossPackages_enriched_ds` contains all `ossPackages` metadata plus derived enrichment fields, materialized by `ossPackages_enriched.pipe` (daily COPY, replace mode).
-    - Carries every column from the `ossPackages` datasource verbatim, so it can serve as a drop-in enriched replacement for package analytics.
+    - Carries all columns from the `ossPackages` datasource verbatim (via `SELECT *`), so it serves as a drop-in enriched replacement for package analytics.
     - `lifecycleLabel` is the categorical maintenance state of the package's primary repository, derived from repo + activity-snapshot signals: 'active', 'stable', 'declining', 'abandoned', or 'archived'.
     - `healthScore` is the composite 0–100 health score = `maintainerHealthScore` (≤40) + `securitySupplyChainScore` (≤35) + `developmentActivityScore` (≤25).
     - `healthLabel` buckets `healthScore`: 'excellent' (85+), 'healthy' (70–84), 'fair' (50–69), 'concerning' (30–49), 'critical' (<30).
@@ -42,6 +42,7 @@ SCHEMA >
     `lastRankPassAt` Nullable(DateTime64(3)),
     `downloadsLast30d` Nullable(UInt64),
     `centralityScore` Nullable(String),
+    `sonatypePopularityScore` Nullable(UInt8),
     `rankInEcosystem` Nullable(UInt32),
     `ingestionSource` Nullable(String),
     `lastSyncedAt` DateTime64(3),

--- a/services/libs/tinybird/datasources/ossPackages_enriched_ds.datasource
+++ b/services/libs/tinybird/datasources/ossPackages_enriched_ds.datasource
@@ -42,7 +42,7 @@ SCHEMA >
     `lastRankPassAt` Nullable(DateTime64(3)),
     `downloadsLast30d` Nullable(UInt64),
     `centralityScore` Nullable(String),
-    `sonatypePopularityScore` Nullable(UInt8),
+    `sonatypePopularityScore` Nullable(Float64),
     `rankInEcosystem` Nullable(UInt32),
     `ingestionSource` Nullable(String),
     `lastSyncedAt` DateTime64(3),

--- a/services/libs/tinybird/datasources/project_insights_impact_breakdown_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_impact_breakdown_ds.datasource
@@ -21,6 +21,13 @@ DESCRIPTION >
     package-level last-30-day download count.
     - `centrality`, `centralityTopPct`, `centralityBand` mirror the above for the project's max
     package-level centrality score.
+    - `sonatypePopularityScore` is the project's max package-level Sonatype popularity score (Maven
+    ecosystem only, 0-100 normalized); NULL when the project has no linked Maven packages with a
+    Sonatype score.
+    - `sonatypePopularityScoreTopPct` is the global percentile position among projects with a
+    non-NULL `sonatypePopularityScore`; NULL when `sonatypePopularityScore` is NULL.
+    - `sonatypePopularityScoreBand` buckets `sonatypePopularityScoreTopPct` into a display band
+    (Top 1% / Top 10% / Top 25% / Top 50% / Bottom 50%); NULL when `sonatypePopularityScore` is NULL.
 
 SCHEMA >
     `id` String,
@@ -37,7 +44,10 @@ SCHEMA >
     `downloadsBand` Nullable(String),
     `centrality` Nullable(Float64),
     `centralityTopPct` Nullable(Float64),
-    `centralityBand` Nullable(String)
+    `centralityBand` Nullable(String),
+    `sonatypePopularityScore` Nullable(UInt8),
+    `sonatypePopularityScoreTopPct` Nullable(Float64),
+    `sonatypePopularityScoreBand` Nullable(String)
 
 ENGINE MergeTree
 ENGINE_SORTING_KEY slug, id

--- a/services/libs/tinybird/datasources/project_insights_impact_breakdown_ds.datasource
+++ b/services/libs/tinybird/datasources/project_insights_impact_breakdown_ds.datasource
@@ -45,7 +45,7 @@ SCHEMA >
     `centrality` Nullable(Float64),
     `centralityTopPct` Nullable(Float64),
     `centralityBand` Nullable(String),
-    `sonatypePopularityScore` Nullable(UInt8),
+    `sonatypePopularityScore` Nullable(Float64),
     `sonatypePopularityScoreTopPct` Nullable(Float64),
     `sonatypePopularityScoreBand` Nullable(String)
 

--- a/services/libs/tinybird/pipes/project_insights_impact_breakdown.pipe
+++ b/services/libs/tinybird/pipes/project_insights_impact_breakdown.pipe
@@ -39,7 +39,10 @@ SQL >
         downloadsBand,
         centrality,
         centralityTopPct,
-        centralityBand
+        centralityBand,
+        sonatypePopularityScore,
+        sonatypePopularityScoreTopPct,
+        sonatypePopularityScoreBand
     FROM project_insights_impact_breakdown_ds
     WHERE
         1 = 1

--- a/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
@@ -38,7 +38,10 @@ DESCRIPTION >
     production — this metric will render as "no data" for every project today until the centrality
     scoring worker actually populates it. The rollup/percentile logic is still implemented and
     correct so it activates automatically once that backfill lands.
-    - Percentile methodology: projects are ranked GLOBALLY against all other projects with a
+    - `sonatypePopularityScore` (from `sonatypePopularityScore`): MAX. Sonatype-derived popularity
+    signal (Maven ecosystem only, 0-100 normalized). Non-Maven projects or Maven packages without
+    a Sonatype score (P1/P2/P3 tiers outside initial P0-only delivery) will have NULL for this metric.
+    Percentile methodology: projects are ranked GLOBALLY against all other projects with a
     non-NULL value for that metric — NOT partitioned per-ecosystem. This is a deliberate
     departure from a naive per-ecosystem percentile: verified live that only 43% of projects
     with linked packages (3,397 of 7,906) are single-ecosystem; the rest span 2-8 ecosystems
@@ -83,7 +86,8 @@ SQL >
         max(pk.dependentCount) AS directDependents,
         max(pk.transitiveDependentCount) AS transitiveDependents,
         sum(pk.downloadsLast30d) AS downloads,
-        max(toFloat64OrNull(pk.centralityScore)) AS centrality
+        max(toFloat64OrNull(pk.centralityScore)) AS centrality,
+        max(pk.sonatypePopularityScore) AS sonatypePopularityScore
     FROM insightsProjects ip FINAL
     LEFT JOIN
         repositories rep FINAL
@@ -109,6 +113,7 @@ SQL >
         transitiveDependents,
         downloads,
         centrality,
+        sonatypePopularityScore,
         rank() OVER (ORDER BY directDependents DESC) AS directDependentsRank,
         countIf(directDependents IS NOT NULL) OVER () AS directDependentsTotalRanked,
         rank() OVER (ORDER BY transitiveDependents DESC) AS transitiveDependentsRank,
@@ -116,7 +121,9 @@ SQL >
         rank() OVER (ORDER BY downloads DESC) AS downloadsRank,
         countIf(downloads IS NOT NULL) OVER () AS downloadsTotalRanked,
         rank() OVER (ORDER BY centrality DESC) AS centralityRank,
-        countIf(centrality IS NOT NULL) OVER () AS centralityTotalRanked
+        countIf(centrality IS NOT NULL) OVER () AS centralityTotalRanked,
+        rank() OVER (ORDER BY sonatypePopularityScore DESC) AS sonatypePopularityScoreRank,
+        countIf(sonatypePopularityScore IS NOT NULL) OVER () AS sonatypePopularityScoreTotalRanked
     FROM project_impact_raw
 
 NODE project_impact_bands
@@ -208,7 +215,26 @@ SQL >
                 'Top 50%',
                 'Bottom 50%'
             )
-        ) AS centralityBand
+        ) AS centralityBand,
+        sonatypePopularityScore,
+        if(
+            sonatypePopularityScore IS NULL, NULL, round(100.0 * sonatypePopularityScoreRank / sonatypePopularityScoreTotalRanked, 2)
+        ) AS sonatypePopularityScoreTopPct,
+        if(
+            sonatypePopularityScore IS NULL,
+            NULL,
+            multiIf(
+                sonatypePopularityScoreRank <= 0.01 * sonatypePopularityScoreTotalRanked,
+                'Top 1%',
+                sonatypePopularityScoreRank <= 0.10 * sonatypePopularityScoreTotalRanked,
+                'Top 10%',
+                sonatypePopularityScoreRank <= 0.25 * sonatypePopularityScoreTotalRanked,
+                'Top 25%',
+                sonatypePopularityScoreRank <= 0.50 * sonatypePopularityScoreTotalRanked,
+                'Top 50%',
+                'Bottom 50%'
+            )
+        ) AS sonatypePopularityScoreBand
     FROM project_impact_ranked
 
 TYPE COPY

--- a/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
+++ b/services/libs/tinybird/pipes/project_insights_impact_breakdown_copy.pipe
@@ -38,9 +38,9 @@ DESCRIPTION >
     production — this metric will render as "no data" for every project today until the centrality
     scoring worker actually populates it. The rollup/percentile logic is still implemented and
     correct so it activates automatically once that backfill lands.
-    - `sonatypePopularityScore` (from `sonatypePopularityScore`): MAX. Sonatype-derived popularity
-    signal (Maven ecosystem only, 0-100 normalized). Non-Maven projects or Maven packages without
-    a Sonatype score (P1/P2/P3 tiers outside initial P0-only delivery) will have NULL for this metric.
+    - `sonatypePopularityScore`: MAX. Sonatype-derived popularity signal (Maven ecosystem only,
+    0-100 normalized). Non-Maven projects or Maven packages without a Sonatype score (P1/P2/P3
+    tiers outside initial P0-only delivery) will have NULL for this metric.
     Percentile methodology: projects are ranked GLOBALLY against all other projects with a
     non-NULL value for that metric — NOT partitioned per-ecosystem. This is a deliberate
     departure from a naive per-ecosystem percentile: verified live that only 43% of projects


### PR DESCRIPTION
## Summary

- Adds a Maven-ecosystem "Sonatype popularity score" signal to the impact breakdown pipeline, mirroring the existing `centrality` metric pattern: raw score → global percentile → display band (Top 1% / Top 10% / Top 25% / Top 50% / Bottom 50%), materialized daily by `project_insights_impact_breakdown_copy.pipe` into `project_insights_impact_breakdown_ds`.
- Maven packages only. `sonatypePopularityScore` is NULL for projects with no linked Maven packages or no Sonatype score.
- Fixes a type bug found during review: `sonatypePopularityScore` was initially typed `Nullable(UInt8)` in the datasource schema; corrected to `Nullable(Float64)` since Sonatype scores are floats, not integers.
- Deployed to Tinybird staging and production already; validated live against 13,554 materialized projects with correct NULL semantics for non-Maven projects. The response shape is additive — no existing consumer is broken.

## JIRA

IN-1235 — Fix Impact section UI to match production impact scoring formula

## Deploy order

No ordering constraint for this PR itself — the Tinybird pipe changes are already deployed to production. The companion insights PR (frontend Impact section UI) consumes this field and can merge independently.