### PR TITLE
fix: distinguish never-scanned repos from real 0.0 OpenSSF Scorecard score (IN-1237)

### DIFF
--- a/services/libs/tinybird/pipes/health_score_v2_security.pipe
+++ b/services/libs/tinybird/pipes/health_score_v2_security.pipe
@@ -91,7 +91,7 @@ SQL >
                         toUInt8(
                             round(least(toFloat64OrZero(rd.scorecardScore), 10) * 0.7)
                         ) AS scorecardScorePts,
-                        (rd.url != '') AS scorecardAvailable,
+                        (rd.scorecardLastRunAt IS NOT NULL) AS scorecardAvailable,
                         rd.scorecardScore AS scorecardScore,
                         toUInt8(
                             2 * coalesce(rd.securityPolicyEnabled, 0)
@@ -128,6 +128,7 @@ SQL >
                             SELECT
                                 url,
                                 argMax(scorecardScore, updatedAt) AS scorecardScore,
+                                argMax(scorecardLastRunAt, updatedAt) AS scorecardLastRunAt,
                                 argMax(securityPolicyEnabled, updatedAt) AS securityPolicyEnabled,
                                 argMax(branchProtectionEnabled, updatedAt) AS branchProtectionEnabled,
                                 argMax(


### PR DESCRIPTION
## Summary
- The `health_score_v2_security` Tinybird pipe computed `scorecardAvailable` from whether a `repos` table row existed (`rd.url != ''`), not whether the OpenSSF Scorecard had actually run. Since every linked package gets a `repos` row during deps.dev seeding regardless of scan status, unscanned repos got `scorecardAvailable=true` with `scorecardScore` defaulting to `'0'`, and the Insights frontend displayed "0.0/10" — indistinguishable from a repo that was genuinely scanned and scored 0.0.
- Fix: derive `scorecardAvailable` from `rd.scorecardLastRunAt IS NOT NULL` instead, and expose `scorecardLastRunAt` through the `rd` aggregation subquery so it's in scope.
- No frontend changes needed — `getScorecardRow()` in `insights/frontend/config/health-breakdown-templates.ts` already renders a `no-data` state when `scorecardAvailable` is false; it was only ever wrong because the upstream signal was wrong.
- No changes needed to the security-category weighting either — `coveredWeight`/`rawScore` already exclude `scorecardAvailable=false` repos from the aggregate, so Health Score v2 will stop penalizing unscanned repos as failing 0s once this pipe is deployed.

Jira: IN-1237

## Deploy notes
Tinybird pipe change only — deploy `health_score_v2_security.pipe` to staging then production. No Insights redeploy required; it reads the pipe live.

## Test plan
- [ ] Deploy pipe, wait for next scheduled copy run (`COPY_SCHEDULE 5 2 * * *`)
- [ ] Query `health_score_v2_security_ds` for a repo known to have never been Scorecard-scanned — confirm `scorecardAvailable=false`
- [ ] Query for a repo with a genuine 0.0 Scorecard score — confirm `scorecardAvailable=true`, `scorecardScore='0'`
- [ ] In Insights, visit that project's health breakdown page — unscanned repo's Scorecard row shows "not available", genuinely-scored-0.0 repo still shows "0.0/10"