### PR TITLE
fix: add missing health score v2 category columns to project_repo_insights pipe

### DIFF
--- a/services/libs/tinybird/pipes/project_repo_insights.pipe
+++ b/services/libs/tinybird/pipes/project_repo_insights.pipe
@@ -12,6 +12,7 @@ DESCRIPTION >
     - `page`: Optional integer for pagination offset calculation, defaults to 0
     - Response: Project and repository records with insights metrics
     - `healthScoreV2`, `healthLabel`, `lifecycleLabel`, `impactScore`, `impactLabel` are the Akrites-methodology fields (see `project_insights_copy_ds` for band definitions); may be null when the record has no linked package data. `healthScoreV2` is distinct from the legacy `healthScore` field.
+    - `maintainerHealthScoreV2` (0-40), `securitySupplyChainScoreV2` (0-35), `developmentActivityScoreV2` (0-25) are the rollup of the Health Score v2 category breakdown (IN-1212) — the three categories that sum to `healthScoreV2`. Null when the record has no value for that category.
 
 TAGS "Insights, Widget", "Project", "Repository"
 
@@ -53,7 +54,10 @@ SQL >
         healthLabel,
         lifecycleLabel,
         impactScore,
-        impactLabel
+        impactLabel,
+        maintainerHealthScoreV2,
+        securitySupplyChainScoreV2,
+        developmentActivityScoreV2
     FROM project_insights_copy_ds
     WHERE
         1 = 1


### PR DESCRIPTION
## Summary
- `project_repo_insights.pipe` (backs Insights' collection detail page project/repo list) was missing `maintainerHealthScoreV2`, `securitySupplyChainScoreV2`, and `developmentActivityScoreV2` in its SELECT list, even though the sibling `project_insights.pipe` already exposed them.
- This caused the collection page's Health Score tooltip category breakdown to show placeholder dashes instead of real values (see [insights#2114](https://github.com/linuxfoundation/insights/pull/2114)).

JIRA: IN-1239

## Deploy status
Already validated and deployed to staging and production via `tb push`.

## Test plan
- [x] Verified via `curl` against the collection project-repos endpoint that the 3 columns now return real values (e.g. PixiJS: 37/12/22)
- [x] Verified live in browser — collection detail page tooltip shows real numbers