### PR TITLE
fix: fall back to identity when unmerging without displayName

### DIFF
--- a/backend/src/api/public/v1/members/createMember.ts
+++ b/backend/src/api/public/v1/members/createMember.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import { z } from 'zod'
 
 import { captureApiChange, memberCreateAction, memberEditIdentitiesAction } from '@crowd/audit-logs'
-import { ConflictError, getProperDisplayName } from '@crowd/common'
+import { ConflictError, normalizeDisplayName } from '@crowd/common'
 import {
   findMemberIdByVerifiedIdentity,
   findMembersByIdentities,
@@ -41,7 +41,7 @@ export async function createMember(req: Request, res: Response): Promise<void> {
   const { displayName, identities } = validateOrThrow(bodySchema, req.body)
   const qx = optionsQx(req)
 
-  const normalizedDisplayName = getProperDisplayName(displayName)
+  const normalizedDisplayName = normalizeDisplayName(displayName)
 
   const { dbMember, dbIdentities } = await qx.tx(async (tx) => {
     // Unverified identities aren't unique in the db, so the same handle or

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -9,9 +9,9 @@ import {
   calculateReach,
   getAttributeValue,
   getCountry,
-  normalizeDisplayName,
   hasAttributeValue,
   isDomainExcluded,
+  normalizeDisplayName,
 } from '@crowd/common'
 import {
   CommonMemberService,

--- a/backend/src/services/memberService.ts
+++ b/backend/src/services/memberService.ts
@@ -9,7 +9,7 @@ import {
   calculateReach,
   getAttributeValue,
   getCountry,
-  getProperDisplayName,
+  normalizeDisplayName,
   hasAttributeValue,
   isDomainExcluded,
 } from '@crowd/common'
@@ -279,7 +279,7 @@ export default class MemberService extends LoggerBase {
     }
 
     if (!data.displayName) {
-      data.displayName = getProperDisplayName(data.username[data.platform][0].username)
+      data.displayName = normalizeDisplayName(data.username[data.platform][0].username)
     }
 
     if (!(data.platform in data.username)) {
@@ -815,7 +815,7 @@ export default class MemberService extends LoggerBase {
       transaction = repoOptions.transaction
 
       if (data.displayName) {
-        data.displayName = getProperDisplayName(data.displayName)
+        data.displayName = normalizeDisplayName(data.displayName)
       }
 
       if (data.attributes) {

--- a/services/apps/data_sink_worker/src/bin/fix-member-displayName.ts
+++ b/services/apps/data_sink_worker/src/bin/fix-member-displayName.ts
@@ -1,4 +1,4 @@
-import { getProperDisplayName } from '@crowd/common'
+import { normalizeDisplayName } from '@crowd/common'
 import { SearchSyncWorkerEmitter } from '@crowd/common_services'
 import { getDbConnection } from '@crowd/data-access-layer/src/database'
 import {
@@ -41,7 +41,7 @@ setImmediate(async () => {
     fixableMembers = result.rows
 
     for (const member of fixableMembers) {
-      const displayName = getProperDisplayName(member.displayName)
+      const displayName = normalizeDisplayName(member.displayName)
       await updateMemberDisplayName(dbClient, member.id, displayName)
 
       searchSyncWorkerEmitter.triggerMemberSync(member.id, false)

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -8,11 +8,11 @@ import {
   getAttributeValue,
   getCountry,
   getEarliestValidDate,
-  normalizeDisplayName,
   hasAttributeValue,
   isDomainExcluded,
   isObjectEmpty,
   isSameMemberIdentity,
+  normalizeDisplayName,
   normalizeMemberIdentities,
   singleOrDefault,
 } from '@crowd/common'

--- a/services/apps/data_sink_worker/src/service/member.service.ts
+++ b/services/apps/data_sink_worker/src/service/member.service.ts
@@ -8,7 +8,7 @@ import {
   getAttributeValue,
   getCountry,
   getEarliestValidDate,
-  getProperDisplayName,
+  normalizeDisplayName,
   hasAttributeValue,
   isDomainExcluded,
   isObjectEmpty,
@@ -370,7 +370,7 @@ export default class MemberService extends LoggerBase {
             dropInvalidEmails: true,
           })
 
-          data.displayName = getProperDisplayName(data.displayName)
+          data.displayName = normalizeDisplayName(data.displayName)
 
           // detect if the member is a bot
           const botDetection = this.botDetectionService.isMemberBot(
@@ -613,7 +613,7 @@ export default class MemberService extends LoggerBase {
 
           // make sure displayName is proper
           if (data.displayName) {
-            data.displayName = getProperDisplayName(data.displayName)
+            data.displayName = normalizeDisplayName(data.displayName)
           }
 
           const toUpdate = this.mergeData(original, originalIdentities, data)

--- a/services/libs/common/src/displayName.ts
+++ b/services/libs/common/src/displayName.ts
@@ -22,9 +22,7 @@ export function normalizeDisplayName(name: string): string {
     return nameParts[0]
   }
 
-  const filteredNameParts = nameParts.filter(
-    (part) => !isValidEmail(part) && !isPartialEmail(part),
-  )
+  const filteredNameParts = nameParts.filter((part) => !isValidEmail(part) && !isPartialEmail(part))
 
   if (filteredNameParts.length > 0) {
     return filteredNameParts.join(' ')

--- a/services/libs/common/src/displayName.ts
+++ b/services/libs/common/src/displayName.ts
@@ -1,4 +1,5 @@
-import { isEmail, isPartialEmail } from './validations'
+import { isValidEmail } from './email'
+import { isPartialEmail } from './validations'
 
 /**
  * Strip email tokens from a name. If the whole string is an email, use the local part.
@@ -15,14 +16,15 @@ export function normalizeDisplayName(name: string): string {
   }
 
   if (nameParts.length === 1) {
-    if (isEmail(nameParts[0]) || isPartialEmail(nameParts[0])) {
+    if (isValidEmail(nameParts[0]) || isPartialEmail(nameParts[0])) {
       return nameParts[0].split('@')[0]
     }
     return nameParts[0]
   }
 
-  // parts that are not emails
-  const filteredNameParts = nameParts.filter((part) => !isEmail(part) && !isPartialEmail(part))
+  const filteredNameParts = nameParts.filter(
+    (part) => !isValidEmail(part) && !isPartialEmail(part),
+  )
 
   if (filteredNameParts.length > 0) {
     return filteredNameParts.join(' ')

--- a/services/libs/common/src/displayName.ts
+++ b/services/libs/common/src/displayName.ts
@@ -5,28 +5,53 @@ import { isPartialEmail } from './validations'
  * Strip email tokens from a name. If the whole string is an email, use the local part.
  */
 export function normalizeDisplayName(name: string): string {
-  const nameParts = name.trim().split(/\s+/)
+  const tokens = name
+    .trim()
+    .split(/\s+/)
+    .map(cleanNamePart)
+    .filter((token) => token.length > 0)
 
-  if (nameParts.length === 1 && !nameParts[0]) {
+  if (tokens.length === 0) {
     throw new Error('Display name cannot be empty')
   }
 
-  if (nameParts.length === 0) {
-    throw new Error('Display name cannot be empty')
+  const withoutEmails = tokens.filter((token) => !isValidEmail(token) && !isPartialEmail(token))
+  if (withoutEmails.length > 0) {
+    return withoutEmails.join(' ')
   }
 
-  if (nameParts.length === 1) {
-    if (isValidEmail(nameParts[0]) || isPartialEmail(nameParts[0])) {
-      return nameParts[0].split('@')[0]
+  return tokens[0].split('@')[0]
+}
+
+function cleanNamePart(part: string): string {
+  let token = part
+
+  if (token.endsWith(',') || token.endsWith(';')) {
+    token = token.slice(0, -1)
+  }
+
+  while (token.length >= 2) {
+    const open = token[0]
+    const close = token[token.length - 1]
+    const isWrapped =
+      (open === '<' && close === '>') ||
+      (open === '(' && close === ')') ||
+      (open === '"' && close === '"') ||
+      (open === "'" && close === "'")
+
+    if (!isWrapped) {
+      break
     }
-    return nameParts[0]
+
+    token = token.slice(1, -1)
   }
 
-  const filteredNameParts = nameParts.filter((part) => !isValidEmail(part) && !isPartialEmail(part))
-
-  if (filteredNameParts.length > 0) {
-    return filteredNameParts.join(' ')
+  while (token.startsWith('@')) {
+    token = token.slice(1)
+  }
+  while (token.endsWith('@')) {
+    token = token.slice(0, -1)
   }
 
-  return nameParts[0].split('@')[0]
+  return token
 }

--- a/services/libs/common/src/displayName.ts
+++ b/services/libs/common/src/displayName.ts
@@ -1,31 +1,9 @@
 import { isEmail, isPartialEmail } from './validations'
 
 /**
- * Get a proper display name from a given name string.
- *
- * If there are multiple name parts and one or multiple of them (but not all) look like email,
- * those parts are removed and the remaining parts are concatenated and returned.
- *
- * If there is one name part and it looks like an email, the part before '@' is returned.
- *
- * If there are multiple name parts and all of them look like emails, the first part before '@' is returned.
- *
- * @param {string} name - The input name string.
- * @returns {string} - The proper display name.
- *
- * @example
- * getProperDisplayName('John Doe') // returns 'John Doe'
- * getProperDisplayName('john.doe@example.com') // returns 'john.doe'
- * getProperDisplayName('John john.doe@example.com Doe') // returns 'John Doe'
- * getProperDisplayName('john.doe@example.com jane.doe@example.com') // returns 'john.doe'
- * getProperDisplayName('john@gmail.com') // returns 'john'
- * getProperDisplayName('john@gmail') // returns 'john'
- * getProperDisplayName('john@gmail.') // returns 'john'
- * getProperDisplayName('john@g') // returns 'john'
- * getProperDisplayName('@johndoe') // returns '@johndoe'
- * getProperDisplayName('johndoe@') // returns 'johndoe@'
+ * Strip email tokens from a name. If the whole string is an email, use the local part.
  */
-export function getProperDisplayName(name: string): string {
+export function normalizeDisplayName(name: string): string {
   const nameParts = name.trim().split(/\s+/)
 
   if (nameParts.length === 1 && !nameParts[0]) {

--- a/services/libs/common/src/validations.ts
+++ b/services/libs/common/src/validations.ts
@@ -10,22 +10,40 @@ const URL_REGEXP = new RegExp(
   'i',
 )
 
-const EMAIL_REGEXP = new RegExp(
-  "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
+const PARTIAL_EMAIL_LOCAL = new Set(
+  "abcdefghijklmnopqrstuvwxyz0123456789!#$%&'*+/=?^_`{|}~-",
 )
-
-const PARTIAL_EMAIL_REGEXP = new RegExp("^[a-z0-9!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+\\.?$")
+const PARTIAL_EMAIL_HOST = new Set('abcdefghijklmnopqrstuvwxyz0123456789-')
 
 export const isUrl = (value: string): boolean => {
   return URL_REGEXP.test(value)
 }
 
-export const isEmail = (value: string): boolean => {
-  return EMAIL_REGEXP.test(value)
+export const isPartialEmail = (value: string): boolean => {
+  const at = value.indexOf('@')
+  if (at <= 0 || at !== value.lastIndexOf('@')) {
+    return false
+  }
+
+  const local = value.slice(0, at)
+  let host = value.slice(at + 1)
+  if (host.endsWith('.')) {
+    host = host.slice(0, -1)
+  }
+  if (!local || !host) {
+    return false
+  }
+
+  return everyCharIn(local, PARTIAL_EMAIL_LOCAL) && everyCharIn(host, PARTIAL_EMAIL_HOST)
 }
 
-export const isPartialEmail = (value: string): boolean => {
-  return PARTIAL_EMAIL_REGEXP.test(value)
+function everyCharIn(value: string, allowed: Set<string>): boolean {
+  for (const char of value) {
+    if (!allowed.has(char)) {
+      return false
+    }
+  }
+  return true
 }
 
 /**

--- a/services/libs/common/src/validations.ts
+++ b/services/libs/common/src/validations.ts
@@ -24,15 +24,14 @@ export const isPartialEmail = (value: string): boolean => {
   }
 
   const local = value.slice(0, at)
-  let host = value.slice(at + 1)
-  if (host.endsWith('.')) {
-    host = host.slice(0, -1)
-  }
-  if (!local || !host) {
-    return false
-  }
+  const host = value.endsWith('.') ? value.slice(at + 1, -1) : value.slice(at + 1)
 
-  return everyCharIn(local, PARTIAL_EMAIL_LOCAL) && everyCharIn(host, PARTIAL_EMAIL_HOST)
+  return (
+    local.length > 0 &&
+    host.length > 0 &&
+    everyCharIn(local, PARTIAL_EMAIL_LOCAL) &&
+    everyCharIn(host, PARTIAL_EMAIL_HOST)
+  )
 }
 
 function everyCharIn(value: string, allowed: Set<string>): boolean {

--- a/services/libs/common/src/validations.ts
+++ b/services/libs/common/src/validations.ts
@@ -10,9 +10,7 @@ const URL_REGEXP = new RegExp(
   'i',
 )
 
-const PARTIAL_EMAIL_LOCAL = new Set(
-  "abcdefghijklmnopqrstuvwxyz0123456789!#$%&'*+/=?^_`{|}~-",
-)
+const PARTIAL_EMAIL_LOCAL = new Set("abcdefghijklmnopqrstuvwxyz0123456789!#$%&'*+/=?^_`{|}~-")
 const PARTIAL_EMAIL_HOST = new Set('abcdefghijklmnopqrstuvwxyz0123456789-')
 
 export const isUrl = (value: string): boolean => {

--- a/services/libs/common_services/src/services/member/unmerge.ts
+++ b/services/libs/common_services/src/services/member/unmerge.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import pick from 'lodash.pick'
 import uniqBy from 'lodash.uniqby'
 
-import { BadRequestError, DEFAULT_TENANT_ID, getProperDisplayName } from '@crowd/common'
+import { BadRequestError, DEFAULT_TENANT_ID, normalizeDisplayName } from '@crowd/common'
 import {
   MEMBER_MERGE_FIELDS,
   MemberField,
@@ -347,7 +347,7 @@ export async function prepareMemberUnmerge(
     throw new BadRequestError('Cannot unmerge: primary member must retain at least one identity')
   }
 
-  const secondaryDisplayName = getProperDisplayName(identity.value)
+  const secondaryDisplayName = normalizeDisplayName(identity.value)
   const secondaryAttributes: IAttributes = {}
 
   const botDetection = new BotDetectionService(logger).isMemberBot(
@@ -476,10 +476,15 @@ export async function unmergeMember(
   // Track roles deleted from primary (for filtering primary orgs)
   let rolesToDelete: IMemberRoleWithOrganization[] = []
 
-  // Create the secondary member
+  const displayName = secondary.displayName || secondary.identities[0]?.value
+
+  if (!displayName) {
+    throw new Error('Cannot unmerge: secondary member is missing a display name')
+  }
+
   const secondaryRow = await createMember(tx, {
     id: secondary.id,
-    displayName: secondary.displayName,
+    displayName: normalizeDisplayName(displayName),
     joinedAt: secondary.joinedAt,
     attributes: secondary.attributes,
     reach: secondary.reach,

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -7,7 +7,7 @@ import {
   TimeoutError,
   generateUUIDv1,
   generateUUIDv4,
-  getProperDisplayName,
+  normalizeDisplayName,
   groupBy,
 } from '@crowd/common'
 import { formatSql, getDbInstance, prepareForModification } from '@crowd/database'
@@ -763,7 +763,7 @@ export async function updateMember(
   }
 
   if (typeof dbData.displayName === 'string' && dbData.displayName) {
-    dbData.displayName = getProperDisplayName(dbData.displayName)
+    dbData.displayName = normalizeDisplayName(dbData.displayName)
   }
 
   if (Array.isArray(dbData.contributions)) {

--- a/services/libs/data-access-layer/src/members/base.ts
+++ b/services/libs/data-access-layer/src/members/base.ts
@@ -7,8 +7,8 @@ import {
   TimeoutError,
   generateUUIDv1,
   generateUUIDv4,
-  normalizeDisplayName,
   groupBy,
+  normalizeDisplayName,
 } from '@crowd/common'
 import { formatSql, getDbInstance, prepareForModification } from '@crowd/database'
 import { getServiceLogger } from '@crowd/logging'

--- a/services/libs/types/src/merging.ts
+++ b/services/libs/types/src/merging.ts
@@ -48,7 +48,7 @@ export interface IMemberUnmergeBackup {
   username: IMemberUsername
   attributes: IAttributes
   identities: IMemberIdentity[]
-  displayName: string
+  displayName?: string
   affiliations: IMemberAffiliationMergeBackup[]
   manuallyCreated: boolean
   manuallyChangedFields: string[]
@@ -62,7 +62,7 @@ export interface IMemberUnmergePreviewResult {
   joinedAt: string
   username: IMemberUsername
   attributes: IAttributes
-  displayName: string
+  displayName?: string | null
   affiliations: IMemberAffiliationMergeBackup[]
   contributions: IMemberContribution[]
   manuallyCreated: boolean


### PR DESCRIPTION
## Summary
Unmerge was inserting a secondary member without `displayName` when the merge backup omitted it, which hit a NOT NULL constraint on `members` and 500'd the API (and looped `dissectMember`).

## Changes
- Fall back to the first identity value when the secondary has no `displayName`, then run `normalizeDisplayName`
- Throw if neither is present, instead of letting Postgres fail
- Rename `getProperDisplayName` to `normalizeDisplayName` and shorten its JSDoc