### PR TITLE
fix: skip non-ASCII emails in Crustdata enrichment

### DIFF
--- a/services/apps/members_enrichment_worker/src/sources/crustdata/service.ts
+++ b/services/apps/members_enrichment_worker/src/sources/crustdata/service.ts
@@ -196,7 +196,12 @@ export default class EnrichmentServiceCrustdata extends LoggerBase implements IE
       }
 
       const email = identity.value?.trim().toLowerCase()
-      if (!email || !identity.verified || seen.has(email) || !isValidEmail(email)) {
+      if (
+        !email ||
+        !identity.verified ||
+        seen.has(email) ||
+        !isValidEmail(email, { allow_utf8_local_part: false })
+      ) {
         continue
       }
 

--- a/services/libs/common/src/email.ts
+++ b/services/libs/common/src/email.ts
@@ -2,9 +2,8 @@ import validator from 'validator'
 
 import { disposableEmailDomains, emailSafeKnownBots, noreplyEmailProviders } from './constants'
 
-export const isValidEmail = (value: string): boolean => {
-  return validator.isEmail(value)
-}
+export const isValidEmail: typeof validator.isEmail = (value, options) =>
+  validator.isEmail(value, options)
 
 /**
  * Extracts username from a GitHub noreply email.


### PR DESCRIPTION
## Summary
Crustdata returns HTTP 400 for work emails with non-ASCII local parts, which fail-fasts `enrichMember` and takes down the hourly batch. Skip those emails at the Crustdata adapter so only identifiers the vendor accepts are sent.

## Changes
- `isValidEmail` forwards `validator.isEmail` options so callers can opt in
- Crustdata `getWorkEmails` passes `{ allow_utf8_local_part: false }`; other callers keep the default

## Deployment
Deploy when no member enrichment workflows are running.