### PR TITLE
fix: comment scoring poc from discovery (CM-1138)

### DIFF
--- a/services/apps/automatic_projects_discovery_worker/src/sources/registry.ts
+++ b/services/apps/automatic_projects_discovery_worker/src/sources/registry.ts
@@ -1,9 +1,10 @@
 import { InsightsDiscussionsSource } from './insights-discussions/source'
-import { LfCriticalityScoreSource } from './lf-criticality-score/source'
+// import { LfCriticalityScoreSource } from './lf-criticality-score/source'
 import { IDiscoverySource } from './types'
 
+// lf-criticality-score disabled locally: no production deployment yet, will be reintegrated later
 const sources: IDiscoverySource[] = [
-  new LfCriticalityScoreSource(),
+  // new LfCriticalityScoreSource(),
   new InsightsDiscussionsSource(),
 ]
 


### PR DESCRIPTION
## Summary
temporarily remove the score poc api from automatic discovery 

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Performance improvement
- [ ] Chore / dependency update
- [ ] Documentation

## JIRA ticket
[CM-1138](https://linuxfoundation.atlassian.net/browse/CM-1138)

[CM-1138]: https://linuxfoundation.atlassian.net/browse/CM-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ