### PR TITLE
docs: add docker builder and runner image adr (CM-1387)

### DIFF
--- a/docs/adr/0019-docker-builder-runner-libc.md
+++ b/docs/adr/0019-docker-builder-runner-libc.md
@@ -1,4 +1,4 @@
-# ADR-0019: Align Docker build and runtime images; use Debian for Temporal workers
+# ADR-0019: Match builder and runner libc; Debian for Temporal TypeScript workers
 
 **Date**: 2026-08-27
 **Status**: accepted
@@ -6,84 +6,110 @@
 
 ## Context
 
-Our Node.js services use multi-stage Docker builds. Dependencies are installed in a builder stage, then `node_modules` is copied into the final runner image.
+Our Node.js services use multi-stage Docker builds. Dependencies are installed in the builder stage and `node_modules` is copied into the runner stage.
 
-Some dependencies include native binaries compiled for a specific operating system, CPU architecture, and C standard library. Alpine uses musl, while Debian uses glibc. Copying native dependencies between these environments can produce an image that builds successfully but fails when the application starts.
+Some Node.js dependencies contain native binaries (`.node` files). These binaries are built against a specific libc:
 
-The pnpm 11 upgrade exposed this existing mismatch. pnpm installs platform-specific optional dependencies for the environment where installation runs. Dependencies installed in an Alpine builder therefore cannot be assumed to work in a Debian runner, or the other way around. The package manager change exposed the problem; it did not create the underlying incompatibility.
+* `node:<major>-alpine` uses **musl**
+* `node:<major>-bookworm-slim` uses **glibc**
 
-Temporal TypeScript workers have an additional constraint: `@temporalio/core-bridge` requires glibc. Temporal explicitly does not support running TypeScript workers on Alpine.
+Because the runner uses the `node_modules` produced by the builder, both stages must use the same libc. Mixing Alpine and Debian can result in native modules failing at runtime — the image builds, then the process dies on boot (`Bindings not found`, missing `ld-linux-x86-64.so.2`, and similar).
+
+This became apparent after upgrading to pnpm 11. Older pnpm often installed optional natives for more than one libc, so a mixed Alpine builder and Debian runner could still start. pnpm 11 only installs natives for the OS it is running on, so the mismatch is no longer hidden. The upgrade exposed an existing Docker issue; it did not create the libc incompatibility.
+
+Temporal TypeScript workers have an additional requirement. `@temporalio/core-bridge` ships a glibc Linux binary only. Temporal does not support Alpine / musl for TypeScript workers.
 
 ## Decision
 
-Builder and runner stages must use the same Node.js base image family and operating system.
+**Builder and runner must always use the same Node.js image family.**
 
-- Temporal TypeScript workers use `node:<major>-bookworm-slim` for both stages.
-- Services whose dependencies support musl may use `node:<major>-alpine` for both stages.
-- Services with another glibc-only native dependency use Debian for both stages.
-- Alpine and Debian must not be mixed when `node_modules` is copied between stages.
+* **Temporal TypeScript workers:** use `node:<major>-bookworm-slim` for both builder and runner.
+* **Other services:** Alpine is fine if all dependencies support musl. Use Alpine for both builder and runner.
+* **Any other glibc-only native dependency:** use Debian for both stages.
 
-For example:
+Never mix Alpine and Debian between builder and runner.
+
+For Temporal workers, the Dockerfile should follow this pattern:
 
 ```dockerfile
 FROM node:24-bookworm-slim AS builder
-# Install dependencies
+
+RUN apt-get update \
+    && apt-get install -y python3 make g++ --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# install dependencies
 
 FROM node:24-bookworm-slim AS runner
-# Copy dependencies from the builder
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy node_modules from builder
 ```
 
-When using a Debian slim image for a Temporal worker, install `ca-certificates` in the runner as required by Temporal.
+Debian slim leaves out `ca-certificates`. Temporal still needs those certs, even without TLS to Temporal itself.
 
-See [Temporal’s Docker guidance for TypeScript workers](https://docs.temporal.io/develop/typescript/workers/run-worker-process#run-a-worker-on-docker), particularly the sections on slim images and why Alpine is unsupported.
+For services that are compatible with musl:
+
+```dockerfile
+FROM node:24-alpine AS builder
+
+RUN apk add --no-cache python3 make g++
+
+# install dependencies
+
+FROM node:24-alpine AS runner
+
+# copy node_modules from builder
+```
+
+Temporal's Docker guidance: [Run a TypeScript Worker process](https://docs.temporal.io/develop/typescript/workers/run-worker-process#run-a-worker-on-docker) — glibc image required, [do not use Alpine](https://docs.temporal.io/develop/typescript/workers/run-worker-process#do-not-use-alpine), and install `ca-certificates` on `node:*-slim`.
 
 ## Alternatives Considered
 
-### Continue mixing Alpine builders and Debian runners
+### Mix Alpine builder and Debian runner
 
-- **Pros**: Requires fewer changes to existing Dockerfiles.
-- **Cons**: Native dependencies installed against musl may not load under glibc, and vice versa. Failures may only appear when the container starts.
-- **Why not**: The result depends on incidental package-manager behavior and is not a reliable deployment model.
+* **Pros**: Smaller build stage; runner can stay Debian.
+* **Cons**: Natives in `node_modules` do not match the process that loads them. Failures show up at container start, not at `docker build`.
+* **Why not**: Relies on the package manager installing extras it no longer installs. Builder and runner must use the same libc.
 
-### Use Alpine for Temporal workers
+### Alpine for Temporal workers
 
-- **Pros**: Smaller base images and one image family for more services.
-- **Cons**: Temporal’s TypeScript SDK does not support musl because its Rust core requires glibc.
-- **Why not**: Compatibility layers or custom musl builds would be unsupported workarounds with additional maintenance and runtime risk.
+* **Pros**: Smaller images; one OS for the fleet.
+* **Cons**: Temporal's TypeScript native (Rust core / `@temporalio/core-bridge`) requires glibc. There is no supported musl build.
+* **Why not**: Temporal documents this as unsupported. Compiling the bridge yourself or adding `gcompat` is a workaround, not a platform we want to maintain.
 
-### Use Debian for every Node.js service
+### Debian for every service
 
-- **Pros**: One image family across the fleet and broader compatibility with native dependencies.
-- **Cons**: Debian slim images are larger than Alpine images, take more registry storage and network transfer, and may produce more operating-system packages and security-scanner findings.
-- **Why not**: Services that are already verified on Alpine do not need to pay those costs.
+* **Pros**: One image family; no "does this need glibc?" check.
+* **Cons**: Debian slim is larger than Alpine (more disk, slower pulls on a cold node). More OS packages, so scanners can report a different / larger CVE set. `apt` vs `apk` in Dockerfiles.
+* **Why not**: Services that already run on Alpine do not need to pay that cost. Only glibc-required services should be Debian.
 
 ## Consequences
 
 ### Positive
 
-- Native dependencies are installed and executed in compatible environments.
-- Temporal TypeScript workers run on an officially supported platform.
-- Docker behavior no longer depends on a package manager installing binaries for multiple platforms.
-- Services without glibc requirements can continue using smaller Alpine images.
-- Future Dockerfiles have a clear default: use the same image family in both stages.
+* Native dependencies are built and executed against the same libc.
+* Temporal workers use a supported runtime.
+* Alpine remains available for services that do not require glibc.
+* The rule holds even if pnpm's optional-dep behavior changes again.
 
 ### Negative
 
-- The service fleet intentionally uses both Alpine and Debian images.
-- Debian-based worker images are larger and may take longer to pull on a new Kubernetes node.
-- Debian and Alpine use different package managers, so Dockerfile setup commands differ.
-- Image security scans may report different findings for each distribution.
+* The fleet intentionally uses both Alpine and Debian.
+* Developers need to keep builder and runner on the same image family.
+* Debian-based Temporal images are larger than Alpine would be, so they cost a bit more registry storage and pull time. That is accepted for Temporal compatibility.
 
 ### Risks
 
-- A service running on Alpine may later add a glibc-only native dependency. Image builds and staging startup checks should verify that the service still boots successfully.
-- Builder and runner images may drift during future Dockerfile changes. Reviews should treat matching image families as a required invariant.
-- Changing a Node major version or Debian release in one stage without changing the other can reintroduce compatibility problems.
+* Someone copies an Alpine Dockerfile for a new Temporal TypeScript worker because most services are Alpine. If the process loads `@temporalio/worker` / `core-bridge`, both stages must be Debian.
 
 ## Rule of Thumb
 
-When a Docker build copies `node_modules` from builder to runner:
+When changing or creating a Node.js Dockerfile:
 
-**Use the same Node.js image family in both stages.**
+**Same libc in builder and runner.**
 
-**Temporal TypeScript worker means Debian with glibc.**
+**Temporal TypeScript worker = Debian.**

--- a/docs/adr/0019-docker-builder-runner-libc.md
+++ b/docs/adr/0019-docker-builder-runner-libc.md
@@ -1,0 +1,89 @@
+# ADR-0019: Align Docker build and runtime images; use Debian for Temporal workers
+
+**Date**: 2026-08-27
+**Status**: accepted
+**Deciders**: Yeganathan S
+
+## Context
+
+Our Node.js services use multi-stage Docker builds. Dependencies are installed in a builder stage, then `node_modules` is copied into the final runner image.
+
+Some dependencies include native binaries compiled for a specific operating system, CPU architecture, and C standard library. Alpine uses musl, while Debian uses glibc. Copying native dependencies between these environments can produce an image that builds successfully but fails when the application starts.
+
+The pnpm 11 upgrade exposed this existing mismatch. pnpm installs platform-specific optional dependencies for the environment where installation runs. Dependencies installed in an Alpine builder therefore cannot be assumed to work in a Debian runner, or the other way around. The package manager change exposed the problem; it did not create the underlying incompatibility.
+
+Temporal TypeScript workers have an additional constraint: `@temporalio/core-bridge` requires glibc. Temporal explicitly does not support running TypeScript workers on Alpine.
+
+## Decision
+
+Builder and runner stages must use the same Node.js base image family and operating system.
+
+- Temporal TypeScript workers use `node:<major>-bookworm-slim` for both stages.
+- Services whose dependencies support musl may use `node:<major>-alpine` for both stages.
+- Services with another glibc-only native dependency use Debian for both stages.
+- Alpine and Debian must not be mixed when `node_modules` is copied between stages.
+
+For example:
+
+```dockerfile
+FROM node:24-bookworm-slim AS builder
+# Install dependencies
+
+FROM node:24-bookworm-slim AS runner
+# Copy dependencies from the builder
+```
+
+When using a Debian slim image for a Temporal worker, install `ca-certificates` in the runner as required by Temporal.
+
+See [Temporal’s Docker guidance for TypeScript workers](https://docs.temporal.io/develop/typescript/workers/run-worker-process#run-a-worker-on-docker), particularly the sections on slim images and why Alpine is unsupported.
+
+## Alternatives Considered
+
+### Continue mixing Alpine builders and Debian runners
+
+- **Pros**: Requires fewer changes to existing Dockerfiles.
+- **Cons**: Native dependencies installed against musl may not load under glibc, and vice versa. Failures may only appear when the container starts.
+- **Why not**: The result depends on incidental package-manager behavior and is not a reliable deployment model.
+
+### Use Alpine for Temporal workers
+
+- **Pros**: Smaller base images and one image family for more services.
+- **Cons**: Temporal’s TypeScript SDK does not support musl because its Rust core requires glibc.
+- **Why not**: Compatibility layers or custom musl builds would be unsupported workarounds with additional maintenance and runtime risk.
+
+### Use Debian for every Node.js service
+
+- **Pros**: One image family across the fleet and broader compatibility with native dependencies.
+- **Cons**: Debian slim images are larger than Alpine images, take more registry storage and network transfer, and may produce more operating-system packages and security-scanner findings.
+- **Why not**: Services that are already verified on Alpine do not need to pay those costs.
+
+## Consequences
+
+### Positive
+
+- Native dependencies are installed and executed in compatible environments.
+- Temporal TypeScript workers run on an officially supported platform.
+- Docker behavior no longer depends on a package manager installing binaries for multiple platforms.
+- Services without glibc requirements can continue using smaller Alpine images.
+- Future Dockerfiles have a clear default: use the same image family in both stages.
+
+### Negative
+
+- The service fleet intentionally uses both Alpine and Debian images.
+- Debian-based worker images are larger and may take longer to pull on a new Kubernetes node.
+- Debian and Alpine use different package managers, so Dockerfile setup commands differ.
+- Image security scans may report different findings for each distribution.
+
+### Risks
+
+- A service running on Alpine may later add a glibc-only native dependency. Image builds and staging startup checks should verify that the service still boots successfully.
+- Builder and runner images may drift during future Dockerfile changes. Reviews should treat matching image families as a required invariant.
+- Changing a Node major version or Debian release in one stage without changing the other can reintroduce compatibility problems.
+
+## Rule of Thumb
+
+When a Docker build copies `node_modules` from builder to runner:
+
+**Use the same Node.js image family in both stages.**
+
+**Temporal TypeScript worker means Debian with glibc.**

--- a/docs/adr/0019-docker-builder-runner-libc.md
+++ b/docs/adr/0019-docker-builder-runner-libc.md
@@ -1,4 +1,4 @@
-# ADR-0019: Match builder and runner libc; Debian for Temporal TypeScript workers
+# ADR-0019: Use matching Node image families in Docker builds
 
 **Date**: 2026-08-27
 **Status**: accepted

--- a/docs/adr/0019-docker-builder-runner-libc.md
+++ b/docs/adr/0019-docker-builder-runner-libc.md
@@ -1,4 +1,4 @@
-# ADR-0019: Use matching Node image families in Docker builds
+# ADR-0019: Same libc in Docker builder and runner
 
 **Date**: 2026-08-27
 **Status**: accepted

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0016](./0016-akrites-cdp-public-api-authentication.md)    | Akrites → CDP public API authentication                                                              | proposed | 2026-07-22 |
 | [ADR-0017](./0017-blast-radius-pipeline-architecture.md)       | Blast radius analysis pipeline — multi-ecosystem architecture                                        | accepted | 2026-08-11 |
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
-| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Match builder and runner libc; Debian for Temporal TypeScript workers                                | accepted | 2026-08-27 |
+| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Use matching Node image families in Docker builds                                                    | accepted | 2026-08-27 |
 
 ## Why ADRs?
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0016](./0016-akrites-cdp-public-api-authentication.md)    | Akrites → CDP public API authentication                                                              | proposed | 2026-07-22 |
 | [ADR-0017](./0017-blast-radius-pipeline-architecture.md)       | Blast radius analysis pipeline — multi-ecosystem architecture                                        | accepted | 2026-08-11 |
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
-| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Use matching Node image families in Docker builds                                                    | accepted | 2026-08-27 |
+| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Same libc in Docker builder and runner                                                               | accepted | 2026-08-27 |
 
 ## Why ADRs?
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0016](./0016-akrites-cdp-public-api-authentication.md)    | Akrites → CDP public API authentication                                                              | proposed | 2026-07-22 |
 | [ADR-0017](./0017-blast-radius-pipeline-architecture.md)       | Blast radius analysis pipeline — multi-ecosystem architecture                                        | accepted | 2026-08-11 |
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
+| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Align Docker build and runtime images; use Debian for Temporal workers                               | accepted | 2026-08-27 |
 
 ## Why ADRs?
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,7 +25,7 @@ Use the `/adr` skill in Claude Code to record new ADRs or query past decisions.
 | [ADR-0016](./0016-akrites-cdp-public-api-authentication.md)    | Akrites → CDP public API authentication                                                              | proposed | 2026-07-22 |
 | [ADR-0017](./0017-blast-radius-pipeline-architecture.md)       | Blast radius analysis pipeline — multi-ecosystem architecture                                        | accepted | 2026-08-11 |
 | [ADR-0018](./0018-per-client-rate-limiting-members-resolve.md) | Per-client rate limiting for `POST /members/resolve` using in-memory store                           | accepted | 2026-08-12 |
-| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Align Docker build and runtime images; use Debian for Temporal workers                               | accepted | 2026-08-27 |
+| [ADR-0019](./0019-docker-builder-runner-libc.md)               | Match builder and runner libc; Debian for Temporal TypeScript workers                                | accepted | 2026-08-27 |
 
 ## Why ADRs?
 


### PR DESCRIPTION
## Summary
Records the Docker base-image decision after the pnpm 11 upgrade: builder and runner must use the same OS/libc, and Temporal TypeScript workers use Debian because glibc is required.

## Changes
- Add ADR-0019 covering matching builder/runner images, Debian for Temporal workers, and why Alpine remains valid for other services
- Index the ADR in `docs/adr/README.md`